### PR TITLE
test(coinbase): reduce patch density in base rate limiting

### DIFF
--- a/tests/unit/gpt_trader/features/brokerages/coinbase/client/test_base_rate_limiting.py
+++ b/tests/unit/gpt_trader/features/brokerages/coinbase/client/test_base_rate_limiting.py
@@ -1,9 +1,35 @@
 """Tests for CoinbaseClientBase throttling/rate limit helpers."""
 
-from unittest.mock import Mock, patch
+from __future__ import annotations
 
+from dataclasses import dataclass
+from unittest.mock import MagicMock, Mock
+
+import pytest
+
+import gpt_trader.features.brokerages.coinbase.client.base as base_module
 from gpt_trader.features.brokerages.coinbase.auth import SimpleAuth
 from gpt_trader.features.brokerages.coinbase.client.base import CoinbaseClientBase
+
+
+@dataclass(slots=True)
+class RateLimitHarness:
+    now: float
+    sleep: MagicMock
+    logger: MagicMock
+
+
+@pytest.fixture
+def rate_limit_harness(monkeypatch: pytest.MonkeyPatch) -> RateLimitHarness:
+    sleep = MagicMock(name="sleep")
+    logger = MagicMock(name="logger")
+    harness = RateLimitHarness(now=0.0, sleep=sleep, logger=logger)
+
+    monkeypatch.setattr(base_module.time, "time", lambda: harness.now)
+    monkeypatch.setattr(base_module.time, "sleep", sleep)
+    monkeypatch.setattr(base_module, "logger", logger)
+
+    return harness
 
 
 class TestCoinbaseClientBaseRateLimiting:
@@ -14,105 +40,80 @@ class TestCoinbaseClientBaseRateLimiting:
         self.auth = Mock(spec=SimpleAuth)
         self.auth.get_headers.return_value = {"Authorization": "Bearer test-token"}
 
-    @patch("gpt_trader.features.brokerages.coinbase.client.base.time.time")
-    def test_check_rate_limit_disabled(self, mock_time: Mock) -> None:
+    def test_check_rate_limit_disabled(self, rate_limit_harness: RateLimitHarness) -> None:
         """Test rate limit checking when disabled."""
-        mock_time.return_value = 1000.0
+        rate_limit_harness.now = 1000.0
         client = CoinbaseClientBase(base_url=self.base_url, auth=self.auth, enable_throttle=False)
 
-        # Should not raise any exceptions or sleep
         client._check_rate_limit()
 
         assert len(client._request_times) == 0
 
-    @patch("gpt_trader.features.brokerages.coinbase.client.base.time.time")
-    @patch("gpt_trader.features.brokerages.coinbase.client.base.time.sleep")
-    @patch("gpt_trader.features.brokerages.coinbase.client.base.logger")
-    def test_check_rate_limit_normal_usage(
-        self, mock_logger: Mock, mock_sleep: Mock, mock_time: Mock
-    ) -> None:
+    def test_check_rate_limit_normal_usage(self, rate_limit_harness: RateLimitHarness) -> None:
         """Test rate limit checking with normal usage."""
-        mock_time.return_value = 1000.0
+        rate_limit_harness.now = 1000.0
         client = CoinbaseClientBase(
             base_url=self.base_url, auth=self.auth, rate_limit_per_minute=10
         )
+        client._adaptive_throttle_enabled = False
 
-        # Add some requests within the limit
-        for i in range(5):
+        for _ in range(5):
             client._check_rate_limit()
 
         assert len(client._request_times) == 5
-        mock_sleep.assert_not_called()
+        rate_limit_harness.sleep.assert_not_called()
 
-    @patch("gpt_trader.features.brokerages.coinbase.client.base.time.time")
-    @patch("gpt_trader.features.brokerages.coinbase.client.base.time.sleep")
-    @patch("gpt_trader.features.brokerages.coinbase.client.base.logger")
-    def test_check_rate_limit_warning_threshold(
-        self, mock_logger: Mock, mock_sleep: Mock, mock_time: Mock
-    ) -> None:
+    def test_check_rate_limit_warning_threshold(self, rate_limit_harness: RateLimitHarness) -> None:
         """Test rate limit warning threshold."""
-        mock_time.return_value = 1000.0
+        rate_limit_harness.now = 1000.0
         client = CoinbaseClientBase(
             base_url=self.base_url, auth=self.auth, rate_limit_per_minute=10
         )
+        client._adaptive_throttle_enabled = False
 
-        # Add requests up to 80% of limit
-        # Need to trigger the warning, which happens when len >= 8
-        for i in range(9):
+        for _ in range(9):
             client._check_rate_limit()
 
-        mock_logger.warning.assert_called_once_with(
+        rate_limit_harness.logger.warning.assert_called_once_with(
             "Approaching rate limit: %d/%d requests in last minute",
             8,
             10,
         )
 
-    @patch("gpt_trader.features.brokerages.coinbase.client.base.time.time")
-    @patch("gpt_trader.features.brokerages.coinbase.client.base.time.sleep")
-    @patch("gpt_trader.features.brokerages.coinbase.client.base.logger")
-    def test_check_rate_limit_exceeded(
-        self, mock_logger: Mock, mock_sleep: Mock, mock_time: Mock
-    ) -> None:
+    def test_check_rate_limit_exceeded(self, rate_limit_harness: RateLimitHarness) -> None:
         """Test rate limit exceeded behavior."""
-        # Start at time 1000
-        mock_time.return_value = 1000.0
+        rate_limit_harness.now = 1000.0
         client = CoinbaseClientBase(base_url=self.base_url, auth=self.auth, rate_limit_per_minute=5)
+        client._adaptive_throttle_enabled = False
 
-        # Add requests up to the limit
-        for i in range(5):
+        for _ in range(5):
             client._check_rate_limit()
 
-        # Next request should trigger rate limiting
-        # Advance time by 30 seconds (still within 1-minute window)
-        mock_time.return_value = 1030.0
+        rate_limit_harness.now = 1030.0
         client._check_rate_limit()
 
-        # Should have slept to respect rate limit
-        assert mock_sleep.call_count >= 1
-        sleep_calls = [c.args[0] for c in mock_sleep.call_args_list if c.args]
+        assert rate_limit_harness.sleep.call_count >= 1
+        sleep_calls = [c.args[0] for c in rate_limit_harness.sleep.call_args_list if c.args]
         assert any(s > 30 for s in sleep_calls)  # remaining time + buffer
 
-        mock_logger.info.assert_called_once()
-        assert "Rate limit reached" in mock_logger.info.call_args[0][0]
+        rate_limit_harness.logger.info.assert_called_once()
+        assert "Rate limit reached" in rate_limit_harness.logger.info.call_args[0][0]
 
-    @patch("gpt_trader.features.brokerages.coinbase.client.base.time.time")
-    def test_check_rate_limit_window_cleanup(self, mock_time: Mock) -> None:
+    def test_check_rate_limit_window_cleanup(self, rate_limit_harness: RateLimitHarness) -> None:
         """Test rate limit window cleanup."""
         client = CoinbaseClientBase(
             base_url=self.base_url, auth=self.auth, rate_limit_per_minute=10
         )
+        client._adaptive_throttle_enabled = False
 
-        # Add requests at time 1000
-        mock_time.return_value = 1000.0
-        for i in range(5):
+        rate_limit_harness.now = 1000.0
+        for _ in range(5):
             client._check_rate_limit()
 
         assert len(client._request_times) == 5
 
-        # Advance time beyond 1 minute window
-        mock_time.return_value = 2000.0
+        rate_limit_harness.now = 2000.0
         client._check_rate_limit()
 
-        # Old requests should be cleaned up
         assert len(client._request_times) == 1
         assert client._request_times[0] == 2000.0

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -11550,7 +11550,7 @@
     "tests/unit/gpt_trader/features/brokerages/coinbase/client/test_base_rate_limiting.py": [
       {
         "name": "TestCoinbaseClientBaseRateLimiting::test_check_rate_limit_disabled",
-        "line": 18,
+        "line": 43,
         "markers": [
           "unit"
         ],
@@ -11559,7 +11559,7 @@
       },
       {
         "name": "TestCoinbaseClientBaseRateLimiting::test_check_rate_limit_normal_usage",
-        "line": 31,
+        "line": 52,
         "markers": [
           "unit"
         ],
@@ -11568,7 +11568,7 @@
       },
       {
         "name": "TestCoinbaseClientBaseRateLimiting::test_check_rate_limit_warning_threshold",
-        "line": 50,
+        "line": 66,
         "markers": [
           "unit"
         ],
@@ -11577,7 +11577,7 @@
       },
       {
         "name": "TestCoinbaseClientBaseRateLimiting::test_check_rate_limit_exceeded",
-        "line": 73,
+        "line": 85,
         "markers": [
           "unit"
         ],
@@ -11586,7 +11586,7 @@
       },
       {
         "name": "TestCoinbaseClientBaseRateLimiting::test_check_rate_limit_window_cleanup",
-        "line": 99,
+        "line": 104,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
Milestone: Coinbase client test-suite maintainability pass

- Replace @patch decorators/context managers with a monkeypatch-based rate limit harness (time.time/time.sleep + logger).
- Disable adaptive throttling in these tests to keep expectations stable and focused on rate limit behavior.
- Regenerate var/agents/testing inventory artifacts.

Verification:
- uv run pytest -q tests/unit/gpt_trader/features/brokerages/coinbase/client/test_base_rate_limiting.py
- uv run python scripts/ci/check_test_hygiene.py
- uv run python scripts/ci/check_legacy_test_triage.py
- uv run python scripts/agents/generate_test_inventory.py
