### PR TITLE
test(live_trade): reduce patch density in bot init

### DIFF
--- a/tests/unit/gpt_trader/features/live_trade/test_bot_initialization.py
+++ b/tests/unit/gpt_trader/features/live_trade/test_bot_initialization.py
@@ -2,15 +2,28 @@
 
 from __future__ import annotations
 
-from unittest.mock import ANY, Mock, patch
+from unittest.mock import ANY, Mock
 
 import pytest
 
+import gpt_trader.features.live_trade.bot as bot_module
 from gpt_trader.features.live_trade.bot import TradingBot
 
 
 class TestTradingBotInitialization:
     """Test TradingBot initialization."""
+
+    @pytest.fixture
+    def engine_mock(self, monkeypatch: pytest.MonkeyPatch) -> Mock:
+        mock_engine = Mock()
+        monkeypatch.setattr(bot_module, "TradingEngine", mock_engine)
+        return mock_engine
+
+    @pytest.fixture
+    def context_mock(self, monkeypatch: pytest.MonkeyPatch) -> Mock:
+        mock_context = Mock()
+        monkeypatch.setattr(bot_module, "CoordinatorContext", mock_context)
+        return mock_context
 
     @pytest.fixture
     def mock_config(self) -> Mock:
@@ -20,7 +33,7 @@ class TestTradingBotInitialization:
         config.interval = 60
         return config
 
-    def test_init_with_config_only(self, mock_config: Mock) -> None:
+    def test_init_with_config_only(self, mock_config: Mock, engine_mock: Mock) -> None:
         """Test initialization with only config."""
         mock_container = Mock()
         # Set container attributes to None for this test
@@ -34,9 +47,8 @@ class TestTradingBotInitialization:
         mock_container.account_telemetry = Mock()
         mock_container.runtime_state = Mock()
 
-        with patch("gpt_trader.features.live_trade.bot.TradingEngine") as mock_engine:
-            mock_engine.return_value = Mock()
-            bot = TradingBot(config=mock_config, container=mock_container)
+        engine_mock.return_value = Mock()
+        bot = TradingBot(config=mock_config, container=mock_container)
 
         assert bot.broker is mock_container.broker
         assert bot.account_manager is mock_container.account_manager
@@ -44,17 +56,21 @@ class TestTradingBotInitialization:
         assert bot.risk_manager is mock_container.risk_manager
         assert bot.runtime_state is mock_container.runtime_state
 
-    def test_init_with_container(self, mock_config: Mock) -> None:
+    def test_init_with_container(self, mock_config: Mock, engine_mock: Mock) -> None:
         """Test initialization with container."""
         mock_container = Mock()
 
-        with patch("gpt_trader.features.live_trade.bot.TradingEngine") as mock_engine:
-            mock_engine.return_value = Mock()
-            bot = TradingBot(config=mock_config, container=mock_container)
+        engine_mock.return_value = Mock()
+        bot = TradingBot(config=mock_config, container=mock_container)
 
         assert bot.container is mock_container
 
-    def test_init_creates_context(self, mock_config: Mock) -> None:
+    def test_init_creates_context(
+        self,
+        mock_config: Mock,
+        engine_mock: Mock,
+        context_mock: Mock,
+    ) -> None:
         """Test that initialization creates CoordinatorContext."""
         mock_container = Mock()
         mock_container.broker = Mock()
@@ -63,39 +79,36 @@ class TestTradingBotInitialization:
         mock_container.orders_store = Mock()
         mock_container.notification_service = Mock()
 
-        with (
-            patch("gpt_trader.features.live_trade.bot.TradingEngine") as mock_engine,
-            patch("gpt_trader.features.live_trade.bot.CoordinatorContext") as mock_context,
-        ):
-            mock_engine.return_value = Mock()
-            mock_context.return_value = Mock()
+        engine_mock.return_value = Mock()
+        context_mock.return_value = Mock()
 
-            bot = TradingBot(config=mock_config, container=mock_container)
+        bot = TradingBot(config=mock_config, container=mock_container)
 
-            mock_context.assert_called_once_with(
-                config=mock_config,
-                container=mock_container,
-                broker=mock_container.broker,
-                broker_calls=ANY,
-                symbols=tuple(mock_config.symbols),
-                risk_manager=mock_container.risk_manager,
-                event_store=mock_container.event_store,
-                orders_store=mock_container.orders_store,
-                notification_service=mock_container.notification_service,
-            )
-            assert bot.context is not None
+        context_mock.assert_called_once_with(
+            config=mock_config,
+            container=mock_container,
+            broker=mock_container.broker,
+            broker_calls=ANY,
+            symbols=tuple(mock_config.symbols),
+            risk_manager=mock_container.risk_manager,
+            event_store=mock_container.event_store,
+            orders_store=mock_container.orders_store,
+            notification_service=mock_container.notification_service,
+        )
+        assert bot.context is not None
 
-    def test_init_creates_engine(self, mock_config: Mock) -> None:
+    def test_init_creates_engine(self, mock_config: Mock, engine_mock: Mock) -> None:
         """Test that initialization creates TradingEngine."""
         mock_container = Mock()
-        with patch("gpt_trader.features.live_trade.bot.TradingEngine") as mock_engine:
-            mock_engine.return_value = Mock()
-            bot = TradingBot(config=mock_config, container=mock_container)
+        engine_mock.return_value = Mock()
+        bot = TradingBot(config=mock_config, container=mock_container)
 
-            assert bot.engine is not None
-            mock_engine.assert_called_once()
+        assert bot.engine is not None
+        engine_mock.assert_called_once()
 
-    def test_init_container_missing_optional_attributes(self, mock_config: Mock) -> None:
+    def test_init_container_missing_optional_attributes(
+        self, mock_config: Mock, engine_mock: Mock
+    ) -> None:
         """Test initialization handles container with missing optional attributes."""
         from types import SimpleNamespace
 
@@ -109,9 +122,8 @@ class TestTradingBotInitialization:
             # Optional attributes not set - getattr will return None
         )
 
-        with patch("gpt_trader.features.live_trade.bot.TradingEngine") as mock_engine:
-            mock_engine.return_value = Mock()
-            bot = TradingBot(config=mock_config, container=mock_container)
+        engine_mock.return_value = Mock()
+        bot = TradingBot(config=mock_config, container=mock_container)
 
         assert bot.broker is mock_container.broker
         assert bot.account_manager is None  # Not set in SimpleNamespace

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -27498,7 +27498,7 @@
     "tests/unit/gpt_trader/features/live_trade/test_bot_initialization.py": [
       {
         "name": "TestTradingBotInitialization::test_init_with_config_only",
-        "line": 23,
+        "line": 36,
         "markers": [
           "unit"
         ],
@@ -27507,7 +27507,7 @@
       },
       {
         "name": "TestTradingBotInitialization::test_init_with_container",
-        "line": 47,
+        "line": 59,
         "markers": [
           "unit"
         ],
@@ -27516,7 +27516,7 @@
       },
       {
         "name": "TestTradingBotInitialization::test_init_creates_context",
-        "line": 57,
+        "line": 68,
         "markers": [
           "unit"
         ],
@@ -27525,7 +27525,7 @@
       },
       {
         "name": "TestTradingBotInitialization::test_init_creates_engine",
-        "line": 88,
+        "line": 100,
         "markers": [
           "unit"
         ],
@@ -27534,7 +27534,7 @@
       },
       {
         "name": "TestTradingBotInitialization::test_init_container_missing_optional_attributes",
-        "line": 98,
+        "line": 109,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary\n- replace TradingEngine/CoordinatorContext patch blocks with monkeypatched fixtures\n- keep initialization assertions intact while simplifying setup\n- regenerate test inventory artifacts\n\n## Testing\n- uv run pytest -q tests/unit/gpt_trader/features/live_trade/test_bot_initialization.py\n- uv run python scripts/ci/check_test_hygiene.py\n- uv run python scripts/ci/check_legacy_test_triage.py\n- uv run python scripts/agents/generate_test_inventory.py