### PR TITLE
test(live_trade): reduce patch density in submit order

### DIFF
--- a/var/agents/testing/source_test_map.json
+++ b/var/agents/testing/source_test_map.json
@@ -994,6 +994,7 @@
       "tests/unit/gpt_trader/features/live_trade/execution/test_order_event_recorder_trade_event.py",
       "tests/unit/gpt_trader/features/live_trade/execution/test_order_submission_core_record_preview.py",
       "tests/unit/gpt_trader/features/live_trade/execution/test_order_submission_core_record_rejection.py",
+      "tests/unit/gpt_trader/features/live_trade/execution/test_order_submission_flows_submit_order.py",
       "tests/unit/gpt_trader/features/live_trade/execution/test_order_submission_observability_latency_metrics.py"
     ],
     "gpt_trader.features.live_trade.execution.order_submission": [
@@ -3860,6 +3861,7 @@
     ],
     "tests/unit/gpt_trader/features/live_trade/execution/test_order_submission_flows_submit_order.py": [
       "gpt_trader.core",
+      "gpt_trader.features.live_trade.execution.order_event_recorder",
       "gpt_trader.features.live_trade.execution.order_submission",
       "gpt_trader.persistence.orders_store"
     ],

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -23247,7 +23247,7 @@
     "tests/unit/gpt_trader/features/live_trade/execution/test_order_submission_flows_submit_order.py": [
       {
         "name": "TestSubmitOrder::test_successful_order_submission",
-        "line": 24,
+        "line": 40,
         "markers": [
           "unit"
         ],
@@ -23256,7 +23256,7 @@
       },
       {
         "name": "TestSubmitOrder::test_rejected_order_returns_none",
-        "line": 56,
+        "line": 68,
         "markers": [
           "unit"
         ],
@@ -23265,7 +23265,7 @@
       },
       {
         "name": "TestSubmitOrder::test_broker_exception_returns_none",
-        "line": 92,
+        "line": 100,
         "markers": [
           "unit"
         ],
@@ -23274,7 +23274,7 @@
       },
       {
         "name": "TestSubmitOrder::test_order_with_none_result_returns_none",
-        "line": 120,
+        "line": 125,
         "markers": [
           "unit"
         ],
@@ -23283,7 +23283,7 @@
       },
       {
         "name": "TestSubmitOrder::test_order_with_none_result_persists_terminal_status",
-        "line": 148,
+        "line": 150,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary\n- replace patch decorators with monkeypatched recorder fixtures\n- keep submit_order assertions intact while reusing shared mocks\n- regenerate test inventory artifacts\n\n## Testing\n- uv run pytest -q tests/unit/gpt_trader/features/live_trade/execution/test_order_submission_flows_submit_order.py\n- uv run python scripts/ci/check_test_hygiene.py\n- uv run python scripts/ci/check_legacy_test_triage.py\n- uv run python scripts/agents/generate_test_inventory.py