### PR TITLE
test(live_trade): reduce patch density in exec metrics

### DIFF
--- a/var/agents/testing/source_test_map.json
+++ b/var/agents/testing/source_test_map.json
@@ -999,7 +999,8 @@
       "tests/unit/gpt_trader/features/live_trade/execution/test_order_submission_core_record_preview.py",
       "tests/unit/gpt_trader/features/live_trade/execution/test_order_submission_core_record_rejection.py",
       "tests/unit/gpt_trader/features/live_trade/execution/test_order_submission_flows_submit_order.py",
-      "tests/unit/gpt_trader/features/live_trade/execution/test_order_submission_observability_latency_metrics.py"
+      "tests/unit/gpt_trader/features/live_trade/execution/test_order_submission_observability_latency_metrics.py",
+      "tests/unit/gpt_trader/features/live_trade/execution/test_order_submission_observability_submission_metrics.py"
     ],
     "gpt_trader.features.live_trade.execution.order_submission": [
       "tests/unit/gpt_trader/features/live_trade/execution/test_order_submission_core_execute_broker_order.py",
@@ -3896,6 +3897,7 @@
     ],
     "tests/unit/gpt_trader/features/live_trade/execution/test_order_submission_observability_submission_metrics.py": [
       "gpt_trader.core",
+      "gpt_trader.features.live_trade.execution.order_event_recorder",
       "gpt_trader.features.live_trade.execution.order_submission",
       "gpt_trader.monitoring.metrics_collector"
     ],

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -21962,7 +21962,7 @@
     "tests/unit/gpt_trader/features/live_trade/execution/test_broker_executor_metrics.py": [
       {
         "name": "TestBrokerCallMetrics::test_successful_call_records_latency_with_success_outcome",
-        "line": 21,
+        "line": 32,
         "markers": [
           "unit"
         ],
@@ -21971,7 +21971,7 @@
       },
       {
         "name": "TestBrokerCallMetrics::test_failed_call_records_latency_with_failure_outcome",
-        "line": 52,
+        "line": 62,
         "markers": [
           "unit"
         ],
@@ -21980,7 +21980,7 @@
       },
       {
         "name": "TestBrokerCallMetrics::test_timeout_error_classified_correctly",
-        "line": 82,
+        "line": 91,
         "markers": [
           "unit"
         ],
@@ -21989,7 +21989,7 @@
       },
       {
         "name": "TestBrokerCallMetrics::test_rate_limit_error_classified_correctly",
-        "line": 109,
+        "line": 117,
         "markers": [
           "unit"
         ],
@@ -21998,7 +21998,7 @@
       },
       {
         "name": "TestBrokerCallMetrics::test_network_error_classified_correctly",
-        "line": 136,
+        "line": 143,
         "markers": [
           "unit"
         ],
@@ -23430,7 +23430,7 @@
     "tests/unit/gpt_trader/features/live_trade/execution/test_order_submission_observability_submission_metrics.py": [
       {
         "name": "TestOrderSubmissionMetrics::test_successful_order_records_metric",
-        "line": 27,
+        "line": 35,
         "markers": [
           "unit"
         ],
@@ -23439,7 +23439,7 @@
       },
       {
         "name": "TestOrderSubmissionMetrics::test_failed_order_records_metric_with_reason",
-        "line": 69,
+        "line": 74,
         "markers": [
           "unit"
         ],
@@ -23448,7 +23448,7 @@
       },
       {
         "name": "TestOrderSubmissionMetricLabels::test_classification_label_used_in_metrics",
-        "line": 120,
+        "line": 132,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary
- replace patch decorators with monkeypatch fixtures in order submission observability metrics tests
- replace patch decorators with a monkeypatch fixture in broker executor metrics tests
- regenerate test inventory artifacts

## Testing
- uv run pytest -q tests/unit/gpt_trader/features/live_trade/execution/test_order_submission_observability_submission_metrics.py tests/unit/gpt_trader/features/live_trade/execution/test_broker_executor_metrics.py
- uv run python scripts/ci/check_test_hygiene.py
- uv run python scripts/ci/check_legacy_test_triage.py
- uv run python scripts/agents/generate_test_inventory.py