### PR TITLE
test(preflight): reduce patch density in risk checks

### DIFF
--- a/tests/unit/gpt_trader/preflight/test_checks_risk.py
+++ b/tests/unit/gpt_trader/preflight/test_checks_risk.py
@@ -2,238 +2,158 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from decimal import Decimal
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
+import gpt_trader.features.live_trade.risk.config as risk_config_module
+from gpt_trader.features.live_trade.risk.config import RiskConfig
 from gpt_trader.preflight.checks.risk import check_risk_configuration
 from gpt_trader.preflight.core import PreflightCheck
+
+
+def _risk_config(**overrides: object) -> RiskConfig:
+    defaults: dict[str, object] = {
+        "max_leverage": 3,
+        "daily_loss_limit": Decimal("500"),
+        "daily_loss_limit_pct": 0.05,
+        "min_liquidation_buffer_pct": 0.15,
+        "max_position_pct_per_symbol": 0.10,
+        "slippage_guard_bps": 50,
+        "kill_switch_enabled": False,
+        "reduce_only_mode": False,
+    }
+    defaults.update(overrides)
+    return RiskConfig(**defaults)
+
+
+@dataclass(slots=True)
+class RiskConfigStub:
+    from_env: MagicMock
+
+    def set(self, **overrides: object) -> RiskConfig:
+        config = _risk_config(**overrides)
+        self.from_env.return_value = config
+        return config
+
+
+@pytest.fixture
+def risk_config_stub(monkeypatch: pytest.MonkeyPatch) -> RiskConfigStub:
+    from_env = MagicMock(name="RiskConfig.from_env", return_value=_risk_config())
+    monkeypatch.setattr(risk_config_module.RiskConfig, "from_env", from_env)
+    return RiskConfigStub(from_env=from_env)
 
 
 class TestCheckRiskConfiguration:
     """Test risk configuration validation."""
 
-    def test_passes_with_valid_config(self) -> None:
+    def test_passes_with_valid_config(self, risk_config_stub: RiskConfigStub) -> None:
         """Should pass when all risk parameters are within bounds."""
         checker = PreflightCheck(profile="dev")
-
-        mock_config = MagicMock()
-        mock_config.max_leverage = 3
-        mock_config.daily_loss_limit = Decimal("500")
-        mock_config.daily_loss_limit_pct = 0.05  # 5%
-        mock_config.min_liquidation_buffer_pct = Decimal("0.15")
-        mock_config.max_position_pct_per_symbol = Decimal("0.10")
-        mock_config.slippage_guard_bps = 50
-        mock_config.kill_switch_enabled = False
-        mock_config.reduce_only_mode = False
-
-        with patch("gpt_trader.features.live_trade.risk.config.RiskConfig") as mock_risk_config:
-            mock_risk_config.from_env.return_value = mock_config
-            result = check_risk_configuration(checker)
+        risk_config_stub.set()
+        result = check_risk_configuration(checker)
 
         assert result is True
         assert any("Max leverage" in s for s in checker.successes)
 
-    def test_fails_with_unsafe_leverage(self) -> None:
+    def test_fails_with_unsafe_leverage(self, risk_config_stub: RiskConfigStub) -> None:
         """Should fail when leverage is outside safe range."""
         checker = PreflightCheck(profile="prod")
-
-        mock_config = MagicMock()
-        mock_config.max_leverage = 15  # Outside 1-10
-        mock_config.daily_loss_limit = Decimal("500")
-        mock_config.daily_loss_limit_pct = 0.05
-        mock_config.min_liquidation_buffer_pct = Decimal("0.15")
-        mock_config.max_position_pct_per_symbol = Decimal("0.10")
-        mock_config.slippage_guard_bps = 50
-        mock_config.kill_switch_enabled = False
-        mock_config.reduce_only_mode = False
-
-        with patch("gpt_trader.features.live_trade.risk.config.RiskConfig") as mock_risk_config:
-            mock_risk_config.from_env.return_value = mock_config
-            result = check_risk_configuration(checker)
+        risk_config_stub.set(max_leverage=15)
+        result = check_risk_configuration(checker)
 
         assert result is False
-        assert any("UNSAFE" in e for e in checker.errors)
+        assert any("UNSAFE VALUE" in e for e in checker.errors)
 
-    def test_fails_with_zero_daily_loss_limit(self) -> None:
-        """Should fail when daily loss limit is zero or negative."""
+    def test_warns_when_no_daily_loss_limit_configured(
+        self, risk_config_stub: RiskConfigStub
+    ) -> None:
+        """Should warn when neither pct nor absolute daily loss limit is configured."""
         checker = PreflightCheck(profile="prod")
+        risk_config_stub.set(daily_loss_limit_pct=0.0, daily_loss_limit=Decimal("0"))
+        result = check_risk_configuration(checker)
 
-        mock_config = MagicMock()
-        mock_config.max_leverage = 3
-        mock_config.daily_loss_limit = Decimal("0")  # Invalid
-        mock_config.min_liquidation_buffer_pct = Decimal("0.15")
-        mock_config.max_position_pct_per_symbol = Decimal("0.10")
-        mock_config.slippage_guard_bps = 50
-        mock_config.kill_switch_enabled = False
-        mock_config.reduce_only_mode = False
+        assert result is True
+        assert any("No daily loss limit configured" in w for w in checker.warnings)
 
-        with patch("gpt_trader.features.live_trade.risk.config.RiskConfig") as mock_risk_config:
-            mock_risk_config.from_env.return_value = mock_config
-            result = check_risk_configuration(checker)
-
-        assert result is False
-
-    def test_fails_with_low_liquidation_buffer(self) -> None:
+    def test_fails_with_low_liquidation_buffer(self, risk_config_stub: RiskConfigStub) -> None:
         """Should fail when liquidation buffer is below 10%."""
         checker = PreflightCheck(profile="prod")
-
-        mock_config = MagicMock()
-        mock_config.max_leverage = 3
-        mock_config.daily_loss_limit = Decimal("500")
-        mock_config.min_liquidation_buffer_pct = Decimal("0.05")  # Below 0.10
-        mock_config.max_position_pct_per_symbol = Decimal("0.10")
-        mock_config.slippage_guard_bps = 50
-        mock_config.kill_switch_enabled = False
-        mock_config.reduce_only_mode = False
-
-        with patch("gpt_trader.features.live_trade.risk.config.RiskConfig") as mock_risk_config:
-            mock_risk_config.from_env.return_value = mock_config
-            result = check_risk_configuration(checker)
+        risk_config_stub.set(min_liquidation_buffer_pct=0.05)
+        result = check_risk_configuration(checker)
 
         assert result is False
 
-    def test_fails_with_excessive_position_size(self) -> None:
+    def test_fails_with_excessive_position_size(self, risk_config_stub: RiskConfigStub) -> None:
         """Should fail when position size exceeds 25%."""
         checker = PreflightCheck(profile="prod")
-
-        mock_config = MagicMock()
-        mock_config.max_leverage = 3
-        mock_config.daily_loss_limit = Decimal("500")
-        mock_config.min_liquidation_buffer_pct = Decimal("0.15")
-        mock_config.max_position_pct_per_symbol = Decimal("0.50")  # Above 0.25
-        mock_config.slippage_guard_bps = 50
-        mock_config.kill_switch_enabled = False
-        mock_config.reduce_only_mode = False
-
-        with patch("gpt_trader.features.live_trade.risk.config.RiskConfig") as mock_risk_config:
-            mock_risk_config.from_env.return_value = mock_config
-            result = check_risk_configuration(checker)
+        risk_config_stub.set(max_position_pct_per_symbol=0.50)
+        result = check_risk_configuration(checker)
 
         assert result is False
 
-    def test_fails_with_slippage_guard_out_of_range(self) -> None:
+    def test_fails_with_slippage_guard_out_of_range(self, risk_config_stub: RiskConfigStub) -> None:
         """Should fail when slippage guard is outside 10-100 bps."""
         checker = PreflightCheck(profile="prod")
-
-        mock_config = MagicMock()
-        mock_config.max_leverage = 3
-        mock_config.daily_loss_limit = Decimal("500")
-        mock_config.min_liquidation_buffer_pct = Decimal("0.15")
-        mock_config.max_position_pct_per_symbol = Decimal("0.10")
-        mock_config.slippage_guard_bps = 5  # Below 10
-        mock_config.kill_switch_enabled = False
-        mock_config.reduce_only_mode = False
-
-        with patch("gpt_trader.features.live_trade.risk.config.RiskConfig") as mock_risk_config:
-            mock_risk_config.from_env.return_value = mock_config
-            result = check_risk_configuration(checker)
+        risk_config_stub.set(slippage_guard_bps=5)
+        result = check_risk_configuration(checker)
 
         assert result is False
 
-    def test_warns_when_kill_switch_enabled(self) -> None:
+    def test_warns_when_kill_switch_enabled(self, risk_config_stub: RiskConfigStub) -> None:
         """Should warn when kill switch is enabled."""
         checker = PreflightCheck(profile="prod")
+        risk_config_stub.set(kill_switch_enabled=True)
+        result = check_risk_configuration(checker)
 
-        mock_config = MagicMock()
-        mock_config.max_leverage = 3
-        mock_config.daily_loss_limit = Decimal("500")
-        mock_config.daily_loss_limit_pct = 0.05
-        mock_config.min_liquidation_buffer_pct = Decimal("0.15")
-        mock_config.max_position_pct_per_symbol = Decimal("0.10")
-        mock_config.slippage_guard_bps = 50
-        mock_config.kill_switch_enabled = True  # Kill switch on
-        mock_config.reduce_only_mode = False
-
-        with patch("gpt_trader.features.live_trade.risk.config.RiskConfig") as mock_risk_config:
-            mock_risk_config.from_env.return_value = mock_config
-            result = check_risk_configuration(checker)
-
-        assert result is True  # Still passes, just warns
+        assert result is True
         assert any("Kill switch" in w for w in checker.warnings)
 
-    def test_warns_when_reduce_only_mode(self) -> None:
+    def test_warns_when_reduce_only_mode(self, risk_config_stub: RiskConfigStub) -> None:
         """Should warn when reduce-only mode is enabled."""
         checker = PreflightCheck(profile="prod")
-
-        mock_config = MagicMock()
-        mock_config.max_leverage = 3
-        mock_config.daily_loss_limit = Decimal("500")
-        mock_config.daily_loss_limit_pct = 0.05
-        mock_config.min_liquidation_buffer_pct = Decimal("0.15")
-        mock_config.max_position_pct_per_symbol = Decimal("0.10")
-        mock_config.slippage_guard_bps = 50
-        mock_config.kill_switch_enabled = False
-        mock_config.reduce_only_mode = True  # Reduce-only on
-
-        with patch("gpt_trader.features.live_trade.risk.config.RiskConfig") as mock_risk_config:
-            mock_risk_config.from_env.return_value = mock_config
-            result = check_risk_configuration(checker)
+        risk_config_stub.set(reduce_only_mode=True)
+        result = check_risk_configuration(checker)
 
         assert result is True
         assert any("Reduce-only" in w for w in checker.warnings)
 
-    def test_warns_on_high_daily_loss_limit(self) -> None:
+    def test_warns_on_high_daily_loss_limit(self, risk_config_stub: RiskConfigStub) -> None:
         """Should warn when daily loss limit pct is high."""
         checker = PreflightCheck(profile="prod")
-
-        mock_config = MagicMock()
-        mock_config.max_leverage = 3
-        mock_config.daily_loss_limit = Decimal("5000")
-        mock_config.daily_loss_limit_pct = 0.15  # 15% - high for testing
-        mock_config.min_liquidation_buffer_pct = Decimal("0.15")
-        mock_config.max_position_pct_per_symbol = Decimal("0.10")
-        mock_config.slippage_guard_bps = 50
-        mock_config.kill_switch_enabled = False
-        mock_config.reduce_only_mode = False
-
-        with patch("gpt_trader.features.live_trade.risk.config.RiskConfig") as mock_risk_config:
-            mock_risk_config.from_env.return_value = mock_config
-            result = check_risk_configuration(checker)
+        risk_config_stub.set(daily_loss_limit_pct=0.15, daily_loss_limit=Decimal("5000"))
+        result = check_risk_configuration(checker)
 
         assert result is True
         assert any("seems high" in w for w in checker.warnings)
 
-    def test_warns_on_aggressive_leverage(self) -> None:
+    def test_warns_on_aggressive_leverage(self, risk_config_stub: RiskConfigStub) -> None:
         """Should warn when leverage exceeds 5x."""
         checker = PreflightCheck(profile="prod")
-
-        mock_config = MagicMock()
-        mock_config.max_leverage = 8  # High but within 1-10
-        mock_config.daily_loss_limit = Decimal("500")
-        mock_config.daily_loss_limit_pct = 0.05
-        mock_config.min_liquidation_buffer_pct = Decimal("0.15")
-        mock_config.max_position_pct_per_symbol = Decimal("0.10")
-        mock_config.slippage_guard_bps = 50
-        mock_config.kill_switch_enabled = False
-        mock_config.reduce_only_mode = False
-
-        with patch("gpt_trader.features.live_trade.risk.config.RiskConfig") as mock_risk_config:
-            mock_risk_config.from_env.return_value = mock_config
-            result = check_risk_configuration(checker)
+        risk_config_stub.set(max_leverage=8)
+        result = check_risk_configuration(checker)
 
         assert result is True
         assert any("aggressive" in w for w in checker.warnings)
 
-    def test_fails_on_exception(self) -> None:
+    def test_fails_on_exception(self, risk_config_stub: RiskConfigStub) -> None:
         """Should fail when config loading throws an exception."""
         checker = PreflightCheck(profile="prod")
-
-        with patch("gpt_trader.features.live_trade.risk.config.RiskConfig") as mock_risk_config:
-            mock_risk_config.from_env.side_effect = Exception("Config error")
-            result = check_risk_configuration(checker)
+        risk_config_stub.from_env.side_effect = Exception("Config error")
+        result = check_risk_configuration(checker)
 
         assert result is False
         assert any("Failed to validate" in e for e in checker.errors)
 
-    def test_prints_section_header(self, capsys: pytest.CaptureFixture) -> None:
+    def test_prints_section_header(
+        self, risk_config_stub: RiskConfigStub, capsys: pytest.CaptureFixture
+    ) -> None:
         """Should print section header."""
         checker = PreflightCheck(profile="dev")
-
-        with patch("gpt_trader.features.live_trade.risk.config.RiskConfig") as mock_risk_config:
-            mock_risk_config.from_env.side_effect = Exception("Skip")
-            check_risk_configuration(checker)
+        risk_config_stub.set()
+        check_risk_configuration(checker)
 
         captured = capsys.readouterr()
         assert "RISK MANAGEMENT" in captured.out

--- a/var/agents/testing/source_test_map.json
+++ b/var/agents/testing/source_test_map.json
@@ -1117,7 +1117,8 @@
       "tests/unit/gpt_trader/features/live_trade/test_leverage_cap.py",
       "tests/unit/gpt_trader/features/live_trade/test_leverage_time_windows.py",
       "tests/unit/gpt_trader/features/live_trade/test_liq_price_buffer.py",
-      "tests/unit/gpt_trader/features/live_trade/test_total_exposure_breach.py"
+      "tests/unit/gpt_trader/features/live_trade/test_total_exposure_breach.py",
+      "tests/unit/gpt_trader/preflight/test_checks_risk.py"
     ],
     "gpt_trader.features.live_trade.risk.manager": [
       "tests/unit/gpt_trader/app/containers/test_risk_validation.py",
@@ -4816,6 +4817,7 @@
       "gpt_trader.preflight.core"
     ],
     "tests/unit/gpt_trader/preflight/test_checks_risk.py": [
+      "gpt_trader.features.live_trade.risk.config",
       "gpt_trader.preflight.checks.risk",
       "gpt_trader.preflight.core"
     ],

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -32790,7 +32790,7 @@
       },
       {
         "name": "test_log_order_event",
-        "line": 105,
+        "line": 103,
         "markers": [
           "unit"
         ],
@@ -32798,7 +32798,7 @@
       },
       {
         "name": "test_log_strategy_decision",
-        "line": 133,
+        "line": 131,
         "markers": [
           "unit"
         ],
@@ -32806,7 +32806,7 @@
       },
       {
         "name": "test_log_execution_error",
-        "line": 157,
+        "line": 155,
         "markers": [
           "unit"
         ],
@@ -32814,7 +32814,7 @@
       },
       {
         "name": "test_log_risk_event",
-        "line": 185,
+        "line": 183,
         "markers": [
           "unit"
         ],
@@ -32822,7 +32822,7 @@
       },
       {
         "name": "test_log_market_data_update",
-        "line": 211,
+        "line": 209,
         "markers": [
           "unit"
         ],
@@ -38991,7 +38991,7 @@
     "tests/unit/gpt_trader/preflight/test_checks_risk.py": [
       {
         "name": "TestCheckRiskConfiguration::test_passes_with_valid_config",
-        "line": 17,
+        "line": 52,
         "markers": [
           "unit"
         ],
@@ -39000,7 +39000,7 @@
       },
       {
         "name": "TestCheckRiskConfiguration::test_fails_with_unsafe_leverage",
-        "line": 38,
+        "line": 61,
         "markers": [
           "unit"
         ],
@@ -39008,17 +39008,17 @@
         "class": "TestCheckRiskConfiguration"
       },
       {
-        "name": "TestCheckRiskConfiguration::test_fails_with_zero_daily_loss_limit",
-        "line": 59,
+        "name": "TestCheckRiskConfiguration::test_warns_when_no_daily_loss_limit_configured",
+        "line": 70,
         "markers": [
           "unit"
         ],
-        "docstring": "Should fail when daily loss limit is zero or negative.",
+        "docstring": "Should warn when neither pct nor absolute daily loss limit is configured.",
         "class": "TestCheckRiskConfiguration"
       },
       {
         "name": "TestCheckRiskConfiguration::test_fails_with_low_liquidation_buffer",
-        "line": 78,
+        "line": 81,
         "markers": [
           "unit"
         ],
@@ -39027,7 +39027,7 @@
       },
       {
         "name": "TestCheckRiskConfiguration::test_fails_with_excessive_position_size",
-        "line": 97,
+        "line": 89,
         "markers": [
           "unit"
         ],
@@ -39036,7 +39036,7 @@
       },
       {
         "name": "TestCheckRiskConfiguration::test_fails_with_slippage_guard_out_of_range",
-        "line": 116,
+        "line": 97,
         "markers": [
           "unit"
         ],
@@ -39045,7 +39045,7 @@
       },
       {
         "name": "TestCheckRiskConfiguration::test_warns_when_kill_switch_enabled",
-        "line": 135,
+        "line": 107,
         "markers": [
           "unit"
         ],
@@ -39054,7 +39054,7 @@
       },
       {
         "name": "TestCheckRiskConfiguration::test_warns_when_reduce_only_mode",
-        "line": 156,
+        "line": 116,
         "markers": [
           "unit"
         ],
@@ -39063,7 +39063,7 @@
       },
       {
         "name": "TestCheckRiskConfiguration::test_warns_on_high_daily_loss_limit",
-        "line": 177,
+        "line": 125,
         "markers": [
           "unit"
         ],
@@ -39072,7 +39072,7 @@
       },
       {
         "name": "TestCheckRiskConfiguration::test_warns_on_aggressive_leverage",
-        "line": 198,
+        "line": 134,
         "markers": [
           "unit"
         ],
@@ -39081,7 +39081,7 @@
       },
       {
         "name": "TestCheckRiskConfiguration::test_fails_on_exception",
-        "line": 219,
+        "line": 143,
         "markers": [
           "unit"
         ],
@@ -39090,7 +39090,7 @@
       },
       {
         "name": "TestCheckRiskConfiguration::test_prints_section_header",
-        "line": 230,
+        "line": 152,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
Milestone: preflight test-suite maintainability pass

- Replace repeated RiskConfig patch blocks with a monkeypatch-based RiskConfig stub fixture.
- Use real RiskConfig instances so failing-path tests exercise actual validation logic (not MagicMock TypeErrors).
- Align the daily-loss-limit test with current behavior (warn when not configured, do not hard-fail).
- Regenerate var/agents/testing inventory artifacts.

Verification:
- uv run pytest -q tests/unit/gpt_trader/preflight/test_checks_risk.py
- uv run python scripts/ci/check_test_hygiene.py
- uv run python scripts/ci/check_legacy_test_triage.py
- uv run python scripts/agents/generate_test_inventory.py
