### PR TITLE
types(daily_report): fix payload typing

### DIFF
--- a/src/gpt_trader/monitoring/daily_report/models.py
+++ b/src/gpt_trader/monitoring/daily_report/models.py
@@ -63,7 +63,7 @@ class DailyReport:
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary."""
-        payload = {
+        payload: dict[str, Any] = {
             "date": self.date,
             "profile": self.profile,
             "generated_at": self.generated_at,


### PR DESCRIPTION
Fixes a MyPy false-positive caused by dict literal type inference (payload inferred as Collection[Collection[str]]), by explicitly typing payload as dict[str, Any].\n\nCI: unblocks Type Check job.