### PR TITLE
test(coinbase): reduce patch density in websocket mixin tests

### DIFF
--- a/tests/unit/gpt_trader/features/brokerages/coinbase/test_websocket_mixin_init_and_get_websocket.py
+++ b/tests/unit/gpt_trader/features/brokerages/coinbase/test_websocket_mixin_init_and_get_websocket.py
@@ -2,12 +2,22 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
+import pytest
+
+import gpt_trader.features.brokerages.coinbase.client.websocket_mixin as websocket_mixin_module
 from tests.unit.gpt_trader.features.brokerages.coinbase.websocket_mixin_test_helpers import (
     MockWebSocketClient,
     _NonCooperativeClient,
 )
+
+
+@pytest.fixture
+def mock_websocket_class(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    mock_ws_class = MagicMock()
+    monkeypatch.setattr(websocket_mixin_module, "CoinbaseWebSocket", mock_ws_class)
+    return mock_ws_class
 
 
 class TestWebSocketClientMixinInitialization:
@@ -36,24 +46,22 @@ class TestWebSocketClientMixinInitialization:
 class TestWebSocketClientMixinGetWebSocket:
     """Tests for _get_websocket singleton management."""
 
-    @patch("gpt_trader.features.brokerages.coinbase.client.websocket_mixin.CoinbaseWebSocket")
-    def test_creates_websocket_on_first_call(self, mock_ws_class):
+    def test_creates_websocket_on_first_call(self, mock_websocket_class: MagicMock):
         """First call should create a new WebSocket instance."""
         mock_ws_instance = MagicMock()
-        mock_ws_class.return_value = mock_ws_instance
+        mock_websocket_class.return_value = mock_ws_instance
 
         client = MockWebSocketClient()
         result = client._get_websocket()
 
-        mock_ws_class.assert_called_once()
+        mock_websocket_class.assert_called_once()
         assert result is mock_ws_instance
         assert client._ws is mock_ws_instance
 
-    @patch("gpt_trader.features.brokerages.coinbase.client.websocket_mixin.CoinbaseWebSocket")
-    def test_returns_same_websocket_on_subsequent_calls(self, mock_ws_class):
+    def test_returns_same_websocket_on_subsequent_calls(self, mock_websocket_class: MagicMock):
         """Subsequent calls should return the same WebSocket instance."""
         mock_ws_instance = MagicMock()
-        mock_ws_class.return_value = mock_ws_instance
+        mock_websocket_class.return_value = mock_ws_instance
 
         client = MockWebSocketClient()
 
@@ -61,11 +69,10 @@ class TestWebSocketClientMixinGetWebSocket:
         second = client._get_websocket()
 
         # Should only create once
-        mock_ws_class.assert_called_once()
+        mock_websocket_class.assert_called_once()
         assert first is second
 
-    @patch("gpt_trader.features.brokerages.coinbase.client.websocket_mixin.CoinbaseWebSocket")
-    def test_passes_auth_credentials_to_websocket(self, mock_ws_class):
+    def test_passes_auth_credentials_to_websocket(self, mock_websocket_class: MagicMock):
         """WebSocket should receive auth credentials if available."""
         mock_auth = MagicMock()
         mock_auth.api_key = "my_api_key"
@@ -74,36 +81,34 @@ class TestWebSocketClientMixinGetWebSocket:
         client = MockWebSocketClient(auth=mock_auth)
         client._get_websocket()
 
-        mock_ws_class.assert_called_once()
-        call_kwargs = mock_ws_class.call_args.kwargs
+        mock_websocket_class.assert_called_once()
+        call_kwargs = mock_websocket_class.call_args.kwargs
         assert call_kwargs["api_key"] == "my_api_key"
         assert call_kwargs["private_key"] == "my_private_key"
 
-    @patch("gpt_trader.features.brokerages.coinbase.client.websocket_mixin.CoinbaseWebSocket")
-    def test_handles_no_auth(self, mock_ws_class):
+    def test_handles_no_auth(self, mock_websocket_class: MagicMock):
         """WebSocket should work without auth credentials."""
         client = MockWebSocketClient(auth=None)
         client._get_websocket()
 
-        mock_ws_class.assert_called_once()
-        call_kwargs = mock_ws_class.call_args.kwargs
+        mock_websocket_class.assert_called_once()
+        call_kwargs = mock_websocket_class.call_args.kwargs
         assert call_kwargs["api_key"] is None
         assert call_kwargs["private_key"] is None
 
 
 class TestWebSocketClientMixinNonCooperativeInit:
-    def test_lazy_initializes_state_when_mixin_init_not_called(self) -> None:
+    def test_lazy_initializes_state_when_mixin_init_not_called(
+        self,
+        mock_websocket_class: MagicMock,
+    ) -> None:
         client = _NonCooperativeClient()
         assert not hasattr(client, "_ws_lock")
         assert not hasattr(client, "_message_queue")
 
-        with patch(
-            "gpt_trader.features.brokerages.coinbase.client.websocket_mixin.CoinbaseWebSocket"
-        ) as mock_ws_class:
-            mock_ws_instance = MagicMock()
-            mock_ws_class.return_value = mock_ws_instance
-
-            result = client._get_websocket()
+        mock_ws_instance = MagicMock()
+        mock_websocket_class.return_value = mock_ws_instance
+        result = client._get_websocket()
 
         assert result is mock_ws_instance
         assert client._ws is mock_ws_instance

--- a/var/agents/testing/source_test_map.json
+++ b/var/agents/testing/source_test_map.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "summary": {
-    "tests_scanned": 915,
+    "tests_scanned": 916,
     "source_modules": 350,
     "unresolved_modules": 3
   },
@@ -624,6 +624,7 @@
       "tests/unit/gpt_trader/features/brokerages/coinbase/client/test_response_cache.py"
     ],
     "gpt_trader.features.brokerages.coinbase.client.websocket_mixin": [
+      "tests/unit/gpt_trader/features/brokerages/coinbase/test_websocket_mixin_init_and_get_websocket.py",
       "tests/unit/gpt_trader/features/brokerages/coinbase/test_websocket_mixin_stream_trades_and_control.py"
     ],
     "gpt_trader.features.brokerages.coinbase.credentials": [
@@ -3440,6 +3441,9 @@
       "gpt_trader.features.brokerages.coinbase.user_event_handler",
       "gpt_trader.features.brokerages.coinbase.ws_events",
       "gpt_trader.persistence.orders_store"
+    ],
+    "tests/unit/gpt_trader/features/brokerages/coinbase/test_websocket_mixin_init_and_get_websocket.py": [
+      "gpt_trader.features.brokerages.coinbase.client.websocket_mixin"
     ],
     "tests/unit/gpt_trader/features/brokerages/coinbase/test_websocket_mixin_stream_trades_and_control.py": [
       "gpt_trader.features.brokerages.coinbase.client.websocket_mixin"

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -17723,7 +17723,7 @@
     "tests/unit/gpt_trader/features/brokerages/coinbase/test_websocket_mixin_init_and_get_websocket.py": [
       {
         "name": "TestWebSocketClientMixinInitialization::test_initialization_creates_attributes",
-        "line": 16,
+        "line": 26,
         "markers": [
           "unit"
         ],
@@ -17732,7 +17732,7 @@
       },
       {
         "name": "TestWebSocketClientMixinInitialization::test_initialization_with_auth",
-        "line": 25,
+        "line": 35,
         "markers": [
           "unit"
         ],
@@ -17741,7 +17741,7 @@
       },
       {
         "name": "TestWebSocketClientMixinGetWebSocket::test_creates_websocket_on_first_call",
-        "line": 40,
+        "line": 49,
         "markers": [
           "unit"
         ],
@@ -17750,7 +17750,7 @@
       },
       {
         "name": "TestWebSocketClientMixinGetWebSocket::test_returns_same_websocket_on_subsequent_calls",
-        "line": 53,
+        "line": 61,
         "markers": [
           "unit"
         ],
@@ -17759,7 +17759,7 @@
       },
       {
         "name": "TestWebSocketClientMixinGetWebSocket::test_passes_auth_credentials_to_websocket",
-        "line": 68,
+        "line": 75,
         "markers": [
           "unit"
         ],
@@ -17768,7 +17768,7 @@
       },
       {
         "name": "TestWebSocketClientMixinGetWebSocket::test_handles_no_auth",
-        "line": 83,
+        "line": 89,
         "markers": [
           "unit"
         ],
@@ -17777,7 +17777,7 @@
       },
       {
         "name": "TestWebSocketClientMixinNonCooperativeInit::test_lazy_initializes_state_when_mixin_init_not_called",
-        "line": 95,
+        "line": 101,
         "markers": [
           "unit"
         ],
@@ -17786,7 +17786,7 @@
       },
       {
         "name": "TestWebSocketClientMixinNonCooperativeInit::test_stop_streaming_safe_when_mixin_init_not_called",
-        "line": 113,
+        "line": 118,
         "markers": [
           "unit"
         ],
@@ -17873,7 +17873,7 @@
     "tests/unit/gpt_trader/features/brokerages/coinbase/test_websocket_mixin_stream_trades_and_control.py": [
       {
         "name": "TestStreamTrades::test_connects_and_subscribes_to_market_trades",
-        "line": 18,
+        "line": 27,
         "markers": [
           "unit"
         ],
@@ -17882,7 +17882,7 @@
       },
       {
         "name": "TestStreamTrades::test_yields_trade_messages",
-        "line": 45,
+        "line": 53,
         "markers": [
           "unit"
         ],
@@ -17891,7 +17891,7 @@
       },
       {
         "name": "TestStreamControl::test_stop_streaming_disconnects_websocket",
-        "line": 70,
+        "line": 77,
         "markers": [
           "unit"
         ],
@@ -17900,7 +17900,7 @@
       },
       {
         "name": "TestStreamControl::test_stop_streaming_handles_disconnect_error",
-        "line": 101,
+        "line": 107,
         "markers": [
           "unit"
         ],
@@ -17909,7 +17909,7 @@
       },
       {
         "name": "TestStreamControl::test_is_streaming_returns_correct_state",
-        "line": 115,
+        "line": 121,
         "markers": [
           "unit"
         ],
@@ -17918,7 +17918,7 @@
       },
       {
         "name": "TestStreamMessageControl::test_stream_messages_stop_event_breaks",
-        "line": 134,
+        "line": 140,
         "markers": [
           "unit"
         ],
@@ -17927,7 +17927,7 @@
       },
       {
         "name": "TestStreamMessageControl::test_stream_messages_stop_sentinel_breaks",
-        "line": 148,
+        "line": 151,
         "markers": [
           "unit"
         ],
@@ -23448,7 +23448,7 @@
       },
       {
         "name": "TestOrderSubmissionMetricLabels::test_classification_label_used_in_metrics",
-        "line": 132,
+        "line": 130,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary
- replace CoinbaseWebSocket patch decorators with monkeypatch fixtures in websocket mixin init/get tests
- replace patch usage in stream/control tests, including queue timeout override
- regenerate test inventory artifacts

## Testing
- uv run pytest -q tests/unit/gpt_trader/features/brokerages/coinbase/test_websocket_mixin_init_and_get_websocket.py tests/unit/gpt_trader/features/brokerages/coinbase/test_websocket_mixin_stream_trades_and_control.py
- uv run python scripts/ci/check_test_hygiene.py
- uv run python scripts/ci/check_legacy_test_triage.py
- uv run python scripts/agents/generate_test_inventory.py