### PR TITLE
test(live_trade): reduce patch density in risk manager tests

### DIFF
--- a/tests/unit/gpt_trader/features/live_trade/test_risk_manager_mark_staleness.py
+++ b/tests/unit/gpt_trader/features/live_trade/test_risk_manager_mark_staleness.py
@@ -3,11 +3,10 @@
 from __future__ import annotations
 
 import time
-from typing import Any
-from unittest.mock import patch
 
 import pytest
 
+import gpt_trader.features.live_trade.risk.manager as risk_manager_module
 from gpt_trader.features.live_trade.risk.manager import LiveRiskManager
 from tests.unit.gpt_trader.features.live_trade.risk_manager_test_utils import (  # naming: allow
     MockConfig,  # naming: allow
@@ -15,10 +14,9 @@ from tests.unit.gpt_trader.features.live_trade.risk_manager_test_utils import ( 
 
 
 @pytest.fixture(autouse=True)
-def mock_load_state():
+def mock_load_state(monkeypatch: pytest.MonkeyPatch) -> None:
     """Prevent LiveRiskManager from loading state during tests."""
-    with patch("gpt_trader.features.live_trade.risk.manager.LiveRiskManager._load_state"):
-        yield
+    monkeypatch.setattr(LiveRiskManager, "_load_state", lambda self: None)
 
 
 class TestCheckMarkStaleness:
@@ -61,10 +59,9 @@ class TestCheckMarkStaleness:
         # 100 < 120, so not stale
         assert manager.check_mark_staleness("BTC-USD") is False
 
-    @patch("time.time")
-    def test_exact_boundary(self, mock_time: Any) -> None:
+    def test_exact_boundary(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test behavior at exact threshold boundary."""
-        mock_time.return_value = 1000.0
+        monkeypatch.setattr(risk_manager_module.time, "time", lambda: 1000.0)
         manager = LiveRiskManager()
         manager.last_mark_update["BTC-USD"] = 880.0  # Exactly 120 seconds ago
 

--- a/tests/unit/gpt_trader/features/live_trade/test_risk_manager_risk_metrics.py
+++ b/tests/unit/gpt_trader/features/live_trade/test_risk_manager_risk_metrics.py
@@ -3,28 +3,25 @@
 from __future__ import annotations
 
 from decimal import Decimal
-from typing import Any
-from unittest.mock import patch
 
 import pytest
 
+import gpt_trader.features.live_trade.risk.manager as risk_manager_module
 from gpt_trader.features.live_trade.risk.manager import LiveRiskManager
 
 
 @pytest.fixture(autouse=True)
-def mock_load_state():
+def mock_load_state(monkeypatch: pytest.MonkeyPatch) -> None:
     """Prevent LiveRiskManager from loading state during tests."""
-    with patch("gpt_trader.features.live_trade.risk.manager.LiveRiskManager._load_state"):
-        yield
+    monkeypatch.setattr(LiveRiskManager, "_load_state", lambda self: None)
 
 
 class TestAppendRiskMetrics:
     """Tests for append_risk_metrics method."""
 
-    @patch("time.time")
-    def test_appends_metrics(self, mock_time: Any) -> None:
+    def test_appends_metrics(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test appends metrics with timestamp."""
-        mock_time.return_value = 12345.0
+        monkeypatch.setattr(risk_manager_module.time, "time", lambda: 12345.0)
         manager = LiveRiskManager()
 
         manager.append_risk_metrics(Decimal("10000"), {"BTC-USD": {"pnl": Decimal("100")}})


### PR DESCRIPTION
## Summary
- Convert `unittest.mock.patch` to `monkeypatch` fixtures in risk manager tests
- `test_risk_manager_risk_metrics.py`: 2 patches converted (_load_state fixture, time.time)
- `test_risk_manager_mark_staleness.py`: 2 patches converted (_load_state fixture, time.time)

## Test plan
- [x] `uv run pytest tests/unit/gpt_trader/features/live_trade/test_risk_manager_risk_metrics.py tests/unit/gpt_trader/features/live_trade/test_risk_manager_mark_staleness.py -v` (10 passed)
- [x] `uv run python scripts/ci/check_test_hygiene.py`
- [x] `uv run python scripts/ci/check_legacy_test_triage.py`
- [x] `uv run python scripts/agents/generate_test_inventory.py`