### PR TITLE
test(paper): reduce patch density in hybrid broker init

### DIFF
--- a/tests/unit/gpt_trader/features/brokerages/paper/test_hybrid_paper_broker_init.py
+++ b/tests/unit/gpt_trader/features/brokerages/paper/test_hybrid_paper_broker_init.py
@@ -3,32 +3,45 @@
 from __future__ import annotations
 
 from decimal import Decimal
-from unittest.mock import patch
+from unittest.mock import MagicMock
 
+import pytest
+
+import gpt_trader.features.brokerages.paper.hybrid as hybrid_module
 from gpt_trader.features.brokerages.paper.hybrid import HybridPaperBroker
 
 
 class TestHybridPaperBrokerInit:
     """Test HybridPaperBroker initialization."""
 
-    @patch("gpt_trader.features.brokerages.paper.hybrid.CoinbaseClient")
-    @patch("gpt_trader.features.brokerages.paper.hybrid.SimpleAuth")
-    def test_init_creates_client(self, mock_auth, mock_client) -> None:
+    @pytest.fixture
+    def auth_mock(self, monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+        mock_auth = MagicMock()
+        monkeypatch.setattr(hybrid_module, "SimpleAuth", mock_auth)
+        return mock_auth
+
+    @pytest.fixture
+    def client_mock(self, monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+        mock_client = MagicMock()
+        monkeypatch.setattr(hybrid_module, "CoinbaseClient", mock_client)
+        return mock_client
+
+    def test_init_creates_client(self, auth_mock: MagicMock, client_mock: MagicMock) -> None:
         """Test initialization creates Coinbase client."""
         broker = HybridPaperBroker(
             api_key="test_key",
             private_key="test_private_key",
         )
 
-        mock_auth.assert_called_once_with(key_name="test_key", private_key="test_private_key")
-        mock_client.assert_called_once()
+        auth_mock.assert_called_once_with(key_name="test_key", private_key="test_private_key")
+        client_mock.assert_called_once()
         assert broker._initial_equity == Decimal("10000")
         assert broker._slippage_bps == 5
         assert broker._commission_bps == Decimal("5")
 
-    @patch("gpt_trader.features.brokerages.paper.hybrid.CoinbaseClient")
-    @patch("gpt_trader.features.brokerages.paper.hybrid.SimpleAuth")
-    def test_init_with_custom_parameters(self, mock_auth, mock_client) -> None:
+    def test_init_with_custom_parameters(
+        self, auth_mock: MagicMock, client_mock: MagicMock
+    ) -> None:
         """Test initialization with custom parameters."""
         broker = HybridPaperBroker(
             api_key="test_key",
@@ -42,9 +55,7 @@ class TestHybridPaperBrokerInit:
         assert broker._slippage_bps == 10
         assert broker._commission_bps == Decimal("10")
 
-    @patch("gpt_trader.features.brokerages.paper.hybrid.CoinbaseClient")
-    @patch("gpt_trader.features.brokerages.paper.hybrid.SimpleAuth")
-    def test_init_creates_usd_balance(self, mock_auth, mock_client) -> None:
+    def test_init_creates_usd_balance(self, auth_mock: MagicMock, client_mock: MagicMock) -> None:
         """Test initialization creates USD balance."""
         broker = HybridPaperBroker(
             api_key="test_key",

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -18437,7 +18437,7 @@
     "tests/unit/gpt_trader/features/brokerages/paper/test_hybrid_paper_broker_init.py": [
       {
         "name": "TestHybridPaperBrokerInit::test_init_creates_client",
-        "line": 16,
+        "line": 29,
         "markers": [
           "unit"
         ],
@@ -18446,7 +18446,7 @@
       },
       {
         "name": "TestHybridPaperBrokerInit::test_init_with_custom_parameters",
-        "line": 31,
+        "line": 42,
         "markers": [
           "unit"
         ],
@@ -18455,7 +18455,7 @@
       },
       {
         "name": "TestHybridPaperBrokerInit::test_init_creates_usd_balance",
-        "line": 47,
+        "line": 56,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary\n- replace SimpleAuth/CoinbaseClient patch decorators with monkeypatched fixtures\n- keep initialization assertions intact while simplifying setup\n- regenerate test inventory artifacts\n\n## Testing\n- uv run pytest -q tests/unit/gpt_trader/features/brokerages/paper/test_hybrid_paper_broker_init.py\n- uv run python scripts/ci/check_test_hygiene.py\n- uv run python scripts/ci/check_legacy_test_triage.py\n- uv run python scripts/agents/generate_test_inventory.py