### PR TITLE
test(monitoring): reduce patch usage in metrics tests

### DIFF
--- a/var/agents/testing/source_test_map.json
+++ b/var/agents/testing/source_test_map.json
@@ -907,7 +907,9 @@
       "tests/unit/gpt_trader/features/live_trade/test_degradation_status_and_clear_all.py"
     ],
     "gpt_trader.features.live_trade.engines": [
-      "tests/unit/gpt_trader/features/live_trade/engines/test_telemetry_health_edges.py"
+      "tests/unit/gpt_trader/features/live_trade/engines/test_telemetry_health_edges.py",
+      "tests/unit/gpt_trader/monitoring/test_memory_metrics.py",
+      "tests/unit/gpt_trader/monitoring/test_resource_metrics_edges.py"
     ],
     "gpt_trader.features.live_trade.engines.base": [
       "tests/integration/test_crash_recovery.py",
@@ -4725,6 +4727,7 @@
       "gpt_trader.monitoring.heartbeat"
     ],
     "tests/unit/gpt_trader/monitoring/test_memory_metrics.py": [
+      "gpt_trader.features.live_trade.engines",
       "gpt_trader.features.live_trade.engines.system_maintenance",
       "gpt_trader.persistence.event_store"
     ],
@@ -4744,6 +4747,7 @@
       "gpt_trader.monitoring.profiling"
     ],
     "tests/unit/gpt_trader/monitoring/test_resource_metrics_edges.py": [
+      "gpt_trader.features.live_trade.engines",
       "gpt_trader.features.live_trade.engines.system_maintenance"
     ],
     "tests/unit/gpt_trader/monitoring/test_runtime_guards_base.py": [

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -9656,7 +9656,7 @@
       },
       {
         "name": "TestInstantiateBot::test_uses_existing_container",
-        "line": 71,
+        "line": 69,
         "markers": [
           "unit"
         ],
@@ -9665,7 +9665,7 @@
       },
       {
         "name": "TestRunBotCleanup::test_clears_container_on_shutdown",
-        "line": 101,
+        "line": 99,
         "markers": [
           "unit"
         ],
@@ -9674,7 +9674,7 @@
       },
       {
         "name": "TestRunBotCleanup::test_clears_container_even_on_exception",
-        "line": 123,
+        "line": 121,
         "markers": [
           "unit"
         ],
@@ -36293,7 +36293,7 @@
     "tests/unit/gpt_trader/monitoring/test_memory_metrics.py": [
       {
         "name": "TestMemoryGaugeEmission::test_event_store_cache_gauges_emitted",
-        "line": 11,
+        "line": 22,
         "markers": [
           "unit"
         ],
@@ -36302,7 +36302,7 @@
       },
       {
         "name": "TestMemoryGaugeEmission::test_event_store_metrics_handles_none_store",
-        "line": 53,
+        "line": 63,
         "markers": [
           "unit"
         ],
@@ -36311,7 +36311,7 @@
       },
       {
         "name": "TestMemoryGaugeEmission::test_event_store_metrics_handles_missing_methods",
-        "line": 74,
+        "line": 83,
         "markers": [
           "unit"
         ],
@@ -36320,7 +36320,7 @@
       },
       {
         "name": "TestEventStoreCacheMetrics::test_get_cache_size",
-        "line": 103,
+        "line": 111,
         "markers": [
           "unit"
         ],
@@ -36329,7 +36329,7 @@
       },
       {
         "name": "TestEventStoreCacheMetrics::test_get_cache_max_size",
-        "line": 118,
+        "line": 126,
         "markers": [
           "unit"
         ],
@@ -36338,7 +36338,7 @@
       },
       {
         "name": "TestEventStoreCacheMetrics::test_get_cache_fill_ratio",
-        "line": 125,
+        "line": 133,
         "markers": [
           "unit"
         ],
@@ -36347,7 +36347,7 @@
       },
       {
         "name": "TestEventStoreCacheMetrics::test_get_cache_fill_ratio_handles_zero_max",
-        "line": 141,
+        "line": 149,
         "markers": [
           "unit"
         ],
@@ -36778,7 +36778,7 @@
     "tests/unit/gpt_trader/monitoring/test_resource_metrics_edges.py": [
       {
         "name": "test_collect_process_metrics_missing_psutil_returns_na",
-        "line": 44,
+        "line": 54,
         "markers": [
           "unit"
         ],
@@ -36786,7 +36786,7 @@
       },
       {
         "name": "test_collect_process_metrics_handles_read_errors",
-        "line": 61,
+        "line": 73,
         "markers": [
           "unit"
         ],
@@ -36794,7 +36794,7 @@
       },
       {
         "name": "test_collect_process_metrics_formats_memory_bounds",
-        "line": 79,
+        "line": 93,
         "markers": [
           "parametrize",
           "unit"
@@ -36803,7 +36803,7 @@
       },
       {
         "name": "test_collect_process_metrics_invalid_cpu_percent_falls_back",
-        "line": 97,
+        "line": 113,
         "markers": [
           "unit"
         ],
@@ -36811,7 +36811,7 @@
       },
       {
         "name": "test_collect_process_metrics_invalid_memory_value_falls_back",
-        "line": 110,
+        "line": 128,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
- Replace unittest.mock.patch usage with pytest monkeypatch fixtures in monitoring metrics tests.\n- Regenerate test inventory artifacts.\n\nTests:\n- uv run pytest -q tests/unit/gpt_trader/monitoring/test_memory_metrics.py tests/unit/gpt_trader/monitoring/test_resource_metrics_edges.py\n- uv run python scripts/ci/check_test_hygiene.py\n- uv run python scripts/ci/check_legacy_test_triage.py\n- uv run python scripts/agents/generate_test_inventory.py