### PR TITLE
test(logging): reduce patch density in env overrides

### DIFF
--- a/tests/unit/gpt_trader/logging/test_setup_configure_logging_env_overrides.py
+++ b/tests/unit/gpt_trader/logging/test_setup_configure_logging_env_overrides.py
@@ -5,11 +5,49 @@ from __future__ import annotations
 import logging
 import logging.handlers
 from pathlib import Path
-from unittest.mock import MagicMock, patch
 
 import pytest
 
+import gpt_trader.logging.setup as logging_setup
 from gpt_trader.logging.setup import configure_logging
+
+
+def _clear_handlers() -> None:
+    root_logger = logging.getLogger()
+    for handler in root_logger.handlers[:]:
+        root_logger.removeHandler(handler)
+        handler.close()
+
+    json_logger = logging.getLogger("gpt_trader.json")
+    for handler in json_logger.handlers[:]:
+        json_logger.removeHandler(handler)
+        handler.close()
+
+
+def _rotating_handlers(logger: logging.Logger) -> list[logging.handlers.RotatingFileHandler]:
+    return [
+        handler
+        for handler in logger.handlers
+        if isinstance(handler, logging.handlers.RotatingFileHandler)
+    ]
+
+
+@pytest.fixture(autouse=True)
+def log_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    for name in (
+        "COINBASE_TRADER_LOG_DIR",
+        "PERPS_LOG_DIR",
+        "COINBASE_TRADER_LOG_MAX_BYTES",
+        "PERPS_LOG_MAX_BYTES",
+        "COINBASE_TRADER_LOG_BACKUP_COUNT",
+        "PERPS_LOG_BACKUP_COUNT",
+        "COINBASE_TRADER_DEBUG",
+        "PERPS_DEBUG",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    log_dir = tmp_path / "logs"
+    monkeypatch.setattr(logging_setup, "LOG_DIR", log_dir)
+    return log_dir
 
 
 class TestConfigureLoggingEnvOverrides:
@@ -18,112 +56,79 @@ class TestConfigureLoggingEnvOverrides:
     @pytest.fixture(autouse=True)
     def reset_logging(self) -> None:
         """Reset logging configuration before each test."""
-        root_logger = logging.getLogger()
-        for handler in root_logger.handlers[:]:
-            root_logger.removeHandler(handler)
-            handler.close()
-
-        json_logger = logging.getLogger("gpt_trader.json")
-        for handler in json_logger.handlers[:]:
-            json_logger.removeHandler(handler)
-            handler.close()
+        _clear_handlers()
 
         yield
 
-        for handler in root_logger.handlers[:]:
-            root_logger.removeHandler(handler)
-            handler.close()
-        for handler in json_logger.handlers[:]:
-            json_logger.removeHandler(handler)
-            handler.close()
+        _clear_handlers()
 
-    @patch("gpt_trader.logging.setup.ensure_directories")
     def test_configure_logging_respects_env_log_dir(
-        self, mock_ensure: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test that PERPS_LOG_DIR environment variable is respected."""
         custom_log_dir = tmp_path / "custom_logs"
         custom_log_dir.mkdir(parents=True, exist_ok=True)
         monkeypatch.setenv("PERPS_LOG_DIR", str(custom_log_dir))
 
-        with patch("gpt_trader.logging.setup.LOG_DIR", str(tmp_path)):
-            configure_logging()
+        configure_logging()
 
         # Check that file handlers were created in the custom directory
-        root_logger = logging.getLogger()
-        rotating_handlers = [
-            h for h in root_logger.handlers if isinstance(h, logging.handlers.RotatingFileHandler)
-        ]
+        rotating_handlers = _rotating_handlers(logging.getLogger())
         # At least one handler should use the custom log directory
-        handler_paths = [getattr(h, "baseFilename", "") for h in rotating_handlers]
-        assert any(str(custom_log_dir) in path for path in handler_paths)
+        handler_paths = [Path(h.baseFilename).parent for h in rotating_handlers]
+        assert custom_log_dir in handler_paths
 
-    @patch("gpt_trader.logging.setup.ensure_directories")
-    @patch("pathlib.Path.mkdir")
     def test_configure_logging_respects_max_bytes_env(
         self,
-        mock_mkdir: MagicMock,
-        mock_ensure: MagicMock,
-        tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test that log size environment variables are respected."""
         custom_max_bytes = 1024 * 1024  # 1 MB
         monkeypatch.setenv("PERPS_LOG_MAX_BYTES", str(custom_max_bytes))
 
-        with patch("gpt_trader.logging.setup.LOG_DIR", str(tmp_path)):
-            configure_logging()
+        configure_logging()
 
-        root_logger = logging.getLogger()
-        rotating_handlers = [
-            h for h in root_logger.handlers if isinstance(h, logging.handlers.RotatingFileHandler)
-        ]
+        rotating_handlers = _rotating_handlers(logging.getLogger()) + _rotating_handlers(
+            logging.getLogger("gpt_trader.json")
+        )
 
         # At least one handler should have the custom max bytes
         assert any(h.maxBytes == custom_max_bytes for h in rotating_handlers)
 
-    @patch("gpt_trader.logging.setup.ensure_directories")
-    @patch("pathlib.Path.mkdir")
     def test_configure_logging_respects_backup_count_env(
         self,
-        mock_mkdir: MagicMock,
-        mock_ensure: MagicMock,
-        tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test that backup count environment variables are respected."""
         custom_backup_count = 20
         monkeypatch.setenv("PERPS_LOG_BACKUP_COUNT", str(custom_backup_count))
 
-        with patch("gpt_trader.logging.setup.LOG_DIR", str(tmp_path)):
-            configure_logging()
+        configure_logging()
 
-        root_logger = logging.getLogger()
-        rotating_handlers = [
-            h for h in root_logger.handlers if isinstance(h, logging.handlers.RotatingFileHandler)
-        ]
+        rotating_handlers = _rotating_handlers(logging.getLogger()) + _rotating_handlers(
+            logging.getLogger("gpt_trader.json")
+        )
 
         # At least one handler should have the custom backup count
         assert any(h.backupCount == custom_backup_count for h in rotating_handlers)
 
-    @patch("gpt_trader.logging.setup.ensure_directories")
-    @patch("pathlib.Path.mkdir")
     def test_configure_logging_enables_debug_with_env(
         self,
-        mock_mkdir: MagicMock,
-        mock_ensure: MagicMock,
-        tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test that PERPS_DEBUG environment variable enables debug logging."""
         monkeypatch.setenv("PERPS_DEBUG", "1")
 
-        with patch("gpt_trader.logging.setup.LOG_DIR", str(tmp_path)):
-            configure_logging()
-
-        # Check that specific loggers are set to DEBUG
         coinbase_logger = logging.getLogger("gpt_trader.features.brokerages.coinbase")
         live_trade_logger = logging.getLogger("gpt_trader.features.live_trade")
+        original_levels = (coinbase_logger.level, live_trade_logger.level)
 
-        assert coinbase_logger.level == logging.DEBUG
-        assert live_trade_logger.level == logging.DEBUG
+        try:
+            configure_logging()
+
+            # Check that specific loggers are set to DEBUG
+            assert coinbase_logger.level == logging.DEBUG
+            assert live_trade_logger.level == logging.DEBUG
+        finally:
+            coinbase_logger.setLevel(original_levels[0])
+            live_trade_logger.setLevel(original_levels[1])

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -32858,7 +32858,7 @@
     "tests/unit/gpt_trader/logging/test_setup_configure_logging_env_overrides.py": [
       {
         "name": "TestConfigureLoggingEnvOverrides::test_configure_logging_respects_env_log_dir",
-        "line": 41,
+        "line": 65,
         "markers": [
           "unit"
         ],
@@ -32867,7 +32867,7 @@
       },
       {
         "name": "TestConfigureLoggingEnvOverrides::test_configure_logging_respects_max_bytes_env",
-        "line": 63,
+        "line": 81,
         "markers": [
           "unit"
         ],
@@ -32876,7 +32876,7 @@
       },
       {
         "name": "TestConfigureLoggingEnvOverrides::test_configure_logging_respects_backup_count_env",
-        "line": 87,
+        "line": 98,
         "markers": [
           "unit"
         ],
@@ -32885,7 +32885,7 @@
       },
       {
         "name": "TestConfigureLoggingEnvOverrides::test_configure_logging_enables_debug_with_env",
-        "line": 111,
+        "line": 115,
         "markers": [
           "unit"
         ],
@@ -39918,7 +39918,7 @@
       },
       {
         "name": "TestGenerateReport::test_prints_recommendations_for_ready",
-        "line": 94,
+        "line": 92,
         "markers": [
           "unit"
         ],
@@ -39927,7 +39927,7 @@
       },
       {
         "name": "TestGenerateReport::test_prints_recommendations_for_not_ready",
-        "line": 106,
+        "line": 104,
         "markers": [
           "unit"
         ],
@@ -39936,7 +39936,7 @@
       },
       {
         "name": "TestGenerateReport::test_saves_json_report",
-        "line": 118,
+        "line": 116,
         "markers": [
           "unit"
         ],
@@ -39945,7 +39945,7 @@
       },
       {
         "name": "TestGenerateReport::test_handles_file_save_error",
-        "line": 135,
+        "line": 133,
         "markers": [
           "unit"
         ],
@@ -39954,7 +39954,7 @@
       },
       {
         "name": "TestGenerateReport::test_prints_section_header",
-        "line": 155,
+        "line": 153,
         "markers": [
           "unit"
         ],
@@ -39963,7 +39963,7 @@
       },
       {
         "name": "TestReportCalculations::test_total_checks_calculated_correctly",
-        "line": 170,
+        "line": 166,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary\n- replace patch decorators/context managers with monkeypatch + tmp_path\n- assert against rotating handler properties and restore debug logger levels\n- regenerate test inventory\n\n## Testing\n- uv run pytest -q tests/unit/gpt_trader/logging/test_setup_configure_logging_env_overrides.py\n- uv run python scripts/ci/check_test_hygiene.py\n- uv run python scripts/ci/check_legacy_test_triage.py\n- uv run python scripts/agents/generate_test_inventory.py