### PR TITLE
test(backtesting): reduce patch density in result

### DIFF
--- a/tests/unit/gpt_trader/backtesting/metrics/test_report_generate_result.py
+++ b/tests/unit/gpt_trader/backtesting/metrics/test_report_generate_result.py
@@ -4,46 +4,64 @@ from __future__ import annotations
 
 from datetime import datetime
 from decimal import Decimal
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
+import pytest
 from tests.unit.gpt_trader.backtesting.metrics.report_test_utils import (  # naming: allow
     create_mock_broker,
     create_mock_risk_metrics,
     create_mock_trade_stats,
 )
 
+import gpt_trader.backtesting.metrics.report as report_module
 from gpt_trader.backtesting.metrics.report import BacktestReporter
+from gpt_trader.backtesting.metrics.risk import RiskMetrics
+from gpt_trader.backtesting.metrics.statistics import TradeStatistics
+
+START_DATE = datetime(2024, 1, 1)
+END_DATE = datetime(2024, 1, 31)
+
+
+@pytest.fixture
+def mock_stats() -> TradeStatistics:
+    return create_mock_trade_stats()
+
+
+@pytest.fixture
+def mock_risk() -> RiskMetrics:
+    return create_mock_risk_metrics()
+
+
+@pytest.fixture
+def metrics_mocks(
+    monkeypatch: pytest.MonkeyPatch,
+    mock_stats: TradeStatistics,
+    mock_risk: RiskMetrics,
+) -> dict[str, MagicMock]:
+    trade_stats = MagicMock(return_value=mock_stats)
+    risk_metrics = MagicMock(return_value=mock_risk)
+    monkeypatch.setattr(report_module, "calculate_trade_statistics", trade_stats)
+    monkeypatch.setattr(report_module, "calculate_risk_metrics", risk_metrics)
+    return {"trade_stats": trade_stats, "risk_metrics": risk_metrics}
 
 
 class TestBacktestReporterGenerateResult:
     """Tests for generate_result method."""
 
-    def test_generate_result_returns_backtest_result(self) -> None:
+    def test_generate_result_returns_backtest_result(self, metrics_mocks) -> None:
         broker = create_mock_broker()
         reporter = BacktestReporter(broker)
-        mock_stats = create_mock_trade_stats()
-        mock_risk = create_mock_risk_metrics()
 
-        with (
-            patch(
-                "gpt_trader.backtesting.metrics.report.calculate_trade_statistics",
-                return_value=mock_stats,
-            ),
-            patch(
-                "gpt_trader.backtesting.metrics.report.calculate_risk_metrics",
-                return_value=mock_risk,
-            ),
-        ):
-            result = reporter.generate_result(
-                start_date=datetime(2024, 1, 1),
-                end_date=datetime(2024, 1, 31),
-            )
+        result = reporter.generate_result(
+            start_date=START_DATE,
+            end_date=END_DATE,
+        )
 
-            assert result.start_date == datetime(2024, 1, 1)
-            assert result.end_date == datetime(2024, 1, 31)
-            assert result.duration_days == 30
+        assert result.start_date == START_DATE
+        assert result.end_date == END_DATE
+        assert result.duration_days == 30
 
-    def test_generate_result_populates_performance(self) -> None:
+    def test_generate_result_populates_performance(self, metrics_mocks) -> None:
         broker = create_mock_broker(
             initial_equity=Decimal("100000"),
             final_equity=Decimal("120000"),
@@ -51,82 +69,46 @@ class TestBacktestReporterGenerateResult:
             total_return_usd=Decimal("20000"),
         )
         reporter = BacktestReporter(broker)
-        mock_stats = create_mock_trade_stats()
-        mock_risk = create_mock_risk_metrics()
 
-        with (
-            patch(
-                "gpt_trader.backtesting.metrics.report.calculate_trade_statistics",
-                return_value=mock_stats,
-            ),
-            patch(
-                "gpt_trader.backtesting.metrics.report.calculate_risk_metrics",
-                return_value=mock_risk,
-            ),
-        ):
-            result = reporter.generate_result(
-                start_date=datetime(2024, 1, 1),
-                end_date=datetime(2024, 1, 31),
-            )
+        result = reporter.generate_result(
+            start_date=START_DATE,
+            end_date=END_DATE,
+        )
 
-            assert result.initial_equity == Decimal("100000")
-            assert result.final_equity == Decimal("120000")
-            assert result.total_return == Decimal("20")
-            assert result.total_return_usd == Decimal("20000")
+        assert result.initial_equity == Decimal("100000")
+        assert result.final_equity == Decimal("120000")
+        assert result.total_return == Decimal("20")
+        assert result.total_return_usd == Decimal("20000")
 
-    def test_generate_result_populates_trade_stats(self) -> None:
+    def test_generate_result_populates_trade_stats(self, metrics_mocks) -> None:
         broker = create_mock_broker()
         reporter = BacktestReporter(broker)
-        mock_stats = create_mock_trade_stats()
-        mock_risk = create_mock_risk_metrics()
 
-        with (
-            patch(
-                "gpt_trader.backtesting.metrics.report.calculate_trade_statistics",
-                return_value=mock_stats,
-            ),
-            patch(
-                "gpt_trader.backtesting.metrics.report.calculate_risk_metrics",
-                return_value=mock_risk,
-            ),
-        ):
-            result = reporter.generate_result(
-                start_date=datetime(2024, 1, 1),
-                end_date=datetime(2024, 1, 31),
-            )
+        result = reporter.generate_result(
+            start_date=START_DATE,
+            end_date=END_DATE,
+        )
 
-            assert result.total_trades == 50
-            assert result.winning_trades == 30
-            assert result.losing_trades == 20
-            assert result.win_rate == Decimal("60")
+        assert result.total_trades == 50
+        assert result.winning_trades == 30
+        assert result.losing_trades == 20
+        assert result.win_rate == Decimal("60")
 
-    def test_generate_result_populates_risk_metrics(self) -> None:
+    def test_generate_result_populates_risk_metrics(self, metrics_mocks) -> None:
         broker = create_mock_broker()
         reporter = BacktestReporter(broker)
-        mock_stats = create_mock_trade_stats()
-        mock_risk = create_mock_risk_metrics()
 
-        with (
-            patch(
-                "gpt_trader.backtesting.metrics.report.calculate_trade_statistics",
-                return_value=mock_stats,
-            ),
-            patch(
-                "gpt_trader.backtesting.metrics.report.calculate_risk_metrics",
-                return_value=mock_risk,
-            ),
-        ):
-            result = reporter.generate_result(
-                start_date=datetime(2024, 1, 1),
-                end_date=datetime(2024, 1, 31),
-            )
+        result = reporter.generate_result(
+            start_date=START_DATE,
+            end_date=END_DATE,
+        )
 
-            assert result.max_drawdown == Decimal("15.5")
-            assert result.max_drawdown_usd == Decimal("15500")
-            assert result.sharpe_ratio == Decimal("1.5")
-            assert result.sortino_ratio == Decimal("2.1")
+        assert result.max_drawdown == Decimal("15.5")
+        assert result.max_drawdown_usd == Decimal("15500")
+        assert result.sharpe_ratio == Decimal("1.5")
+        assert result.sortino_ratio == Decimal("2.1")
 
-    def test_generate_result_calculates_unrealized_pnl(self) -> None:
+    def test_generate_result_calculates_unrealized_pnl(self, metrics_mocks) -> None:
         broker = create_mock_broker()
         # Add mock positions with unrealized PnL
         mock_position1 = MagicMock()
@@ -136,22 +118,10 @@ class TestBacktestReporterGenerateResult:
         broker.positions = {"BTC-USD": mock_position1, "ETH-USD": mock_position2}
 
         reporter = BacktestReporter(broker)
-        mock_stats = create_mock_trade_stats()
-        mock_risk = create_mock_risk_metrics()
 
-        with (
-            patch(
-                "gpt_trader.backtesting.metrics.report.calculate_trade_statistics",
-                return_value=mock_stats,
-            ),
-            patch(
-                "gpt_trader.backtesting.metrics.report.calculate_risk_metrics",
-                return_value=mock_risk,
-            ),
-        ):
-            result = reporter.generate_result(
-                start_date=datetime(2024, 1, 1),
-                end_date=datetime(2024, 1, 31),
-            )
+        result = reporter.generate_result(
+            start_date=START_DATE,
+            end_date=END_DATE,
+        )
 
-            assert result.unrealized_pnl == Decimal("800")
+        assert result.unrealized_pnl == Decimal("800")

--- a/var/agents/testing/source_test_map.json
+++ b/var/agents/testing/source_test_map.json
@@ -161,6 +161,7 @@
     ],
     "gpt_trader.backtesting.metrics.risk": [
       "tests/unit/gpt_trader/backtesting/metrics/test_report_generate_csv_row.py",
+      "tests/unit/gpt_trader/backtesting/metrics/test_report_generate_result.py",
       "tests/unit/gpt_trader/backtesting/metrics/test_report_generate_summary.py",
       "tests/unit/gpt_trader/backtesting/metrics/test_risk_calculate_risk_metrics.py",
       "tests/unit/gpt_trader/backtesting/metrics/test_risk_drawdown_metrics.py",
@@ -175,6 +176,7 @@
       "tests/unit/gpt_trader/features/optimize/objectives/test_single_trade_quality_objectives.py"
     ],
     "gpt_trader.backtesting.metrics.statistics": [
+      "tests/unit/gpt_trader/backtesting/metrics/test_report_generate_result.py",
       "tests/unit/gpt_trader/backtesting/metrics/test_statistics_calculate_trade_statistics.py",
       "tests/unit/gpt_trader/backtesting/metrics/test_statistics_pnl_metrics.py",
       "tests/unit/gpt_trader/backtesting/metrics/test_statistics_position_metrics.py",
@@ -2642,7 +2644,9 @@
       "gpt_trader.backtesting.metrics.risk"
     ],
     "tests/unit/gpt_trader/backtesting/metrics/test_report_generate_result.py": [
-      "gpt_trader.backtesting.metrics.report"
+      "gpt_trader.backtesting.metrics.report",
+      "gpt_trader.backtesting.metrics.risk",
+      "gpt_trader.backtesting.metrics.statistics"
     ],
     "tests/unit/gpt_trader/backtesting/metrics/test_report_generate_summary.py": [
       "gpt_trader.backtesting.metrics.report",

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -5254,7 +5254,7 @@
     "tests/unit/gpt_trader/backtesting/metrics/test_report_generate_result.py": [
       {
         "name": "TestBacktestReporterGenerateResult::test_generate_result_returns_backtest_result",
-        "line": 21,
+        "line": 51,
         "markers": [
           "unit"
         ],
@@ -5263,7 +5263,7 @@
       },
       {
         "name": "TestBacktestReporterGenerateResult::test_generate_result_populates_performance",
-        "line": 46,
+        "line": 64,
         "markers": [
           "unit"
         ],
@@ -5272,7 +5272,7 @@
       },
       {
         "name": "TestBacktestReporterGenerateResult::test_generate_result_populates_trade_stats",
-        "line": 77,
+        "line": 83,
         "markers": [
           "unit"
         ],
@@ -5281,7 +5281,7 @@
       },
       {
         "name": "TestBacktestReporterGenerateResult::test_generate_result_populates_risk_metrics",
-        "line": 103,
+        "line": 97,
         "markers": [
           "unit"
         ],
@@ -5290,7 +5290,7 @@
       },
       {
         "name": "TestBacktestReporterGenerateResult::test_generate_result_calculates_unrealized_pnl",
-        "line": 129,
+        "line": 111,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary\n- replace patch context managers with monkeypatched calculation fixtures\n- reuse shared date constants and mock stats/risk fixtures\n- regenerate test inventory artifacts\n\n## Testing\n- uv run pytest -q tests/unit/gpt_trader/backtesting/metrics/test_report_generate_result.py\n- uv run python scripts/ci/check_test_hygiene.py\n- uv run python scripts/ci/check_legacy_test_triage.py\n- uv run python scripts/agents/generate_test_inventory.py