### PR TITLE
Refactor PerpsBot bootstrap into helpers

### DIFF
--- a/src/bot_v2/config/env_utils.py
+++ b/src/bot_v2/config/env_utils.py
@@ -1,0 +1,143 @@
+"""Shared helpers for parsing configuration values from environment variables."""
+
+from __future__ import annotations
+
+import os
+from decimal import Decimal
+from typing import Callable, Dict, Optional, TypeVar
+
+T = TypeVar("T")
+
+_TRUE_VALUES = {"1", "true", "t", "yes", "y", "on"}
+_FALSE_VALUES = {"0", "false", "f", "no", "n", "off"}
+
+
+class EnvVarError(ValueError):
+    """Raised when an environment variable cannot be parsed."""
+
+
+def _get_env(var_name: str) -> Optional[str]:
+    """Fetch and normalise the value of an environment variable."""
+    raw = os.getenv(var_name)
+    if raw is None:
+        return None
+    value = raw.strip()
+    return value if value else None
+
+
+def coerce_env_value(var_name: str, cast: Callable[[str], T]) -> Optional[T]:
+    """Return ``cast`` applied to ``var_name`` if it is set."""
+    value = _get_env(var_name)
+    if value is None:
+        return None
+    try:
+        return cast(value)
+    except Exception as exc:  # pragma: no cover - defensive
+        raise EnvVarError(
+            f"Environment variable {var_name} could not be parsed: {value!r}"
+        ) from exc
+
+
+def get_env_int(var_name: str) -> Optional[int]:
+    """Read an integer from ``var_name`` if present."""
+    return coerce_env_value(var_name, int)
+
+
+def get_env_float(var_name: str) -> Optional[float]:
+    """Read a float from ``var_name`` if present."""
+    return coerce_env_value(var_name, float)
+
+
+def get_env_decimal(var_name: str) -> Optional[Decimal]:
+    """Read a :class:`~decimal.Decimal` from ``var_name`` if present."""
+    return coerce_env_value(var_name, Decimal)
+
+
+def get_env_bool(var_name: str) -> Optional[bool]:
+    """Parse a boolean value from ``var_name``.
+
+    Accepted truthy values: ``{"1", "true", "t", "yes", "y", "on"}``
+    Accepted falsy values: ``{"0", "false", "f", "no", "n", "off"}``
+    """
+
+    value = _get_env(var_name)
+    if value is None:
+        return None
+
+    normalised = value.lower()
+    if normalised in _TRUE_VALUES:
+        return True
+    if normalised in _FALSE_VALUES:
+        return False
+
+    raise EnvVarError(
+        f"Environment variable {var_name} expected a boolean value but received {value!r}."
+    )
+
+
+def parse_env_mapping(
+    var_name: str,
+    cast: Callable[[str], T],
+    *,
+    item_delimiter: str = ",",
+    kv_delimiter: str = ":",
+    allow_empty: bool = True,
+) -> Dict[str, T]:
+    """Parse a mapping from an environment variable.
+
+    ``var_name`` should contain values in the form ``"KEY:VALUE,KEY2:VALUE2"``.
+    ``cast`` is applied to each value; errors raise :class:`EnvVarError`.
+    """
+
+    value = _get_env(var_name)
+    if value is None:
+        return {}
+
+    result: Dict[str, T] = {}
+    pairs = value.split(item_delimiter)
+    for raw_pair in pairs:
+        pair = raw_pair.strip()
+        if not pair:
+            if allow_empty:
+                continue
+            raise EnvVarError(
+                f"Environment variable {var_name} contains an empty mapping entry."
+            )
+
+        if kv_delimiter not in pair:
+            raise EnvVarError(
+                f"Environment variable {var_name} has an invalid entry {pair!r}; expected 'KEY{kv_delimiter}VALUE'."
+            )
+
+        key, raw_val = pair.split(kv_delimiter, 1)
+        key = key.strip()
+        if not key:
+            raise EnvVarError(
+                f"Environment variable {var_name} includes an entry with an empty key."
+            )
+
+        raw_val = raw_val.strip()
+        if not raw_val:
+            raise EnvVarError(
+                f"Environment variable {var_name} includes an entry for {key!r} with an empty value."
+            )
+
+        try:
+            result[key] = cast(raw_val)
+        except Exception as exc:
+            raise EnvVarError(
+                f"Environment variable {var_name} could not cast value {raw_val!r} for key {key!r}."
+            ) from exc
+
+    return result
+
+
+__all__ = [
+    "EnvVarError",
+    "coerce_env_value",
+    "get_env_bool",
+    "get_env_decimal",
+    "get_env_float",
+    "get_env_int",
+    "parse_env_mapping",
+]

--- a/src/bot_v2/orchestration/perps_bootstrap.py
+++ b/src/bot_v2/orchestration/perps_bootstrap.py
@@ -1,0 +1,207 @@
+"""Bootstrap helpers for preparing PerpsBot dependencies."""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Mapping, Sequence
+
+from bot_v2.persistence.event_store import EventStore
+from bot_v2.persistence.orders_store import OrdersStore
+from bot_v2.system_paths import RUNTIME_DATA_DIR
+
+from .configuration import BotConfig, Profile, TOP_VOLUME_BASES
+from .service_registry import ServiceRegistry, empty_registry
+
+_DEFAULT_ALLOWED_PERPS: frozenset[str] = frozenset({
+    "BTC-PERP",
+    "ETH-PERP",
+    "SOL-PERP",
+    "XRP-PERP",
+})
+
+
+@dataclass(frozen=True)
+class BootstrapLogRecord:
+    """Captured log entry emitted during bootstrap."""
+
+    level: int
+    message: str
+    args: tuple[object, ...] = ()
+
+
+@dataclass(frozen=True)
+class RuntimePaths:
+    """Materialized runtime directories for the bot."""
+
+    storage_dir: Path
+    event_store_root: Path
+
+
+@dataclass(frozen=True)
+class PerpsBootstrapResult:
+    """Outcome of preparing dependencies for :class:`PerpsBot`."""
+
+    config: BotConfig
+    registry: ServiceRegistry
+    runtime_paths: RuntimePaths
+    event_store: EventStore
+    orders_store: OrdersStore
+    logs: list[BootstrapLogRecord]
+
+
+def normalise_symbols(
+    requested: Sequence[str] | None,
+    *,
+    derivatives_enabled: bool,
+    default_quote: str,
+    allowed_perps: Iterable[str] = _DEFAULT_ALLOWED_PERPS,
+    fallback_bases: Sequence[str] = TOP_VOLUME_BASES,
+) -> tuple[list[str], list[BootstrapLogRecord]]:
+    """Return canonical symbol list for the configured runtime."""
+
+    logs: list[BootstrapLogRecord] = []
+    allowed_set = set(allowed_perps)
+    normalised: list[str] = []
+
+    for raw in requested or []:
+        symbol = (raw or "").strip().upper()
+        if not symbol:
+            continue
+
+        if derivatives_enabled:
+            if symbol not in allowed_set:
+                logs.append(
+                    BootstrapLogRecord(
+                        logging.WARNING,
+                        "Filtering unsupported perpetual symbol %s. Allowed perps: %s",
+                        (symbol, sorted(allowed_set)),
+                    )
+                )
+                continue
+            normalised.append(symbol)
+            continue
+
+        if symbol.endswith("-PERP"):
+            base = symbol.split("-", 1)[0]
+            replacement = f"{base}-{default_quote.upper()}"
+            logs.append(
+                BootstrapLogRecord(
+                    logging.WARNING,
+                    "Derivatives disabled. Replacing %s with spot symbol %s",
+                    (symbol, replacement),
+                )
+            )
+            symbol = replacement
+
+        normalised.append(symbol)
+
+    # Deduplicate while preserving the first occurrence order
+    normalised = list(dict.fromkeys(normalised))
+
+    if normalised:
+        return normalised, logs
+
+    if derivatives_enabled:
+        fallback = ["BTC-PERP", "ETH-PERP"]
+    else:
+        quote = default_quote.upper()
+        fallback = [f"{base}-{quote}" for base in fallback_bases]
+
+    logs.append(
+        BootstrapLogRecord(
+            logging.INFO,
+            "No valid symbols provided. Falling back to %s",
+            (fallback,),
+        )
+    )
+    return fallback, logs
+
+
+def resolve_runtime_paths(
+    profile: Profile,
+    env: Mapping[str, str] | None = None,
+) -> RuntimePaths:
+    """Determine and materialise storage directories for the bot."""
+
+    env_map: Mapping[str, str] = env or os.environ
+
+    runtime_root = Path(env_map.get("GPT_TRADER_RUNTIME_ROOT", str(RUNTIME_DATA_DIR)))
+    storage_dir = runtime_root / f"perps_bot/{profile.value}"
+    storage_dir.mkdir(parents=True, exist_ok=True)
+
+    event_root = env_map.get("EVENT_STORE_ROOT")
+    if event_root:
+        event_store_root = Path(event_root)
+        if "perps_bot" not in set(event_store_root.parts):
+            event_store_root = event_store_root / "perps_bot" / profile.value
+    else:
+        event_store_root = storage_dir
+
+    event_store_root.mkdir(parents=True, exist_ok=True)
+    return RuntimePaths(storage_dir=storage_dir, event_store_root=event_store_root)
+
+
+def prepare_perps_bot(
+    config: BotConfig,
+    registry: ServiceRegistry | None = None,
+    *,
+    env: Mapping[str, str] | None = None,
+) -> PerpsBootstrapResult:
+    """Prepare directories and registry dependencies for :class:`PerpsBot`."""
+
+    env_map: Mapping[str, str]
+    if env is None:
+        env_map = os.environ
+    else:
+        env_map = env
+
+    derivatives_enabled = (
+        config.profile != Profile.SPOT
+        and env_map.get("COINBASE_ENABLE_DERIVATIVES", "0") == "1"
+    )
+    default_quote = env_map.get("COINBASE_DEFAULT_QUOTE", "USD").upper()
+
+    symbols, logs = normalise_symbols(
+        config.symbols,
+        derivatives_enabled=derivatives_enabled,
+        default_quote=default_quote,
+    )
+    config.symbols = list(symbols)
+
+    runtime_paths = resolve_runtime_paths(config.profile, env_map)
+
+    prepared_registry = registry or empty_registry(config)
+    if prepared_registry.config is not config:
+        prepared_registry = prepared_registry.with_updates(config=config)
+
+    event_store = prepared_registry.event_store
+    if event_store is None:
+        event_store = EventStore(root=runtime_paths.event_store_root)
+        prepared_registry = prepared_registry.with_updates(event_store=event_store)
+
+    orders_store = prepared_registry.orders_store
+    if orders_store is None:
+        orders_store = OrdersStore(storage_path=runtime_paths.storage_dir)
+        prepared_registry = prepared_registry.with_updates(orders_store=orders_store)
+
+    return PerpsBootstrapResult(
+        config=config,
+        registry=prepared_registry,
+        runtime_paths=runtime_paths,
+        event_store=event_store,
+        orders_store=orders_store,
+        logs=logs,
+    )
+
+
+__all__ = [
+    "BootstrapLogRecord",
+    "PerpsBootstrapResult",
+    "prepare_perps_bot",
+    "normalise_symbols",
+    "resolve_runtime_paths",
+    "RuntimePaths",
+]

--- a/tests/unit/bot_v2/config/test_env_utils.py
+++ b/tests/unit/bot_v2/config/test_env_utils.py
@@ -1,0 +1,51 @@
+from decimal import Decimal
+
+import pytest
+
+from bot_v2.config.env_utils import (
+    EnvVarError,
+    get_env_bool,
+    get_env_decimal,
+    parse_env_mapping,
+)
+
+
+def test_parse_env_mapping_success(monkeypatch):
+    monkeypatch.setenv("TEST_MAPPING", "BTC-PERP:10, ETH-PERP: 5")
+
+    result = parse_env_mapping("TEST_MAPPING", int)
+
+    assert result == {"BTC-PERP": 10, "ETH-PERP": 5}
+
+
+def test_parse_env_mapping_invalid_pair_raises(monkeypatch):
+    monkeypatch.setenv("TEST_MAPPING", "BTC-PERP-10")
+
+    with pytest.raises(EnvVarError) as exc:
+        parse_env_mapping("TEST_MAPPING", int)
+
+    assert "TEST_MAPPING" in str(exc.value)
+
+
+def test_get_env_bool_accepts_various_truthy_values(monkeypatch):
+    monkeypatch.setenv("TEST_BOOL", "Yes")
+    assert get_env_bool("TEST_BOOL") is True
+
+    monkeypatch.setenv("TEST_BOOL", "off")
+    assert get_env_bool("TEST_BOOL") is False
+
+
+def test_get_env_bool_invalid_value(monkeypatch):
+    monkeypatch.setenv("TEST_BOOL", "maybe")
+
+    with pytest.raises(EnvVarError):
+        get_env_bool("TEST_BOOL")
+
+
+def test_get_env_decimal(monkeypatch):
+    monkeypatch.setenv("TEST_DECIMAL", "100.5")
+
+    value = get_env_decimal("TEST_DECIMAL")
+
+    assert isinstance(value, Decimal)
+    assert value == Decimal("100.5")

--- a/tests/unit/bot_v2/config/test_live_trade_config_env.py
+++ b/tests/unit/bot_v2/config/test_live_trade_config_env.py
@@ -1,0 +1,30 @@
+import pytest
+
+from bot_v2.config.live_trade_config import RiskConfig
+from bot_v2.config.env_utils import EnvVarError
+
+
+def test_from_env_populates_mappings(monkeypatch):
+    monkeypatch.setenv("RISK_LEVERAGE_MAX_PER_SYMBOL", "BTC-PERP:10")
+    monkeypatch.setenv("RISK_DAY_MMR_PER_SYMBOL", "BTC-PERP:0.01")
+    monkeypatch.setenv("RISK_ENABLE_PRE_TRADE_LIQ_PROJECTION", "true")
+
+    config = RiskConfig.from_env()
+
+    assert config.leverage_max_per_symbol == {"BTC-PERP": 10}
+    assert config.day_mmr_per_symbol == {"BTC-PERP": 0.01}
+    assert config.enable_pre_trade_liq_projection is True
+
+
+def test_from_env_invalid_mapping_raises(monkeypatch):
+    monkeypatch.setenv("RISK_LEVERAGE_MAX_PER_SYMBOL", "BTC-PERP-10")
+
+    with pytest.raises(EnvVarError):
+        RiskConfig.from_env()
+
+
+def test_from_env_invalid_boolean_raises(monkeypatch):
+    monkeypatch.setenv("RISK_ENABLE_PRE_TRADE_LIQ_PROJECTION", "notabool")
+
+    with pytest.raises(EnvVarError):
+        RiskConfig.from_env()

--- a/tests/unit/bot_v2/orchestration/test_perps_bootstrap.py
+++ b/tests/unit/bot_v2/orchestration/test_perps_bootstrap.py
@@ -1,0 +1,82 @@
+from pathlib import Path
+
+import logging
+
+from bot_v2.orchestration.configuration import BotConfig, Profile
+from bot_v2.orchestration.perps_bootstrap import (
+    normalise_symbols,
+    prepare_perps_bot,
+    resolve_runtime_paths,
+)
+from bot_v2.orchestration.service_registry import empty_registry
+from bot_v2.persistence.event_store import EventStore
+
+
+def test_normalise_symbols_filters_unsupported_perps():
+    symbols, logs = normalise_symbols(
+        ["BTC-PERP", "DOGE-PERP"],
+        derivatives_enabled=True,
+        default_quote="USD",
+        allowed_perps={"BTC-PERP"},
+    )
+
+    assert symbols == ["BTC-PERP"]
+    assert any("Filtering unsupported" in record.message for record in logs)
+
+
+def test_normalise_symbols_replaces_perps_when_disabled():
+    symbols, logs = normalise_symbols(
+        ["btc-perp", "eth-usd"],
+        derivatives_enabled=False,
+        default_quote="usd",
+    )
+
+    assert symbols == ["BTC-USD", "ETH-USD"]
+    assert any("Derivatives disabled" in record.message for record in logs)
+
+
+def test_normalise_symbols_uses_fallback_when_empty():
+    fallback_bases = ["BTC", "ETH"]
+    symbols, logs = normalise_symbols(
+        [],
+        derivatives_enabled=False,
+        default_quote="eur",
+        fallback_bases=fallback_bases,
+    )
+
+    assert symbols == ["BTC-EUR", "ETH-EUR"]
+    assert logs and logs[-1].level == logging.INFO
+
+
+def test_resolve_runtime_paths_respects_environment(tmp_path):
+    env = {
+        "GPT_TRADER_RUNTIME_ROOT": str(tmp_path / "runtime"),
+        "EVENT_STORE_ROOT": str(tmp_path / "events"),
+    }
+
+    paths = resolve_runtime_paths(Profile.DEV, env)
+
+    assert paths.storage_dir == Path(env["GPT_TRADER_RUNTIME_ROOT"]) / "perps_bot/dev"
+    assert paths.storage_dir.exists()
+    assert paths.event_store_root == Path(env["EVENT_STORE_ROOT"]) / "perps_bot/dev"
+    assert paths.event_store_root.exists()
+
+
+def test_prepare_perps_bot_reuses_injected_event_store(tmp_path):
+    env = {
+        "COINBASE_ENABLE_DERIVATIVES": "1",
+        "GPT_TRADER_RUNTIME_ROOT": str(tmp_path / "runtime"),
+        "EVENT_STORE_ROOT": str(tmp_path / "events"),
+    }
+
+    config = BotConfig(profile=Profile.DEV, symbols=["BTC-PERP", "DOGE-PERP"])
+    custom_store = EventStore(root=tmp_path / "custom")
+    registry = empty_registry(config).with_updates(event_store=custom_store)
+
+    result = prepare_perps_bot(config, registry, env=env)
+
+    assert result.event_store is custom_store
+    assert result.registry.event_store is custom_store
+    assert result.orders_store is not None
+    assert config.symbols == ["BTC-PERP"]
+    assert result.runtime_paths.storage_dir == Path(env["GPT_TRADER_RUNTIME_ROOT"]) / "perps_bot/dev"


### PR DESCRIPTION
## Summary
- extract symbol normalisation, runtime path resolution, and registry population into dedicated `perps_bootstrap` helpers
- simplify `PerpsBot.__init__` to consume the bootstrap result and centralise logging of symbol adjustments
- add unit coverage for symbol normalisation, path resolution, and bootstrap dependency reuse scenarios

## Testing
- pytest tests/unit/bot_v2/orchestration/test_perps_bootstrap.py tests/unit/bot_v2/orchestration/test_perps_bot.py -q *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68e3cb6b99d08325bc9d4c2789b1191c