### PR TITLE
strategy(regime): add regime_follow trend mode

### DIFF
--- a/src/gpt_trader/app/config/bot_config.py
+++ b/src/gpt_trader/app/config/bot_config.py
@@ -166,6 +166,8 @@ class BotConfig:
     # - regime_switcher = switch between trend and mean reversion by regime
     strategy_type: StrategyType = "baseline"
 
+    regime_switcher_trend_mode: Literal["delegate", "regime_follow"] = "delegate"
+
     # General config (not nested)
     symbols: list[str] = field(default_factory=lambda: ["BTC-USD", "ETH-USD"])
     interval: int = 60  # seconds

--- a/src/gpt_trader/features/live_trade/factory.py
+++ b/src/gpt_trader/features/live_trade/factory.py
@@ -134,6 +134,8 @@ def create_strategy(config: "BotConfig") -> TradingStrategy:
             mean_reversion_strategy_factory=mean_reversion_factory,
             regime_detector=detector,
             required_lookback_bars=required_lookback,
+            trend_mode=config.regime_switcher_trend_mode,
+            enable_shorts=config.enable_shorts,
         )
 
     else:


### PR DESCRIPTION
## Summary
- add a regime_follow trend mode for regime_switcher to align decisions with bull/bear regimes
- expose and wire the regime_trend_mode knob through the backtest runner
- add unit coverage for regime_follow decisions

## Evidence
- WFA: 1/6 pass; runtime_data/canary/reports/walk_forward_20260117_235908/summary.md
- Failed-gates breakdown (window counts):
  - total_trades: 3
  - trades_per_100_bars: 3
  - fee_drag_per_trade: 1
  - profit_factor: 2
  - sharpe_ratio: 2
  - net_profit_factor: 2
- Note: default remains delegate; regime_follow is opt-in via --regime-trend-mode regime_follow.