### PR TITLE
test(live_trade): reduce patch density in guard telemetry

### DIFF
--- a/var/agents/testing/source_test_map.json
+++ b/var/agents/testing/source_test_map.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "summary": {
     "tests_scanned": 915,
-    "source_modules": 349,
+    "source_modules": 350,
     "unresolved_modules": 3
   },
   "source_to_tests": {
@@ -963,7 +963,8 @@
       "tests/unit/gpt_trader/features/live_trade/engines/test_strategy_engine_chaos_guard_failures.py",
       "tests/unit/gpt_trader/features/live_trade/execution/test_api_health_guard.py",
       "tests/unit/gpt_trader/features/live_trade/execution/test_guard_manager_cache.py",
-      "tests/unit/gpt_trader/features/live_trade/execution/test_guard_manager_cancel_and_safe_run.py"
+      "tests/unit/gpt_trader/features/live_trade/execution/test_guard_manager_cancel_and_safe_run.py",
+      "tests/unit/gpt_trader/features/live_trade/execution/test_guard_manager_steps_and_telemetry.py"
     ],
     "gpt_trader.features.live_trade.execution.guards": [
       "tests/unit/gpt_trader/features/live_trade/execution/test_daily_loss_guard.py",
@@ -976,6 +977,9 @@
     ],
     "gpt_trader.features.live_trade.execution.guards.liquidation_buffer": [
       "tests/unit/gpt_trader/features/live_trade/execution/test_liquidation_buffer_guard.py"
+    ],
+    "gpt_trader.features.live_trade.execution.guards.pnl_telemetry": [
+      "tests/unit/gpt_trader/features/live_trade/execution/test_guard_manager_steps_and_telemetry.py"
     ],
     "gpt_trader.features.live_trade.execution.guards.volatility": [
       "tests/unit/gpt_trader/features/live_trade/execution/test_volatility_guard.py"
@@ -3768,6 +3772,8 @@
       "gpt_trader.features.live_trade.execution.guards"
     ],
     "tests/unit/gpt_trader/features/live_trade/execution/test_guard_manager_steps_and_telemetry.py": [
+      "gpt_trader.features.live_trade.execution.guard_manager",
+      "gpt_trader.features.live_trade.execution.guards.pnl_telemetry",
       "gpt_trader.features.live_trade.guard_errors"
     ],
     "tests/unit/gpt_trader/features/live_trade/execution/test_liquidation_buffer_guard.py": [
@@ -5906,6 +5912,7 @@
     "gpt_trader.features.live_trade.execution.broker_executor": "src/gpt_trader/features/live_trade/execution/broker_executor.py",
     "gpt_trader.features.live_trade.execution.guards": "src/gpt_trader/features/live_trade/execution/guards/__init__.py",
     "gpt_trader.features.live_trade.execution.guards.daily_loss": "src/gpt_trader/features/live_trade/execution/guards/daily_loss.py",
+    "gpt_trader.features.live_trade.execution.guards.pnl_telemetry": "src/gpt_trader/features/live_trade/execution/guards/pnl_telemetry.py",
     "gpt_trader.features.live_trade.execution.guards.liquidation_buffer": "src/gpt_trader/features/live_trade/execution/guards/liquidation_buffer.py",
     "gpt_trader.features.live_trade.execution.order_event_recorder": "src/gpt_trader/features/live_trade/execution/order_event_recorder.py",
     "gpt_trader.features.live_trade.execution.decision_trace": "src/gpt_trader/features/live_trade/execution/decision_trace.py",

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -22495,7 +22495,7 @@
     "tests/unit/gpt_trader/features/live_trade/execution/test_guard_manager_steps_and_telemetry.py": [
       {
         "name": "test_run_guard_step_success",
-        "line": 14,
+        "line": 37,
         "markers": [
           "unit"
         ],
@@ -22503,7 +22503,7 @@
       },
       {
         "name": "test_run_guard_step_recoverable_error",
-        "line": 26,
+        "line": 46,
         "markers": [
           "unit"
         ],
@@ -22511,7 +22511,7 @@
       },
       {
         "name": "test_run_guard_step_unrecoverable_error",
-        "line": 42,
+        "line": 59,
         "markers": [
           "unit"
         ],
@@ -22519,7 +22519,7 @@
       },
       {
         "name": "test_run_guard_step_unexpected_error",
-        "line": 55,
+        "line": 71,
         "markers": [
           "unit"
         ],
@@ -22527,7 +22527,7 @@
       },
       {
         "name": "test_log_guard_telemetry_success",
-        "line": 67,
+        "line": 80,
         "markers": [
           "unit"
         ],
@@ -22535,7 +22535,7 @@
       },
       {
         "name": "test_log_guard_telemetry_failure_raises",
-        "line": 79,
+        "line": 86,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary\n- replace patch blocks with monkeypatched guard telemetry fixtures\n- reuse shared mocks for guard success/failure and pnl telemetry logging\n- regenerate test inventory artifacts\n\n## Testing\n- uv run pytest -q tests/unit/gpt_trader/features/live_trade/execution/test_guard_manager_steps_and_telemetry.py\n- uv run python scripts/ci/check_test_hygiene.py\n- uv run python scripts/ci/check_legacy_test_triage.py\n- uv run python scripts/agents/generate_test_inventory.py