### PR TITLE
ci: fix ruff + mypy failures

### DIFF
--- a/src/gpt_trader/features/live_trade/engines/strategy.py
+++ b/src/gpt_trader/features/live_trade/engines/strategy.py
@@ -951,7 +951,7 @@ class TradingEngine(BaseEngine):
             for symbol in symbols
         ]
         results = await asyncio.gather(*tasks, return_exceptions=True)
-        failures: list[BaseException] = []
+        failures: list[Exception] = []
 
         for symbol, res in zip(symbols, results):
             if isinstance(res, Exception):

--- a/tests/unit/gpt_trader/features/live_trade/engines/test_strategy_engine.py
+++ b/tests/unit/gpt_trader/features/live_trade/engines/test_strategy_engine.py
@@ -118,6 +118,7 @@ def engine(context, mock_strategy, application_container):
         engine._order_validator.run_pre_trade_validation.return_value = None
         # Mock maybe_preview_order_async as an async mock
         from unittest.mock import AsyncMock
+
         engine._order_validator.maybe_preview_order_async = AsyncMock(return_value=None)
         engine._order_validator.maybe_preview_order.return_value = None
         engine._order_validator.finalize_reduce_only_flag.return_value = False

--- a/tests/unit/gpt_trader/features/live_trade/execution/test_validation_async.py
+++ b/tests/unit/gpt_trader/features/live_trade/execution/test_validation_async.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 from decimal import Decimal
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
+
 import pytest
 
 from gpt_trader.core import OrderSide, OrderType, TimeInForce
 from gpt_trader.features.live_trade.execution.validation import OrderValidator
 from gpt_trader.features.live_trade.risk import ValidationError
+
 
 @pytest.fixture
 def validator(
@@ -27,6 +29,7 @@ def validator(
         record_rejection_callback=record_rejection,
         failure_tracker=mock_failure_tracker,
     )
+
 
 @pytest.mark.asyncio
 async def test_maybe_preview_order_async_success(
@@ -71,6 +74,7 @@ async def test_maybe_preview_order_async_success(
     # Check success record
     mock_failure_tracker.record_success.assert_called_once_with("order_preview")
 
+
 @pytest.mark.asyncio
 async def test_maybe_preview_order_async_validation_error(
     mock_risk_manager: MagicMock,
@@ -102,6 +106,7 @@ async def test_maybe_preview_order_async_validation_error(
             reduce_only=False,
             leverage=10,
         )
+
 
 @pytest.mark.asyncio
 async def test_maybe_preview_order_async_generic_error(
@@ -137,6 +142,7 @@ async def test_maybe_preview_order_async_generic_error(
 
     broker.preview_order.assert_called_once()
     mock_failure_tracker.record_failure.assert_called_once_with("order_preview")
+
 
 @pytest.mark.asyncio
 async def test_maybe_preview_order_async_disabled(


### PR DESCRIPTION
Fixes CI failures introduced on main:

- Ruff: remove unused import + sort imports in `test_validation_async.py`.
- Mypy: narrow `failures` from `list[BaseException]` to `list[Exception]` in `TradingEngine`.

Local checks:
- `uv run ruff check .`
- `uv run mypy src`
- `uv run pytest tests/unit/gpt_trader/features/live_trade/execution/test_validation_async.py`