### PR TITLE
test(tui): reduce patch density in default handlers

### DIFF
--- a/tests/unit/gpt_trader/tui/mixins/test_event_handlers_default_handlers.py
+++ b/tests/unit/gpt_trader/tui/mixins/test_event_handlers_default_handlers.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
+import pytest
 from textual.widgets import Static
 
+import gpt_trader.tui.mixins.event_handlers as event_handlers
 from gpt_trader.tui.events import (
     BotModeChanged,
     BotStateChanged,
@@ -21,17 +23,27 @@ from gpt_trader.tui.mixins import EventHandlerMixin
 from gpt_trader.tui.responsive_state import ResponsiveState
 
 
+class TestWidget(EventHandlerMixin, Static):
+    __test__ = False
+
+
+@pytest.fixture
+def widget() -> TestWidget:
+    return TestWidget()
+
+
+@pytest.fixture
+def mock_logger(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    logger = MagicMock()
+    monkeypatch.setattr(event_handlers, "logger", logger)
+    return logger
+
+
 class TestDefaultEventHandlers:
     """Test default event handler implementations."""
 
-    @patch("gpt_trader.tui.mixins.event_handlers.logger")
-    def test_on_bot_state_changed_logs_default(self, mock_logger):
+    def test_on_bot_state_changed_logs_default(self, widget, mock_logger):
         """Test default on_bot_state_changed logs event."""
-
-        class TestWidget(EventHandlerMixin, Static):
-            pass
-
-        widget = TestWidget()
         event = BotStateChanged(running=True, uptime=123.5)
 
         widget.on_bot_state_changed(event)
@@ -43,14 +55,8 @@ class TestDefaultEventHandlers:
         assert "running=True" in call_args
         assert "123.5" in call_args
 
-    @patch("gpt_trader.tui.mixins.event_handlers.logger")
-    def test_on_bot_mode_changed_logs_default(self, mock_logger):
+    def test_on_bot_mode_changed_logs_default(self, widget, mock_logger):
         """Test default on_bot_mode_changed logs event."""
-
-        class TestWidget(EventHandlerMixin, Static):
-            pass
-
-        widget = TestWidget()
         event = BotModeChanged(new_mode="live", old_mode="demo")
 
         widget.on_bot_mode_changed(event)
@@ -62,14 +68,8 @@ class TestDefaultEventHandlers:
         assert "demo" in call_args
         assert "live" in call_args
 
-    @patch("gpt_trader.tui.mixins.event_handlers.logger")
-    def test_on_state_update_received_logs_default(self, mock_logger):
+    def test_on_state_update_received_logs_default(self, widget, mock_logger):
         """Test default on_state_update_received logs event."""
-
-        class TestWidget(EventHandlerMixin, Static):
-            pass
-
-        widget = TestWidget()
         mock_status = MagicMock()
         event = StateUpdateReceived(status=mock_status)
 
@@ -80,15 +80,10 @@ class TestDefaultEventHandlers:
         assert "TestWidget" in call_args
         assert "StateUpdateReceived" in call_args
 
-    @patch("gpt_trader.tui.mixins.event_handlers.logger")
-    def test_on_state_validation_failed_logs_warnings(self, mock_logger):
+    def test_on_state_validation_failed_logs_warnings(self, widget, mock_logger):
         """Test default on_state_validation_failed logs warnings."""
         from gpt_trader.tui.events import FieldValidationError
 
-        class TestWidget(EventHandlerMixin, Static):
-            pass
-
-        widget = TestWidget()
         errors = [
             FieldValidationError(field="field1", message="Error 1", severity="error"),
             FieldValidationError(field="field2", message="Error 2", severity="warning"),
@@ -99,28 +94,16 @@ class TestDefaultEventHandlers:
 
         assert mock_logger.warning.call_count == 3
 
-    @patch("gpt_trader.tui.mixins.event_handlers.logger")
-    def test_on_state_validation_passed_logs_default(self, mock_logger):
+    def test_on_state_validation_passed_logs_default(self, widget, mock_logger):
         """Test default on_state_validation_passed logs event."""
-
-        class TestWidget(EventHandlerMixin, Static):
-            pass
-
-        widget = TestWidget()
         event = StateValidationPassed()
 
         widget.on_state_validation_passed(event)
 
         mock_logger.debug.assert_called_once()
 
-    @patch("gpt_trader.tui.mixins.event_handlers.logger")
-    def test_on_state_delta_update_applied_logs_default(self, mock_logger):
+    def test_on_state_delta_update_applied_logs_default(self, widget, mock_logger):
         """Test default on_state_delta_update_applied logs event."""
-
-        class TestWidget(EventHandlerMixin, Static):
-            pass
-
-        widget = TestWidget()
         event = StateDeltaUpdateApplied(
             components_updated=["market", "positions"], use_full_update=False
         )
@@ -132,14 +115,8 @@ class TestDefaultEventHandlers:
         assert "market, positions" in call_args
         assert "full_update=False" in call_args
 
-    @patch("gpt_trader.tui.mixins.event_handlers.logger")
-    def test_on_responsive_state_changed_logs_default(self, mock_logger):
+    def test_on_responsive_state_changed_logs_default(self, widget, mock_logger):
         """Test default on_responsive_state_changed logs event."""
-
-        class TestWidget(EventHandlerMixin, Static):
-            pass
-
-        widget = TestWidget()
         event = ResponsiveStateChanged(state=ResponsiveState.COMFORTABLE, width=140)
 
         widget.on_responsive_state_changed(event)
@@ -149,14 +126,8 @@ class TestDefaultEventHandlers:
         assert "COMFORTABLE" in call_args
         assert "140" in call_args
 
-    @patch("gpt_trader.tui.mixins.event_handlers.logger")
-    def test_on_theme_changed_logs_default(self, mock_logger):
+    def test_on_theme_changed_logs_default(self, widget, mock_logger):
         """Test default on_theme_changed logs event."""
-
-        class TestWidget(EventHandlerMixin, Static):
-            pass
-
-        widget = TestWidget()
         event = ThemeChanged(theme_mode="dark")
 
         widget.on_theme_changed(event)
@@ -165,28 +136,16 @@ class TestDefaultEventHandlers:
         call_args = mock_logger.debug.call_args[0][0]
         assert "dark" in call_args
 
-    @patch("gpt_trader.tui.mixins.event_handlers.logger")
-    def test_on_error_occurred_logs_error_severity(self, mock_logger):
+    def test_on_error_occurred_logs_error_severity(self, widget, mock_logger):
         """Test on_error_occurred logs with correct severity."""
-
-        class TestWidget(EventHandlerMixin, Static):
-            pass
-
-        widget = TestWidget()
         event = ErrorOccurred(message="Test error", severity="error", context="test_context")
 
         widget.on_error_occurred(event)
 
         mock_logger.error.assert_called_once()
 
-    @patch("gpt_trader.tui.mixins.event_handlers.logger")
-    def test_on_error_occurred_logs_warning_severity(self, mock_logger):
+    def test_on_error_occurred_logs_warning_severity(self, widget, mock_logger):
         """Test on_error_occurred logs warning for warning severity."""
-
-        class TestWidget(EventHandlerMixin, Static):
-            pass
-
-        widget = TestWidget()
         event = ErrorOccurred(message="Test warning", severity="warning", context="test_context")
 
         widget.on_error_occurred(event)

--- a/var/agents/testing/source_test_map.json
+++ b/var/agents/testing/source_test_map.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "summary": {
     "tests_scanned": 915,
-    "source_modules": 347,
+    "source_modules": 348,
     "unresolved_modules": 3
   },
   "source_to_tests": {
@@ -1829,6 +1829,9 @@
       "tests/unit/gpt_trader/tui/mixins/test_event_handlers_custom_overrides.py",
       "tests/unit/gpt_trader/tui/mixins/test_event_handlers_default_handlers.py",
       "tests/unit/gpt_trader/tui/mixins/test_event_handlers_utilities_and_docs.py"
+    ],
+    "gpt_trader.tui.mixins.event_handlers": [
+      "tests/unit/gpt_trader/tui/mixins/test_event_handlers_default_handlers.py"
     ],
     "gpt_trader.tui.responsive_state": [
       "tests/unit/gpt_trader/tui/mixins/test_event_handlers_default_handlers.py",
@@ -4948,6 +4951,7 @@
     "tests/unit/gpt_trader/tui/mixins/test_event_handlers_default_handlers.py": [
       "gpt_trader.tui.events",
       "gpt_trader.tui.mixins",
+      "gpt_trader.tui.mixins.event_handlers",
       "gpt_trader.tui.responsive_state"
     ],
     "tests/unit/gpt_trader/tui/mixins/test_event_handlers_utilities_and_docs.py": [
@@ -6009,6 +6013,7 @@
     "gpt_trader.tui.demo.mock_data": "src/gpt_trader/tui/demo/mock_data.py",
     "gpt_trader.tui.mixins": "src/gpt_trader/tui/mixins/__init__.py",
     "gpt_trader.tui.events": "src/gpt_trader/tui/events.py",
+    "gpt_trader.tui.mixins.event_handlers": "src/gpt_trader/tui/mixins/event_handlers.py",
     "gpt_trader.tui.responsive_state": "src/gpt_trader/tui/responsive_state.py",
     "gpt_trader.tui.screens.alert_history": "src/gpt_trader/tui/screens/alert_history.py",
     "gpt_trader.tui.services.alert_manager": "src/gpt_trader/tui/services/alert_manager.py",

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -11577,7 +11577,7 @@
       },
       {
         "name": "TestCoinbaseClientBaseRateLimiting::test_check_rate_limit_exceeded",
-        "line": 85,
+        "line": 83,
         "markers": [
           "unit"
         ],
@@ -11586,7 +11586,7 @@
       },
       {
         "name": "TestCoinbaseClientBaseRateLimiting::test_check_rate_limit_window_cleanup",
-        "line": 104,
+        "line": 102,
         "markers": [
           "unit"
         ],
@@ -43160,7 +43160,7 @@
     "tests/unit/gpt_trader/tui/mixins/test_event_handlers_default_handlers.py": [
       {
         "name": "TestDefaultEventHandlers::test_on_bot_state_changed_logs_default",
-        "line": 28,
+        "line": 45,
         "markers": [
           "unit"
         ],
@@ -43169,7 +43169,7 @@
       },
       {
         "name": "TestDefaultEventHandlers::test_on_bot_mode_changed_logs_default",
-        "line": 47,
+        "line": 58,
         "markers": [
           "unit"
         ],
@@ -43178,7 +43178,7 @@
       },
       {
         "name": "TestDefaultEventHandlers::test_on_state_update_received_logs_default",
-        "line": 66,
+        "line": 71,
         "markers": [
           "unit"
         ],
@@ -43187,7 +43187,7 @@
       },
       {
         "name": "TestDefaultEventHandlers::test_on_state_validation_failed_logs_warnings",
-        "line": 84,
+        "line": 83,
         "markers": [
           "unit"
         ],
@@ -43196,7 +43196,7 @@
       },
       {
         "name": "TestDefaultEventHandlers::test_on_state_validation_passed_logs_default",
-        "line": 103,
+        "line": 97,
         "markers": [
           "unit"
         ],
@@ -43205,7 +43205,7 @@
       },
       {
         "name": "TestDefaultEventHandlers::test_on_state_delta_update_applied_logs_default",
-        "line": 117,
+        "line": 105,
         "markers": [
           "unit"
         ],
@@ -43214,7 +43214,7 @@
       },
       {
         "name": "TestDefaultEventHandlers::test_on_responsive_state_changed_logs_default",
-        "line": 136,
+        "line": 118,
         "markers": [
           "unit"
         ],
@@ -43223,7 +43223,7 @@
       },
       {
         "name": "TestDefaultEventHandlers::test_on_theme_changed_logs_default",
-        "line": 153,
+        "line": 129,
         "markers": [
           "unit"
         ],
@@ -43232,7 +43232,7 @@
       },
       {
         "name": "TestDefaultEventHandlers::test_on_error_occurred_logs_error_severity",
-        "line": 169,
+        "line": 139,
         "markers": [
           "unit"
         ],
@@ -43241,7 +43241,7 @@
       },
       {
         "name": "TestDefaultEventHandlers::test_on_error_occurred_logs_warning_severity",
-        "line": 183,
+        "line": 147,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary\n- replace patch decorators with fixtures that monkeypatch the event handler logger\n- reuse a shared TestWidget fixture for default handler coverage\n- regenerate test inventory artifacts\n\n## Testing\n- uv run pytest -q tests/unit/gpt_trader/tui/mixins/test_event_handlers_default_handlers.py\n- uv run python scripts/ci/check_test_hygiene.py\n- uv run python scripts/ci/check_legacy_test_triage.py\n- uv run python scripts/agents/generate_test_inventory.py