### PR TITLE
test(preflight): reduce patch density in report tests

### DIFF
--- a/tests/unit/gpt_trader/preflight/test_report.py
+++ b/tests/unit/gpt_trader/preflight/test_report.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import builtins
 import json
 from pathlib import Path
-from unittest.mock import patch
+from typing import Any
 
 import pytest
 
@@ -12,20 +13,29 @@ from gpt_trader.preflight.core import PreflightCheck
 from gpt_trader.preflight.report import generate_report
 
 
+@pytest.fixture
+def report_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+def _read_report(tmp_path: Path) -> dict[str, Any]:
+    paths = sorted(tmp_path.glob("preflight_report_*.json"))
+    assert len(paths) == 1
+    return json.loads(paths[0].read_text(encoding="utf-8"))
+
+
 class TestGenerateReport:
     """Test report generation."""
 
     def test_returns_ready_status_with_no_errors_few_warnings(
-        self, capsys: pytest.CaptureFixture, tmp_path: Path
+        self, report_cwd: Path, capsys: pytest.CaptureFixture
     ) -> None:
-        """Should return READY status with no errors and few warnings."""
         checker = PreflightCheck()
         checker.context.successes.extend(["Success 1", "Success 2", "Success 3"])
         checker.context.warnings.extend(["Warning 1", "Warning 2"])  # <= 3 warnings
 
-        with patch("gpt_trader.preflight.report.Path") as mock_path:
-            mock_path.return_value = tmp_path / "report.json"
-            success, status = generate_report(checker)
+        success, status = generate_report(checker)
 
         assert success is True
         assert status == "READY"
@@ -35,16 +45,13 @@ class TestGenerateReport:
         assert "System is READY for production trading" in captured.out
 
     def test_returns_review_status_with_many_warnings(
-        self, capsys: pytest.CaptureFixture, tmp_path: Path
+        self, report_cwd: Path, capsys: pytest.CaptureFixture
     ) -> None:
-        """Should return REVIEW status with >3 warnings but no errors."""
         checker = PreflightCheck()
-        checker.context.successes.extend(["Success 1"])
+        checker.context.successes.append("Success 1")
         checker.context.warnings.extend(["Warning 1", "Warning 2", "Warning 3", "Warning 4"])
 
-        with patch("gpt_trader.preflight.report.Path") as mock_path:
-            mock_path.return_value = tmp_path / "report.json"
-            success, status = generate_report(checker)
+        success, status = generate_report(checker)
 
         assert success is True  # Still "success" (no errors)
         assert status == "REVIEW"
@@ -54,16 +61,13 @@ class TestGenerateReport:
         assert "review before proceeding" in captured.out
 
     def test_returns_not_ready_status_with_errors(
-        self, capsys: pytest.CaptureFixture, tmp_path: Path
+        self, report_cwd: Path, capsys: pytest.CaptureFixture
     ) -> None:
-        """Should return NOT READY status with any errors."""
         checker = PreflightCheck()
-        checker.context.successes.extend(["Success 1"])
+        checker.context.successes.append("Success 1")
         checker.context.errors.append("Critical error")
 
-        with patch("gpt_trader.preflight.report.Path") as mock_path:
-            mock_path.return_value = tmp_path / "report.json"
-            success, status = generate_report(checker)
+        success, status = generate_report(checker)
 
         assert success is False
         assert status == "NOT READY"
@@ -72,16 +76,13 @@ class TestGenerateReport:
         assert "NOT READY" in captured.out
         assert "critical issues must be resolved" in captured.out
 
-    def test_prints_summary_counts(self, capsys: pytest.CaptureFixture, tmp_path: Path) -> None:
-        """Should print summary of passed/warnings/failed counts."""
+    def test_prints_summary_counts(self, report_cwd: Path, capsys: pytest.CaptureFixture) -> None:
         checker = PreflightCheck()
         checker.context.successes.extend(["S1", "S2", "S3"])
         checker.context.warnings.extend(["W1", "W2"])
         checker.context.errors.append("E1")
 
-        with patch("gpt_trader.preflight.report.Path") as mock_path:
-            mock_path.return_value = tmp_path / "report.json"
-            generate_report(checker)
+        generate_report(checker)
 
         captured = capsys.readouterr()
         assert "Passed: 3" in captured.out
@@ -89,54 +90,37 @@ class TestGenerateReport:
         assert "Failed: 1" in captured.out
 
     def test_prints_recommendations_for_ready(
-        self, capsys: pytest.CaptureFixture, tmp_path: Path
+        self, report_cwd: Path, capsys: pytest.CaptureFixture
     ) -> None:
-        """Should print appropriate recommendations for READY status."""
         checker = PreflightCheck(profile="canary")
         checker.context.successes.append("Success")
 
-        with patch("gpt_trader.preflight.report.Path") as mock_path:
-            mock_path.return_value = tmp_path / "report.json"
-            generate_report(checker)
+        generate_report(checker)
 
         captured = capsys.readouterr()
         assert "--dry-run" in captured.out
         assert "tiny positions" in captured.out
 
     def test_prints_recommendations_for_not_ready(
-        self, capsys: pytest.CaptureFixture, tmp_path: Path
+        self, report_cwd: Path, capsys: pytest.CaptureFixture
     ) -> None:
-        """Should print appropriate recommendations for NOT READY status."""
         checker = PreflightCheck()
         checker.context.errors.append("Error")
 
-        with patch("gpt_trader.preflight.report.Path") as mock_path:
-            mock_path.return_value = tmp_path / "report.json"
-            generate_report(checker)
+        generate_report(checker)
 
         captured = capsys.readouterr()
         assert "Fix all critical errors" in captured.out
         assert "Run tests:" in captured.out
 
-    def test_saves_json_report(self, capsys: pytest.CaptureFixture, tmp_path: Path) -> None:
-        """Should save JSON report to file."""
+    def test_saves_json_report(self, report_cwd: Path) -> None:
         checker = PreflightCheck(profile="prod")
         checker.context.successes.extend(["S1", "S2"])
         checker.context.warnings.append("W1")
 
-        # Use actual path for this test
-        report_path = tmp_path / "test_report.json"
+        generate_report(checker)
 
-        with patch("gpt_trader.preflight.report.Path") as mock_path_class:
-            mock_path_class.return_value = report_path
-            generate_report(checker)
-
-        # Verify file was created with correct content
-        assert report_path.exists()
-
-        with open(report_path) as f:
-            report_data = json.load(f)
-
+        report_data = _read_report(report_cwd)
         assert report_data["profile"] == "prod"
         assert report_data["status"] == "READY"
         assert report_data["successes"] == 2
@@ -146,31 +130,31 @@ class TestGenerateReport:
         assert report_data["details"]["warnings"] == ["W1"]
         assert "timestamp" in report_data
 
-    def test_handles_file_save_error(self, capsys: pytest.CaptureFixture, tmp_path: Path) -> None:
-        """Should handle file save errors gracefully."""
+    def test_handles_file_save_error(
+        self, report_cwd: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
         checker = PreflightCheck()
         checker.context.successes.append("Success")
 
-        with patch("gpt_trader.preflight.report.Path"):
-            # Simulate open failing
-            with patch("builtins.open", side_effect=PermissionError("Cannot write")):
-                success, status = generate_report(checker)
+        def deny_open(*_args: object, **_kwargs: object) -> Any:
+            raise PermissionError("Cannot write")
 
-        # Should still return correct status even if save fails
+        monkeypatch.setattr(builtins, "open", deny_open)
+
+        success, status = generate_report(checker)
+
         assert success is True
         assert status == "READY"
 
         captured = capsys.readouterr()
         assert "Could not save report" in captured.out
+        assert not list(report_cwd.glob("preflight_report_*.json"))
 
-    def test_prints_section_header(self, capsys: pytest.CaptureFixture, tmp_path: Path) -> None:
-        """Should print section header."""
+    def test_prints_section_header(self, report_cwd: Path, capsys: pytest.CaptureFixture) -> None:
         checker = PreflightCheck()
         checker.context.successes.append("Success")
 
-        with patch("gpt_trader.preflight.report.Path") as mock_path:
-            mock_path.return_value = tmp_path / "report.json"
-            generate_report(checker)
+        generate_report(checker)
 
         captured = capsys.readouterr()
         assert "PREFLIGHT REPORT" in captured.out
@@ -179,21 +163,13 @@ class TestGenerateReport:
 class TestReportCalculations:
     """Test report calculations."""
 
-    def test_total_checks_calculated_correctly(
-        self, capsys: pytest.CaptureFixture, tmp_path: Path
-    ) -> None:
-        """Total checks should be sum of successes + warnings + errors."""
+    def test_total_checks_calculated_correctly(self, report_cwd: Path) -> None:
         checker = PreflightCheck()
         checker.context.successes.extend(["S1", "S2", "S3"])
         checker.context.warnings.extend(["W1", "W2"])
         checker.context.errors.append("E1")
 
-        with patch("gpt_trader.preflight.report.Path") as mock_path_class:
-            report_path = tmp_path / "report.json"
-            mock_path_class.return_value = report_path
-            generate_report(checker)
+        generate_report(checker)
 
-        with open(report_path) as f:
-            report_data = json.load(f)
-
+        report_data = _read_report(report_cwd)
         assert report_data["total_checks"] == 6  # 3 + 2 + 1

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -39882,47 +39882,47 @@
     "tests/unit/gpt_trader/preflight/test_report.py": [
       {
         "name": "TestGenerateReport::test_returns_ready_status_with_no_errors_few_warnings",
-        "line": 18,
+        "line": 31,
         "markers": [
           "unit"
         ],
-        "docstring": "Should return READY status with no errors and few warnings.",
+        "docstring": "",
         "class": "TestGenerateReport"
       },
       {
         "name": "TestGenerateReport::test_returns_review_status_with_many_warnings",
-        "line": 37,
+        "line": 47,
         "markers": [
           "unit"
         ],
-        "docstring": "Should return REVIEW status with >3 warnings but no errors.",
+        "docstring": "",
         "class": "TestGenerateReport"
       },
       {
         "name": "TestGenerateReport::test_returns_not_ready_status_with_errors",
-        "line": 56,
+        "line": 63,
         "markers": [
           "unit"
         ],
-        "docstring": "Should return NOT READY status with any errors.",
+        "docstring": "",
         "class": "TestGenerateReport"
       },
       {
         "name": "TestGenerateReport::test_prints_summary_counts",
-        "line": 75,
+        "line": 79,
         "markers": [
           "unit"
         ],
-        "docstring": "Should print summary of passed/warnings/failed counts.",
+        "docstring": "",
         "class": "TestGenerateReport"
       },
       {
         "name": "TestGenerateReport::test_prints_recommendations_for_ready",
-        "line": 91,
+        "line": 94,
         "markers": [
           "unit"
         ],
-        "docstring": "Should print appropriate recommendations for READY status.",
+        "docstring": "",
         "class": "TestGenerateReport"
       },
       {
@@ -39931,43 +39931,43 @@
         "markers": [
           "unit"
         ],
-        "docstring": "Should print appropriate recommendations for NOT READY status.",
+        "docstring": "",
         "class": "TestGenerateReport"
       },
       {
         "name": "TestGenerateReport::test_saves_json_report",
-        "line": 121,
+        "line": 118,
         "markers": [
           "unit"
         ],
-        "docstring": "Should save JSON report to file.",
+        "docstring": "",
         "class": "TestGenerateReport"
       },
       {
         "name": "TestGenerateReport::test_handles_file_save_error",
-        "line": 149,
+        "line": 135,
         "markers": [
           "unit"
         ],
-        "docstring": "Should handle file save errors gracefully.",
+        "docstring": "",
         "class": "TestGenerateReport"
       },
       {
         "name": "TestGenerateReport::test_prints_section_header",
-        "line": 166,
+        "line": 155,
         "markers": [
           "unit"
         ],
-        "docstring": "Should print section header.",
+        "docstring": "",
         "class": "TestGenerateReport"
       },
       {
         "name": "TestReportCalculations::test_total_checks_calculated_correctly",
-        "line": 182,
+        "line": 170,
         "markers": [
           "unit"
         ],
-        "docstring": "Total checks should be sum of successes + warnings + errors.",
+        "docstring": "",
         "class": "TestReportCalculations"
       }
     ],


### PR DESCRIPTION
Milestone: preflight test-suite maintainability pass

- Replace repeated Path patching with tmp_path + chdir (report written to temp cwd).
- Centralize report file discovery/reading via a small helper.
- Use monkeypatch for open() failure case (no unittest.mock.patch blocks).
- Regenerate var/agents/testing inventory artifacts.

Verification:
- uv run pytest -q tests/unit/gpt_trader/preflight/test_report.py
- uv run python scripts/ci/check_test_hygiene.py
- uv run python scripts/ci/check_legacy_test_triage.py
- uv run python scripts/agents/generate_test_inventory.py
