### PR TITLE
test(execution): reduce patch density in order submission tests

### DIFF
--- a/tests/unit/gpt_trader/features/live_trade/execution/test_order_submission_core_process_rejection.py
+++ b/tests/unit/gpt_trader/features/live_trade/execution/test_order_submission_core_process_rejection.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 from decimal import Decimal
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
+import gpt_trader.features.live_trade.execution.order_event_recorder as order_event_recorder_module
 from gpt_trader.core import OrderSide, OrderType, TimeInForce
 from gpt_trader.features.live_trade.execution.order_submission import OrderSubmitter
 from gpt_trader.persistence.orders_store import OrderStatus as StoreOrderStatus
@@ -60,18 +61,18 @@ class TestProcessRejection:
             },
         )
 
-    @patch("gpt_trader.features.live_trade.execution.order_event_recorder.emit_metric")
-    @patch("gpt_trader.features.live_trade.execution.order_event_recorder.get_monitoring_logger")
     def test_normal_mode_raises_error(
         self,
-        mock_get_logger: MagicMock,
-        mock_emit_metric: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
         submitter: OrderSubmitter,
         rejected_order: MagicMock,
     ) -> None:
         """Test that normal mode raises RuntimeError."""
         mock_logger = MagicMock()
-        mock_get_logger.return_value = mock_logger
+        monkeypatch.setattr(
+            order_event_recorder_module, "get_monitoring_logger", lambda: mock_logger
+        )
+        monkeypatch.setattr(order_event_recorder_module, "emit_metric", MagicMock())
 
         rejected_order.status = MagicMock()
         rejected_order.status.value = "CANCELLED"

--- a/tests/unit/gpt_trader/features/live_trade/execution/test_order_submission_flows_retry_idempotency.py
+++ b/tests/unit/gpt_trader/features/live_trade/execution/test_order_submission_flows_retry_idempotency.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 from decimal import Decimal
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
+import pytest
+
+import gpt_trader.features.live_trade.execution.order_event_recorder as order_event_recorder_module
 from gpt_trader.core import (
     OrderSide,
     OrderType,
@@ -15,17 +18,18 @@ from gpt_trader.features.live_trade.execution.order_submission import OrderSubmi
 class TestRetryPathIdempotency:
     """Tests ensuring retry paths don't create duplicate client_order_ids."""
 
-    @patch("gpt_trader.features.live_trade.execution.order_event_recorder.get_monitoring_logger")
     def test_provided_client_order_id_is_reused_on_retry(
         self,
-        mock_get_logger: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
         mock_broker: MagicMock,
         mock_event_store: MagicMock,
         open_orders: list[str],
     ) -> None:
         """Test that a provided client_order_id is reused across retries."""
         mock_logger = MagicMock()
-        mock_get_logger.return_value = mock_logger
+        monkeypatch.setattr(
+            order_event_recorder_module, "get_monitoring_logger", lambda: mock_logger
+        )
 
         captured_client_ids: list[str] = []
 
@@ -75,17 +79,18 @@ class TestRetryPathIdempotency:
         assert captured_client_ids[1] == "retry-test-123"
         assert captured_client_ids[0] == captured_client_ids[1]
 
-    @patch("gpt_trader.features.live_trade.execution.order_event_recorder.get_monitoring_logger")
     def test_generated_client_order_id_differs_per_submission(
         self,
-        mock_get_logger: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
         mock_broker: MagicMock,
         mock_event_store: MagicMock,
         open_orders: list[str],
     ) -> None:
         """Test that auto-generated client_order_ids are unique per submission."""
         mock_logger = MagicMock()
-        mock_get_logger.return_value = mock_logger
+        monkeypatch.setattr(
+            order_event_recorder_module, "get_monitoring_logger", lambda: mock_logger
+        )
 
         captured_client_ids: list[str] = []
 

--- a/tests/unit/gpt_trader/features/live_trade/execution/test_order_submission_flows_transient_failure.py
+++ b/tests/unit/gpt_trader/features/live_trade/execution/test_order_submission_flows_transient_failure.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 from decimal import Decimal
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
+import pytest
+
+import gpt_trader.features.live_trade.execution.order_event_recorder as order_event_recorder_module
 from gpt_trader.core import (
     Order,
     OrderSide,
@@ -20,16 +23,16 @@ from gpt_trader.utilities.datetime_helpers import utc_now
 class TestTransientFailureWithClientOrderIdReuse:
     """Integration test for transient failure followed by success."""
 
-    @patch("gpt_trader.features.live_trade.execution.order_event_recorder.emit_metric")
-    @patch("gpt_trader.features.live_trade.execution.order_event_recorder.get_monitoring_logger")
     def test_transient_failure_then_success_reuses_client_order_id(
         self,
-        mock_get_logger: MagicMock,
-        mock_emit_metric: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test that transient failure followed by success reuses client_order_id."""
         mock_logger = MagicMock()
-        mock_get_logger.return_value = mock_logger
+        monkeypatch.setattr(
+            order_event_recorder_module, "get_monitoring_logger", lambda: mock_logger
+        )
+        monkeypatch.setattr(order_event_recorder_module, "emit_metric", MagicMock())
 
         captured_client_ids: list[str] = []
         call_count = [0]


### PR DESCRIPTION
## Summary
- Convert `unittest.mock.patch` to `monkeypatch` fixtures in order submission resilience tests
- `test_order_submission_flows_transient_failure.py`: 2 patches converted (emit_metric, get_monitoring_logger)
- `test_order_submission_flows_retry_idempotency.py`: 2 patches converted (get_monitoring_logger x2)
- `test_order_submission_core_process_rejection.py`: 2 patches converted (emit_metric, get_monitoring_logger)

## Test plan
- [x] `uv run pytest tests/unit/gpt_trader/features/live_trade/execution/test_order_submission_flows_transient_failure.py tests/unit/gpt_trader/features/live_trade/execution/test_order_submission_flows_retry_idempotency.py tests/unit/gpt_trader/features/live_trade/execution/test_order_submission_core_process_rejection.py -v` (5 passed)
- [x] `uv run python scripts/ci/check_test_hygiene.py`
- [x] `uv run python scripts/ci/check_legacy_test_triage.py`
- [x] `uv run python scripts/agents/generate_test_inventory.py`