### PR TITLE
test(live_trade): reduce patch density in order preview

### DIFF
--- a/tests/unit/gpt_trader/features/live_trade/execution/test_order_event_recorder_preview.py
+++ b/tests/unit/gpt_trader/features/live_trade/execution/test_order_event_recorder_preview.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 from decimal import Decimal
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
+import pytest
+
+import gpt_trader.features.live_trade.execution.order_event_recorder as order_event_recorder
 from gpt_trader.core import (
     OrderSide,
     OrderType,
@@ -12,16 +15,27 @@ from gpt_trader.core import (
 from gpt_trader.features.live_trade.execution.order_event_recorder import OrderEventRecorder
 
 
+@pytest.fixture
+def recorder_mocks(monkeypatch: pytest.MonkeyPatch) -> dict[str, MagicMock]:
+    monitoring_logger = MagicMock()
+    get_monitoring_logger = MagicMock(return_value=monitoring_logger)
+    emit_metric = MagicMock()
+    monkeypatch.setattr(order_event_recorder, "get_monitoring_logger", get_monitoring_logger)
+    monkeypatch.setattr(order_event_recorder, "emit_metric", emit_metric)
+    return {
+        "monitoring_logger": monitoring_logger,
+        "get_monitoring_logger": get_monitoring_logger,
+        "emit_metric": emit_metric,
+    }
+
+
 class TestRecordPreview:
     """Tests for record_preview method."""
 
-    @patch("gpt_trader.features.live_trade.execution.order_event_recorder.emit_metric")
-    @patch("gpt_trader.features.live_trade.execution.order_event_recorder.get_monitoring_logger")
     def test_record_preview_skips_when_preview_is_none(
         self,
-        mock_get_logger: MagicMock,
-        mock_emit_metric: MagicMock,
         order_event_recorder: OrderEventRecorder,
+        recorder_mocks: dict[str, MagicMock],
     ) -> None:
         """Test that record_preview does nothing when preview is None."""
         order_event_recorder.record_preview(
@@ -33,21 +47,16 @@ class TestRecordPreview:
             preview=None,
         )
 
-        mock_emit_metric.assert_not_called()
-        mock_get_logger.assert_not_called()
+        recorder_mocks["emit_metric"].assert_not_called()
+        recorder_mocks["get_monitoring_logger"].assert_not_called()
 
-    @patch("gpt_trader.features.live_trade.execution.order_event_recorder.emit_metric")
-    @patch("gpt_trader.features.live_trade.execution.order_event_recorder.get_monitoring_logger")
     def test_record_preview_emits_metric(
         self,
-        mock_get_logger: MagicMock,
-        mock_emit_metric: MagicMock,
         order_event_recorder: OrderEventRecorder,
         mock_event_store: MagicMock,
+        recorder_mocks: dict[str, MagicMock],
     ) -> None:
         """Test that record_preview emits metric with correct data."""
-        mock_logger = MagicMock()
-        mock_get_logger.return_value = mock_logger
         preview = {"fee": "0.001", "estimated_fill": "50000"}
 
         order_event_recorder.record_preview(
@@ -59,8 +68,9 @@ class TestRecordPreview:
             preview=preview,
         )
 
-        mock_emit_metric.assert_called_once()
-        call_args = mock_emit_metric.call_args
+        emit_metric = recorder_mocks["emit_metric"]
+        emit_metric.assert_called_once()
+        call_args = emit_metric.call_args
         assert call_args[0][0] is mock_event_store
         assert call_args[0][1] == "test-bot-123"
         metric_data = call_args[0][2]
@@ -72,18 +82,12 @@ class TestRecordPreview:
         assert metric_data["price"] == "50000"
         assert metric_data["preview"] == preview
 
-    @patch("gpt_trader.features.live_trade.execution.order_event_recorder.emit_metric")
-    @patch("gpt_trader.features.live_trade.execution.order_event_recorder.get_monitoring_logger")
     def test_record_preview_uses_market_for_none_price(
         self,
-        mock_get_logger: MagicMock,
-        mock_emit_metric: MagicMock,
         order_event_recorder: OrderEventRecorder,
+        recorder_mocks: dict[str, MagicMock],
     ) -> None:
         """Test that 'market' is used when price is None."""
-        mock_logger = MagicMock()
-        mock_get_logger.return_value = mock_logger
-
         order_event_recorder.record_preview(
             symbol="BTC-USD",
             side=OrderSide.BUY,
@@ -93,22 +97,16 @@ class TestRecordPreview:
             preview={"some": "data"},
         )
 
-        call_args = mock_emit_metric.call_args
+        call_args = recorder_mocks["emit_metric"].call_args
         metric_data = call_args[0][2]
         assert metric_data["price"] == "market"
 
-    @patch("gpt_trader.features.live_trade.execution.order_event_recorder.emit_metric")
-    @patch("gpt_trader.features.live_trade.execution.order_event_recorder.get_monitoring_logger")
     def test_record_preview_logs_event(
         self,
-        mock_get_logger: MagicMock,
-        mock_emit_metric: MagicMock,
         order_event_recorder: OrderEventRecorder,
+        recorder_mocks: dict[str, MagicMock],
     ) -> None:
         """Test that record_preview logs to monitoring logger."""
-        mock_logger = MagicMock()
-        mock_get_logger.return_value = mock_logger
-
         order_event_recorder.record_preview(
             symbol="ETH-USD",
             side=OrderSide.SELL,
@@ -118,25 +116,22 @@ class TestRecordPreview:
             preview={"data": "value"},
         )
 
-        mock_logger.log_event.assert_called_once()
-        call_kwargs = mock_logger.log_event.call_args.kwargs
+        monitoring_logger = recorder_mocks["monitoring_logger"]
+        monitoring_logger.log_event.assert_called_once()
+        call_kwargs = monitoring_logger.log_event.call_args.kwargs
         assert call_kwargs["event_type"] == "order_preview"
         assert call_kwargs["symbol"] == "ETH-USD"
         assert call_kwargs["side"] == "SELL"
         assert call_kwargs["component"] == "TradingEngine"
 
-    @patch("gpt_trader.features.live_trade.execution.order_event_recorder.emit_metric")
-    @patch("gpt_trader.features.live_trade.execution.order_event_recorder.get_monitoring_logger")
     def test_record_preview_handles_log_exception(
         self,
-        mock_get_logger: MagicMock,
-        mock_emit_metric: MagicMock,
         order_event_recorder: OrderEventRecorder,
+        recorder_mocks: dict[str, MagicMock],
     ) -> None:
         """Test that record_preview handles logging exceptions gracefully."""
-        mock_logger = MagicMock()
-        mock_logger.log_event.side_effect = RuntimeError("Log failure")
-        mock_get_logger.return_value = mock_logger
+        monitoring_logger = recorder_mocks["monitoring_logger"]
+        monitoring_logger.log_event.side_effect = RuntimeError("Log failure")
 
         # Should not raise
         order_event_recorder.record_preview(
@@ -147,5 +142,5 @@ class TestRecordPreview:
             price=Decimal("50000"),
             preview={"data": "value"},
         )
-        mock_emit_metric.assert_called_once()
-        mock_logger.log_event.assert_called_once()
+        recorder_mocks["emit_metric"].assert_called_once()
+        monitoring_logger.log_event.assert_called_once()

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -22829,7 +22829,7 @@
     "tests/unit/gpt_trader/features/live_trade/execution/test_order_event_recorder_preview.py": [
       {
         "name": "TestRecordPreview::test_record_preview_skips_when_preview_is_none",
-        "line": 20,
+        "line": 35,
         "markers": [
           "unit"
         ],
@@ -22838,7 +22838,7 @@
       },
       {
         "name": "TestRecordPreview::test_record_preview_emits_metric",
-        "line": 41,
+        "line": 53,
         "markers": [
           "unit"
         ],
@@ -22847,7 +22847,7 @@
       },
       {
         "name": "TestRecordPreview::test_record_preview_uses_market_for_none_price",
-        "line": 77,
+        "line": 85,
         "markers": [
           "unit"
         ],
@@ -22856,7 +22856,7 @@
       },
       {
         "name": "TestRecordPreview::test_record_preview_logs_event",
-        "line": 102,
+        "line": 104,
         "markers": [
           "unit"
         ],
@@ -22865,7 +22865,7 @@
       },
       {
         "name": "TestRecordPreview::test_record_preview_handles_log_exception",
-        "line": 130,
+        "line": 127,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary\n- replace patch decorators with monkeypatch-based recorder mocks\n- share emit_metric/logger stubs across tests\n- regenerate test inventory\n\n## Testing\n- uv run pytest -q tests/unit/gpt_trader/features/live_trade/execution/test_order_event_recorder_preview.py\n- uv run python scripts/ci/check_test_hygiene.py\n- uv run python scripts/ci/check_legacy_test_triage.py\n- uv run python scripts/agents/generate_test_inventory.py