### PR TITLE
test(monitoring): reduce patch density in positions reconciler

### DIFF
--- a/tests/unit/gpt_trader/monitoring/system/test_positions_reconciler_edges.py
+++ b/tests/unit/gpt_trader/monitoring/system/test_positions_reconciler_edges.py
@@ -3,31 +3,58 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
+import gpt_trader.monitoring.system as system_module
+import gpt_trader.monitoring.system.positions as positions_module
 from gpt_trader.monitoring.system.positions import PositionReconciler
 
 
-def test_normalize_positions_skips_missing_symbol_and_handles_quantity_errors() -> None:
+@pytest.fixture
+def positions_logger(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    mock_logger = MagicMock()
+    monkeypatch.setattr(positions_module, "logger", mock_logger)
+    return mock_logger
+
+
+@pytest.fixture
+def quantity_from_mock(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    mock_quantity = MagicMock()
+    monkeypatch.setattr(positions_module, "quantity_from", mock_quantity)
+    return mock_quantity
+
+
+@pytest.fixture
+def emit_metric_mock(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    mock_emit = MagicMock()
+    monkeypatch.setattr(positions_module, "emit_metric", mock_emit)
+    return mock_emit
+
+
+@pytest.fixture
+def plog(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    logger = MagicMock()
+    monkeypatch.setattr(system_module, "get_logger", lambda: logger)
+    return logger
+
+
+def test_normalize_positions_skips_missing_symbol_and_handles_quantity_errors(
+    positions_logger: MagicMock,
+    quantity_from_mock: MagicMock,
+) -> None:
     reconciler = PositionReconciler(event_store=MagicMock(), bot_id="bot-1")
     positions = [
         SimpleNamespace(symbol=None, side="LONG"),
         SimpleNamespace(symbol="BTC-USD", side="LONG"),
     ]
 
-    with (
-        patch(
-            "gpt_trader.monitoring.system.positions.quantity_from",
-            side_effect=RuntimeError("bad quantity"),
-        ),
-        patch("gpt_trader.monitoring.system.positions.logger") as mock_logger,
-    ):
-        normalized = reconciler._normalize_positions(positions)
+    quantity_from_mock.side_effect = RuntimeError("bad quantity")
+    normalized = reconciler._normalize_positions(positions)
 
     assert normalized == {}
-    mock_logger.exception.assert_called_once()
+    positions_logger.exception.assert_called_once()
 
 
 def test_calculate_diff_tracks_changed_added_removed() -> None:
@@ -63,39 +90,35 @@ async def test_fetch_positions_returns_empty_on_error() -> None:
     assert await reconciler._fetch_positions(bot) == []
 
 
-def test_emit_position_changes_success_calls_log_and_emit_metric() -> None:
+def test_emit_position_changes_success_calls_log_and_emit_metric(
+    emit_metric_mock: MagicMock,
+    plog: MagicMock,
+) -> None:
     reconciler = PositionReconciler(event_store=MagicMock(), bot_id="bot-1")
     changes = {
         "BTC-USD": {"old": {}, "new": {"quantity": "1.5", "side": "LONG"}},
         "ETH-USD": {"old": {}, "new": {"quantity": "0", "side": ""}},
     }
-    plog = MagicMock()
 
-    with (
-        patch("gpt_trader.monitoring.system.get_logger", return_value=plog),
-        patch("gpt_trader.monitoring.system.positions.emit_metric") as mock_emit,
-    ):
-        reconciler._emit_position_changes(None, changes)
+    reconciler._emit_position_changes(None, changes)
 
     assert plog.log_position_change.call_count == 2
-    payload = mock_emit.call_args[0][2]
+    payload = emit_metric_mock.call_args[0][2]
     assert payload["event_type"] == "position_drift"
     assert payload["changes"] == changes
 
 
-def test_emit_position_changes_logs_debug_on_failure_and_emits_metric() -> None:
+def test_emit_position_changes_logs_debug_on_failure_and_emits_metric(
+    emit_metric_mock: MagicMock,
+    plog: MagicMock,
+    positions_logger: MagicMock,
+) -> None:
     reconciler = PositionReconciler(event_store=MagicMock(), bot_id="bot-1")
     changes = {"BTC-USD": {"old": {}, "new": {"quantity": "1", "side": "LONG"}}}
-    plog = MagicMock()
     plog.log_position_change.side_effect = RuntimeError("boom")
 
-    with (
-        patch("gpt_trader.monitoring.system.get_logger", return_value=plog),
-        patch("gpt_trader.monitoring.system.positions.emit_metric") as mock_emit,
-        patch("gpt_trader.monitoring.system.positions.logger") as mock_logger,
-    ):
-        reconciler._emit_position_changes(None, changes)
+    reconciler._emit_position_changes(None, changes)
 
-    mock_logger.debug.assert_called_once()
-    payload = mock_emit.call_args[0][2]
+    positions_logger.debug.assert_called_once()
+    payload = emit_metric_mock.call_args[0][2]
     assert payload["event_type"] == "position_drift"

--- a/var/agents/testing/source_test_map.json
+++ b/var/agents/testing/source_test_map.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "summary": {
     "tests_scanned": 915,
-    "source_modules": 348,
+    "source_modules": 349,
     "unresolved_modules": 3
   },
   "source_to_tests": {
@@ -1603,6 +1603,9 @@
       "tests/unit/gpt_trader/tui/test_app_core.py",
       "tests/unit/gpt_trader/tui/test_state_resilience_and_performance.py",
       "tests/unit/gpt_trader/tui/test_state_update_from_bot_status.py"
+    ],
+    "gpt_trader.monitoring.system": [
+      "tests/unit/gpt_trader/monitoring/system/test_positions_reconciler_edges.py"
     ],
     "gpt_trader.monitoring.system.metrics": [
       "tests/unit/gpt_trader/monitoring/system/test_metrics.py"
@@ -4612,6 +4615,7 @@
       "gpt_trader.monitoring.system.metrics"
     ],
     "tests/unit/gpt_trader/monitoring/system/test_positions_reconciler_edges.py": [
+      "gpt_trader.monitoring.system",
       "gpt_trader.monitoring.system.positions"
     ],
     "tests/unit/gpt_trader/monitoring/test_alert_types_alert_creation.py": [
@@ -5977,6 +5981,7 @@
     "gpt_trader.monitoring.notifications.backends": "src/gpt_trader/monitoring/notifications/backends.py",
     "gpt_trader.monitoring.notifications.service": "src/gpt_trader/monitoring/notifications/service.py",
     "gpt_trader.monitoring.system.metrics": "src/gpt_trader/monitoring/system/metrics.py",
+    "gpt_trader.monitoring.system": "src/gpt_trader/monitoring/system/__init__.py",
     "gpt_trader.monitoring.system.positions": "src/gpt_trader/monitoring/system/positions.py",
     "gpt_trader.monitoring.guards": "src/gpt_trader/monitoring/guards/__init__.py",
     "gpt_trader.monitoring.guards.manager": "src/gpt_trader/monitoring/guards/manager.py",

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -34862,7 +34862,7 @@
     "tests/unit/gpt_trader/monitoring/system/test_positions_reconciler_edges.py": [
       {
         "name": "test_normalize_positions_skips_missing_symbol_and_handles_quantity_errors",
-        "line": 13,
+        "line": 43,
         "markers": [
           "unit"
         ],
@@ -34870,7 +34870,7 @@
       },
       {
         "name": "test_calculate_diff_tracks_changed_added_removed",
-        "line": 33,
+        "line": 60,
         "markers": [
           "unit"
         ],
@@ -34878,7 +34878,7 @@
       },
       {
         "name": "test_fetch_positions_returns_empty_on_error",
-        "line": 55,
+        "line": 82,
         "markers": [
           "asyncio",
           "unit"
@@ -34887,7 +34887,7 @@
       },
       {
         "name": "test_emit_position_changes_success_calls_log_and_emit_metric",
-        "line": 66,
+        "line": 93,
         "markers": [
           "unit"
         ],
@@ -34895,7 +34895,7 @@
       },
       {
         "name": "test_emit_position_changes_logs_debug_on_failure_and_emits_metric",
-        "line": 86,
+        "line": 111,
         "markers": [
           "unit"
         ],
@@ -36686,7 +36686,7 @@
     "tests/unit/gpt_trader/monitoring/test_profiling.py": [
       {
         "name": "TestProfileSample::test_profile_sample_creation",
-        "line": 27,
+        "line": 28,
         "markers": [
           "unit"
         ],
@@ -36695,7 +36695,7 @@
       },
       {
         "name": "TestProfileSample::test_profile_sample_with_labels",
-        "line": 35,
+        "line": 36,
         "markers": [
           "unit"
         ],
@@ -36704,7 +36704,7 @@
       },
       {
         "name": "TestProfileSample::test_profile_sample_to_dict",
-        "line": 42,
+        "line": 43,
         "markers": [
           "unit"
         ],
@@ -36713,7 +36713,7 @@
       },
       {
         "name": "TestRecordProfile::test_record_profile_calls_histogram",
-        "line": 61,
+        "line": 62,
         "markers": [
           "unit"
         ],
@@ -36722,7 +36722,7 @@
       },
       {
         "name": "TestRecordProfile::test_record_profile_with_labels",
-        "line": 73,
+        "line": 74,
         "markers": [
           "unit"
         ],
@@ -36731,7 +36731,7 @@
       },
       {
         "name": "TestProfileSpan::test_profile_span_records_duration",
-        "line": 92,
+        "line": 93,
         "markers": [
           "unit"
         ],
@@ -36740,7 +36740,7 @@
       },
       {
         "name": "TestProfileSpan::test_profile_span_with_labels",
-        "line": 108,
+        "line": 109,
         "markers": [
           "unit"
         ],
@@ -36749,7 +36749,7 @@
       },
       {
         "name": "TestProfileSpan::test_profile_span_tolerates_exceptions",
-        "line": 116,
+        "line": 117,
         "markers": [
           "unit"
         ],
@@ -36758,7 +36758,7 @@
       },
       {
         "name": "TestProfileSpan::test_profile_span_updates_sample_timestamp",
-        "line": 140,
+        "line": 139,
         "markers": [
           "unit"
         ],
@@ -36767,7 +36767,7 @@
       },
       {
         "name": "TestProfileSpan::test_profile_span_measures_duration",
-        "line": 153,
+        "line": 150,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary\n- replace patch blocks with monkeypatched fixtures for logger, emit_metric, and quantity parsing\n- reuse a shared plog fixture for position change logging\n- regenerate test inventory artifacts\n\n## Testing\n- uv run pytest -q tests/unit/gpt_trader/monitoring/system/test_positions_reconciler_edges.py\n- uv run python scripts/ci/check_test_hygiene.py\n- uv run python scripts/ci/check_legacy_test_triage.py\n- uv run python scripts/agents/generate_test_inventory.py