### PR TITLE
test(backtesting): reduce patch density in report summary

### DIFF
--- a/tests/unit/gpt_trader/backtesting/metrics/test_report_generate_summary.py
+++ b/tests/unit/gpt_trader/backtesting/metrics/test_report_generate_summary.py
@@ -2,140 +2,115 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from decimal import Decimal
-from unittest.mock import patch
+from unittest.mock import MagicMock
 
+import pytest
 from tests.unit.gpt_trader.backtesting.metrics.report_test_utils import (  # naming: allow
     create_mock_broker,
     create_mock_risk_metrics,
     create_mock_trade_stats,
 )
 
+import gpt_trader.backtesting.metrics.report as report_module
 from gpt_trader.backtesting.metrics.report import BacktestReporter
 from gpt_trader.backtesting.metrics.risk import RiskMetrics
+
+
+@dataclass(slots=True)
+class SummaryStubs:
+    trade_stats: object
+    risk_metrics: RiskMetrics
+    calculate_trade_statistics: MagicMock
+    calculate_risk_metrics: MagicMock
+
+
+@pytest.fixture
+def reporter() -> BacktestReporter:
+    return BacktestReporter(create_mock_broker())
+
+
+@pytest.fixture
+def summary_stubs(monkeypatch: pytest.MonkeyPatch) -> SummaryStubs:
+    trade_stats = create_mock_trade_stats()
+    risk_metrics = create_mock_risk_metrics()
+
+    calculate_trade_statistics = MagicMock(
+        name="calculate_trade_statistics",
+        return_value=trade_stats,
+    )
+    calculate_risk_metrics = MagicMock(
+        name="calculate_risk_metrics",
+        return_value=risk_metrics,
+    )
+
+    monkeypatch.setattr(report_module, "calculate_trade_statistics", calculate_trade_statistics)
+    monkeypatch.setattr(report_module, "calculate_risk_metrics", calculate_risk_metrics)
+
+    return SummaryStubs(
+        trade_stats=trade_stats,
+        risk_metrics=risk_metrics,
+        calculate_trade_statistics=calculate_trade_statistics,
+        calculate_risk_metrics=calculate_risk_metrics,
+    )
 
 
 class TestBacktestReporterGenerateSummary:
     """Tests for generate_summary method."""
 
-    def test_generate_summary_returns_string(self) -> None:
-        broker = create_mock_broker()
-        reporter = BacktestReporter(broker)
-        mock_stats = create_mock_trade_stats()
-        mock_risk = create_mock_risk_metrics()
+    def test_generate_summary_returns_string(
+        self, reporter: BacktestReporter, summary_stubs: SummaryStubs
+    ) -> None:
+        summary = reporter.generate_summary()
 
-        with (
-            patch(
-                "gpt_trader.backtesting.metrics.report.calculate_trade_statistics",
-                return_value=mock_stats,
-            ),
-            patch(
-                "gpt_trader.backtesting.metrics.report.calculate_risk_metrics",
-                return_value=mock_risk,
-            ),
-        ):
-            summary = reporter.generate_summary()
+        assert isinstance(summary, str)
+        assert summary
 
-            assert isinstance(summary, str)
-            assert len(summary) > 0
+    def test_generate_summary_includes_performance_section(
+        self, reporter: BacktestReporter, summary_stubs: SummaryStubs
+    ) -> None:
+        summary = reporter.generate_summary()
 
-    def test_generate_summary_includes_performance_section(self) -> None:
-        broker = create_mock_broker()
-        reporter = BacktestReporter(broker)
-        mock_stats = create_mock_trade_stats()
-        mock_risk = create_mock_risk_metrics()
+        assert "PERFORMANCE" in summary
+        assert "Initial Equity" in summary
+        assert "Final Equity" in summary
+        assert "Total Return" in summary
 
-        with (
-            patch(
-                "gpt_trader.backtesting.metrics.report.calculate_trade_statistics",
-                return_value=mock_stats,
-            ),
-            patch(
-                "gpt_trader.backtesting.metrics.report.calculate_risk_metrics",
-                return_value=mock_risk,
-            ),
-        ):
-            summary = reporter.generate_summary()
+    def test_generate_summary_includes_risk_metrics_section(
+        self, reporter: BacktestReporter, summary_stubs: SummaryStubs
+    ) -> None:
+        summary = reporter.generate_summary()
 
-            assert "PERFORMANCE" in summary
-            assert "Initial Equity" in summary
-            assert "Final Equity" in summary
-            assert "Total Return" in summary
+        assert "RISK METRICS" in summary
+        assert "Max Drawdown" in summary
+        assert "Sharpe Ratio" in summary
+        assert "Sortino Ratio" in summary
 
-    def test_generate_summary_includes_risk_metrics_section(self) -> None:
-        broker = create_mock_broker()
-        reporter = BacktestReporter(broker)
-        mock_stats = create_mock_trade_stats()
-        mock_risk = create_mock_risk_metrics()
+    def test_generate_summary_includes_trade_statistics_section(
+        self, reporter: BacktestReporter, summary_stubs: SummaryStubs
+    ) -> None:
+        summary = reporter.generate_summary()
 
-        with (
-            patch(
-                "gpt_trader.backtesting.metrics.report.calculate_trade_statistics",
-                return_value=mock_stats,
-            ),
-            patch(
-                "gpt_trader.backtesting.metrics.report.calculate_risk_metrics",
-                return_value=mock_risk,
-            ),
-        ):
-            summary = reporter.generate_summary()
+        assert "TRADE STATISTICS" in summary
+        assert "Total Trades" in summary
+        assert "Win Rate" in summary
+        assert "Profit Factor" in summary
 
-            assert "RISK METRICS" in summary
-            assert "Max Drawdown" in summary
-            assert "Sharpe Ratio" in summary
-            assert "Sortino Ratio" in summary
+    def test_generate_summary_includes_costs_section(
+        self, reporter: BacktestReporter, summary_stubs: SummaryStubs
+    ) -> None:
+        summary = reporter.generate_summary()
 
-    def test_generate_summary_includes_trade_statistics_section(self) -> None:
-        broker = create_mock_broker()
-        reporter = BacktestReporter(broker)
-        mock_stats = create_mock_trade_stats()
-        mock_risk = create_mock_risk_metrics()
+        assert "COSTS" in summary
+        assert "Total Fees" in summary
+        assert "Avg Slippage" in summary
+        assert "Funding PnL" in summary
 
-        with (
-            patch(
-                "gpt_trader.backtesting.metrics.report.calculate_trade_statistics",
-                return_value=mock_stats,
-            ),
-            patch(
-                "gpt_trader.backtesting.metrics.report.calculate_risk_metrics",
-                return_value=mock_risk,
-            ),
-        ):
-            summary = reporter.generate_summary()
-
-            assert "TRADE STATISTICS" in summary
-            assert "Total Trades" in summary
-            assert "Win Rate" in summary
-            assert "Profit Factor" in summary
-
-    def test_generate_summary_includes_costs_section(self) -> None:
-        broker = create_mock_broker()
-        reporter = BacktestReporter(broker)
-        mock_stats = create_mock_trade_stats()
-        mock_risk = create_mock_risk_metrics()
-
-        with (
-            patch(
-                "gpt_trader.backtesting.metrics.report.calculate_trade_statistics",
-                return_value=mock_stats,
-            ),
-            patch(
-                "gpt_trader.backtesting.metrics.report.calculate_risk_metrics",
-                return_value=mock_risk,
-            ),
-        ):
-            summary = reporter.generate_summary()
-
-            assert "COSTS" in summary
-            assert "Total Fees" in summary
-            assert "Avg Slippage" in summary
-            assert "Funding PnL" in summary
-
-    def test_generate_summary_handles_none_sharpe(self) -> None:
-        broker = create_mock_broker()
-        reporter = BacktestReporter(broker)
-        mock_stats = create_mock_trade_stats()
-        mock_risk = RiskMetrics(
+    def test_generate_summary_handles_none_sharpe(
+        self, reporter: BacktestReporter, summary_stubs: SummaryStubs
+    ) -> None:
+        summary_stubs.calculate_risk_metrics.return_value = RiskMetrics(
             max_drawdown_pct=Decimal("15"),
             max_drawdown_usd=Decimal("15000"),
             avg_drawdown_pct=Decimal("5"),
@@ -144,8 +119,8 @@ class TestBacktestReporterGenerateSummary:
             annualized_return_pct=Decimal("0"),
             daily_return_avg=Decimal("0"),
             daily_return_std=Decimal("0"),
-            sharpe_ratio=None,  # No Sharpe ratio
-            sortino_ratio=None,  # No Sortino ratio
+            sharpe_ratio=None,
+            sortino_ratio=None,
             calmar_ratio=None,
             volatility_annualized=Decimal("0"),
             downside_volatility=Decimal("0"),
@@ -156,17 +131,7 @@ class TestBacktestReporterGenerateSummary:
             var_99_daily=Decimal("0"),
         )
 
-        with (
-            patch(
-                "gpt_trader.backtesting.metrics.report.calculate_trade_statistics",
-                return_value=mock_stats,
-            ),
-            patch(
-                "gpt_trader.backtesting.metrics.report.calculate_risk_metrics",
-                return_value=mock_risk,
-            ),
-        ):
-            summary = reporter.generate_summary()
+        summary = reporter.generate_summary()
 
-            assert "Sharpe Ratio:       N/A" in summary
-            assert "Sortino Ratio:      N/A" in summary
+        assert "Sharpe Ratio:       N/A" in summary
+        assert "Sortino Ratio:      N/A" in summary

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -5301,7 +5301,7 @@
     "tests/unit/gpt_trader/backtesting/metrics/test_report_generate_summary.py": [
       {
         "name": "TestBacktestReporterGenerateSummary::test_generate_summary_returns_string",
-        "line": 21,
+        "line": 62,
         "markers": [
           "unit"
         ],
@@ -5310,7 +5310,7 @@
       },
       {
         "name": "TestBacktestReporterGenerateSummary::test_generate_summary_includes_performance_section",
-        "line": 42,
+        "line": 70,
         "markers": [
           "unit"
         ],
@@ -5319,7 +5319,7 @@
       },
       {
         "name": "TestBacktestReporterGenerateSummary::test_generate_summary_includes_risk_metrics_section",
-        "line": 65,
+        "line": 80,
         "markers": [
           "unit"
         ],
@@ -5328,7 +5328,7 @@
       },
       {
         "name": "TestBacktestReporterGenerateSummary::test_generate_summary_includes_trade_statistics_section",
-        "line": 88,
+        "line": 90,
         "markers": [
           "unit"
         ],
@@ -5337,7 +5337,7 @@
       },
       {
         "name": "TestBacktestReporterGenerateSummary::test_generate_summary_includes_costs_section",
-        "line": 111,
+        "line": 100,
         "markers": [
           "unit"
         ],
@@ -5346,7 +5346,7 @@
       },
       {
         "name": "TestBacktestReporterGenerateSummary::test_generate_summary_handles_none_sharpe",
-        "line": 134,
+        "line": 110,
         "markers": [
           "unit"
         ],
@@ -39045,7 +39045,7 @@
       },
       {
         "name": "TestCheckRiskConfiguration::test_warns_when_kill_switch_enabled",
-        "line": 107,
+        "line": 105,
         "markers": [
           "unit"
         ],
@@ -39054,7 +39054,7 @@
       },
       {
         "name": "TestCheckRiskConfiguration::test_warns_when_reduce_only_mode",
-        "line": 116,
+        "line": 114,
         "markers": [
           "unit"
         ],
@@ -39063,7 +39063,7 @@
       },
       {
         "name": "TestCheckRiskConfiguration::test_warns_on_high_daily_loss_limit",
-        "line": 125,
+        "line": 123,
         "markers": [
           "unit"
         ],
@@ -39072,7 +39072,7 @@
       },
       {
         "name": "TestCheckRiskConfiguration::test_warns_on_aggressive_leverage",
-        "line": 134,
+        "line": 132,
         "markers": [
           "unit"
         ],
@@ -39081,7 +39081,7 @@
       },
       {
         "name": "TestCheckRiskConfiguration::test_fails_on_exception",
-        "line": 143,
+        "line": 141,
         "markers": [
           "unit"
         ],
@@ -39090,7 +39090,7 @@
       },
       {
         "name": "TestCheckRiskConfiguration::test_prints_section_header",
-        "line": 152,
+        "line": 150,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
Milestone: backtesting metrics test-suite maintainability pass

- Replace repeated calculate_* patch blocks with a single monkeypatch-based fixture (SummaryStubs).
- Use shared reporter fixture to remove boilerplate broker/reporter setup.
- Preserve existing summary content assertions (sections + N/A Sharpe/Sortino formatting).
- Regenerate var/agents/testing inventory artifacts.

Verification:
- uv run pytest -q tests/unit/gpt_trader/backtesting/metrics/test_report_generate_summary.py
- uv run python scripts/ci/check_test_hygiene.py
- uv run python scripts/ci/check_legacy_test_triage.py
- uv run python scripts/agents/generate_test_inventory.py
