### PR TITLE
test(logging): reduce patch density in runtime helpers

### DIFF
--- a/tests/unit/gpt_trader/logging/test_runtime_helpers.py
+++ b/tests/unit/gpt_trader/logging/test_runtime_helpers.py
@@ -3,9 +3,14 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from decimal import Decimal
-from unittest.mock import MagicMock, patch
+from typing import Any
+from unittest.mock import MagicMock
 
+import pytest
+
+import gpt_trader.logging.runtime_helpers as runtime_helpers
 from gpt_trader.logging.runtime_helpers import (
     get_runtime_logger,
     log_execution_error,
@@ -17,7 +22,51 @@ from gpt_trader.logging.runtime_helpers import (
 )
 
 
-def test_get_runtime_logger():
+@dataclass(slots=True)
+class RuntimeLogHarness:
+    logger: MagicMock
+    base_context: dict[str, Any]
+    add_domain_field: MagicMock
+
+
+@pytest.fixture
+def runtime_log_harness(monkeypatch: pytest.MonkeyPatch) -> RuntimeLogHarness:
+    logger = MagicMock(name="runtime_logger")
+    base_context: dict[str, Any] = {}
+
+    def get_log_context() -> dict[str, Any]:
+        return dict(base_context)
+
+    monkeypatch.setattr(runtime_helpers, "get_log_context", get_log_context)
+    monkeypatch.setattr(runtime_helpers, "get_runtime_logger", lambda *_args, **_kwargs: logger)
+
+    add_domain_field = MagicMock(name="add_domain_field")
+    monkeypatch.setattr(runtime_helpers, "add_domain_field", add_domain_field)
+
+    return RuntimeLogHarness(
+        logger=logger,
+        base_context=base_context,
+        add_domain_field=add_domain_field,
+    )
+
+
+def _assert_logged(
+    logger: MagicMock, *, level: int, message: str, exc_info: bool | None = None
+) -> dict[str, Any]:
+    logger.log.assert_called_once()
+    args, kwargs = logger.log.call_args
+
+    assert args[0] == level
+    assert args[1] == message
+    if exc_info is not None:
+        assert kwargs["exc_info"] is exc_info
+
+    extra = kwargs.get("extra")
+    assert isinstance(extra, dict)
+    return extra
+
+
+def test_get_runtime_logger() -> None:
     """Test getting a runtime logger."""
     logger = get_runtime_logger("test_component")
     assert logger.name == "gpt_trader.json.test_component"
@@ -27,190 +76,155 @@ def test_get_runtime_logger():
     assert logger.name == "test_component"
 
 
-@patch("gpt_trader.logging.runtime_helpers.get_log_context")
-def test_log_trading_operation(mock_get_log_context):
+def test_log_trading_operation(runtime_log_harness: RuntimeLogHarness) -> None:
     """Test logging a trading operation."""
-    # Mock get_log_context to return correlation_id and the expected symbol
-    mock_get_log_context.return_value = {"correlation_id": "test-123", "symbol": "BTC-USD"}
+    runtime_log_harness.base_context.update({"correlation_id": "test-123", "symbol": "BTC-USD"})
 
-    with patch("gpt_trader.logging.runtime_helpers.get_runtime_logger") as mock_logger:
-        mock_log = MagicMock()
-        mock_logger.return_value = mock_log
+    log_trading_operation(
+        operation="test_operation",
+        symbol="BTC-USD",
+        level=logging.INFO,
+        test_field="test_value",
+    )
 
-        log_trading_operation(
-            operation="test_operation",
-            symbol="BTC-USD",
-            level=logging.INFO,
-            test_field="test_value",
-        )
+    runtime_log_harness.add_domain_field.assert_called_once_with("symbol", "BTC-USD")
 
-        # Check that the logger was called with the correct context
-        mock_log.log.assert_called_once()
-        args, kwargs = mock_log.log.call_args
-        assert args[0] == logging.INFO  # level
-        assert args[1] == "test_operation"  # message
-        assert "extra" in kwargs
-        assert kwargs["extra"]["symbol"] == "BTC-USD"
-        assert kwargs["extra"]["operation"] == "test_operation"
-        assert kwargs["extra"]["test_field"] == "test_value"
-        assert kwargs["extra"]["correlation_id"] == "test-123"
+    extra = _assert_logged(
+        runtime_log_harness.logger,
+        level=logging.INFO,
+        message="test_operation",
+    )
+    assert extra["symbol"] == "BTC-USD"
+    assert extra["operation"] == "test_operation"
+    assert extra["test_field"] == "test_value"
+    assert extra["correlation_id"] == "test-123"
 
 
-@patch("gpt_trader.logging.runtime_helpers.get_log_context")
-def test_log_order_event(mock_get_log_context):
+def test_log_order_event(runtime_log_harness: RuntimeLogHarness) -> None:
     """Test logging an order event."""
-    mock_get_log_context.return_value = {"correlation_id": "order-456"}
+    runtime_log_harness.base_context.update({"correlation_id": "order-456"})
 
-    with patch("gpt_trader.logging.runtime_helpers.get_runtime_logger") as mock_logger:
-        mock_log = MagicMock()
-        mock_logger.return_value = mock_log
+    log_order_event(
+        event_type="order_placed",
+        order_id="order-123",
+        symbol="ETH-USD",
+        side="buy",
+        quantity=Decimal("1.5"),
+        price=Decimal("3000.25"),
+        level=logging.INFO,
+    )
 
-        log_order_event(
-            event_type="order_placed",
-            order_id="order-123",
-            symbol="ETH-USD",
-            side="buy",
-            quantity=Decimal("1.5"),
-            price=Decimal("3000.25"),
-            level=logging.INFO,
-        )
-
-        # Check that the logger was called with the correct context
-        mock_log.log.assert_called_once()
-        args, kwargs = mock_log.log.call_args
-        assert args[0] == logging.INFO  # level
-        assert args[1] == "Order event: order_placed"  # message
-        assert "extra" in kwargs
-        assert kwargs["extra"]["event_type"] == "order_placed"
-        assert kwargs["extra"]["order_id"] == "order-123"
-        assert kwargs["extra"]["symbol"] == "ETH-USD"
-        assert kwargs["extra"]["side"] == "buy"
-        assert kwargs["extra"]["quantity"] == 1.5
-        assert kwargs["extra"]["price"] == 3000.25
-        assert kwargs["extra"]["correlation_id"] == "order-456"
+    extra = _assert_logged(
+        runtime_log_harness.logger,
+        level=logging.INFO,
+        message="Order event: order_placed",
+    )
+    assert extra["event_type"] == "order_placed"
+    assert extra["order_id"] == "order-123"
+    assert extra["symbol"] == "ETH-USD"
+    assert extra["side"] == "buy"
+    assert extra["quantity"] == 1.5
+    assert extra["price"] == 3000.25
+    assert extra["correlation_id"] == "order-456"
 
 
-@patch("gpt_trader.logging.runtime_helpers.get_log_context")
-def test_log_strategy_decision(mock_get_log_context):
+def test_log_strategy_decision(runtime_log_harness: RuntimeLogHarness) -> None:
     """Test logging a strategy decision."""
-    mock_get_log_context.return_value = {"correlation_id": "strategy-789"}
+    runtime_log_harness.base_context.update({"correlation_id": "strategy-789"})
 
-    with patch("gpt_trader.logging.runtime_helpers.get_runtime_logger") as mock_logger:
-        mock_log = MagicMock()
-        mock_logger.return_value = mock_log
+    log_strategy_decision(
+        symbol="BTC-USD",
+        decision="BUY",
+        reason="RSI oversold",
+        confidence=0.85,
+        level=logging.INFO,
+    )
 
-        log_strategy_decision(
-            symbol="BTC-USD",
-            decision="BUY",
-            reason="RSI oversold",
-            confidence=0.85,
-            level=logging.INFO,
-        )
-
-        # Check that the logger was called with the correct context
-        mock_log.log.assert_called_once()
-        args, kwargs = mock_log.log.call_args
-        assert args[0] == logging.INFO  # level
-        assert args[1] == "Strategy decision for BTC-USD: BUY"  # message
-        assert "extra" in kwargs
-        assert kwargs["extra"]["symbol"] == "BTC-USD"
-        assert kwargs["extra"]["decision"] == "BUY"
-        assert kwargs["extra"]["reason"] == "RSI oversold"
-        assert kwargs["extra"]["confidence"] == 0.85
-        assert kwargs["extra"]["correlation_id"] == "strategy-789"
+    extra = _assert_logged(
+        runtime_log_harness.logger,
+        level=logging.INFO,
+        message="Strategy decision for BTC-USD: BUY",
+    )
+    assert extra["symbol"] == "BTC-USD"
+    assert extra["decision"] == "BUY"
+    assert extra["reason"] == "RSI oversold"
+    assert extra["confidence"] == 0.85
+    assert extra["correlation_id"] == "strategy-789"
 
 
-@patch("gpt_trader.logging.runtime_helpers.get_log_context")
-def test_log_execution_error(mock_get_log_context):
+def test_log_execution_error(runtime_log_harness: RuntimeLogHarness) -> None:
     """Test logging an execution error."""
-    mock_get_log_context.return_value = {"correlation_id": "error-123"}
+    runtime_log_harness.base_context.update({"correlation_id": "error-123"})
 
-    with patch("gpt_trader.logging.runtime_helpers.get_runtime_logger") as mock_logger:
-        mock_log = MagicMock()
-        mock_logger.return_value = mock_log
+    test_error = ValueError("Test error message")
 
-        test_error = ValueError("Test error message")
+    log_execution_error(
+        error=test_error,
+        operation="place_order",
+        symbol="ETH-USD",
+        order_id="order-456",
+        level=logging.ERROR,
+    )
 
-        log_execution_error(
-            error=test_error,
-            operation="place_order",
-            symbol="ETH-USD",
-            order_id="order-456",
-            level=logging.ERROR,
-        )
-
-        # Check that the logger was called with the correct context
-        mock_log.log.assert_called_once()
-        args, kwargs = mock_log.log.call_args
-        assert args[0] == logging.ERROR  # level
-        assert args[1] == "Execution error in place_order: Test error message"  # message
-        assert kwargs["exc_info"] is True
-        assert "extra" in kwargs
-        assert kwargs["extra"]["operation"] == "place_order"
-        assert kwargs["extra"]["error_type"] == "ValueError"
-        assert kwargs["extra"]["error_message"] == "Test error message"
-        assert kwargs["extra"]["symbol"] == "ETH-USD"
-        assert kwargs["extra"]["order_id"] == "order-456"
-        assert kwargs["extra"]["correlation_id"] == "error-123"
+    extra = _assert_logged(
+        runtime_log_harness.logger,
+        level=logging.ERROR,
+        message="Execution error in place_order: Test error message",
+        exc_info=True,
+    )
+    assert extra["operation"] == "place_order"
+    assert extra["error_type"] == "ValueError"
+    assert extra["error_message"] == "Test error message"
+    assert extra["symbol"] == "ETH-USD"
+    assert extra["order_id"] == "order-456"
+    assert extra["correlation_id"] == "error-123"
 
 
-@patch("gpt_trader.logging.runtime_helpers.get_log_context")
-def test_log_risk_event(mock_get_log_context):
+def test_log_risk_event(runtime_log_harness: RuntimeLogHarness) -> None:
     """Test logging a risk event."""
-    mock_get_log_context.return_value = {"correlation_id": "risk-456"}
+    runtime_log_harness.base_context.update({"correlation_id": "risk-456"})
 
-    with patch("gpt_trader.logging.runtime_helpers.get_runtime_logger") as mock_logger:
-        mock_log = MagicMock()
-        mock_logger.return_value = mock_log
+    log_risk_event(
+        event_type="circuit_breaker_triggered",
+        symbol="BTC-USD",
+        trigger_value=0.15,
+        threshold=0.10,
+        action="reduce_only",
+        level=logging.WARNING,
+    )
 
-        log_risk_event(
-            event_type="circuit_breaker_triggered",
-            symbol="BTC-USD",
-            trigger_value=0.15,
-            threshold=0.10,
-            action="reduce_only",
-            level=logging.WARNING,
-        )
-
-        # Check that the logger was called with the correct context
-        mock_log.log.assert_called_once()
-        args, kwargs = mock_log.log.call_args
-        assert args[0] == logging.WARNING  # level
-        assert args[1] == "Risk event: circuit_breaker_triggered"  # message
-        assert "extra" in kwargs
-        assert kwargs["extra"]["event_type"] == "circuit_breaker_triggered"
-        assert kwargs["extra"]["symbol"] == "BTC-USD"
-        assert kwargs["extra"]["trigger_value"] == "0.15"
-        assert kwargs["extra"]["threshold"] == "0.10"
-        assert kwargs["extra"]["action"] == "reduce_only"
-        assert kwargs["extra"]["correlation_id"] == "risk-456"
+    extra = _assert_logged(
+        runtime_log_harness.logger,
+        level=logging.WARNING,
+        message="Risk event: circuit_breaker_triggered",
+    )
+    assert extra["event_type"] == "circuit_breaker_triggered"
+    assert extra["symbol"] == "BTC-USD"
+    assert extra["trigger_value"] == "0.15"
+    assert extra["threshold"] == "0.10"
+    assert extra["action"] == "reduce_only"
+    assert extra["correlation_id"] == "risk-456"
 
 
-@patch("gpt_trader.logging.runtime_helpers.get_log_context")
-def test_log_market_data_update(mock_get_log_context):
+def test_log_market_data_update(runtime_log_harness: RuntimeLogHarness) -> None:
     """Test logging a market data update."""
-    mock_get_log_context.return_value = {"correlation_id": "market-789"}
+    runtime_log_harness.base_context.update({"correlation_id": "market-789"})
 
-    with patch("gpt_trader.logging.runtime_helpers.get_runtime_logger") as mock_logger:
-        mock_log = MagicMock()
-        mock_logger.return_value = mock_log
+    log_market_data_update(
+        symbol="BTC-USD",
+        price=Decimal("50000.50"),
+        volume=Decimal("100.25"),
+        timestamp=1640995200.123,
+        level=logging.DEBUG,
+    )
 
-        log_market_data_update(
-            symbol="BTC-USD",
-            price=Decimal("50000.50"),
-            volume=Decimal("100.25"),
-            timestamp=1640995200.123,
-            level=logging.DEBUG,
-        )
-
-        # Check that the logger was called with the correct context
-        mock_log.log.assert_called_once()
-        args, kwargs = mock_log.log.call_args
-        assert args[0] == logging.DEBUG  # level
-        assert args[1] == "Market data update: BTC-USD"  # message
-        assert "extra" in kwargs
-        assert kwargs["extra"]["symbol"] == "BTC-USD"
-        assert kwargs["extra"]["price"] == 50000.50
-        assert kwargs["extra"]["volume"] == 100.25
-        assert kwargs["extra"]["timestamp"] == 1640995200.123
-        assert kwargs["extra"]["correlation_id"] == "market-789"
+    extra = _assert_logged(
+        runtime_log_harness.logger,
+        level=logging.DEBUG,
+        message="Market data update: BTC-USD",
+    )
+    assert extra["symbol"] == "BTC-USD"
+    assert extra["price"] == 50000.50
+    assert extra["volume"] == 100.25
+    assert extra["timestamp"] == 1640995200.123
+    assert extra["correlation_id"] == "market-789"

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -32774,7 +32774,7 @@
     "tests/unit/gpt_trader/logging/test_runtime_helpers.py": [
       {
         "name": "test_get_runtime_logger",
-        "line": 20,
+        "line": 69,
         "markers": [
           "unit"
         ],
@@ -32782,7 +32782,7 @@
       },
       {
         "name": "test_log_trading_operation",
-        "line": 31,
+        "line": 79,
         "markers": [
           "unit"
         ],
@@ -32790,7 +32790,7 @@
       },
       {
         "name": "test_log_order_event",
-        "line": 60,
+        "line": 105,
         "markers": [
           "unit"
         ],
@@ -32798,7 +32798,7 @@
       },
       {
         "name": "test_log_strategy_decision",
-        "line": 94,
+        "line": 133,
         "markers": [
           "unit"
         ],
@@ -32806,7 +32806,7 @@
       },
       {
         "name": "test_log_execution_error",
-        "line": 124,
+        "line": 157,
         "markers": [
           "unit"
         ],
@@ -32814,7 +32814,7 @@
       },
       {
         "name": "test_log_risk_event",
-        "line": 158,
+        "line": 185,
         "markers": [
           "unit"
         ],
@@ -32822,7 +32822,7 @@
       },
       {
         "name": "test_log_market_data_update",
-        "line": 190,
+        "line": 211,
         "markers": [
           "unit"
         ],
@@ -32979,7 +32979,7 @@
       },
       {
         "name": "TestConfigureLoggingModesAndIdempotency::test_configure_logging_cli_mode_creates_stream_handler",
-        "line": 91,
+        "line": 89,
         "markers": [
           "unit"
         ],
@@ -32988,7 +32988,7 @@
       },
       {
         "name": "TestConfigureLoggingModesAndIdempotency::test_configure_logging_file_handlers_present_in_both_modes",
-        "line": 102,
+        "line": 98,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
Milestone: logging test-suite maintainability pass

- Replace repeated @patch usage with a monkeypatch-based runtime log harness (stubs get_log_context/get_runtime_logger/add_domain_field).
- Centralize log call assertions with a small helper for consistent level/message/extra validation.
- Regenerate var/agents/testing inventory artifacts.

Verification:
- uv run pytest -q tests/unit/gpt_trader/logging/test_runtime_helpers.py
- uv run python scripts/ci/check_test_hygiene.py
- uv run python scripts/ci/check_legacy_test_triage.py
- uv run python scripts/agents/generate_test_inventory.py
