### PR TITLE
test(coinbase): reduce patch density in ws edges/transports

### DIFF
--- a/tests/unit/gpt_trader/features/brokerages/coinbase/test_coinbase_websocket_edges.py
+++ b/tests/unit/gpt_trader/features/brokerages/coinbase/test_coinbase_websocket_edges.py
@@ -3,16 +3,22 @@
 from __future__ import annotations
 
 import json
-from unittest.mock import patch
+from unittest.mock import MagicMock
 
+import pytest
+
+import gpt_trader.features.brokerages.coinbase.ws as ws_module
 from gpt_trader.features.brokerages.coinbase.ws import CoinbaseWebSocket
 
 
-def test_subscribe_user_events_without_credentials_logs_warning() -> None:
+def test_subscribe_user_events_without_credentials_logs_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     ws = CoinbaseWebSocket(api_key=None, private_key=None)
 
-    with patch("gpt_trader.features.brokerages.coinbase.ws.logger") as mock_logger:
-        ws.subscribe_user_events()
+    mock_logger = MagicMock()
+    monkeypatch.setattr(ws_module, "logger", mock_logger)
+    ws.subscribe_user_events()
 
     mock_logger.warning.assert_called_once_with(
         "Cannot subscribe to user events without API credentials"
@@ -20,20 +26,22 @@ def test_subscribe_user_events_without_credentials_logs_warning() -> None:
     assert ws.subscriptions == []
 
 
-def test_on_message_heartbeat_updates_timestamps() -> None:
+def test_on_message_heartbeat_updates_timestamps(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     ws = CoinbaseWebSocket()
 
-    with patch(
-        "gpt_trader.features.brokerages.coinbase.ws.time.time",
-        side_effect=[1.0, 2.0],
-    ):
-        ws._on_message(None, json.dumps({"channel": "heartbeats"}))
+    time_calls = iter([1.0, 2.0])
+    monkeypatch.setattr(ws_module.time, "time", lambda: next(time_calls))
+    ws._on_message(None, json.dumps({"channel": "heartbeats"}))
 
     assert ws._last_message_ts == 1.0
     assert ws._last_heartbeat_ts == 2.0
 
 
-def test_on_message_sequence_gap_increments_and_passes_flag() -> None:
+def test_on_message_sequence_gap_increments_and_passes_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     captured: list[dict] = []
 
     def _capture(message: dict) -> None:
@@ -41,20 +49,23 @@ def test_on_message_sequence_gap_increments_and_passes_flag() -> None:
 
     ws = CoinbaseWebSocket(on_message=_capture)
 
-    with patch("gpt_trader.features.brokerages.coinbase.ws.time.time", return_value=1.0):
-        ws._on_message(None, json.dumps({"sequence": 1, "channel": "ticker"}))
-        ws._on_message(None, json.dumps({"sequence": 3, "channel": "ticker"}))
+    monkeypatch.setattr(ws_module.time, "time", lambda: 1.0)
+    ws._on_message(None, json.dumps({"sequence": 1, "channel": "ticker"}))
+    ws._on_message(None, json.dumps({"sequence": 3, "channel": "ticker"}))
 
     assert ws._gap_count == 1
     assert captured[-1].get("gap_detected") is True
 
 
-def test_invalid_json_logs_error_and_preserves_last_message_ts() -> None:
+def test_invalid_json_logs_error_and_preserves_last_message_ts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     ws = CoinbaseWebSocket()
     ws._last_message_ts = 10.0
 
-    with patch("gpt_trader.features.brokerages.coinbase.ws.logger") as mock_logger:
-        ws._on_message(None, "not-json")
+    mock_logger = MagicMock()
+    monkeypatch.setattr(ws_module, "logger", mock_logger)
+    ws._on_message(None, "not-json")
 
     assert ws._last_message_ts == 10.0
     mock_logger.error.assert_called_once()

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -15875,7 +15875,7 @@
     "tests/unit/gpt_trader/features/brokerages/coinbase/test_coinbase_websocket_edges.py": [
       {
         "name": "test_subscribe_user_events_without_credentials_logs_warning",
-        "line": 11,
+        "line": 14,
         "markers": [
           "unit"
         ],
@@ -15883,7 +15883,7 @@
       },
       {
         "name": "test_on_message_heartbeat_updates_timestamps",
-        "line": 23,
+        "line": 29,
         "markers": [
           "unit"
         ],
@@ -15891,7 +15891,7 @@
       },
       {
         "name": "test_on_message_sequence_gap_increments_and_passes_flag",
-        "line": 36,
+        "line": 42,
         "markers": [
           "unit"
         ],
@@ -15899,7 +15899,7 @@
       },
       {
         "name": "test_invalid_json_logs_error_and_preserves_last_message_ts",
-        "line": 52,
+        "line": 60,
         "markers": [
           "unit"
         ],
@@ -17319,7 +17319,7 @@
     "tests/unit/gpt_trader/features/brokerages/coinbase/test_transports_environment_options.py": [
       {
         "name": "TestTransportEnvironmentOptions::test_transport_environment_variable_parsing",
-        "line": 13,
+        "line": 16,
         "markers": [
           "unit"
         ],
@@ -17328,7 +17328,7 @@
       },
       {
         "name": "TestTransportEnvironmentOptions::test_transport_empty_subprotocols",
-        "line": 30,
+        "line": 33,
         "markers": [
           "unit"
         ],
@@ -17337,7 +17337,7 @@
       },
       {
         "name": "TestTransportEnvironmentOptions::test_transport_mixed_whitespace_subprotocols",
-        "line": 45,
+        "line": 54,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary
- replace websocket/logger/time patch blocks with monkeypatch in ws edge tests
- replace websocket connection/trace patch blocks with monkeypatch in transport environment option tests
- regenerate test inventory artifacts

## Testing
- uv run pytest -q tests/unit/gpt_trader/features/brokerages/coinbase/test_transports_environment_options.py tests/unit/gpt_trader/features/brokerages/coinbase/test_coinbase_websocket_edges.py
- uv run python scripts/ci/check_test_hygiene.py
- uv run python scripts/ci/check_legacy_test_triage.py
- uv run python scripts/agents/generate_test_inventory.py