### PR TITLE
test(preflight): reduce patch density in test suite

### DIFF
--- a/tests/unit/gpt_trader/preflight/test_checks_test_suite.py
+++ b/tests/unit/gpt_trader/preflight/test_checks_test_suite.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import subprocess
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -11,124 +11,114 @@ from gpt_trader.preflight.checks.test_suite import check_test_suite
 from gpt_trader.preflight.core import PreflightCheck
 
 
+def _make_result(stdout: str, stderr: str = "") -> MagicMock:
+    result = MagicMock()
+    result.stdout = stdout
+    result.stderr = stderr
+    return result
+
+
+@pytest.fixture
+def run_stub(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    stub = MagicMock()
+    monkeypatch.setattr(subprocess, "run", stub)
+    return stub
+
+
 class TestCheckTestSuite:
     """Test test suite validation."""
 
-    def test_passes_when_all_tests_pass(self) -> None:
+    def test_passes_when_all_tests_pass(self, run_stub: MagicMock) -> None:
         """Should pass when pytest reports all tests passing."""
         checker = PreflightCheck(profile="dev")
 
-        mock_result = MagicMock()
-        mock_result.stdout = "15 passed in 2.5s"
-        mock_result.stderr = ""
-
-        with patch("subprocess.run", return_value=mock_result):
-            result = check_test_suite(checker)
+        run_stub.return_value = _make_result("15 passed in 2.5s")
+        result = check_test_suite(checker)
 
         assert result is True
         assert any("15 core tests passed" in s for s in checker.successes)
 
-    def test_fails_when_tests_fail(self) -> None:
+    def test_fails_when_tests_fail(self, run_stub: MagicMock) -> None:
         """Should fail when pytest reports failing tests."""
         checker = PreflightCheck(profile="dev")
 
-        mock_result = MagicMock()
-        mock_result.stdout = "12 passed, 3 failed in 2.5s"
-        mock_result.stderr = ""
-
-        with patch("subprocess.run", return_value=mock_result):
-            result = check_test_suite(checker)
+        run_stub.return_value = _make_result("12 passed, 3 failed in 2.5s")
+        result = check_test_suite(checker)
 
         assert result is False
         assert any("3 tests failed" in w for w in checker.warnings)
 
-    def test_fails_when_no_passed_in_output(self) -> None:
+    def test_fails_when_no_passed_in_output(self, run_stub: MagicMock) -> None:
         """Should fail when output doesn't contain 'passed'."""
         checker = PreflightCheck(profile="dev")
 
-        mock_result = MagicMock()
-        mock_result.stdout = "ERROR: No tests collected"
-        mock_result.stderr = ""
-
-        with patch("subprocess.run", return_value=mock_result):
-            result = check_test_suite(checker)
+        run_stub.return_value = _make_result("ERROR: No tests collected")
+        result = check_test_suite(checker)
 
         assert result is False
         assert any("failed" in e for e in checker.errors)
 
-    def test_fails_on_timeout(self) -> None:
+    def test_fails_on_timeout(self, run_stub: MagicMock) -> None:
         """Should fail when tests timeout."""
         checker = PreflightCheck(profile="dev")
 
-        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("pytest", 30)):
-            result = check_test_suite(checker)
+        run_stub.side_effect = subprocess.TimeoutExpired("pytest", 30)
+        result = check_test_suite(checker)
 
         assert result is False
         assert any("timed out" in e for e in checker.errors)
 
-    def test_fails_on_exception(self) -> None:
+    def test_fails_on_exception(self, run_stub: MagicMock) -> None:
         """Should fail when subprocess raises an exception."""
         checker = PreflightCheck(profile="dev")
 
-        with patch("subprocess.run", side_effect=FileNotFoundError("pytest not found")):
-            result = check_test_suite(checker)
+        run_stub.side_effect = FileNotFoundError("pytest not found")
+        result = check_test_suite(checker)
 
         assert result is False
         assert any("Failed to run tests" in e for e in checker.errors)
 
-    def test_shows_output_when_verbose(self, capsys: pytest.CaptureFixture) -> None:
+    def test_shows_output_when_verbose(
+        self, capsys: pytest.CaptureFixture, run_stub: MagicMock
+    ) -> None:
         """Should show output when verbose and tests fail."""
         checker = PreflightCheck(profile="dev", verbose=True)
 
-        mock_result = MagicMock()
-        mock_result.stdout = "Error details here"
-        mock_result.stderr = "Some warnings"
-
-        with patch("subprocess.run", return_value=mock_result):
-            check_test_suite(checker)
+        run_stub.return_value = _make_result("Error details here", "Some warnings")
+        check_test_suite(checker)
 
         captured = capsys.readouterr()
         assert "Error details here" in captured.out
 
-    def test_prints_section_header(self, capsys: pytest.CaptureFixture) -> None:
+    def test_prints_section_header(
+        self, capsys: pytest.CaptureFixture, run_stub: MagicMock
+    ) -> None:
         """Should print section header."""
         checker = PreflightCheck(profile="dev")
 
-        mock_result = MagicMock()
-        mock_result.stdout = "10 passed"
-        mock_result.stderr = ""
-
-        with patch("subprocess.run", return_value=mock_result):
-            check_test_suite(checker)
+        run_stub.return_value = _make_result("10 passed")
+        check_test_suite(checker)
 
         captured = capsys.readouterr()
         assert "TEST SUITE" in captured.out
 
-    def test_parses_passed_count_correctly(self) -> None:
+    def test_parses_passed_count_correctly(self, run_stub: MagicMock) -> None:
         """Should correctly parse various passed count formats."""
         checker = PreflightCheck(profile="dev")
 
-        mock_result = MagicMock()
-        mock_result.stdout = "===== 157 passed, 2 skipped in 5.23s ====="
-        mock_result.stderr = ""
-
-        with patch("subprocess.run", return_value=mock_result):
-            result = check_test_suite(checker)
+        run_stub.return_value = _make_result("===== 157 passed, 2 skipped in 5.23s =====")
+        result = check_test_suite(checker)
 
         assert result is True
         assert any("157 core tests passed" in s for s in checker.successes)
 
-    def test_handles_passed_without_count(self) -> None:
+    def test_handles_passed_without_count(self, run_stub: MagicMock) -> None:
         """Should handle 'passed' keyword without extractable count."""
         checker = PreflightCheck(profile="dev")
 
-        mock_result = MagicMock()
         # "passed" is present but no number before it
-        mock_result.stdout = "All tests passed successfully"
-        mock_result.stderr = ""
-
-        with patch("subprocess.run", return_value=mock_result):
-            result = check_test_suite(checker)
+        run_stub.return_value = _make_result("All tests passed successfully")
+        result = check_test_suite(checker)
 
         # Should still pass since "passed" is in output
         assert result is True

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -39294,7 +39294,7 @@
     "tests/unit/gpt_trader/preflight/test_checks_test_suite.py": [
       {
         "name": "TestCheckTestSuite::test_passes_when_all_tests_pass",
-        "line": 17,
+        "line": 31,
         "markers": [
           "unit"
         ],
@@ -39303,7 +39303,7 @@
       },
       {
         "name": "TestCheckTestSuite::test_fails_when_tests_fail",
-        "line": 31,
+        "line": 41,
         "markers": [
           "unit"
         ],
@@ -39312,7 +39312,7 @@
       },
       {
         "name": "TestCheckTestSuite::test_fails_when_no_passed_in_output",
-        "line": 45,
+        "line": 51,
         "markers": [
           "unit"
         ],
@@ -39321,7 +39321,7 @@
       },
       {
         "name": "TestCheckTestSuite::test_fails_on_timeout",
-        "line": 59,
+        "line": 61,
         "markers": [
           "unit"
         ],
@@ -39330,7 +39330,7 @@
       },
       {
         "name": "TestCheckTestSuite::test_fails_on_exception",
-        "line": 69,
+        "line": 71,
         "markers": [
           "unit"
         ],
@@ -39339,7 +39339,7 @@
       },
       {
         "name": "TestCheckTestSuite::test_shows_output_when_verbose",
-        "line": 79,
+        "line": 81,
         "markers": [
           "unit"
         ],
@@ -39357,7 +39357,7 @@
       },
       {
         "name": "TestCheckTestSuite::test_parses_passed_count_correctly",
-        "line": 107,
+        "line": 105,
         "markers": [
           "unit"
         ],
@@ -39366,7 +39366,7 @@
       },
       {
         "name": "TestCheckTestSuite::test_handles_passed_without_count",
-        "line": 121,
+        "line": 115,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary\n- replace patch context managers with a monkeypatched subprocess.run fixture\n- reuse a shared helper for stdout/stderr mock results\n- regenerate test inventory artifacts\n\n## Testing\n- uv run pytest -q tests/unit/gpt_trader/preflight/test_checks_test_suite.py\n- uv run python scripts/ci/check_test_hygiene.py\n- uv run python scripts/ci/check_legacy_test_triage.py\n- uv run python scripts/agents/generate_test_inventory.py