### PR TITLE
test(app/container): reduce patch density in container tests

### DIFF
--- a/tests/integration/test_container_lifecycle_runtime.py
+++ b/tests/integration/test_container_lifecycle_runtime.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import MagicMock
 
 import pytest
 
+import gpt_trader.app.container as container_module
 from gpt_trader.app.config import BotConfig
 from gpt_trader.app.container import (
     ApplicationContainer,
@@ -171,19 +172,25 @@ class TestContainerServiceAccess:
 class TestContainerDebugLogging:
     """Test container lifecycle debug logging."""
 
-    def test_set_container_logs_debug(self, mock_config: BotConfig) -> None:
+    def test_set_container_logs_debug(
+        self, mock_config: BotConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         container = ApplicationContainer(mock_config)
+        mock_logger = MagicMock()
+        monkeypatch.setattr(container_module, "logger", mock_logger)
 
-        with patch("gpt_trader.app.container.logger") as mock_logger:
-            set_application_container(container)
-
-            mock_logger.debug.assert_called()
-
-    def test_clear_container_logs_debug(self, mock_config: BotConfig) -> None:
-        container = ApplicationContainer(mock_config)
         set_application_container(container)
 
-        with patch("gpt_trader.app.container.logger") as mock_logger:
-            clear_application_container()
+        mock_logger.debug.assert_called()
 
-            mock_logger.debug.assert_called()
+    def test_clear_container_logs_debug(
+        self, mock_config: BotConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        container = ApplicationContainer(mock_config)
+        set_application_container(container)
+        mock_logger = MagicMock()
+        monkeypatch.setattr(container_module, "logger", mock_logger)
+
+        clear_application_container()
+
+        mock_logger.debug.assert_called()

--- a/tests/unit/gpt_trader/app/test_application_container_bot_creation.py
+++ b/tests/unit/gpt_trader/app/test_application_container_bot_creation.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
+import pytest
+
+import gpt_trader.features.live_trade.bot as bot_module
 from gpt_trader.app.config import BotConfig
 from gpt_trader.app.container import ApplicationContainer
 
@@ -11,8 +14,7 @@ from gpt_trader.app.container import ApplicationContainer
 class TestApplicationContainerBotCreation:
     """Test cases for ApplicationContainer.create_bot()."""
 
-    @patch("gpt_trader.features.live_trade.bot.TradingBot")
-    def test_create_bot(self, mock_bot_class: MagicMock, mock_config: BotConfig) -> None:
+    def test_create_bot(self, mock_config: BotConfig, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test that TradingBot is created correctly from container."""
         from gpt_trader.app.containers.brokerage import BrokerageContainer
 
@@ -25,7 +27,8 @@ class TestApplicationContainerBotCreation:
             MagicMock(),
             MagicMock(),
         )
-        mock_bot_class.return_value = mock_bot
+        mock_bot_class = MagicMock(return_value=mock_bot)
+        monkeypatch.setattr(bot_module, "TradingBot", mock_bot_class)
 
         container = ApplicationContainer(mock_config)
         container._brokerage = BrokerageContainer(
@@ -46,9 +49,8 @@ class TestApplicationContainerBotCreation:
 
         assert bot == mock_bot
 
-    @patch("gpt_trader.features.live_trade.bot.TradingBot")
     def test_create_bot_includes_notification_service(
-        self, mock_bot_class: MagicMock, mock_config: BotConfig
+        self, mock_config: BotConfig, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test that TradingBot is created with notification service."""
         from gpt_trader.app.containers.brokerage import BrokerageContainer
@@ -62,7 +64,8 @@ class TestApplicationContainerBotCreation:
             MagicMock(),
             MagicMock(),
         )
-        mock_bot_class.return_value = mock_bot
+        mock_bot_class = MagicMock(return_value=mock_bot)
+        monkeypatch.setattr(bot_module, "TradingBot", mock_bot_class)
 
         container = ApplicationContainer(mock_config)
         container._brokerage = BrokerageContainer(

--- a/tests/unit/gpt_trader/app/test_application_container_resources.py
+++ b/tests/unit/gpt_trader/app/test_application_container_resources.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
+import pytest
+
+import gpt_trader.app.containers.brokerage as brokerage_module
 from gpt_trader.app.config import BotConfig
 from gpt_trader.app.container import ApplicationContainer
 from gpt_trader.persistence.event_store import EventStore
@@ -67,13 +70,13 @@ class TestApplicationContainerResources:
         orders_store2 = container.orders_store
         assert orders_store is orders_store2
 
-    @patch("gpt_trader.app.containers.brokerage.MarketDataService")
     def test_market_data_service_creation(
-        self, mock_market_data_service: MagicMock, mock_config: BotConfig
+        self, mock_config: BotConfig, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test that market data service is created correctly."""
         mock_instance = MagicMock()
-        mock_market_data_service.return_value = mock_instance
+        mock_market_data_service = MagicMock(return_value=mock_instance)
+        monkeypatch.setattr(brokerage_module, "MarketDataService", mock_market_data_service)
 
         container = ApplicationContainer(mock_config)
 
@@ -86,13 +89,13 @@ class TestApplicationContainerResources:
         market_data_service2 = container.market_data_service
         assert market_data_service is market_data_service2
 
-    @patch("gpt_trader.app.containers.brokerage.ProductCatalog")
     def test_product_catalog_creation(
-        self, mock_product_catalog: MagicMock, mock_config: BotConfig
+        self, mock_config: BotConfig, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Test that product catalog is created correctly."""
         mock_instance = MagicMock()
-        mock_product_catalog.return_value = mock_instance
+        mock_product_catalog = MagicMock(return_value=mock_instance)
+        monkeypatch.setattr(brokerage_module, "ProductCatalog", mock_product_catalog)
 
         container = ApplicationContainer(mock_config)
 

--- a/var/agents/testing/source_test_map.json
+++ b/var/agents/testing/source_test_map.json
@@ -889,6 +889,7 @@
     "gpt_trader.features.live_trade.bot": [
       "tests/integration/test_core_validation.py",
       "tests/integration/test_paper_mode.py",
+      "tests/unit/gpt_trader/app/test_application_container_bot_creation.py",
       "tests/unit/gpt_trader/app/test_bootstrap.py",
       "tests/unit/gpt_trader/features/live_trade/test_bot_engine_delegation.py",
       "tests/unit/gpt_trader/features/live_trade/test_bot_flatten_and_stop.py",
@@ -2591,7 +2592,8 @@
     "tests/unit/gpt_trader/app/test_application_container_bot_creation.py": [
       "gpt_trader.app.config",
       "gpt_trader.app.container",
-      "gpt_trader.app.containers.brokerage"
+      "gpt_trader.app.containers.brokerage",
+      "gpt_trader.features.live_trade.bot"
     ],
     "tests/unit/gpt_trader/app/test_application_container_registry.py": [
       "gpt_trader.app.config",

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -1210,7 +1210,7 @@
     "tests/integration/test_container_lifecycle_runtime.py": [
       {
         "name": "TestContainerLifecycleTUI::test_tui_unmount_clears_container",
-        "line": 43,
+        "line": 44,
         "markers": [
           "integration",
           "asyncio"
@@ -1220,7 +1220,7 @@
       },
       {
         "name": "TestContainerLifecycleTUI::test_tui_lifecycle_integration",
-        "line": 54,
+        "line": 55,
         "markers": [
           "integration",
           "asyncio"
@@ -1230,7 +1230,7 @@
       },
       {
         "name": "TestContainerLifecycleMultipleCycles::test_multiple_bot_cycles_no_leak",
-        "line": 72,
+        "line": 73,
         "markers": [
           "integration"
         ],
@@ -1239,7 +1239,7 @@
       },
       {
         "name": "TestContainerLifecycleMultipleCycles::test_container_services_are_fresh_each_cycle",
-        "line": 85,
+        "line": 86,
         "markers": [
           "integration"
         ],
@@ -1248,7 +1248,7 @@
       },
       {
         "name": "TestContainerLifecycleErrorPaths::test_container_cleared_when_bot_creation_fails",
-        "line": 105,
+        "line": 106,
         "markers": [
           "integration"
         ],
@@ -1257,7 +1257,7 @@
       },
       {
         "name": "TestContainerLifecycleErrorPaths::test_container_cleared_on_async_error",
-        "line": 119,
+        "line": 120,
         "markers": [
           "integration",
           "asyncio"
@@ -1267,7 +1267,7 @@
       },
       {
         "name": "TestContainerServiceAccess::test_services_accessible_after_registration",
-        "line": 139,
+        "line": 140,
         "markers": [
           "integration"
         ],
@@ -1276,7 +1276,7 @@
       },
       {
         "name": "TestContainerServiceAccess::test_services_not_accessible_after_clear",
-        "line": 150,
+        "line": 151,
         "markers": [
           "integration"
         ],
@@ -1285,7 +1285,7 @@
       },
       {
         "name": "TestContainerServiceAccess::test_service_resolution_functions_handle_missing_container",
-        "line": 159,
+        "line": 160,
         "markers": [
           "integration"
         ],
@@ -1294,7 +1294,7 @@
       },
       {
         "name": "TestContainerDebugLogging::test_set_container_logs_debug",
-        "line": 174,
+        "line": 175,
         "markers": [
           "integration"
         ],
@@ -1303,7 +1303,7 @@
       },
       {
         "name": "TestContainerDebugLogging::test_clear_container_logs_debug",
-        "line": 182,
+        "line": 186,
         "markers": [
           "integration"
         ],
@@ -3659,7 +3659,7 @@
     "tests/unit/gpt_trader/app/test_application_container_bot_creation.py": [
       {
         "name": "TestApplicationContainerBotCreation::test_create_bot",
-        "line": 15,
+        "line": 17,
         "markers": [
           "unit"
         ],
@@ -3668,7 +3668,7 @@
       },
       {
         "name": "TestApplicationContainerBotCreation::test_create_bot_includes_notification_service",
-        "line": 50,
+        "line": 54,
         "markers": [
           "unit"
         ],
@@ -3782,7 +3782,7 @@
     "tests/unit/gpt_trader/app/test_application_container_resources.py": [
       {
         "name": "TestApplicationContainerResources::test_container_initialization",
-        "line": 16,
+        "line": 19,
         "markers": [
           "unit"
         ],
@@ -3791,7 +3791,7 @@
       },
       {
         "name": "TestApplicationContainerResources::test_config_controller_creation",
-        "line": 33,
+        "line": 36,
         "markers": [
           "unit"
         ],
@@ -3800,7 +3800,7 @@
       },
       {
         "name": "TestApplicationContainerResources::test_event_store_creation",
-        "line": 46,
+        "line": 49,
         "markers": [
           "unit"
         ],
@@ -3809,7 +3809,7 @@
       },
       {
         "name": "TestApplicationContainerResources::test_orders_store_creation",
-        "line": 58,
+        "line": 61,
         "markers": [
           "unit"
         ],
@@ -3818,7 +3818,7 @@
       },
       {
         "name": "TestApplicationContainerResources::test_market_data_service_creation",
-        "line": 71,
+        "line": 73,
         "markers": [
           "unit"
         ],
@@ -3827,7 +3827,7 @@
       },
       {
         "name": "TestApplicationContainerResources::test_product_catalog_creation",
-        "line": 90,
+        "line": 92,
         "markers": [
           "unit"
         ],
@@ -3836,7 +3836,7 @@
       },
       {
         "name": "TestApplicationContainerResources::test_broker_creation",
-        "line": 108,
+        "line": 111,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary
- Convert `@patch` decorators and context managers to `monkeypatch.setattr()` in Application Container tests
- Files converted:
  - `test_application_container_resources.py` (2 patches)
  - `test_application_container_bot_creation.py` (2 patches)
  - `test_container_lifecycle_runtime.py` (2 patches)
- Total patches converted: 6

## Test plan
- [x] `uv run pytest tests/unit/gpt_trader/app/test_application_container_resources.py tests/unit/gpt_trader/app/test_application_container_bot_creation.py -v` (9 passed)
- [x] `uv run pytest tests/integration/test_container_lifecycle_runtime.py -v -m integration` (11 passed)
- [x] `uv run python scripts/ci/check_test_hygiene.py` (passed)
- [x] `uv run python scripts/ci/check_legacy_test_triage.py` (passed)
- [x] `uv run python scripts/agents/generate_test_inventory.py` (regenerated)