### PR TITLE
test(live_trade): reduce patch density in order event recorder tests

### DIFF
--- a/tests/unit/gpt_trader/features/live_trade/execution/test_order_event_recorder_submission_attempt.py
+++ b/tests/unit/gpt_trader/features/live_trade/execution/test_order_event_recorder_submission_attempt.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 from decimal import Decimal
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
+import pytest
+
+import gpt_trader.features.live_trade.execution.order_event_recorder as order_event_recorder_module
 from gpt_trader.core import OrderSide, OrderType
 from gpt_trader.features.live_trade.execution.order_event_recorder import OrderEventRecorder
 
@@ -12,15 +15,16 @@ from gpt_trader.features.live_trade.execution.order_event_recorder import OrderE
 class TestRecordSubmissionAttempt:
     """Tests for record_submission_attempt method."""
 
-    @patch("gpt_trader.features.live_trade.execution.order_event_recorder.get_monitoring_logger")
     def test_record_submission_attempt_logs_correctly(
         self,
-        mock_get_logger: MagicMock,
         order_event_recorder: OrderEventRecorder,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test that submission attempt is logged correctly."""
         mock_logger = MagicMock()
-        mock_get_logger.return_value = mock_logger
+        monkeypatch.setattr(
+            order_event_recorder_module, "get_monitoring_logger", lambda: mock_logger
+        )
 
         order_event_recorder.record_submission_attempt(
             submit_id="client-123",
@@ -40,15 +44,16 @@ class TestRecordSubmissionAttempt:
             price=50000.0,
         )
 
-    @patch("gpt_trader.features.live_trade.execution.order_event_recorder.get_monitoring_logger")
     def test_record_submission_attempt_handles_none_price(
         self,
-        mock_get_logger: MagicMock,
         order_event_recorder: OrderEventRecorder,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test that submission attempt handles None price."""
         mock_logger = MagicMock()
-        mock_get_logger.return_value = mock_logger
+        monkeypatch.setattr(
+            order_event_recorder_module, "get_monitoring_logger", lambda: mock_logger
+        )
 
         order_event_recorder.record_submission_attempt(
             submit_id="client-123",
@@ -62,16 +67,17 @@ class TestRecordSubmissionAttempt:
         call_kwargs = mock_logger.log_order_submission.call_args.kwargs
         assert call_kwargs["price"] is None
 
-    @patch("gpt_trader.features.live_trade.execution.order_event_recorder.get_monitoring_logger")
     def test_record_submission_attempt_handles_exception(
         self,
-        mock_get_logger: MagicMock,
         order_event_recorder: OrderEventRecorder,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test that submission attempt handles exceptions gracefully."""
         mock_logger = MagicMock()
         mock_logger.log_order_submission.side_effect = RuntimeError("Log failure")
-        mock_get_logger.return_value = mock_logger
+        monkeypatch.setattr(
+            order_event_recorder_module, "get_monitoring_logger", lambda: mock_logger
+        )
 
         # Should not raise
         order_event_recorder.record_submission_attempt(

--- a/tests/unit/gpt_trader/features/live_trade/execution/test_order_event_recorder_success.py
+++ b/tests/unit/gpt_trader/features/live_trade/execution/test_order_event_recorder_success.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 from decimal import Decimal
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
+import pytest
+
+import gpt_trader.features.live_trade.execution.order_event_recorder as order_event_recorder_module
 from gpt_trader.core import OrderSide
 from gpt_trader.features.live_trade.execution.order_event_recorder import OrderEventRecorder
 
@@ -12,14 +15,16 @@ from gpt_trader.features.live_trade.execution.order_event_recorder import OrderE
 class TestRecordSuccess:
     """Tests for record_success method."""
 
-    @patch("gpt_trader.features.live_trade.execution.order_event_recorder.logger")
     def test_record_success_logs_order_info(
         self,
-        mock_logger: MagicMock,
         order_event_recorder: OrderEventRecorder,
         order_event_mock_order: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test that successful order is logged."""
+        mock_logger = MagicMock()
+        monkeypatch.setattr(order_event_recorder_module, "logger", mock_logger)
+
         # record_success only logs, doesn't interact with event_store
         # Just verify it doesn't raise
         order_event_recorder.record_success(
@@ -35,14 +40,16 @@ class TestRecordSuccess:
         assert call_kwargs["symbol"] == "BTC-USD"
         assert call_kwargs["reduce_only"] is False
 
-    @patch("gpt_trader.features.live_trade.execution.order_event_recorder.logger")
     def test_record_success_handles_reduce_only(
         self,
-        mock_logger: MagicMock,
         order_event_recorder: OrderEventRecorder,
         order_event_mock_order: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test that reduce_only flag is handled."""
+        mock_logger = MagicMock()
+        monkeypatch.setattr(order_event_recorder_module, "logger", mock_logger)
+
         order_event_recorder.record_success(
             order=order_event_mock_order,
             symbol="BTC-USD",
@@ -55,14 +62,16 @@ class TestRecordSuccess:
         call_kwargs = mock_logger.info.call_args.kwargs
         assert call_kwargs["reduce_only"] is True
 
-    @patch("gpt_trader.features.live_trade.execution.order_event_recorder.logger")
     def test_record_success_handles_market_price(
         self,
-        mock_logger: MagicMock,
         order_event_recorder: OrderEventRecorder,
         order_event_mock_order: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test that 'market' as display_price is handled."""
+        mock_logger = MagicMock()
+        monkeypatch.setattr(order_event_recorder_module, "logger", mock_logger)
+
         order_event_recorder.record_success(
             order=order_event_mock_order,
             symbol="BTC-USD",

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -22705,7 +22705,7 @@
     "tests/unit/gpt_trader/features/live_trade/execution/test_order_event_recorder_edge_cases.py": [
       {
         "name": "TestOrderEventRecorderEdgeCases::test_recorder_with_empty_bot_id",
-        "line": 14,
+        "line": 17,
         "markers": [
           "unit"
         ],
@@ -22714,7 +22714,7 @@
       },
       {
         "name": "TestOrderEventRecorderEdgeCases::test_record_rejection_with_decimal_quantity",
-        "line": 21,
+        "line": 22,
         "markers": [
           "unit"
         ],
@@ -22723,7 +22723,7 @@
       },
       {
         "name": "TestOrderEventRecorderEdgeCases::test_record_trade_event_uses_order_quantity_when_available",
-        "line": 44,
+        "line": 47,
         "markers": [
           "unit"
         ],
@@ -22879,7 +22879,7 @@
     "tests/unit/gpt_trader/features/live_trade/execution/test_order_event_recorder_submission_attempt.py": [
       {
         "name": "TestRecordSubmissionAttempt::test_record_submission_attempt_logs_correctly",
-        "line": 16,
+        "line": 18,
         "markers": [
           "unit"
         ],
@@ -22888,7 +22888,7 @@
       },
       {
         "name": "TestRecordSubmissionAttempt::test_record_submission_attempt_handles_none_price",
-        "line": 44,
+        "line": 47,
         "markers": [
           "unit"
         ],
@@ -22897,7 +22897,7 @@
       },
       {
         "name": "TestRecordSubmissionAttempt::test_record_submission_attempt_handles_exception",
-        "line": 66,
+        "line": 70,
         "markers": [
           "unit"
         ],
@@ -22908,7 +22908,7 @@
     "tests/unit/gpt_trader/features/live_trade/execution/test_order_event_recorder_success.py": [
       {
         "name": "TestRecordSuccess::test_record_success_logs_order_info",
-        "line": 16,
+        "line": 18,
         "markers": [
           "unit"
         ],
@@ -22917,7 +22917,7 @@
       },
       {
         "name": "TestRecordSuccess::test_record_success_handles_reduce_only",
-        "line": 39,
+        "line": 43,
         "markers": [
           "unit"
         ],
@@ -22926,7 +22926,7 @@
       },
       {
         "name": "TestRecordSuccess::test_record_success_handles_market_price",
-        "line": 59,
+        "line": 65,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary
- Convert `@patch` decorators to `monkeypatch` fixtures in order event recorder tests
- Reduces patch density by 9 patches across 3 files:
  - `test_order_event_recorder_success.py`: 3 patches on `logger`
  - `test_order_event_recorder_submission_attempt.py`: 3 patches on `get_monitoring_logger`
  - `test_order_event_recorder_edge_cases.py`: 3 patches on `emit_metric`/`get_monitoring_logger`

## Test plan
- [x] All 9 tests pass
- [x] Test hygiene check passes
- [x] Legacy test triage check passes
- [x] Test inventory regenerated