### PR TITLE
test(coinbase): reduce patch density in request retries

### DIFF
--- a/tests/unit/gpt_trader/features/brokerages/coinbase/client/test_base_request_retries.py
+++ b/tests/unit/gpt_trader/features/brokerages/coinbase/client/test_base_request_retries.py
@@ -1,6 +1,7 @@
 """Tests for CoinbaseClientBase retry and rate-limit behavior."""
 
-from unittest.mock import Mock, patch
+import time
+from unittest.mock import Mock
 
 import pytest
 import requests
@@ -11,6 +12,13 @@ from gpt_trader.features.brokerages.coinbase.client.metrics import APIMetricsCol
 from gpt_trader.features.brokerages.coinbase.errors import RateLimitError
 
 
+@pytest.fixture
+def sleep_mock(monkeypatch: pytest.MonkeyPatch) -> Mock:
+    mock_sleep = Mock()
+    monkeypatch.setattr(time, "sleep", mock_sleep)
+    return mock_sleep
+
+
 class TestCoinbaseClientBaseRequestRetries:
     """Test CoinbaseClientBase retry behavior."""
 
@@ -19,7 +27,7 @@ class TestCoinbaseClientBaseRequestRetries:
         self.auth = Mock(spec=SimpleAuth)
         self.auth.get_headers.return_value = {"Authorization": "Bearer test-token"}
 
-    def test_request_rate_limit_invalid_retry_after(self) -> None:
+    def test_request_rate_limit_invalid_retry_after(self, sleep_mock: Mock) -> None:
         """Test rate limit retry-after defaults on invalid header."""
         client = CoinbaseClientBase(base_url=self.base_url, auth=self.auth)
         mock_transport = Mock()
@@ -29,24 +37,22 @@ class TestCoinbaseClientBaseRequestRetries:
         ]
         client.set_transport_for_testing(mock_transport)
 
-        with patch("time.sleep") as mock_sleep:
-            result = client._request("GET", "/api/v3/test")
+        result = client._request("GET", "/api/v3/test")
 
         assert result == {"success": True}
-        mock_sleep.assert_called_once_with(1.0)
+        sleep_mock.assert_called_once_with(1.0)
 
-    def test_request_rate_limit_exhausts_retries(self) -> None:
+    def test_request_rate_limit_exhausts_retries(self, sleep_mock: Mock) -> None:
         """Test rate limit errors exhaust retries and raise."""
         client = CoinbaseClientBase(base_url=self.base_url, auth=self.auth)
         mock_transport = Mock()
         mock_transport.return_value = (429, {"retry-after": "0"}, '{"error": "rate_limited"}')
         client.set_transport_for_testing(mock_transport)
 
-        with patch("time.sleep"):
-            with pytest.raises(RateLimitError):
-                client._request("GET", "/api/v3/test")
+        with pytest.raises(RateLimitError):
+            client._request("GET", "/api/v3/test")
 
-    def test_request_5xx_error_with_retry(self) -> None:
+    def test_request_5xx_error_with_retry(self, sleep_mock: Mock) -> None:
         """Test request with 5xx error and retry."""
         client = CoinbaseClientBase(base_url=self.base_url, auth=self.auth)
         client._metrics = APIMetricsCollector(max_history=10)
@@ -58,15 +64,14 @@ class TestCoinbaseClientBaseRequestRetries:
         ]
         client.set_transport_for_testing(mock_transport)
 
-        with patch("time.sleep") as mock_sleep:
-            result = client._request("GET", "/api/v3/test")
+        result = client._request("GET", "/api/v3/test")
 
         assert result == {"success": True}
         assert mock_transport.call_count == 2
-        mock_sleep.assert_called_once()
+        sleep_mock.assert_called_once()
         assert client.get_api_metrics()["total_errors"] == 0
 
-    def test_request_rate_limit_error_with_retry_after(self) -> None:
+    def test_request_rate_limit_error_with_retry_after(self, sleep_mock: Mock) -> None:
         """Test request with rate limit error and retry-after header."""
         client = CoinbaseClientBase(base_url=self.base_url, auth=self.auth)
         mock_transport = Mock()
@@ -76,13 +81,12 @@ class TestCoinbaseClientBaseRequestRetries:
         ]
         client.set_transport_for_testing(mock_transport)
 
-        with patch("time.sleep") as mock_sleep:
-            result = client._request("GET", "/api/v3/test")
+        result = client._request("GET", "/api/v3/test")
 
         assert result == {"success": True}
-        mock_sleep.assert_called_once_with(5.0)  # Should use retry-after value
+        sleep_mock.assert_called_once_with(5.0)  # Should use retry-after value
 
-    def test_request_network_error_with_retry(self) -> None:
+    def test_request_network_error_with_retry(self, sleep_mock: Mock) -> None:
         """Test request with network error and retry."""
         client = CoinbaseClientBase(base_url=self.base_url, auth=self.auth)
         client._metrics = APIMetricsCollector(max_history=10)
@@ -98,24 +102,22 @@ class TestCoinbaseClientBaseRequestRetries:
         ]
         client.set_transport_for_testing(mock_transport)
 
-        with patch("time.sleep") as mock_sleep:
-            result = client._request("GET", "/api/v3/test")
+        result = client._request("GET", "/api/v3/test")
 
         assert result == {"success": True}
         assert mock_transport.call_count == 2
-        mock_sleep.assert_called_once()
+        sleep_mock.assert_called_once()
         assert client.get_api_metrics()["total_errors"] == 0
 
-    def test_request_max_retries_exceeded(self) -> None:
+    def test_request_max_retries_exceeded(self, sleep_mock: Mock) -> None:
         """Test request with max retries exceeded."""
         client = CoinbaseClientBase(base_url=self.base_url, auth=self.auth)
         mock_transport = Mock()
         mock_transport.return_value = (500, {}, '{"error": "INTERNAL_ERROR"}')
         client.set_transport_for_testing(mock_transport)
 
-        with patch("time.sleep"):
-            with pytest.raises(Exception):  # Should raise some kind of HTTP error
-                client._request("GET", "/api/v3/test")
+        with pytest.raises(Exception):  # Should raise some kind of HTTP error
+            client._request("GET", "/api/v3/test")
 
         # Should have attempted max retries + 1 initial call
         assert mock_transport.call_count == 4  # Default max_retries is 3

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -11674,7 +11674,7 @@
     "tests/unit/gpt_trader/features/brokerages/coinbase/client/test_base_request_retries.py": [
       {
         "name": "TestCoinbaseClientBaseRequestRetries::test_request_rate_limit_invalid_retry_after",
-        "line": 22,
+        "line": 30,
         "markers": [
           "unit"
         ],
@@ -11683,7 +11683,7 @@
       },
       {
         "name": "TestCoinbaseClientBaseRequestRetries::test_request_rate_limit_exhausts_retries",
-        "line": 38,
+        "line": 45,
         "markers": [
           "unit"
         ],
@@ -11692,7 +11692,7 @@
       },
       {
         "name": "TestCoinbaseClientBaseRequestRetries::test_request_5xx_error_with_retry",
-        "line": 49,
+        "line": 55,
         "markers": [
           "unit"
         ],
@@ -11701,7 +11701,7 @@
       },
       {
         "name": "TestCoinbaseClientBaseRequestRetries::test_request_rate_limit_error_with_retry_after",
-        "line": 69,
+        "line": 74,
         "markers": [
           "unit"
         ],
@@ -11710,7 +11710,7 @@
       },
       {
         "name": "TestCoinbaseClientBaseRequestRetries::test_request_network_error_with_retry",
-        "line": 85,
+        "line": 89,
         "markers": [
           "unit"
         ],
@@ -11719,7 +11719,7 @@
       },
       {
         "name": "TestCoinbaseClientBaseRequestRetries::test_request_max_retries_exceeded",
-        "line": 109,
+        "line": 112,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary\n- replace time.sleep patching with a shared monkeypatched sleep fixture\n- keep retry assertions intact while simplifying test setup\n- regenerate test inventory artifacts\n\n## Testing\n- uv run pytest -q tests/unit/gpt_trader/features/brokerages/coinbase/client/test_base_request_retries.py\n- uv run python scripts/ci/check_test_hygiene.py\n- uv run python scripts/ci/check_legacy_test_triage.py\n- uv run python scripts/agents/generate_test_inventory.py