### PR TITLE
test(utilities/backtesting): reduce patch density

### DIFF
--- a/tests/unit/gpt_trader/backtesting/metrics/test_report_reporter_basics.py
+++ b/tests/unit/gpt_trader/backtesting/metrics/test_report_reporter_basics.py
@@ -2,15 +2,31 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import Mock
 
+import pytest
 from tests.unit.gpt_trader.backtesting.metrics.report_test_utils import (  # naming: allow
     create_mock_broker,
     create_mock_risk_metrics,
     create_mock_trade_stats,
 )
 
+import gpt_trader.backtesting.metrics.report as report_module
 from gpt_trader.backtesting.metrics.report import BacktestReporter
+
+
+@pytest.fixture
+def trade_statistics_calculator_mock(monkeypatch: pytest.MonkeyPatch) -> Mock:
+    mock_calculator = Mock()
+    monkeypatch.setattr(report_module, "calculate_trade_statistics", mock_calculator)
+    return mock_calculator
+
+
+@pytest.fixture
+def risk_metrics_calculator_mock(monkeypatch: pytest.MonkeyPatch) -> Mock:
+    mock_calculator = Mock()
+    monkeypatch.setattr(report_module, "calculate_risk_metrics", mock_calculator)
+    return mock_calculator
 
 
 class TestBacktestReporterInit:
@@ -33,65 +49,65 @@ class TestBacktestReporterInit:
 class TestBacktestReporterTradeStatistics:
     """Tests for trade_statistics property."""
 
-    def test_trade_statistics_lazy_loads(self) -> None:
+    def test_trade_statistics_lazy_loads(
+        self,
+        trade_statistics_calculator_mock: Mock,
+    ) -> None:
         broker = create_mock_broker()
         reporter = BacktestReporter(broker)
         mock_stats = create_mock_trade_stats()
+        trade_statistics_calculator_mock.return_value = mock_stats
 
-        with patch(
-            "gpt_trader.backtesting.metrics.report.calculate_trade_statistics",
-            return_value=mock_stats,
-        ) as mock_calculator:
-            stats = reporter.trade_statistics
+        stats = reporter.trade_statistics
 
-            mock_calculator.assert_called_once_with(broker)
-            assert stats is mock_stats
+        trade_statistics_calculator_mock.assert_called_once_with(broker)
+        assert stats is mock_stats
 
-    def test_trade_statistics_caches_result(self) -> None:
+    def test_trade_statistics_caches_result(
+        self,
+        trade_statistics_calculator_mock: Mock,
+    ) -> None:
         broker = create_mock_broker()
         reporter = BacktestReporter(broker)
         mock_stats = create_mock_trade_stats()
+        trade_statistics_calculator_mock.return_value = mock_stats
 
-        with patch(
-            "gpt_trader.backtesting.metrics.report.calculate_trade_statistics",
-            return_value=mock_stats,
-        ) as mock_calculator:
-            stats1 = reporter.trade_statistics
-            stats2 = reporter.trade_statistics
+        stats1 = reporter.trade_statistics
+        stats2 = reporter.trade_statistics
 
-            # Should only call once due to caching
-            mock_calculator.assert_called_once()
-            assert stats1 is stats2
+        # Should only call once due to caching
+        trade_statistics_calculator_mock.assert_called_once()
+        assert stats1 is stats2
 
 
 class TestBacktestReporterRiskMetrics:
     """Tests for risk_metrics property."""
 
-    def test_risk_metrics_lazy_loads(self) -> None:
+    def test_risk_metrics_lazy_loads(
+        self,
+        risk_metrics_calculator_mock: Mock,
+    ) -> None:
         broker = create_mock_broker()
         reporter = BacktestReporter(broker)
         mock_risk = create_mock_risk_metrics()
+        risk_metrics_calculator_mock.return_value = mock_risk
 
-        with patch(
-            "gpt_trader.backtesting.metrics.report.calculate_risk_metrics",
-            return_value=mock_risk,
-        ) as mock_calculator:
-            risk = reporter.risk_metrics
+        risk = reporter.risk_metrics
 
-            mock_calculator.assert_called_once_with(broker)
-            assert risk is mock_risk
+        risk_metrics_calculator_mock.assert_called_once_with(broker)
+        assert risk is mock_risk
 
-    def test_risk_metrics_caches_result(self) -> None:
+    def test_risk_metrics_caches_result(
+        self,
+        risk_metrics_calculator_mock: Mock,
+    ) -> None:
         broker = create_mock_broker()
         reporter = BacktestReporter(broker)
         mock_risk = create_mock_risk_metrics()
+        risk_metrics_calculator_mock.return_value = mock_risk
 
-        with patch(
-            "gpt_trader.backtesting.metrics.report.calculate_risk_metrics",
-            return_value=mock_risk,
-        ) as mock_calculator:
-            risk1 = reporter.risk_metrics
-            risk2 = reporter.risk_metrics
+        risk1 = reporter.risk_metrics
+        risk2 = reporter.risk_metrics
 
-            mock_calculator.assert_called_once()
-            assert risk1 is risk2
+        risk_metrics_calculator_mock.assert_called_once()
+        assert risk1 is risk2

--- a/tests/unit/gpt_trader/utilities/test_console_logging_functions.py
+++ b/tests/unit/gpt_trader/utilities/test_console_logging_functions.py
@@ -1,9 +1,10 @@
 """Tests for console logging global helpers."""
 
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 
+import gpt_trader.utilities.console_logging as console_logging_module
 from gpt_trader.utilities.console_logging import (
     console_cache,
     console_data,
@@ -19,45 +20,53 @@ from gpt_trader.utilities.console_logging import (
 )
 
 
+@pytest.fixture
+def console_logger_mock(monkeypatch: pytest.MonkeyPatch) -> Mock:
+    mock_logger = Mock()
+    monkeypatch.setattr(console_logging_module, "ConsoleLogger", Mock(return_value=mock_logger))
+    return mock_logger
+
+
+@pytest.fixture
+def get_console_logger_mock(monkeypatch: pytest.MonkeyPatch) -> Mock:
+    mock_logger = Mock()
+    monkeypatch.setattr(
+        console_logging_module, "get_console_logger", Mock(return_value=mock_logger)
+    )
+    return mock_logger
+
+
 class TestConsoleLoggingFunctions:
     """Tests for console logging utilities."""
 
-    def test_end_to_end_logging_workflow(self):
+    def test_end_to_end_logging_workflow(self, console_logger_mock: Mock):
         """Test complete logging workflow."""
-        import gpt_trader.utilities.console_logging
+        console_logging_module._console_logger = None
 
-        gpt_trader.utilities.console_logging._console_logger = None
+        console_section("Trading Session")
+        console_success("Connected to broker")
+        console_order("Order placed", symbol="BTC-USD", quantity=1.0)
+        console_position("Position updated", symbol="BTC-USD", quantity=1.0)
+        console_data("Market data received", symbols=["BTC-USD", "ETH-USD"])
 
-        mock_logger = Mock()
-        with patch(
-            "gpt_trader.utilities.console_logging.ConsoleLogger", return_value=mock_logger
-        ) as mock_console:
-            console_section("Trading Session")
-            console_success("Connected to broker")
-            console_order("Order placed", symbol="BTC-USD", quantity=1.0)
-            console_position("Position updated", symbol="BTC-USD", quantity=1.0)
-            console_data("Market data received", symbols=["BTC-USD", "ETH-USD"])
+        console_logging_module.ConsoleLogger.assert_called_once_with(enable_console=True)
+        assert console_logging_module._console_logger is console_logger_mock
 
-            mock_console.assert_called_once_with(enable_console=True)
-            assert gpt_trader.utilities.console_logging._console_logger is mock_logger
-
-            mock_logger.print_section.assert_called_once_with("Trading Session", "=", 50)
-            mock_logger.success.assert_called_once_with("Connected to broker")
-            mock_logger.order.assert_called_once_with(
-                "Order placed", symbol="BTC-USD", quantity=1.0
-            )
-            mock_logger.position.assert_called_once_with(
-                "Position updated", symbol="BTC-USD", quantity=1.0
-            )
-            mock_logger.data.assert_called_once_with(
-                "Market data received", symbols=["BTC-USD", "ETH-USD"]
-            )
+        console_logger_mock.print_section.assert_called_once_with("Trading Session", "=", 50)
+        console_logger_mock.success.assert_called_once_with("Connected to broker")
+        console_logger_mock.order.assert_called_once_with(
+            "Order placed", symbol="BTC-USD", quantity=1.0
+        )
+        console_logger_mock.position.assert_called_once_with(
+            "Position updated", symbol="BTC-USD", quantity=1.0
+        )
+        console_logger_mock.data.assert_called_once_with(
+            "Market data received", symbols=["BTC-USD", "ETH-USD"]
+        )
 
     def test_all_context_methods(self):
         """Test all context-specific methods work without errors."""
-        import gpt_trader.utilities.console_logging
-
-        gpt_trader.utilities.console_logging._console_logger = None
+        console_logging_module._console_logger = None
 
         methods = [
             console_data,
@@ -73,11 +82,9 @@ class TestConsoleLoggingFunctions:
             except Exception as e:
                 pytest.fail(f"Method {method.__name__} raised exception: {e}")
 
-    def test_table_formatting_complex_data(self):
+    def test_table_formatting_complex_data(self, console_logger_mock: Mock):
         """Test table formatting with complex data."""
-        import gpt_trader.utilities.console_logging
-
-        gpt_trader.utilities.console_logging._console_logger = None
+        console_logging_module._console_logger = None
 
         headers = ["Symbol", "Price", "Quantity", "Value", "P&L", "P&L %"]
         rows = [
@@ -86,23 +93,19 @@ class TestConsoleLoggingFunctions:
             ["SOL-USD", "123.45", "100.0", "12,345.00", "+567.89", "+4.81%"],
         ]
 
-        mock_logger = Mock()
-        with patch("gpt_trader.utilities.console_logging.ConsoleLogger", return_value=mock_logger):
-            console_table(headers, rows)
-            console_table(headers, [])
-            single_row = [rows[0]]
-            console_table(headers, single_row)
+        console_table(headers, rows)
+        console_table(headers, [])
+        single_row = [rows[0]]
+        console_table(headers, single_row)
 
-        assert mock_logger.print_table.call_count == 3
-        assert mock_logger.print_table.call_args_list[0].args == (headers, rows)
-        assert mock_logger.print_table.call_args_list[1].args == (headers, [])
-        assert mock_logger.print_table.call_args_list[2].args == (headers, single_row)
+        assert console_logger_mock.print_table.call_count == 3
+        assert console_logger_mock.print_table.call_args_list[0].args == (headers, rows)
+        assert console_logger_mock.print_table.call_args_list[1].args == (headers, [])
+        assert console_logger_mock.print_table.call_args_list[2].args == (headers, single_row)
 
     def test_error_handling_in_global_functions(self):
         """Test error handling in global console functions."""
-        import gpt_trader.utilities.console_logging
-
-        gpt_trader.utilities.console_logging._console_logger = None
+        console_logging_module._console_logger = None
 
         try:
             console_success("Test message")
@@ -112,53 +115,45 @@ class TestConsoleLoggingFunctions:
         except Exception as e:
             pytest.fail(f"Global console functions raised exception: {e}")
 
-    def test_function_parameter_passing(self):
+    def test_function_parameter_passing(self, get_console_logger_mock: Mock):
         """Test that parameters are correctly passed to underlying logger."""
-        with patch("gpt_trader.utilities.console_logging.get_console_logger") as mock_get_logger:
-            mock_logger = Mock()
-            mock_get_logger.return_value = mock_logger
+        console_success("Test", string_param="value", int_param=42, float_param=3.14)
+        get_console_logger_mock.success.assert_called_once_with(
+            "Test", string_param="value", int_param=42, float_param=3.14
+        )
 
-            console_success("Test", string_param="value", int_param=42, float_param=3.14)
-            mock_logger.success.assert_called_once_with(
-                "Test", string_param="value", int_param=42, float_param=3.14
-            )
+        get_console_logger_mock.reset_mock()
+        console_error("Error", exception=ValueError("test"), none_param=None)
+        get_console_logger_mock.error.assert_called_once()
+        call_args = get_console_logger_mock.error.call_args
+        assert call_args[0][0] == "Error"
+        assert "exception" in call_args[1]
+        assert "none_param" in call_args[1]
+        assert call_args[1]["none_param"] is None
 
-            mock_logger.reset_mock()
-            console_error("Error", exception=ValueError("test"), none_param=None)
-            mock_logger.error.assert_called_once()
-            call_args = mock_logger.error.call_args
-            assert call_args[0][0] == "Error"
-            assert "exception" in call_args[1]
-            assert "none_param" in call_args[1]
-            assert call_args[1]["none_param"] is None
-
-    def test_multiple_function_calls(self):
+    def test_multiple_function_calls(self, get_console_logger_mock: Mock):
         """Test multiple calls to console functions."""
-        with patch("gpt_trader.utilities.console_logging.get_console_logger") as mock_get_logger:
-            mock_logger = Mock()
-            mock_get_logger.return_value = mock_logger
+        console_success("Success 1")
+        console_error("Error 1")
+        console_warning("Warning 1")
+        console_info("Info 1")
 
-            console_success("Success 1")
-            console_error("Error 1")
-            console_warning("Warning 1")
-            console_info("Info 1")
+        assert get_console_logger_mock.success.call_count == 1
+        assert get_console_logger_mock.error.call_count == 1
+        assert get_console_logger_mock.warning.call_count == 1
+        assert get_console_logger_mock.info.call_count == 1
 
-            assert mock_logger.success.call_count == 1
-            assert mock_logger.error.call_count == 1
-            assert mock_logger.warning.call_count == 1
-            assert mock_logger.info.call_count == 1
+        expected_calls = [
+            (("Success 1",), {}),
+            (("Error 1",), {}),
+            (("Warning 1",), {}),
+            (("Info 1",), {}),
+        ]
 
-            expected_calls = [
-                (("Success 1",), {}),
-                (("Error 1",), {}),
-                (("Warning 1",), {}),
-                (("Info 1",), {}),
-            ]
+        actual_calls = []
+        for method_name in ["success", "error", "warning", "info"]:
+            method = getattr(get_console_logger_mock, method_name)
+            if method.called:
+                actual_calls.append((method.call_args[0], method.call_args[1]))
 
-            actual_calls = []
-            for method_name in ["success", "error", "warning", "info"]:
-                method = getattr(mock_logger, method_name)
-                if method.called:
-                    actual_calls.append((method.call_args[0], method.call_args[1]))
-
-            assert actual_calls == expected_calls
+        assert actual_calls == expected_calls

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -5302,7 +5302,7 @@
     "tests/unit/gpt_trader/backtesting/metrics/test_report_reporter_basics.py": [
       {
         "name": "TestBacktestReporterInit::test_init_stores_broker",
-        "line": 19,
+        "line": 36,
         "markers": [
           "unit"
         ],
@@ -5311,7 +5311,7 @@
       },
       {
         "name": "TestBacktestReporterInit::test_init_stats_are_none",
-        "line": 25,
+        "line": 42,
         "markers": [
           "unit"
         ],
@@ -5320,7 +5320,7 @@
       },
       {
         "name": "TestBacktestReporterTradeStatistics::test_trade_statistics_lazy_loads",
-        "line": 36,
+        "line": 53,
         "markers": [
           "unit"
         ],
@@ -5329,7 +5329,7 @@
       },
       {
         "name": "TestBacktestReporterTradeStatistics::test_trade_statistics_caches_result",
-        "line": 50,
+        "line": 67,
         "markers": [
           "unit"
         ],
@@ -5338,7 +5338,7 @@
       },
       {
         "name": "TestBacktestReporterRiskMetrics::test_risk_metrics_lazy_loads",
-        "line": 70,
+        "line": 87,
         "markers": [
           "unit"
         ],
@@ -5347,7 +5347,7 @@
       },
       {
         "name": "TestBacktestReporterRiskMetrics::test_risk_metrics_caches_result",
-        "line": 84,
+        "line": 101,
         "markers": [
           "unit"
         ],
@@ -55383,7 +55383,7 @@
     "tests/unit/gpt_trader/utilities/test_console_logging_functions.py": [
       {
         "name": "TestConsoleLoggingFunctions::test_end_to_end_logging_workflow",
-        "line": 25,
+        "line": 42,
         "markers": [
           "unit"
         ],
@@ -55392,7 +55392,7 @@
       },
       {
         "name": "TestConsoleLoggingFunctions::test_all_context_methods",
-        "line": 56,
+        "line": 67,
         "markers": [
           "unit"
         ],
@@ -55401,7 +55401,7 @@
       },
       {
         "name": "TestConsoleLoggingFunctions::test_table_formatting_complex_data",
-        "line": 76,
+        "line": 85,
         "markers": [
           "unit"
         ],
@@ -55410,7 +55410,7 @@
       },
       {
         "name": "TestConsoleLoggingFunctions::test_error_handling_in_global_functions",
-        "line": 101,
+        "line": 106,
         "markers": [
           "unit"
         ],
@@ -55419,7 +55419,7 @@
       },
       {
         "name": "TestConsoleLoggingFunctions::test_function_parameter_passing",
-        "line": 115,
+        "line": 118,
         "markers": [
           "unit"
         ],
@@ -55428,7 +55428,7 @@
       },
       {
         "name": "TestConsoleLoggingFunctions::test_multiple_function_calls",
-        "line": 135,
+        "line": 134,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary
- replace console logger patch usage with monkeypatch fixtures in console logging helper tests
- replace metrics calculator patch usage with monkeypatch fixtures in reporter basics tests
- regenerate test inventory artifacts

## Testing
- uv run pytest -q tests/unit/gpt_trader/utilities/test_console_logging_functions.py tests/unit/gpt_trader/backtesting/metrics/test_report_reporter_basics.py
- uv run python scripts/ci/check_test_hygiene.py
- uv run python scripts/ci/check_legacy_test_triage.py
- uv run python scripts/agents/generate_test_inventory.py