### PR TITLE
test(live_trade): reduce patch density in order preview core

### DIFF
--- a/var/agents/testing/source_test_map.json
+++ b/var/agents/testing/source_test_map.json
@@ -992,6 +992,7 @@
       "tests/unit/gpt_trader/features/live_trade/execution/test_order_event_recorder_submission_attempt.py",
       "tests/unit/gpt_trader/features/live_trade/execution/test_order_event_recorder_success.py",
       "tests/unit/gpt_trader/features/live_trade/execution/test_order_event_recorder_trade_event.py",
+      "tests/unit/gpt_trader/features/live_trade/execution/test_order_submission_core_record_preview.py",
       "tests/unit/gpt_trader/features/live_trade/execution/test_order_submission_core_record_rejection.py",
       "tests/unit/gpt_trader/features/live_trade/execution/test_order_submission_observability_latency_metrics.py"
     ],
@@ -3838,6 +3839,7 @@
     ],
     "tests/unit/gpt_trader/features/live_trade/execution/test_order_submission_core_record_preview.py": [
       "gpt_trader.core",
+      "gpt_trader.features.live_trade.execution.order_event_recorder",
       "gpt_trader.features.live_trade.execution.order_submission"
     ],
     "tests/unit/gpt_trader/features/live_trade/execution/test_order_submission_core_record_rejection.py": [

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -23131,7 +23131,7 @@
     "tests/unit/gpt_trader/features/live_trade/execution/test_order_submission_core_record_preview.py": [
       {
         "name": "TestRecordPreview::test_record_preview_with_preview_data",
-        "line": 17,
+        "line": 32,
         "markers": [
           "unit"
         ],
@@ -23140,7 +23140,7 @@
       },
       {
         "name": "TestRecordPreview::test_record_preview_with_none_preview_skips",
-        "line": 42,
+        "line": 53,
         "markers": [
           "unit"
         ],
@@ -23149,7 +23149,7 @@
       },
       {
         "name": "TestRecordPreview::test_record_preview_market_price",
-        "line": 61,
+        "line": 70,
         "markers": [
           "unit"
         ],
@@ -23158,7 +23158,7 @@
       },
       {
         "name": "TestRecordPreview::test_record_preview_handles_logger_exception",
-        "line": 85,
+        "line": 89,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary\n- replace patch decorators with monkeypatched recorder fixtures\n- inject shared emit_metric/logger stubs in preview tests\n- regenerate test inventory artifacts\n\n## Testing\n- uv run pytest -q tests/unit/gpt_trader/features/live_trade/execution/test_order_submission_core_record_preview.py\n- uv run python scripts/ci/check_test_hygiene.py\n- uv run python scripts/ci/check_legacy_test_triage.py\n- uv run python scripts/agents/generate_test_inventory.py