### PR TITLE
test(logging): reduce patch usage in setup smoke test

### DIFF
--- a/tests/unit/gpt_trader/logging/test_setup_smoke.py
+++ b/tests/unit/gpt_trader/logging/test_setup_smoke.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 import logging.handlers
 from pathlib import Path
-from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -37,14 +36,14 @@ class TestLoggingSetupSmoke:
             json_logger.removeHandler(handler)
             handler.close()
 
-    @patch("gpt_trader.logging.setup.ensure_directories")
-    @patch("pathlib.Path.mkdir")
     def test_logging_works_after_configuration(
-        self, mock_mkdir: MagicMock, mock_ensure: MagicMock, tmp_path: Path
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test that logging actually works after configuration."""
-        with patch("gpt_trader.logging.setup.LOG_DIR", str(tmp_path)):
-            configure_logging()
+        import gpt_trader.logging.setup as logging_setup
+
+        monkeypatch.setattr(logging_setup, "LOG_DIR", tmp_path / "logs")
+        configure_logging()
 
         # Should not raise any exceptions
         logger = logging.getLogger("test_logger")

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -32982,7 +32982,7 @@
     "tests/unit/gpt_trader/logging/test_setup_smoke.py": [
       {
         "name": "TestLoggingSetupSmoke::test_logging_works_after_configuration",
-        "line": 42,
+        "line": 39,
         "markers": [
           "unit"
         ],
@@ -36302,7 +36302,7 @@
       },
       {
         "name": "TestMemoryGaugeEmission::test_event_store_metrics_handles_none_store",
-        "line": 63,
+        "line": 61,
         "markers": [
           "unit"
         ],
@@ -36311,7 +36311,7 @@
       },
       {
         "name": "TestMemoryGaugeEmission::test_event_store_metrics_handles_missing_methods",
-        "line": 83,
+        "line": 79,
         "markers": [
           "unit"
         ],
@@ -36320,7 +36320,7 @@
       },
       {
         "name": "TestEventStoreCacheMetrics::test_get_cache_size",
-        "line": 111,
+        "line": 107,
         "markers": [
           "unit"
         ],
@@ -36329,7 +36329,7 @@
       },
       {
         "name": "TestEventStoreCacheMetrics::test_get_cache_max_size",
-        "line": 126,
+        "line": 122,
         "markers": [
           "unit"
         ],
@@ -36338,7 +36338,7 @@
       },
       {
         "name": "TestEventStoreCacheMetrics::test_get_cache_fill_ratio",
-        "line": 133,
+        "line": 129,
         "markers": [
           "unit"
         ],
@@ -36347,7 +36347,7 @@
       },
       {
         "name": "TestEventStoreCacheMetrics::test_get_cache_fill_ratio_handles_zero_max",
-        "line": 149,
+        "line": 145,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
- Drop patching of pathlib.Path.mkdir/ensure_directories by using tmp_path + monkeypatch to point LOG_DIR at an isolated temp logs dir.\n- Update test inventory artifacts.\n\nTests:\n- uv run pytest -q tests/unit/gpt_trader/logging/test_setup_smoke.py\n- uv run python scripts/ci/check_test_hygiene.py\n- uv run python scripts/ci/check_legacy_test_triage.py\n- uv run python scripts/agents/generate_test_inventory.py