### PR TITLE
fix: Set ENV and encryption key in secrets_manager_with_vault fixture

### DIFF
--- a/tests/unit/gpt_trader/security/secrets_manager/conftest.py
+++ b/tests/unit/gpt_trader/security/secrets_manager/conftest.py
@@ -158,8 +158,14 @@ def secrets_manager_with_vault(
     secrets_dir: Path,
 ) -> Any:
     """SecretsManager instance with mocked vault."""
+    from cryptography.fernet import Fernet
+
     from gpt_trader.config.runtime_settings import load_runtime_settings
     from gpt_trader.security.secrets_manager import SecretsManager
+
+    # Set required environment variables for SecretsManager
+    monkeypatch.setenv("ENV", "development")
+    monkeypatch.setenv("GPT_TRADER_ENCRYPTION_KEY", Fernet.generate_key().decode())
 
     # Enable vault with stub
     monkeypatch.setenv("VAULT_TOKEN", "test-token")


### PR DESCRIPTION
The fixture was calling load_runtime_settings() which reads from actual
environment variables, bypassing the mocked settings. This caused test
failures when ENV and GPT_TRADER_ENCRYPTION_KEY weren't set.

Now sets ENV=development and generates a Fernet encryption key via
monkeypatch.setenv() before calling load_runtime_settings().