### PR TITLE
test(monitoring): reduce patch density in daily report edges

### DIFF
--- a/tests/unit/gpt_trader/monitoring/daily_report/test_generator_edges.py
+++ b/tests/unit/gpt_trader/monitoring/daily_report/test_generator_edges.py
@@ -4,18 +4,18 @@ from __future__ import annotations
 
 import json
 from datetime import UTC, datetime, timedelta
-from unittest.mock import patch
+from unittest.mock import MagicMock
 
+import pytest
+
+import gpt_trader.monitoring.daily_report.generator as generator_module
 from gpt_trader.monitoring.daily_report.generator import DailyReportGenerator
 from gpt_trader.monitoring.daily_report.models import DailyReport
 
 
-def test_generate_uses_expected_files_and_cutoff(tmp_path) -> None:
-    date = datetime(2024, 2, 2, 12, 30, 0, tzinfo=UTC)
-    generator = DailyReportGenerator(profile="alpha", data_dir=tmp_path)
-    expected_cutoff = date - timedelta(hours=6)
-
-    pnl_metrics = {
+@pytest.fixture
+def pnl_metrics() -> dict[str, float]:
+    return {
         "equity": 100.0,
         "equity_change": 1.0,
         "equity_change_pct": 1.0,
@@ -25,7 +25,11 @@ def test_generate_uses_expected_files_and_cutoff(tmp_path) -> None:
         "total_pnl": 0.0,
         "fees_paid": 0.0,
     }
-    trade_metrics = {
+
+
+@pytest.fixture
+def trade_metrics() -> dict[str, float | int]:
+    return {
         "win_rate": 0.0,
         "profit_factor": 0.0,
         "sharpe_ratio": 0.0,
@@ -39,137 +43,95 @@ def test_generate_uses_expected_files_and_cutoff(tmp_path) -> None:
         "largest_win": 0.0,
         "largest_loss": 0.0,
     }
-    risk_metrics = {"guard_triggers": {}, "circuit_breaker_state": {}}
-    health_metrics = {
+
+
+@pytest.fixture
+def risk_metrics() -> dict[str, dict]:
+    return {"guard_triggers": {}, "circuit_breaker_state": {}}
+
+
+@pytest.fixture
+def health_metrics() -> dict[str, int]:
+    return {
         "stale_marks_count": 0,
         "ws_reconnects": 0,
         "unfilled_orders": 0,
         "api_errors": 0,
     }
 
-    with (
-        patch("gpt_trader.monitoring.daily_report.generator.load_metrics") as mock_metrics,
-        patch("gpt_trader.monitoring.daily_report.generator.load_events_since") as mock_events,
-        patch(
-            "gpt_trader.monitoring.daily_report.generator.load_liveness_snapshot",
-            return_value=None,
-        ) as mock_liveness,
-        patch(
-            "gpt_trader.monitoring.daily_report.generator.load_runtime_fingerprint",
-            return_value=None,
-        ) as mock_runtime,
-        patch(
-            "gpt_trader.monitoring.daily_report.generator.calculate_pnl_metrics",
-            return_value=pnl_metrics,
-        ),
-        patch(
-            "gpt_trader.monitoring.daily_report.generator.calculate_trade_metrics",
-            return_value=trade_metrics,
-        ),
-        patch(
-            "gpt_trader.monitoring.daily_report.generator.calculate_symbol_metrics",
-            return_value=[],
-        ),
-        patch(
-            "gpt_trader.monitoring.daily_report.generator.calculate_risk_metrics",
-            return_value=risk_metrics,
-        ),
-        patch(
-            "gpt_trader.monitoring.daily_report.generator.calculate_health_metrics",
-            return_value=health_metrics,
-        ),
-    ):
-        mock_metrics.return_value = {"account": {"equity": 100}}
-        mock_events.return_value = []
 
-        report = generator.generate(date=date, lookback_hours=6)
+@pytest.fixture
+def generator_mocks(
+    monkeypatch: pytest.MonkeyPatch,
+    pnl_metrics: dict[str, float],
+    trade_metrics: dict[str, float | int],
+    risk_metrics: dict[str, dict],
+    health_metrics: dict[str, int],
+) -> dict[str, MagicMock]:
+    mocks: dict[str, MagicMock] = {
+        "load_metrics": MagicMock(return_value={"account": {"equity": 100}}),
+        "load_events_since": MagicMock(return_value=[]),
+        "calculate_pnl_metrics": MagicMock(return_value=pnl_metrics),
+        "calculate_trade_metrics": MagicMock(return_value=trade_metrics),
+        "calculate_symbol_metrics": MagicMock(return_value=[]),
+        "calculate_risk_metrics": MagicMock(return_value=risk_metrics),
+        "calculate_health_metrics": MagicMock(return_value=health_metrics),
+        "load_unfilled_orders_count": MagicMock(return_value=0),
+        "load_liveness_snapshot": MagicMock(return_value=None),
+        "load_runtime_fingerprint": MagicMock(return_value=None),
+    }
 
-    mock_metrics.assert_called_once_with(generator.metrics_file)
-    mock_events.assert_called_once_with(generator.events_file, expected_cutoff)
-    assert mock_liveness.call_count == 0
-    assert mock_runtime.call_count == 0
+    for name, mock in mocks.items():
+        monkeypatch.setattr(generator_module, name, mock)
+
+    return mocks
+
+
+@pytest.fixture
+def fixed_generated_at(monkeypatch: pytest.MonkeyPatch) -> datetime:
+    generated_at = datetime(2024, 2, 2, 14, 0, 0, tzinfo=UTC)
+
+    class FixedDateTime:
+        @staticmethod
+        def now(_tz=None) -> datetime:
+            return generated_at
+
+    monkeypatch.setattr(generator_module, "datetime", FixedDateTime)
+    return generated_at
+
+
+def test_generate_uses_expected_files_and_cutoff(tmp_path, generator_mocks) -> None:
+    date = datetime(2024, 2, 2, 12, 30, 0, tzinfo=UTC)
+    generator = DailyReportGenerator(profile="alpha", data_dir=tmp_path)
+    expected_cutoff = date - timedelta(hours=6)
+
+    report = generator.generate(date=date, lookback_hours=6)
+
+    generator_mocks["load_metrics"].assert_called_once_with(generator.metrics_file)
+    generator_mocks["load_events_since"].assert_called_once_with(
+        generator.events_file, expected_cutoff
+    )
+    assert generator_mocks["load_liveness_snapshot"].call_count == 0
+    assert generator_mocks["load_runtime_fingerprint"].call_count == 0
     assert report.liveness is None
     assert report.runtime is None
     assert report.date == "2024-02-02"
     assert report.profile == "alpha"
 
 
-def test_generate_liveness_uses_generated_at(tmp_path) -> None:
+def test_generate_liveness_uses_generated_at(tmp_path, generator_mocks, fixed_generated_at) -> None:
     date = datetime(2024, 2, 2, 12, 30, 0, tzinfo=UTC)
     generator = DailyReportGenerator(profile="alpha", data_dir=tmp_path)
     events_db = tmp_path / "events.db"
     events_db.write_text("db")
+    generator_mocks["load_metrics"].return_value = {}
 
-    with (
-        patch("gpt_trader.monitoring.daily_report.generator.load_metrics", return_value={}),
-        patch("gpt_trader.monitoring.daily_report.generator.load_events_since", return_value=[]),
-        patch(
-            "gpt_trader.monitoring.daily_report.generator.calculate_pnl_metrics",
-            return_value={
-                "equity": 100.0,
-                "equity_change": 0.0,
-                "equity_change_pct": 0.0,
-                "realized_pnl": 0.0,
-                "unrealized_pnl": 0.0,
-                "funding_pnl": 0.0,
-                "total_pnl": 0.0,
-                "fees_paid": 0.0,
-            },
-        ),
-        patch(
-            "gpt_trader.monitoring.daily_report.generator.calculate_trade_metrics",
-            return_value={
-                "win_rate": 0.0,
-                "profit_factor": 0.0,
-                "sharpe_ratio": 0.0,
-                "max_drawdown": 0.0,
-                "max_drawdown_pct": 0.0,
-                "total_trades": 0,
-                "winning_trades": 0,
-                "losing_trades": 0,
-                "avg_win": 0.0,
-                "avg_loss": 0.0,
-                "largest_win": 0.0,
-                "largest_loss": 0.0,
-            },
-        ),
-        patch(
-            "gpt_trader.monitoring.daily_report.generator.calculate_symbol_metrics", return_value=[]
-        ),
-        patch(
-            "gpt_trader.monitoring.daily_report.generator.calculate_risk_metrics",
-            return_value={
-                "guard_triggers": {},
-                "circuit_breaker_state": {},
-            },
-        ),
-        patch(
-            "gpt_trader.monitoring.daily_report.generator.calculate_health_metrics",
-            return_value={
-                "stale_marks_count": 0,
-                "ws_reconnects": 0,
-                "unfilled_orders": 0,
-                "api_errors": 0,
-            },
-        ),
-        patch(
-            "gpt_trader.monitoring.daily_report.generator.load_liveness_snapshot"
-        ) as mock_liveness,
-        patch(
-            "gpt_trader.monitoring.daily_report.generator.load_runtime_fingerprint",
-            return_value=None,
-        ),
-        patch("gpt_trader.monitoring.daily_report.generator.datetime") as mock_datetime,
-    ):
-        generated_at = datetime(2024, 2, 2, 14, 0, 0, tzinfo=UTC)
-        mock_datetime.now.return_value = generated_at
-        mock_datetime.UTC = UTC
-        mock_datetime.side_effect = datetime
+    report = generator.generate(date=date, lookback_hours=6)
 
-        report = generator.generate(date=date, lookback_hours=6)
-
-    mock_liveness.assert_called_once_with(events_db, now=generated_at)
-    assert report.generated_at == generated_at.isoformat()
+    generator_mocks["load_liveness_snapshot"].assert_called_once_with(
+        events_db, now=fixed_generated_at
+    )
+    assert report.generated_at == fixed_generated_at.isoformat()
 
 
 def test_save_report_writes_json_and_text(tmp_path) -> None:

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -33659,7 +33659,7 @@
     "tests/unit/gpt_trader/monitoring/daily_report/test_generator_edges.py": [
       {
         "name": "test_generate_uses_expected_files_and_cutoff",
-        "line": 13,
+        "line": 103,
         "markers": [
           "unit"
         ],
@@ -33667,7 +33667,7 @@
       },
       {
         "name": "test_generate_liveness_uses_generated_at",
-        "line": 97,
+        "line": 122,
         "markers": [
           "unit"
         ],
@@ -33675,7 +33675,7 @@
       },
       {
         "name": "test_save_report_writes_json_and_text",
-        "line": 175,
+        "line": 139,
         "markers": [
           "unit"
         ],
@@ -55256,7 +55256,7 @@
     "tests/unit/gpt_trader/utilities/test_async_utils_scenarios.py": [
       {
         "name": "TestAsyncScenarios::test_rate_limiting_with_batch_processing",
-        "line": 44,
+        "line": 42,
         "markers": [
           "asyncio",
           "unit"
@@ -55266,7 +55266,7 @@
       },
       {
         "name": "TestAsyncScenarios::test_caching_with_retry",
-        "line": 65,
+        "line": 63,
         "markers": [
           "asyncio",
           "unit"
@@ -55276,7 +55276,7 @@
       },
       {
         "name": "TestAsyncScenarios::test_timeout_with_concurrency",
-        "line": 94,
+        "line": 92,
         "markers": [
           "asyncio",
           "unit"
@@ -55286,7 +55286,7 @@
       },
       {
         "name": "TestAsyncScenarios::test_complex_async_workflow",
-        "line": 109,
+        "line": 107,
         "markers": [
           "asyncio",
           "unit"


### PR DESCRIPTION
- Refactors DailyReportGenerator edge tests to reuse metric fixtures and centralize generator dependency mocks.
- Keeps existing cutoff/liveness/generated_at and save_report assertions intact.
- Updates var/agents/testing/test_inventory.json to track the refactor.

Verification:
- uv run pytest -q tests/unit/gpt_trader/monitoring/daily_report/test_generator_edges.py
- uv run python scripts/ci/check_test_hygiene.py
- uv run python scripts/ci/check_legacy_test_triage.py
- uv run python scripts/agents/generate_test_inventory.py