### PR TITLE
test(monitoring): reduce patch density in edge tests

### DIFF
--- a/tests/unit/gpt_trader/monitoring/test_status_reporter_edges.py
+++ b/tests/unit/gpt_trader/monitoring/test_status_reporter_edges.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from decimal import Decimal
-from unittest.mock import patch
+from unittest.mock import MagicMock
+
+import pytest
 
 from gpt_trader.monitoring.status_reporter import StatusReporter
 
@@ -35,8 +37,10 @@ def test_update_positions_coerces_invalid_and_skips_non_dict() -> None:
     assert position["side"] == "LONG"
 
 
-@patch("gpt_trader.monitoring.status_reporter.time.time", return_value=123.45)
-def test_update_orders_invalid_fields_use_defaults(mock_time) -> None:
+def test_update_orders_invalid_fields_use_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    import gpt_trader.monitoring.status_reporter as status_reporter
+
+    monkeypatch.setattr(status_reporter.time, "time", lambda: 123.45)
     reporter = StatusReporter()
 
     reporter.update_orders(
@@ -110,10 +114,14 @@ def test_update_strategy_generates_decision_id_and_handles_invalid_timestamp() -
     assert second.decision_id == ""
 
 
-@patch("gpt_trader.monitoring.status_reporter.record_gauge", side_effect=RuntimeError("boom"))
-def test_update_equity_swallows_record_gauge_exceptions(mock_record_gauge) -> None:
+def test_update_equity_swallows_record_gauge_exceptions(monkeypatch: pytest.MonkeyPatch) -> None:
+    import gpt_trader.monitoring.status_reporter as status_reporter
+
+    mock_record_gauge = MagicMock(side_effect=RuntimeError("boom"))
+    monkeypatch.setattr(status_reporter, "record_gauge", mock_record_gauge)
     reporter = StatusReporter()
 
     reporter.update_equity(Decimal("123.45"))
 
+    mock_record_gauge.assert_called()
     assert reporter._equity == Decimal("123.45")

--- a/var/agents/testing/source_test_map.json
+++ b/var/agents/testing/source_test_map.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "summary": {
     "tests_scanned": 918,
-    "source_modules": 351,
+    "source_modules": 352,
     "unresolved_modules": 3
   },
   "source_to_tests": {
@@ -1480,6 +1480,9 @@
       "tests/unit/gpt_trader/monitoring/test_guard_manager_e2e_runtime.py",
       "tests/unit/gpt_trader/monitoring/test_guard_manager_edges.py",
       "tests/unit/gpt_trader/monitoring/test_runtime_guards_base.py"
+    ],
+    "gpt_trader.monitoring.configuration_guardian": [
+      "tests/unit/gpt_trader/monitoring/configuration_guardian/test_guardian_edges.py"
     ],
     "gpt_trader.monitoring.configuration_guardian.detector": [
       "tests/unit/gpt_trader/monitoring/configuration_guardian/test_detector_edges.py",
@@ -4576,6 +4579,7 @@
       "gpt_trader.monitoring.configuration_guardian.responses"
     ],
     "tests/unit/gpt_trader/monitoring/configuration_guardian/test_guardian_edges.py": [
+      "gpt_trader.monitoring.configuration_guardian",
       "gpt_trader.monitoring.configuration_guardian.guardian",
       "gpt_trader.monitoring.configuration_guardian.models"
     ],
@@ -6019,6 +6023,7 @@
     "gpt_trader.monitoring.configuration_guardian.models": "src/gpt_trader/monitoring/configuration_guardian/models.py",
     "gpt_trader.monitoring.configuration_guardian.environment": "src/gpt_trader/monitoring/configuration_guardian/environment.py",
     "gpt_trader.monitoring.configuration_guardian.responses": "src/gpt_trader/monitoring/configuration_guardian/responses.py",
+    "gpt_trader.monitoring.configuration_guardian": "src/gpt_trader/monitoring/configuration_guardian/__init__.py",
     "gpt_trader.monitoring.configuration_guardian.guardian": "src/gpt_trader/monitoring/configuration_guardian/guardian.py",
     "gpt_trader.monitoring.configuration_guardian.state_validator": "src/gpt_trader/monitoring/configuration_guardian/state_validator.py",
     "gpt_trader.monitoring.daily_report.generator": "src/gpt_trader/monitoring/daily_report/generator.py",

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -33095,7 +33095,7 @@
     "tests/unit/gpt_trader/monitoring/configuration_guardian/test_guardian_edges.py": [
       {
         "name": "test_monitor_exception_logged_and_other_monitors_continue",
-        "line": 50,
+        "line": 61,
         "markers": [
           "unit"
         ],
@@ -33103,7 +33103,7 @@
       },
       {
         "name": "test_check_records_events_only_when_present",
-        "line": 76,
+        "line": 88,
         "markers": [
           "unit"
         ],
@@ -33111,7 +33111,7 @@
       },
       {
         "name": "test_reset_baseline_updates_monitors_and_logs_user",
-        "line": 105,
+        "line": 117,
         "markers": [
           "unit"
         ],
@@ -33119,7 +33119,7 @@
       },
       {
         "name": "test_get_state_includes_baseline_monitor_count_and_summary",
-        "line": 127,
+        "line": 140,
         "markers": [
           "unit"
         ],
@@ -36855,7 +36855,7 @@
     "tests/unit/gpt_trader/monitoring/test_status_reporter_edges.py": [
       {
         "name": "test_update_positions_coerces_invalid_and_skips_non_dict",
-        "line": 11,
+        "line": 13,
         "markers": [
           "unit"
         ],
@@ -36863,7 +36863,7 @@
       },
       {
         "name": "test_update_orders_invalid_fields_use_defaults",
-        "line": 39,
+        "line": 40,
         "markers": [
           "unit"
         ],
@@ -36871,7 +36871,7 @@
       },
       {
         "name": "test_update_account_skips_zero_or_invalid_balances",
-        "line": 70,
+        "line": 74,
         "markers": [
           "unit"
         ],
@@ -36879,7 +36879,7 @@
       },
       {
         "name": "test_update_strategy_generates_decision_id_and_handles_invalid_timestamp",
-        "line": 90,
+        "line": 94,
         "markers": [
           "unit"
         ],
@@ -36887,7 +36887,7 @@
       },
       {
         "name": "test_update_equity_swallows_record_gauge_exceptions",
-        "line": 114,
+        "line": 117,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
Swaps remaining `patch(...)` usage to `monkeypatch` fixtures in monitoring edge tests.

- `tests/unit/gpt_trader/monitoring/test_status_reporter_edges.py`
- `tests/unit/gpt_trader/monitoring/configuration_guardian/test_guardian_edges.py`
- Regenerates inventory artifacts.

Validation:
- `uv run pytest -q tests/unit/gpt_trader/monitoring/test_status_reporter_edges.py tests/unit/gpt_trader/monitoring/configuration_guardian/test_guardian_edges.py`
- `uv run python scripts/ci/check_test_hygiene.py`
- `uv run python scripts/ci/check_legacy_test_triage.py`
- `uv run python scripts/agents/generate_test_inventory.py`