### PR TITLE
test(live_trade): reduce patch density in rejection/validation tests

### DIFF
--- a/var/agents/testing/source_test_map.json
+++ b/var/agents/testing/source_test_map.json
@@ -1002,6 +1002,7 @@
       "tests/unit/gpt_trader/features/live_trade/execution/test_order_submission_core_record_rejection.py",
       "tests/unit/gpt_trader/features/live_trade/execution/test_order_submission_flows_submit_order.py",
       "tests/unit/gpt_trader/features/live_trade/execution/test_order_submission_observability_latency_metrics.py",
+      "tests/unit/gpt_trader/features/live_trade/execution/test_order_submission_observability_rejection_recording.py",
       "tests/unit/gpt_trader/features/live_trade/execution/test_order_submission_observability_submission_metrics.py"
     ],
     "gpt_trader.features.live_trade.execution.order_submission": [
@@ -3898,6 +3899,7 @@
     ],
     "tests/unit/gpt_trader/features/live_trade/execution/test_order_submission_observability_rejection_recording.py": [
       "gpt_trader.core",
+      "gpt_trader.features.live_trade.execution.order_event_recorder",
       "gpt_trader.features.live_trade.execution.order_submission",
       "gpt_trader.persistence.orders_store"
     ],

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -23410,7 +23410,7 @@
     "tests/unit/gpt_trader/features/live_trade/execution/test_order_submission_observability_rejection_recording.py": [
       {
         "name": "TestRecordRejectionConsistency::test_rejection_from_broker_status_includes_classified_reason",
-        "line": 20,
+        "line": 33,
         "markers": [
           "unit"
         ],
@@ -23419,7 +23419,7 @@
       },
       {
         "name": "TestRecordRejectionConsistency::test_exception_rejection_uses_classified_reason",
-        "line": 75,
+        "line": 83,
         "markers": [
           "unit"
         ],
@@ -24249,7 +24249,7 @@
     "tests/unit/gpt_trader/features/live_trade/execution/test_validation_metrics_and_escalation.py": [
       {
         "name": "TestMetricsRecording::test_mark_staleness_failure_records_metric",
-        "line": 14,
+        "line": 24,
         "markers": [
           "unit"
         ],
@@ -24258,7 +24258,7 @@
       },
       {
         "name": "TestMetricsRecording::test_slippage_guard_failure_records_metric",
-        "line": 42,
+        "line": 51,
         "markers": [
           "unit"
         ],
@@ -24267,7 +24267,7 @@
       },
       {
         "name": "TestMetricsRecording::test_preview_failure_records_metric",
-        "line": 75,
+        "line": 83,
         "markers": [
           "unit"
         ],
@@ -24276,7 +24276,7 @@
       },
       {
         "name": "TestFailureTrackerIntegration::test_success_resets_mark_staleness_counter",
-        "line": 115,
+        "line": 123,
         "markers": [
           "unit"
         ],
@@ -24285,7 +24285,7 @@
       },
       {
         "name": "TestFailureTrackerIntegration::test_failure_increments_slippage_counter",
-        "line": 142,
+        "line": 150,
         "markers": [
           "unit"
         ],
@@ -24294,7 +24294,7 @@
       },
       {
         "name": "TestFailureTrackerIntegration::test_escalation_triggered_after_repeated_failures",
-        "line": 180,
+        "line": 187,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary
- replace monitoring logger/metric patch decorators with monkeypatch fixtures in rejection recording tests
- replace validation record_counter patch decorators with a monkeypatch fixture for metrics/escalation tests
- regenerate test inventory artifacts

## Testing
- uv run pytest -q tests/unit/gpt_trader/features/live_trade/execution/test_order_submission_observability_rejection_recording.py tests/unit/gpt_trader/features/live_trade/execution/test_validation_metrics_and_escalation.py
- uv run python scripts/ci/check_test_hygiene.py
- uv run python scripts/ci/check_legacy_test_triage.py
- uv run python scripts/agents/generate_test_inventory.py