### PR TITLE
test(coinbase): reduce patch density in ws mixin tests

### DIFF
--- a/tests/unit/gpt_trader/features/brokerages/coinbase/test_websocket_mixin_stream_orderbook.py
+++ b/tests/unit/gpt_trader/features/brokerages/coinbase/test_websocket_mixin_stream_orderbook.py
@@ -3,21 +3,30 @@
 from __future__ import annotations
 
 import threading
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
+import pytest
+
+import gpt_trader.features.brokerages.coinbase.client.websocket_mixin as websocket_mixin_module
 from tests.unit.gpt_trader.features.brokerages.coinbase.websocket_mixin_test_helpers import (
     MockWebSocketClient,
 )
 
 
+@pytest.fixture
+def mock_websocket_class(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    mock_ws_class = MagicMock()
+    monkeypatch.setattr(websocket_mixin_module, "CoinbaseWebSocket", mock_ws_class)
+    return mock_ws_class
+
+
 class TestStreamOrderbook:
     """Tests for stream_orderbook method."""
 
-    @patch("gpt_trader.features.brokerages.coinbase.client.websocket_mixin.CoinbaseWebSocket")
-    def test_connects_and_subscribes_to_level2(self, mock_ws_class):
+    def test_connects_and_subscribes_to_level2(self, mock_websocket_class: MagicMock):
         """stream_orderbook with level>=2 should subscribe to level2 channel."""
         mock_ws = MagicMock()
-        mock_ws_class.return_value = mock_ws
+        mock_websocket_class.return_value = mock_ws
 
         client = MockWebSocketClient()
 
@@ -43,11 +52,10 @@ class TestStreamOrderbook:
         mock_ws.connect.assert_called_once()
         mock_ws.subscribe.assert_called_once_with(["BTC-USD", "ETH-USD"], ["level2"])
 
-    @patch("gpt_trader.features.brokerages.coinbase.client.websocket_mixin.CoinbaseWebSocket")
-    def test_subscribes_to_ticker_for_level1(self, mock_ws_class):
+    def test_subscribes_to_ticker_for_level1(self, mock_websocket_class: MagicMock):
         """stream_orderbook with level=1 should subscribe to ticker channel."""
         mock_ws = MagicMock()
-        mock_ws_class.return_value = mock_ws
+        mock_websocket_class.return_value = mock_ws
 
         client = MockWebSocketClient()
 
@@ -69,11 +77,10 @@ class TestStreamOrderbook:
 
         mock_ws.subscribe.assert_called_once_with(["BTC-USD"], ["ticker"])
 
-    @patch("gpt_trader.features.brokerages.coinbase.client.websocket_mixin.CoinbaseWebSocket")
-    def test_include_trades_adds_channel(self, mock_ws_class):
+    def test_include_trades_adds_channel(self, mock_websocket_class: MagicMock):
         """stream_orderbook should include market_trades when requested."""
         mock_ws = MagicMock()
-        mock_ws_class.return_value = mock_ws
+        mock_websocket_class.return_value = mock_ws
 
         client = MockWebSocketClient()
         stop_event = threading.Event()
@@ -96,11 +103,10 @@ class TestStreamOrderbook:
 
         mock_ws.subscribe.assert_called_once_with(["BTC-USD"], ["level2", "market_trades"])
 
-    @patch("gpt_trader.features.brokerages.coinbase.client.websocket_mixin.CoinbaseWebSocket")
-    def test_include_user_events_subscribes(self, mock_ws_class):
+    def test_include_user_events_subscribes(self, mock_websocket_class: MagicMock):
         """stream_orderbook should subscribe to user events when requested."""
         mock_ws = MagicMock()
-        mock_ws_class.return_value = mock_ws
+        mock_websocket_class.return_value = mock_ws
 
         client = MockWebSocketClient()
         stop_event = threading.Event()

--- a/tests/unit/gpt_trader/features/brokerages/coinbase/test_websocket_mixin_ws_health.py
+++ b/tests/unit/gpt_trader/features/brokerages/coinbase/test_websocket_mixin_ws_health.py
@@ -3,18 +3,27 @@
 from __future__ import annotations
 
 import threading
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
+import pytest
+
+import gpt_trader.features.brokerages.coinbase.client.websocket_mixin as websocket_mixin_module
 from tests.unit.gpt_trader.features.brokerages.coinbase.websocket_mixin_test_helpers import (
     MockWebSocketClient,
 )
 
 
+@pytest.fixture
+def mock_websocket_class(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    mock_ws_class = MagicMock()
+    monkeypatch.setattr(websocket_mixin_module, "CoinbaseWebSocket", mock_ws_class)
+    return mock_ws_class
+
+
 class TestGetWSHealth:
     """Tests for get_ws_health method."""
 
-    @patch("gpt_trader.features.brokerages.coinbase.client.websocket_mixin.CoinbaseWebSocket")
-    def test_returns_empty_dict_when_no_ws(self, mock_ws_class):
+    def test_returns_empty_dict_when_no_ws(self, mock_websocket_class: MagicMock):
         """get_ws_health should return empty dict when no WebSocket exists."""
         client = MockWebSocketClient()
 
@@ -24,8 +33,7 @@ class TestGetWSHealth:
 
         assert result == {}
 
-    @patch("gpt_trader.features.brokerages.coinbase.client.websocket_mixin.CoinbaseWebSocket")
-    def test_returns_health_dict_from_ws(self, mock_ws_class):
+    def test_returns_health_dict_from_ws(self, mock_websocket_class: MagicMock):
         """get_ws_health should return health dict from underlying WebSocket."""
         mock_ws = MagicMock()
         mock_health = {
@@ -38,7 +46,7 @@ class TestGetWSHealth:
             "reconnect_count": 1,
         }
         mock_ws.get_health.return_value = mock_health
-        mock_ws_class.return_value = mock_ws
+        mock_websocket_class.return_value = mock_ws
 
         client = MockWebSocketClient()
 
@@ -50,12 +58,11 @@ class TestGetWSHealth:
         assert result == mock_health
         mock_ws.get_health.assert_called_once()
 
-    @patch("gpt_trader.features.brokerages.coinbase.client.websocket_mixin.CoinbaseWebSocket")
-    def test_returns_empty_dict_after_stop_streaming(self, mock_ws_class):
+    def test_returns_empty_dict_after_stop_streaming(self, mock_websocket_class: MagicMock):
         """get_ws_health should return empty dict after WebSocket is cleaned up."""
         mock_ws = MagicMock()
         mock_ws.get_health.return_value = {"connected": True}
-        mock_ws_class.return_value = mock_ws
+        mock_websocket_class.return_value = mock_ws
 
         client = MockWebSocketClient()
 
@@ -68,12 +75,11 @@ class TestGetWSHealth:
         assert result == {}
         assert client._ws is None
 
-    @patch("gpt_trader.features.brokerages.coinbase.client.websocket_mixin.CoinbaseWebSocket")
-    def test_is_thread_safe(self, mock_ws_class):
+    def test_is_thread_safe(self, mock_websocket_class: MagicMock):
         """get_ws_health should be thread-safe using the lock."""
         mock_ws = MagicMock()
         mock_ws.get_health.return_value = {"connected": True}
-        mock_ws_class.return_value = mock_ws
+        mock_websocket_class.return_value = mock_ws
 
         client = MockWebSocketClient()
         client._get_websocket()

--- a/var/agents/testing/source_test_map.json
+++ b/var/agents/testing/source_test_map.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "summary": {
-    "tests_scanned": 916,
+    "tests_scanned": 918,
     "source_modules": 350,
     "unresolved_modules": 3
   },
@@ -625,7 +625,9 @@
     ],
     "gpt_trader.features.brokerages.coinbase.client.websocket_mixin": [
       "tests/unit/gpt_trader/features/brokerages/coinbase/test_websocket_mixin_init_and_get_websocket.py",
-      "tests/unit/gpt_trader/features/brokerages/coinbase/test_websocket_mixin_stream_trades_and_control.py"
+      "tests/unit/gpt_trader/features/brokerages/coinbase/test_websocket_mixin_stream_orderbook.py",
+      "tests/unit/gpt_trader/features/brokerages/coinbase/test_websocket_mixin_stream_trades_and_control.py",
+      "tests/unit/gpt_trader/features/brokerages/coinbase/test_websocket_mixin_ws_health.py"
     ],
     "gpt_trader.features.brokerages.coinbase.credentials": [
       "tests/unit/gpt_trader/features/brokerages/coinbase/test_credentials_resolution.py"
@@ -3447,7 +3449,13 @@
     "tests/unit/gpt_trader/features/brokerages/coinbase/test_websocket_mixin_init_and_get_websocket.py": [
       "gpt_trader.features.brokerages.coinbase.client.websocket_mixin"
     ],
+    "tests/unit/gpt_trader/features/brokerages/coinbase/test_websocket_mixin_stream_orderbook.py": [
+      "gpt_trader.features.brokerages.coinbase.client.websocket_mixin"
+    ],
     "tests/unit/gpt_trader/features/brokerages/coinbase/test_websocket_mixin_stream_trades_and_control.py": [
+      "gpt_trader.features.brokerages.coinbase.client.websocket_mixin"
+    ],
+    "tests/unit/gpt_trader/features/brokerages/coinbase/test_websocket_mixin_ws_health.py": [
       "gpt_trader.features.brokerages.coinbase.client.websocket_mixin"
     ],
     "tests/unit/gpt_trader/features/brokerages/coinbase/test_ws_events_dispatcher.py": [

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -17826,7 +17826,7 @@
     "tests/unit/gpt_trader/features/brokerages/coinbase/test_websocket_mixin_stream_orderbook.py": [
       {
         "name": "TestStreamOrderbook::test_connects_and_subscribes_to_level2",
-        "line": 17,
+        "line": 26,
         "markers": [
           "unit"
         ],
@@ -17835,7 +17835,7 @@
       },
       {
         "name": "TestStreamOrderbook::test_subscribes_to_ticker_for_level1",
-        "line": 47,
+        "line": 55,
         "markers": [
           "unit"
         ],
@@ -17844,7 +17844,7 @@
       },
       {
         "name": "TestStreamOrderbook::test_include_trades_adds_channel",
-        "line": 73,
+        "line": 80,
         "markers": [
           "unit"
         ],
@@ -17853,7 +17853,7 @@
       },
       {
         "name": "TestStreamOrderbook::test_include_user_events_subscribes",
-        "line": 100,
+        "line": 106,
         "markers": [
           "unit"
         ],
@@ -17862,7 +17862,7 @@
       },
       {
         "name": "TestStreamOrderbook::test_yields_messages_from_callback",
-        "line": 126,
+        "line": 132,
         "markers": [
           "unit"
         ],
@@ -17938,7 +17938,7 @@
     "tests/unit/gpt_trader/features/brokerages/coinbase/test_websocket_mixin_ws_health.py": [
       {
         "name": "TestGetWSHealth::test_returns_empty_dict_when_no_ws",
-        "line": 17,
+        "line": 26,
         "markers": [
           "unit"
         ],
@@ -17947,7 +17947,7 @@
       },
       {
         "name": "TestGetWSHealth::test_returns_health_dict_from_ws",
-        "line": 28,
+        "line": 36,
         "markers": [
           "unit"
         ],
@@ -17956,7 +17956,7 @@
       },
       {
         "name": "TestGetWSHealth::test_returns_empty_dict_after_stop_streaming",
-        "line": 54,
+        "line": 61,
         "markers": [
           "unit"
         ],
@@ -17965,7 +17965,7 @@
       },
       {
         "name": "TestGetWSHealth::test_is_thread_safe",
-        "line": 72,
+        "line": 78,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary
- replace CoinbaseWebSocket patch decorators with monkeypatch fixtures in ws health/orderbook mixin tests
- keep stream orderbook assertions while removing patch context usage
- regenerate test inventory artifacts

## Testing
- uv run pytest -q tests/unit/gpt_trader/features/brokerages/coinbase/test_websocket_mixin_ws_health.py tests/unit/gpt_trader/features/brokerages/coinbase/test_websocket_mixin_stream_orderbook.py
- uv run python scripts/ci/check_test_hygiene.py
- uv run python scripts/ci/check_legacy_test_triage.py
- uv run python scripts/agents/generate_test_inventory.py