### PR TITLE
test(live_trade/coinbase): reduce patch density

### DIFF
--- a/tests/unit/gpt_trader/features/brokerages/coinbase/test_ws_reconnection_degradation_callback.py
+++ b/tests/unit/gpt_trader/features/brokerages/coinbase/test_ws_reconnection_degradation_callback.py
@@ -2,15 +2,19 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+import pytest
 
+import gpt_trader.features.brokerages.coinbase.ws as ws_module
 from gpt_trader.features.brokerages.coinbase.ws import CoinbaseWebSocket
 
 
 class TestWebSocketDegradationCallback:
     """Tests for degradation callback when max attempts exceeded."""
 
-    def test_callback_triggered_on_max_attempts(self) -> None:
+    def test_callback_triggered_on_max_attempts(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         """Test that degradation callback is triggered when max attempts exceeded."""
         callback_called = []
 
@@ -20,27 +24,22 @@ class TestWebSocketDegradationCallback:
         ws = CoinbaseWebSocket(on_max_attempts_exceeded=on_max_exceeded)
 
         # Set up to exceed max attempts
-        with (
-            patch(
-                "gpt_trader.features.brokerages.coinbase.ws.WS_RECONNECT_MAX_ATTEMPTS",
-                3,
-            ),
-            patch(
-                "gpt_trader.features.brokerages.coinbase.ws.WS_RECONNECT_PAUSE_SECONDS",
-                300,
-            ),
-        ):
-            ws._reconnect_count = 3  # At max
-            ws._running.set()
+        monkeypatch.setattr(ws_module, "WS_RECONNECT_MAX_ATTEMPTS", 3)
+        monkeypatch.setattr(ws_module, "WS_RECONNECT_PAUSE_SECONDS", 300)
+        ws._reconnect_count = 3  # At max
+        ws._running.set()
 
-            # Trigger close (will exceed max on increment)
-            ws._on_close(None, 1000, "Connection lost")
+        # Trigger close (will exceed max on increment)
+        ws._on_close(None, 1000, "Connection lost")
 
         # Callback should have been called
         assert len(callback_called) == 1
         assert callback_called[0] == 300
 
-    def test_callback_only_triggered_once(self) -> None:
+    def test_callback_only_triggered_once(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         """Test that degradation callback is only triggered once per max-exceeded event."""
         callback_count = []
 
@@ -49,44 +48,44 @@ class TestWebSocketDegradationCallback:
 
         ws = CoinbaseWebSocket(on_max_attempts_exceeded=on_max_exceeded)
 
-        with patch(
-            "gpt_trader.features.brokerages.coinbase.ws.WS_RECONNECT_MAX_ATTEMPTS",
-            3,
-        ):
-            ws._reconnect_count = 3
-            ws._running.set()
+        monkeypatch.setattr(ws_module, "WS_RECONNECT_MAX_ATTEMPTS", 3)
+        ws._reconnect_count = 3
+        ws._running.set()
 
-            # First close - should trigger callback
-            ws._on_close(None, 1000, "Connection lost")
+        # First close - should trigger callback
+        ws._on_close(None, 1000, "Connection lost")
 
-            # Second close - should NOT trigger callback again
-            # Note: After max attempts triggered, _running is cleared
-            # so we need to set it again to simulate another close
-            ws._running.set()
-            ws._shutdown.set()  # Prevent actual reconnection attempt
-            ws._on_close(None, 1000, "Connection lost again")
+        # Second close - should NOT trigger callback again
+        # Note: After max attempts triggered, _running is cleared
+        # so we need to set it again to simulate another close
+        ws._running.set()
+        ws._shutdown.set()  # Prevent actual reconnection attempt
+        ws._on_close(None, 1000, "Connection lost again")
 
         # Callback should only be called once
         assert len(callback_count) == 1
 
-    def test_no_callback_when_none_provided(self) -> None:
+    def test_no_callback_when_none_provided(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         """Test that missing callback doesn't cause errors."""
         ws = CoinbaseWebSocket(on_max_attempts_exceeded=None)
 
-        with patch(
-            "gpt_trader.features.brokerages.coinbase.ws.WS_RECONNECT_MAX_ATTEMPTS",
-            3,
-        ):
-            ws._reconnect_count = 3
-            ws._running.set()
+        monkeypatch.setattr(ws_module, "WS_RECONNECT_MAX_ATTEMPTS", 3)
+        ws._reconnect_count = 3
+        ws._running.set()
 
-            # Should not raise even without callback
-            ws._on_close(None, 1000, "Connection lost")
+        # Should not raise even without callback
+        ws._on_close(None, 1000, "Connection lost")
 
         # Verify max_attempts_triggered flag is set
         assert ws._max_attempts_triggered is True
 
-    def test_callback_exception_does_not_crash(self) -> None:
+    def test_callback_exception_does_not_crash(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         """Test that exception in callback is handled gracefully."""
 
         def bad_callback(pause_seconds: int) -> None:
@@ -94,15 +93,12 @@ class TestWebSocketDegradationCallback:
 
         ws = CoinbaseWebSocket(on_max_attempts_exceeded=bad_callback)
 
-        with patch(
-            "gpt_trader.features.brokerages.coinbase.ws.WS_RECONNECT_MAX_ATTEMPTS",
-            3,
-        ):
-            ws._reconnect_count = 3
-            ws._running.set()
+        monkeypatch.setattr(ws_module, "WS_RECONNECT_MAX_ATTEMPTS", 3)
+        ws._reconnect_count = 3
+        ws._running.set()
 
-            # Should not raise even with bad callback
-            ws._on_close(None, 1000, "Connection lost")
+        # Should not raise even with bad callback
+        ws._on_close(None, 1000, "Connection lost")
 
         # Should still set the triggered flag
         assert ws._max_attempts_triggered is True

--- a/tests/unit/gpt_trader/features/live_trade/test_bot_engine_delegation.py
+++ b/tests/unit/gpt_trader/features/live_trade/test_bot_engine_delegation.py
@@ -2,29 +2,36 @@
 
 from __future__ import annotations
 
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 
+import gpt_trader.features.live_trade.bot as bot_module
 from gpt_trader.features.live_trade.bot import TradingBot
+
+
+@pytest.fixture
+def mock_engine_class(monkeypatch: pytest.MonkeyPatch) -> Mock:
+    mock_engine_class = Mock()
+    monkeypatch.setattr(bot_module, "TradingEngine", mock_engine_class)
+    return mock_engine_class
 
 
 class TestTradingBotExecuteDecision:
     """Test TradingBot execute_decision method."""
 
     @pytest.fixture
-    def bot(self) -> TradingBot:
+    def bot(self, mock_engine_class: Mock) -> TradingBot:
         """Create a TradingBot with mocked engine."""
         config = Mock()
         config.symbols = ["BTC-PERP-USDC"]
         config.interval = 60
         mock_container = Mock()
 
-        with patch("gpt_trader.features.live_trade.bot.TradingEngine") as mock_engine:
-            engine = Mock()
-            engine.execute_decision = Mock(return_value="order-123")
-            mock_engine.return_value = engine
-            bot = TradingBot(config=config, container=mock_container)
+        engine = Mock()
+        engine.execute_decision = Mock(return_value="order-123")
+        mock_engine_class.return_value = engine
+        bot = TradingBot(config=config, container=mock_container)
 
         return bot
 
@@ -48,17 +55,19 @@ class TestTradingBotExecuteDecision:
             "BTC-PERP-USDC", decision, mark, product, position_state
         )
 
-    def test_execute_decision_returns_none_when_engine_lacks_method(self) -> None:
+    def test_execute_decision_returns_none_when_engine_lacks_method(
+        self,
+        mock_engine_class: Mock,
+    ) -> None:
         """Test execute_decision returns None if engine lacks the method."""
         config = Mock()
         config.symbols = ["BTC-PERP-USDC"]
         config.interval = 60
         mock_container = Mock()
 
-        with patch("gpt_trader.features.live_trade.bot.TradingEngine") as mock_engine:
-            engine = Mock(spec=[])  # No execute_decision
-            mock_engine.return_value = engine
-            bot = TradingBot(config=config, container=mock_container)
+        engine = Mock(spec=[])  # No execute_decision
+        mock_engine_class.return_value = engine
+        bot = TradingBot(config=config, container=mock_container)
 
         result = bot.execute_decision(
             symbol="BTC-PERP-USDC",
@@ -85,7 +94,7 @@ class TestTradingBotExecuteDecision:
 class TestTradingBotGetProduct:
     """Test TradingBot get_product method."""
 
-    def test_get_product_with_broker(self) -> None:
+    def test_get_product_with_broker(self, mock_engine_class: Mock) -> None:
         """Test get_product when broker is available."""
         config = Mock()
         config.symbols = ["BTC-PERP-USDC"]
@@ -99,16 +108,15 @@ class TestTradingBotGetProduct:
         mock_container.event_store = Mock()
         mock_container.notification_service = Mock()
 
-        with patch("gpt_trader.features.live_trade.bot.TradingEngine") as mock_engine:
-            mock_engine.return_value = Mock()
-            bot = TradingBot(config=config, container=mock_container)
+        mock_engine_class.return_value = Mock()
+        bot = TradingBot(config=config, container=mock_container)
 
         result = bot.get_product("BTC-PERP-USDC")
 
         assert result is mock_product
         mock_container.broker.get_product.assert_called_once_with("BTC-PERP-USDC")
 
-    def test_get_product_without_broker(self) -> None:
+    def test_get_product_without_broker(self, mock_engine_class: Mock) -> None:
         """Test get_product when broker is None."""
         config = Mock()
         config.symbols = ["BTC-PERP-USDC"]
@@ -121,15 +129,14 @@ class TestTradingBotGetProduct:
         mock_container.event_store = Mock()
         mock_container.notification_service = Mock()
 
-        with patch("gpt_trader.features.live_trade.bot.TradingEngine") as mock_engine:
-            mock_engine.return_value = Mock()
-            bot = TradingBot(config=config, container=mock_container)
+        mock_engine_class.return_value = Mock()
+        bot = TradingBot(config=config, container=mock_container)
 
         result = bot.get_product("BTC-PERP-USDC")
 
         assert result is None
 
-    def test_get_product_broker_without_method(self) -> None:
+    def test_get_product_broker_without_method(self, mock_engine_class: Mock) -> None:
         """Test get_product when broker lacks get_product method."""
         config = Mock()
         config.symbols = ["BTC-PERP-USDC"]
@@ -141,9 +148,8 @@ class TestTradingBotGetProduct:
         mock_container.event_store = Mock()
         mock_container.notification_service = Mock()
 
-        with patch("gpt_trader.features.live_trade.bot.TradingEngine") as mock_engine:
-            mock_engine.return_value = Mock()
-            bot = TradingBot(config=config, container=mock_container)
+        mock_engine_class.return_value = Mock()
+        bot = TradingBot(config=config, container=mock_container)
 
         result = bot.get_product("BTC-PERP-USDC")
 

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -18309,7 +18309,7 @@
     "tests/unit/gpt_trader/features/brokerages/coinbase/test_ws_reconnection_degradation_callback.py": [
       {
         "name": "TestWebSocketDegradationCallback::test_callback_triggered_on_max_attempts",
-        "line": 13,
+        "line": 14,
         "markers": [
           "unit"
         ],
@@ -18318,7 +18318,7 @@
       },
       {
         "name": "TestWebSocketDegradationCallback::test_callback_only_triggered_once",
-        "line": 43,
+        "line": 39,
         "markers": [
           "unit"
         ],
@@ -18327,7 +18327,7 @@
       },
       {
         "name": "TestWebSocketDegradationCallback::test_no_callback_when_none_provided",
-        "line": 72,
+        "line": 68,
         "markers": [
           "unit"
         ],
@@ -18336,7 +18336,7 @@
       },
       {
         "name": "TestWebSocketDegradationCallback::test_callback_exception_does_not_crash",
-        "line": 89,
+        "line": 85,
         "markers": [
           "unit"
         ],
@@ -27430,7 +27430,7 @@
     "tests/unit/gpt_trader/features/live_trade/test_bot_engine_delegation.py": [
       {
         "name": "TestTradingBotExecuteDecision::test_execute_decision_delegates_to_engine",
-        "line": 31,
+        "line": 38,
         "markers": [
           "unit"
         ],
@@ -27439,7 +27439,7 @@
       },
       {
         "name": "TestTradingBotExecuteDecision::test_execute_decision_returns_none_when_engine_lacks_method",
-        "line": 51,
+        "line": 58,
         "markers": [
           "unit"
         ],
@@ -27448,7 +27448,7 @@
       },
       {
         "name": "TestTradingBotExecuteDecision::test_execute_decision_with_minimal_args",
-        "line": 70,
+        "line": 79,
         "markers": [
           "unit"
         ],
@@ -27457,7 +27457,7 @@
       },
       {
         "name": "TestTradingBotGetProduct::test_get_product_with_broker",
-        "line": 88,
+        "line": 97,
         "markers": [
           "unit"
         ],
@@ -27466,7 +27466,7 @@
       },
       {
         "name": "TestTradingBotGetProduct::test_get_product_without_broker",
-        "line": 111,
+        "line": 119,
         "markers": [
           "unit"
         ],
@@ -27475,7 +27475,7 @@
       },
       {
         "name": "TestTradingBotGetProduct::test_get_product_broker_without_method",
-        "line": 132,
+        "line": 139,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary
- replace TradingEngine patch blocks with a monkeypatch fixture in bot delegation tests
- replace ws constant patch usage with monkeypatch in reconnection degradation callback tests
- regenerate test inventory artifacts

## Testing
- uv run pytest -q tests/unit/gpt_trader/features/live_trade/test_bot_engine_delegation.py tests/unit/gpt_trader/features/brokerages/coinbase/test_ws_reconnection_degradation_callback.py
- uv run python scripts/ci/check_test_hygiene.py
- uv run python scripts/ci/check_legacy_test_triage.py
- uv run python scripts/agents/generate_test_inventory.py