### PR TITLE
Refactor logging setup mode tests

### DIFF
--- a/tests/unit/gpt_trader/logging/test_setup_configure_logging_modes_and_idempotency.py
+++ b/tests/unit/gpt_trader/logging/test_setup_configure_logging_modes_and_idempotency.py
@@ -5,11 +5,53 @@ from __future__ import annotations
 import logging
 import logging.handlers
 from pathlib import Path
-from unittest.mock import MagicMock, patch
 
 import pytest
 
+import gpt_trader.logging.setup as logging_setup
 from gpt_trader.logging.setup import configure_logging
+
+_EXCLUDED_CONSOLE_HANDLER_TYPES = {"LogCaptureHandler", "LogCaptureFixture"}
+
+
+def _clear_handlers() -> None:
+    root_logger = logging.getLogger()
+    for handler in root_logger.handlers[:]:
+        root_logger.removeHandler(handler)
+        handler.close()
+
+    json_logger = logging.getLogger("gpt_trader.json")
+    for handler in json_logger.handlers[:]:
+        json_logger.removeHandler(handler)
+        handler.close()
+
+
+def _console_handlers() -> list[logging.Handler]:
+    root_logger = logging.getLogger()
+    return [
+        handler
+        for handler in root_logger.handlers
+        if isinstance(handler, logging.StreamHandler)
+        and not isinstance(handler, logging.handlers.RotatingFileHandler)
+        and type(handler).__name__ not in _EXCLUDED_CONSOLE_HANDLER_TYPES
+    ]
+
+
+def _file_targets(logger: logging.Logger) -> list[str]:
+    return [
+        handler.baseFilename
+        for handler in logger.handlers
+        if isinstance(handler, logging.handlers.RotatingFileHandler)
+    ]
+
+
+@pytest.fixture
+def log_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    for name in ("COINBASE_TRADER_LOG_DIR", "PERPS_LOG_DIR"):
+        monkeypatch.delenv(name, raising=False)
+    log_dir = tmp_path / "logs"
+    monkeypatch.setattr(logging_setup, "LOG_DIR", log_dir)
+    return log_dir
 
 
 class TestConfigureLoggingModesAndIdempotency:
@@ -18,117 +60,67 @@ class TestConfigureLoggingModesAndIdempotency:
     @pytest.fixture(autouse=True)
     def reset_logging(self) -> None:
         """Reset logging configuration before each test."""
-        root_logger = logging.getLogger()
-        for handler in root_logger.handlers[:]:
-            root_logger.removeHandler(handler)
-            handler.close()
-
-        json_logger = logging.getLogger("gpt_trader.json")
-        for handler in json_logger.handlers[:]:
-            json_logger.removeHandler(handler)
-            handler.close()
+        _clear_handlers()
 
         yield
 
-        for handler in root_logger.handlers[:]:
-            root_logger.removeHandler(handler)
-            handler.close()
-        for handler in json_logger.handlers[:]:
-            json_logger.removeHandler(handler)
-            handler.close()
+        _clear_handlers()
 
-    @patch("gpt_trader.logging.setup.ensure_directories")
-    @patch("pathlib.Path.mkdir")
-    def test_configure_logging_idempotent(
-        self, mock_mkdir: MagicMock, mock_ensure: MagicMock, tmp_path: Path
-    ) -> None:
+    def test_configure_logging_idempotent(self, log_dir: Path) -> None:
         """Test that calling configure_logging multiple times doesn't duplicate handlers."""
-        with patch("gpt_trader.logging.setup.LOG_DIR", str(tmp_path)):
-            configure_logging()
-            initial_handler_count = len(logging.getLogger().handlers)
+        configure_logging()
+        configure_logging()
 
-            configure_logging()
-            second_handler_count = len(logging.getLogger().handlers)
+        root_targets = _file_targets(logging.getLogger())
+        json_targets = _file_targets(logging.getLogger("gpt_trader.json"))
 
-        # Handler count should not increase
-        # (it might be slightly different due to deduplication logic, but shouldn't double)
-        assert second_handler_count <= initial_handler_count + 2
+        assert len(root_targets) == len(set(root_targets))
+        assert len(json_targets) == len(set(json_targets))
 
-    @patch("gpt_trader.logging.setup.ensure_directories")
-    @patch("pathlib.Path.mkdir")
-    def test_configure_logging_tui_mode_suppresses_stream_handler(
-        self, mock_mkdir: MagicMock, mock_ensure: MagicMock, tmp_path: Path
-    ) -> None:
+    def test_configure_logging_tui_mode_suppresses_stream_handler(self, log_dir: Path) -> None:
         """Test that TUI mode suppresses StreamHandler to prevent display corruption."""
-        with patch("gpt_trader.logging.setup.LOG_DIR", str(tmp_path)):
-            configure_logging(tui_mode=True)
+        configure_logging(tui_mode=True)
 
-        root_logger = logging.getLogger()
-        # Filter for console StreamHandlers only (exclude RotatingFileHandler and test handlers)
-        console_handlers = [
-            h
-            for h in root_logger.handlers
-            if isinstance(h, logging.StreamHandler)
-            and not isinstance(h, logging.handlers.RotatingFileHandler)
-            and type(h).__name__ not in {"LogCaptureHandler", "LogCaptureFixture"}
-        ]
+        console_handlers = _console_handlers()
 
         # No console StreamHandler should be present in TUI mode
         assert len(console_handlers) == 0, "TUI mode should not have console StreamHandler"
 
-    @patch("gpt_trader.logging.setup.ensure_directories")
-    @patch("pathlib.Path.mkdir")
-    def test_configure_logging_cli_mode_creates_stream_handler(
-        self, mock_mkdir: MagicMock, mock_ensure: MagicMock, tmp_path: Path
-    ) -> None:
+    def test_configure_logging_cli_mode_creates_stream_handler(self, log_dir: Path) -> None:
         """Test that CLI mode creates StreamHandler for console output."""
-        with patch("gpt_trader.logging.setup.LOG_DIR", str(tmp_path)):
-            configure_logging(tui_mode=False)
+        configure_logging(tui_mode=False)
 
-        root_logger = logging.getLogger()
-        # Filter for console StreamHandlers only (exclude RotatingFileHandler and test handlers)
-        console_handlers = [
-            h
-            for h in root_logger.handlers
-            if isinstance(h, logging.StreamHandler)
-            and not isinstance(h, logging.handlers.RotatingFileHandler)
-            and type(h).__name__ not in {"LogCaptureHandler", "LogCaptureFixture"}
-        ]
+        console_handlers = _console_handlers()
 
         # At least one console StreamHandler should be present in CLI mode
         assert len(console_handlers) >= 1, "CLI mode should have console StreamHandler"
 
-    @patch("gpt_trader.logging.setup.ensure_directories")
-    @patch("pathlib.Path.mkdir")
-    def test_configure_logging_file_handlers_present_in_both_modes(
-        self, mock_mkdir: MagicMock, mock_ensure: MagicMock, tmp_path: Path
-    ) -> None:
+    def test_configure_logging_file_handlers_present_in_both_modes(self, log_dir: Path) -> None:
         """Test that file handlers are present in both TUI and CLI modes."""
-        # Test TUI mode
-        with patch("gpt_trader.logging.setup.LOG_DIR", str(tmp_path)):
-            configure_logging(tui_mode=True)
+        expected_root = {"coinbase_trader.log", "critical_events.log"}
+        expected_json = {"coinbase_trader.jsonl", "critical_events.jsonl"}
 
-        root_logger = logging.getLogger()
-        tui_file_handlers = [
-            h for h in root_logger.handlers if isinstance(h, logging.handlers.RotatingFileHandler)
-        ]
-        assert len(tui_file_handlers) >= 2, "TUI mode should have file handlers"
+        # Test TUI mode
+        configure_logging(tui_mode=True)
+
+        root_targets = {Path(target).name for target in _file_targets(logging.getLogger())}
+        json_targets = {
+            Path(target).name for target in _file_targets(logging.getLogger("gpt_trader.json"))
+        }
+        assert expected_root.issubset(root_targets)
+        assert expected_json.issubset(json_targets)
 
         # Reset handlers
-        for handler in root_logger.handlers[:]:
-            root_logger.removeHandler(handler)
-            handler.close()
+        _clear_handlers()
 
         # Test CLI mode
-        with patch("gpt_trader.logging.setup.LOG_DIR", str(tmp_path)):
-            configure_logging(tui_mode=False)
+        configure_logging(tui_mode=False)
 
-        cli_file_handlers = [
-            h for h in root_logger.handlers if isinstance(h, logging.handlers.RotatingFileHandler)
-        ]
-        assert len(cli_file_handlers) >= 2, "CLI mode should have file handlers"
-
-        # Both modes should have same number of file handlers
-        assert len(tui_file_handlers) == len(
-            cli_file_handlers
-        ), "Both modes should have the same file handlers"
+        cli_root_targets = {Path(target).name for target in _file_targets(logging.getLogger())}
+        cli_json_targets = {
+            Path(target).name for target in _file_targets(logging.getLogger("gpt_trader.json"))
+        }
+        assert expected_root.issubset(cli_root_targets)
+        assert expected_json.issubset(cli_json_targets)
+        assert root_targets == cli_root_targets
+        assert json_targets == cli_json_targets

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -32961,7 +32961,7 @@
     "tests/unit/gpt_trader/logging/test_setup_configure_logging_modes_and_idempotency.py": [
       {
         "name": "TestConfigureLoggingModesAndIdempotency::test_configure_logging_idempotent",
-        "line": 42,
+        "line": 69,
         "markers": [
           "unit"
         ],
@@ -32970,7 +32970,7 @@
       },
       {
         "name": "TestConfigureLoggingModesAndIdempotency::test_configure_logging_tui_mode_suppresses_stream_handler",
-        "line": 59,
+        "line": 80,
         "markers": [
           "unit"
         ],
@@ -32979,7 +32979,7 @@
       },
       {
         "name": "TestConfigureLoggingModesAndIdempotency::test_configure_logging_cli_mode_creates_stream_handler",
-        "line": 81,
+        "line": 91,
         "markers": [
           "unit"
         ],
@@ -32988,7 +32988,7 @@
       },
       {
         "name": "TestConfigureLoggingModesAndIdempotency::test_configure_logging_file_handlers_present_in_both_modes",
-        "line": 103,
+        "line": 102,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary\n- refactor logging setup mode/idempotency tests to use fixtures and monkeypatch\n- assert on file handler targets instead of raw counts\n- regenerate test inventory\n\n## Testing\n- uv run pytest -q tests/unit/gpt_trader/logging/test_setup_configure_logging_modes_and_idempotency.py\n- uv run python scripts/ci/check_test_hygiene.py\n- uv run python scripts/ci/check_legacy_test_triage.py\n- uv run python scripts/agents/generate_test_inventory.py