### PR TITLE
test(monitoring): reduce patch density in metrics

### DIFF
--- a/tests/unit/gpt_trader/monitoring/system/test_metrics.py
+++ b/tests/unit/gpt_trader/monitoring/system/test_metrics.py
@@ -4,9 +4,44 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
+import pytest
+
+import gpt_trader.monitoring.system as system_module
+import gpt_trader.monitoring.system.metrics as metrics_module
 from gpt_trader.monitoring.system.metrics import MetricsPublisher
+
+
+@pytest.fixture
+def emit_metric_mock(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    mock_emit = MagicMock()
+    monkeypatch.setattr(metrics_module, "emit_metric", mock_emit)
+    return mock_emit
+
+
+@pytest.fixture
+def plog_mock(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    mock_logger = MagicMock()
+    monkeypatch.setattr(system_module, "get_logger", lambda: mock_logger)
+    return mock_logger
+
+
+@pytest.fixture
+def metrics_logger(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    mock_logger = MagicMock()
+    monkeypatch.setattr(metrics_module, "logger", mock_logger)
+    return mock_logger
+
+
+@pytest.fixture
+def publisher(tmp_path: Path) -> MetricsPublisher:
+    return MetricsPublisher(
+        event_store=MagicMock(),
+        bot_id="bot-123",
+        profile="TEST",
+        base_dir=tmp_path,
+    )
 
 
 class TestMetricsPublisherInit:
@@ -27,40 +62,32 @@ class TestMetricsPublisherInit:
 class TestMetricsPublisherPublish:
     """Tests for MetricsPublisher.publish method."""
 
-    def test_publishes_to_event_store(self, tmp_path: Path) -> None:
-        event_store = MagicMock()
-        publisher = MetricsPublisher(
-            event_store=event_store,
-            bot_id="bot-123",
-            profile="TEST",
-            base_dir=tmp_path,
-        )
+    def test_publishes_to_event_store(
+        self,
+        emit_metric_mock: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+        publisher: MetricsPublisher,
+    ) -> None:
+        monkeypatch.setattr(publisher, "_log_update", MagicMock())
+        publisher.publish({"cycle": 1, "pnl": 100.0})
 
-        with patch("gpt_trader.monitoring.system.metrics.emit_metric") as mock_emit:
-            with patch.object(publisher, "_log_update"):
-                publisher.publish({"cycle": 1, "pnl": 100.0})
+        emit_metric_mock.assert_called_once()
+        call_args = emit_metric_mock.call_args
+        assert call_args[0][1] == "bot-123"
+        assert call_args[0][2]["event_type"] == "cycle_metrics"
+        assert call_args[0][2]["cycle"] == 1
 
-            mock_emit.assert_called_once()
-            call_args = mock_emit.call_args
-            assert call_args[0][1] == "bot-123"
-            assert call_args[0][2]["event_type"] == "cycle_metrics"
-            assert call_args[0][2]["cycle"] == 1
-
-    def test_writes_snapshot(self, tmp_path: Path) -> None:
-        event_store = MagicMock()
-        publisher = MetricsPublisher(
-            event_store=event_store,
-            bot_id="bot-123",
-            profile="TEST",
-            base_dir=tmp_path,
-        )
-
-        with patch("gpt_trader.monitoring.system.metrics.emit_metric"):
-            with patch.object(publisher, "_log_update"):
-                publisher.publish({"cycle": 1, "pnl": 100.0})
+    def test_writes_snapshot(
+        self,
+        emit_metric_mock: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+        publisher: MetricsPublisher,
+    ) -> None:
+        monkeypatch.setattr(publisher, "_log_update", MagicMock())
+        publisher.publish({"cycle": 1, "pnl": 100.0})
 
         # Check file was created
-        metrics_path = tmp_path / "TEST" / "metrics.json"
+        metrics_path = publisher._base_dir / publisher._profile / "metrics.json"
         assert metrics_path.exists()
 
         with metrics_path.open() as f:
@@ -72,116 +99,65 @@ class TestMetricsPublisherPublish:
 class TestMetricsPublisherWriteSnapshot:
     """Tests for MetricsPublisher._write_snapshot method."""
 
-    def test_creates_directories(self, tmp_path: Path) -> None:
-        event_store = MagicMock()
-        publisher = MetricsPublisher(
-            event_store=event_store,
-            bot_id="bot-123",
-            profile="TEST",
-            base_dir=tmp_path,
-        )
-
+    def test_creates_directories(self, tmp_path: Path, publisher: MetricsPublisher) -> None:
         publisher._write_snapshot({"test": "data"})
 
         expected_dir = tmp_path / "TEST"
         assert expected_dir.exists()
 
-    def test_handles_write_errors(self, tmp_path: Path) -> None:
-        event_store = MagicMock()
-        publisher = MetricsPublisher(
-            event_store=event_store,
-            bot_id="bot-123",
-            profile="TEST",
-            base_dir=tmp_path,
-        )
-
+    def test_handles_write_errors(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        metrics_logger: MagicMock,
+        publisher: MetricsPublisher,
+    ) -> None:
         # Mock _target_dirs to return an unwritable path
-        with patch.object(publisher, "_target_dirs", return_value=[Path("/nonexistent/path")]):
-            # Should not raise, just log
-            with patch("gpt_trader.monitoring.system.metrics.logger") as mock_logger:
-                publisher._write_snapshot({"test": "data"})
-                mock_logger.debug.assert_called_once()
+        monkeypatch.setattr(publisher, "_target_dirs", lambda: [Path("/nonexistent/path")])
+        # Should not raise, just log
+        publisher._write_snapshot({"test": "data"})
+        metrics_logger.debug.assert_called_once()
 
 
 class TestMetricsPublisherLogUpdate:
     """Tests for MetricsPublisher._log_update method."""
 
-    def test_logs_metrics(self, tmp_path: Path) -> None:
-        event_store = MagicMock()
-        publisher = MetricsPublisher(
-            event_store=event_store,
-            bot_id="bot-123",
-            profile="TEST",
-            base_dir=tmp_path,
+    def test_logs_metrics(self, plog_mock: MagicMock, publisher: MetricsPublisher) -> None:
+        publisher._log_update({"cycle": 1, "pnl": 100.0})
+
+        plog_mock.log_event.assert_called_once()
+
+    def test_filters_large_fields(self, plog_mock: MagicMock, publisher: MetricsPublisher) -> None:
+        publisher._log_update(
+            {
+                "cycle": 1,
+                "pnl": 100.0,
+                "positions": [{"sym": "BTC"}],  # Should be filtered
+                "decisions": [{"action": "buy"}],  # Should be filtered
+            }
         )
 
-        with patch("gpt_trader.monitoring.system.get_logger") as mock_get_plog:
-            mock_logger = MagicMock()
-            mock_get_plog.return_value = mock_logger
+        call_kwargs = plog_mock.log_event.call_args[1]
+        assert "cycle" in call_kwargs
+        assert "pnl" in call_kwargs
+        assert "positions" not in call_kwargs
+        assert "decisions" not in call_kwargs
 
-            publisher._log_update({"cycle": 1, "pnl": 100.0})
-
-            mock_logger.log_event.assert_called_once()
-
-    def test_filters_large_fields(self, tmp_path: Path) -> None:
-        event_store = MagicMock()
-        publisher = MetricsPublisher(
-            event_store=event_store,
-            bot_id="bot-123",
-            profile="TEST",
-            base_dir=tmp_path,
-        )
-
-        with patch("gpt_trader.monitoring.system.get_logger") as mock_get_plog:
-            mock_logger = MagicMock()
-            mock_get_plog.return_value = mock_logger
-
-            publisher._log_update(
-                {
-                    "cycle": 1,
-                    "pnl": 100.0,
-                    "positions": [{"sym": "BTC"}],  # Should be filtered
-                    "decisions": [{"action": "buy"}],  # Should be filtered
-                }
-            )
-
-            call_kwargs = mock_logger.log_event.call_args[1]
-            assert "cycle" in call_kwargs
-            assert "pnl" in call_kwargs
-            assert "positions" not in call_kwargs
-            assert "decisions" not in call_kwargs
-
-    def test_handles_log_errors(self, tmp_path: Path) -> None:
-        event_store = MagicMock()
-        publisher = MetricsPublisher(
-            event_store=event_store,
-            bot_id="bot-123",
-            profile="TEST",
-            base_dir=tmp_path,
-        )
-
-        with patch("gpt_trader.monitoring.system.get_logger") as mock_get_plog:
-            mock_logger = MagicMock()
-            mock_logger.log_event.side_effect = Exception("Log error")
-            mock_get_plog.return_value = mock_logger
-            with patch("gpt_trader.monitoring.system.metrics.logger") as mock_logger_internal:
-                publisher._log_update({"cycle": 1})
-                mock_logger.log_event.assert_called_once()
-                mock_logger_internal.debug.assert_called_once()
+    def test_handles_log_errors(
+        self,
+        plog_mock: MagicMock,
+        metrics_logger: MagicMock,
+        publisher: MetricsPublisher,
+    ) -> None:
+        plog_mock.log_event.side_effect = Exception("Log error")
+        publisher._log_update({"cycle": 1})
+        plog_mock.log_event.assert_called_once()
+        metrics_logger.debug.assert_called_once()
 
 
 class TestMetricsPublisherWriteHealthStatus:
     """Tests for MetricsPublisher.write_health_status method."""
 
-    def test_writes_health_status(self, tmp_path: Path) -> None:
-        event_store = MagicMock()
-        publisher = MetricsPublisher(
-            event_store=event_store,
-            bot_id="bot-123",
-            profile="TEST",
-            base_dir=tmp_path,
-        )
-
+    def test_writes_health_status(self, tmp_path: Path, publisher: MetricsPublisher) -> None:
         publisher.write_health_status(ok=True, message="System healthy")
 
         health_path = tmp_path / "TEST" / "health.json"
@@ -194,15 +170,7 @@ class TestMetricsPublisherWriteHealthStatus:
             assert data["error"] == ""
             assert "timestamp" in data
 
-    def test_writes_unhealthy_status(self, tmp_path: Path) -> None:
-        event_store = MagicMock()
-        publisher = MetricsPublisher(
-            event_store=event_store,
-            bot_id="bot-123",
-            profile="TEST",
-            base_dir=tmp_path,
-        )
-
+    def test_writes_unhealthy_status(self, tmp_path: Path, publisher: MetricsPublisher) -> None:
         publisher.write_health_status(ok=False, error="Connection lost")
 
         health_path = tmp_path / "TEST" / "health.json"

--- a/var/agents/testing/source_test_map.json
+++ b/var/agents/testing/source_test_map.json
@@ -1605,6 +1605,7 @@
       "tests/unit/gpt_trader/tui/test_state_update_from_bot_status.py"
     ],
     "gpt_trader.monitoring.system": [
+      "tests/unit/gpt_trader/monitoring/system/test_metrics.py",
       "tests/unit/gpt_trader/monitoring/system/test_positions_reconciler_edges.py"
     ],
     "gpt_trader.monitoring.system.metrics": [
@@ -4612,6 +4613,7 @@
       "gpt_trader.monitoring.notifications.service"
     ],
     "tests/unit/gpt_trader/monitoring/system/test_metrics.py": [
+      "gpt_trader.monitoring.system",
       "gpt_trader.monitoring.system.metrics"
     ],
     "tests/unit/gpt_trader/monitoring/system/test_positions_reconciler_edges.py": [
@@ -5980,8 +5982,8 @@
     "gpt_trader.monitoring.guards.builtins": "src/gpt_trader/monitoring/guards/builtins.py",
     "gpt_trader.monitoring.notifications.backends": "src/gpt_trader/monitoring/notifications/backends.py",
     "gpt_trader.monitoring.notifications.service": "src/gpt_trader/monitoring/notifications/service.py",
-    "gpt_trader.monitoring.system.metrics": "src/gpt_trader/monitoring/system/metrics.py",
     "gpt_trader.monitoring.system": "src/gpt_trader/monitoring/system/__init__.py",
+    "gpt_trader.monitoring.system.metrics": "src/gpt_trader/monitoring/system/metrics.py",
     "gpt_trader.monitoring.system.positions": "src/gpt_trader/monitoring/system/positions.py",
     "gpt_trader.monitoring.guards": "src/gpt_trader/monitoring/guards/__init__.py",
     "gpt_trader.monitoring.guards.manager": "src/gpt_trader/monitoring/guards/manager.py",

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -34761,7 +34761,7 @@
     "tests/unit/gpt_trader/monitoring/system/test_metrics.py": [
       {
         "name": "TestMetricsPublisherInit::test_stores_config",
-        "line": 15,
+        "line": 50,
         "markers": [
           "unit"
         ],
@@ -34770,7 +34770,7 @@
       },
       {
         "name": "TestMetricsPublisherPublish::test_publishes_to_event_store",
-        "line": 30,
+        "line": 65,
         "markers": [
           "unit"
         ],
@@ -34779,7 +34779,7 @@
       },
       {
         "name": "TestMetricsPublisherPublish::test_writes_snapshot",
-        "line": 49,
+        "line": 80,
         "markers": [
           "unit"
         ],
@@ -34788,7 +34788,7 @@
       },
       {
         "name": "TestMetricsPublisherWriteSnapshot::test_creates_directories",
-        "line": 75,
+        "line": 102,
         "markers": [
           "unit"
         ],
@@ -34797,7 +34797,7 @@
       },
       {
         "name": "TestMetricsPublisherWriteSnapshot::test_handles_write_errors",
-        "line": 89,
+        "line": 108,
         "markers": [
           "unit"
         ],
@@ -34806,7 +34806,7 @@
       },
       {
         "name": "TestMetricsPublisherLogUpdate::test_logs_metrics",
-        "line": 109,
+        "line": 124,
         "markers": [
           "unit"
         ],
@@ -34815,7 +34815,7 @@
       },
       {
         "name": "TestMetricsPublisherLogUpdate::test_filters_large_fields",
-        "line": 126,
+        "line": 129,
         "markers": [
           "unit"
         ],
@@ -34824,7 +34824,7 @@
       },
       {
         "name": "TestMetricsPublisherLogUpdate::test_handles_log_errors",
-        "line": 154,
+        "line": 145,
         "markers": [
           "unit"
         ],
@@ -34833,7 +34833,7 @@
       },
       {
         "name": "TestMetricsPublisherWriteHealthStatus::test_writes_health_status",
-        "line": 176,
+        "line": 160,
         "markers": [
           "unit"
         ],
@@ -34842,7 +34842,7 @@
       },
       {
         "name": "TestMetricsPublisherWriteHealthStatus::test_writes_unhealthy_status",
-        "line": 197,
+        "line": 173,
         "markers": [
           "unit"
         ],
@@ -34851,7 +34851,7 @@
       },
       {
         "name": "TestTargetDirs::test_returns_profile_specific_path",
-        "line": 219,
+        "line": 187,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary\n- replace patch/patch.object blocks with monkeypatched fixtures and local stubs\n- reuse a shared MetricsPublisher fixture to keep tests compact and below hygiene limits\n- regenerate test inventory artifacts\n\n## Testing\n- uv run pytest -q tests/unit/gpt_trader/monitoring/system/test_metrics.py\n- uv run python scripts/ci/check_test_hygiene.py\n- uv run python scripts/ci/check_legacy_test_triage.py\n- uv run python scripts/agents/generate_test_inventory.py