### PR TITLE
Add {0} placeholder to workflow shells

### DIFF
--- a/.github/workflows/bot-v2.yml
+++ b/.github/workflows/bot-v2.yml
@@ -41,7 +41,7 @@ permissions:
 
 defaults:
   run:
-    shell: bash --noprofile --norc
+    shell: bash --noprofile --norc {0}
 
 jobs:
   # Code Quality Checks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions:
 
 defaults:
   run:
-    shell: bash --noprofile --norc
+    shell: bash --noprofile --norc {0}
 
 env:
   PYTHON_VERSION: "3.12"

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -15,7 +15,7 @@ permissions:
 
 defaults:
   run:
-    shell: bash --noprofile --norc
+    shell: bash --noprofile --norc {0}
 
 env:
   PYTHON_VERSION: "3.12"

--- a/.github/workflows/nightly_validation.yml
+++ b/.github/workflows/nightly_validation.yml
@@ -16,7 +16,7 @@ permissions:
 
 defaults:
   run:
-    shell: bash --noprofile --norc
+    shell: bash --noprofile --norc {0}
 
 env:
   PYTHON_VERSION: "3.12"

--- a/.github/workflows/perps-validation.yml
+++ b/.github/workflows/perps-validation.yml
@@ -17,7 +17,7 @@ permissions:
 
 defaults:
   run:
-    shell: bash --noprofile --norc
+    shell: bash --noprofile --norc {0}
 
 env:
   PYTHON_VERSION: "3.12"

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -13,7 +13,7 @@ permissions:
 
 defaults:
   run:
-    shell: bash --noprofile --norc
+    shell: bash --noprofile --norc {0}
 
 env:
   PYTHON_VERSION: "3.12"

--- a/.github/workflows/targeted-suites.yml
+++ b/.github/workflows/targeted-suites.yml
@@ -45,7 +45,7 @@ permissions:
 
 defaults:
   run:
-    shell: bash --noprofile --norc
+    shell: bash --noprofile --norc {0}
 
 env:
   PYTHON_VERSION: "3.12"


### PR DESCRIPTION
## Summary
- update `defaults.run.shell` to use the required `{0}` placeholder across workflows
- fix invalid shell option errors on the latest GitHub runners

## Testing
- n/a (workflow-only change)
