### PR TITLE
Add regime filter and volatility-aware position sizing

### DIFF
--- a/config/profiles/spot.yaml
+++ b/config/profiles/spot.yaml
@@ -12,6 +12,9 @@ strategy:
       oversold: 40
       overbought: 70
     trend_filter: null
+    regime_filter:
+      window: 14
+      adx_threshold: 25
   eth:
     type: ma
     short_window: 10
@@ -22,6 +25,9 @@ strategy:
       multiplier: 1.1
     momentum_filter: null
     trend_filter: null
+    regime_filter:
+      window: 14
+      adx_threshold: 25
   sol:
     type: ma
     short_window: 8
@@ -34,6 +40,9 @@ strategy:
       oversold: 35
       overbought: 70
     trend_filter: null
+    regime_filter:
+      window: 14
+      adx_threshold: 25
   xrp:
     type: ma
     short_window: 12
@@ -46,6 +55,9 @@ strategy:
       oversold: 30
       overbought: 68
     trend_filter: null
+    regime_filter:
+      window: 14
+      adx_threshold: 28
   ltc:
     type: ma
     short_window: 7
@@ -58,6 +70,9 @@ strategy:
       oversold: 38
       overbought: 72
     trend_filter: null
+    regime_filter:
+      window: 14
+      adx_threshold: 27
   ada:
     type: ma
     short_window: 12
@@ -70,6 +85,9 @@ strategy:
       oversold: 32
       overbought: 68
     trend_filter: null
+    regime_filter:
+      window: 14
+      adx_threshold: 28
   doge:
     type: ma
     short_window: 15
@@ -82,6 +100,9 @@ strategy:
       oversold: 28
       overbought: 65
     trend_filter: null
+    regime_filter:
+      window: 14
+      adx_threshold: 30
   bch:
     type: ma
     short_window: 6
@@ -94,6 +115,9 @@ strategy:
       oversold: 37
       overbought: 70
     trend_filter: null
+    regime_filter:
+      window: 14
+      adx_threshold: 26
   avax:
     type: ma
     short_window: 9
@@ -106,6 +130,9 @@ strategy:
       oversold: 34
       overbought: 70
     trend_filter: null
+    regime_filter:
+      window: 14
+      adx_threshold: 27
   link:
     type: ma
     short_window: 9
@@ -118,6 +145,9 @@ strategy:
       oversold: 35
       overbought: 71
     trend_filter: null
+    regime_filter:
+      window: 14
+      adx_threshold: 27
 risk:
   commission_bps: 2.5
   max_position_pct: 0.2

--- a/src/bot_v2/features/position_sizing/types.py
+++ b/src/bot_v2/features/position_sizing/types.py
@@ -60,6 +60,7 @@ class PositionSizeRequest:
     confidence: float | None = None
     market_regime: str | None = None
     volatility: float | None = None
+    recent_prices: list[float] | None = None  # For volatility-aware Kelly sizing
 
     # Risk parameters
     risk_params: RiskParameters = field(default_factory=RiskParameters)


### PR DESCRIPTION
Implement two key strategy upgrades:

1. **Regime Filter using ADX**
   - Add ADX (Average Directional Index) indicator to measure trend strength
   - Filter MA crossover signals to only trade when ADX ≥ threshold (25-30)
   - Skip choppy/ranging markets where MA crossovers are unreliable
   - Add configurable ADX thresholds per symbol in spot.yaml
   - Log regime (trending/choppy) with every trading decision

2. **Volatility-Aware Position Sizing**
   - Keep fractional Kelly criterion (0.25 default)
   - Scale position size by realized volatility regime
   - Halve Kelly fraction when volatility > p75 (high vol periods)
   - Protect against Kelly's sensitivity to mis-estimated edge
   - Add price history support to position sizing requests

Technical changes:
- indicators.py: Add calculate_adx() with +DI, -DI, ADX calculation
- strategy_orchestrator.py: Add regime_filter check in spot filters
- kelly.py: Add kelly_with_volatility_scaling() function
- position_sizing.py: Integrate vol-aware Kelly into intelligent sizing
- types.py: Add recent_prices field to PositionSizeRequest
- spot.yaml: Add regime_filter config for all 10 symbols
- Comprehensive unit tests for ADX and vol-aware Kelly

Benefits:
- Fewer false signals in choppy markets (better win rate)
- Reduced position sizes during high volatility (better risk control)
- Improved risk-adjusted returns through regime-aware trading

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary

- What changed and why?

## Checklist

- [ ] CI is green (tests, lint, format)
- [ ] Tests added/updated for new behavior
- [ ] Docs/README updated (if applicable)
- [ ] No `sys.path` hacks; imports follow `from bot_v2...`
- [ ] No stray files in repo root

## Testing

- Steps to validate locally (commands, expected results)

## Risk/rollback

- Risks introduced and mitigation
- Safe rollback steps
