### PR TITLE
test(backtesting): reduce patch density in report generator

### DIFF
--- a/tests/unit/gpt_trader/backtesting/metrics/test_report_generate_backtest_report.py
+++ b/tests/unit/gpt_trader/backtesting/metrics/test_report_generate_backtest_report.py
@@ -3,42 +3,49 @@
 from __future__ import annotations
 
 from datetime import datetime
-from unittest.mock import patch
+from unittest.mock import MagicMock
 
+import pytest
 from tests.unit.gpt_trader.backtesting.metrics.report_test_utils import (  # naming: allow
     create_mock_broker,
     create_mock_risk_metrics,
     create_mock_trade_stats,
 )
 
+import gpt_trader.backtesting.metrics.report as report_module
 from gpt_trader.backtesting.metrics.report import generate_backtest_report
 
 
 class TestGenerateBacktestReportFunction:
     """Tests for generate_backtest_report convenience function."""
 
-    def test_returns_backtest_result(self) -> None:
+    def test_returns_backtest_result(self, monkeypatch: pytest.MonkeyPatch) -> None:
         broker = create_mock_broker()
         mock_stats = create_mock_trade_stats()
         mock_risk = create_mock_risk_metrics()
 
-        with (
-            patch(
-                "gpt_trader.backtesting.metrics.report.calculate_trade_statistics",
-                return_value=mock_stats,
-            ),
-            patch(
-                "gpt_trader.backtesting.metrics.report.calculate_risk_metrics",
-                return_value=mock_risk,
-            ),
-        ):
-            result = generate_backtest_report(
-                broker=broker,
-                start_date=datetime(2024, 1, 1),
-                end_date=datetime(2024, 2, 1),
-            )
+        mock_calculate_trade_statistics = MagicMock(return_value=mock_stats)
+        mock_calculate_risk_metrics = MagicMock(return_value=mock_risk)
+        monkeypatch.setattr(
+            report_module,
+            "calculate_trade_statistics",
+            mock_calculate_trade_statistics,
+        )
+        monkeypatch.setattr(
+            report_module,
+            "calculate_risk_metrics",
+            mock_calculate_risk_metrics,
+        )
 
-            assert result is not None
-            assert result.start_date == datetime(2024, 1, 1)
-            assert result.end_date == datetime(2024, 2, 1)
-            assert result.duration_days == 31
+        result = generate_backtest_report(
+            broker=broker,
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 2, 1),
+        )
+
+        assert result is not None
+        assert result.start_date == datetime(2024, 1, 1)
+        assert result.end_date == datetime(2024, 2, 1)
+        assert result.duration_days == 31
+        mock_calculate_trade_statistics.assert_called_once_with(broker)
+        mock_calculate_risk_metrics.assert_called_once_with(broker)

--- a/var/agents/testing/source_test_map.json
+++ b/var/agents/testing/source_test_map.json
@@ -701,9 +701,11 @@
       "tests/unit/gpt_trader/features/brokerages/coinbase/test_coinbase_system.py"
     ],
     "gpt_trader.features.brokerages.coinbase.rest.base": [
-      "tests/unit/gpt_trader/features/brokerages/coinbase/rest/test_base_execute_order_payload.py"
+      "tests/unit/gpt_trader/features/brokerages/coinbase/rest/test_base_execute_order_payload.py",
+      "tests/unit/gpt_trader/features/brokerages/coinbase/rest/test_base_find_existing_order_by_client_id.py"
     ],
     "gpt_trader.features.brokerages.coinbase.rest.order_service": [
+      "tests/unit/gpt_trader/features/brokerages/coinbase/rest/test_contract_suite_order_service_queries_and_fills.py",
       "tests/unit/gpt_trader/features/brokerages/coinbase/rest/test_order_service_edges.py",
       "tests/unit/gpt_trader/features/brokerages/coinbase/rest/test_orders_cancel_order.py",
       "tests/unit/gpt_trader/features/brokerages/coinbase/rest/test_orders_close_position.py",
@@ -3175,7 +3177,8 @@
       "gpt_trader.features.brokerages.coinbase.rest.base"
     ],
     "tests/unit/gpt_trader/features/brokerages/coinbase/rest/test_base_find_existing_order_by_client_id.py": [
-      "gpt_trader.core"
+      "gpt_trader.core",
+      "gpt_trader.features.brokerages.coinbase.rest.base"
     ],
     "tests/unit/gpt_trader/features/brokerages/coinbase/rest/test_base_position_metrics.py": [
       "gpt_trader.features.brokerages.coinbase.utilities"
@@ -3195,7 +3198,8 @@
     ],
     "tests/unit/gpt_trader/features/brokerages/coinbase/rest/test_contract_suite_order_service_queries_and_fills.py": [
       "gpt_trader.core",
-      "gpt_trader.features.brokerages.coinbase.errors"
+      "gpt_trader.features.brokerages.coinbase.errors",
+      "gpt_trader.features.brokerages.coinbase.rest.order_service"
     ],
     "tests/unit/gpt_trader/features/brokerages/coinbase/rest/test_contract_suite_pnl_service.py": [
       "gpt_trader.features.brokerages.coinbase.rest.pnl_service",
@@ -5924,8 +5928,8 @@
     "gpt_trader.features.brokerages.coinbase.client.portfolio": "src/gpt_trader/features/brokerages/coinbase/client/portfolio.py",
     "gpt_trader.features.brokerages.coinbase.rest.base": "src/gpt_trader/features/brokerages/coinbase/rest/base.py",
     "gpt_trader.features.brokerages.coinbase.rest.portfolio_service": "src/gpt_trader/features/brokerages/coinbase/rest/portfolio_service.py",
-    "gpt_trader.features.brokerages.coinbase.rest.pnl_service": "src/gpt_trader/features/brokerages/coinbase/rest/pnl_service.py",
     "gpt_trader.features.brokerages.coinbase.rest.order_service": "src/gpt_trader/features/brokerages/coinbase/rest/order_service.py",
+    "gpt_trader.features.brokerages.coinbase.rest.pnl_service": "src/gpt_trader/features/brokerages/coinbase/rest/pnl_service.py",
     "gpt_trader.features.brokerages.coinbase.rest.protocols": "src/gpt_trader/features/brokerages/coinbase/rest/protocols.py",
     "gpt_trader.features.brokerages.coinbase.rest.position_state_store": "src/gpt_trader/features/brokerages/coinbase/rest/position_state_store.py",
     "gpt_trader.features.brokerages.coinbase.rest.product_service": "src/gpt_trader/features/brokerages/coinbase/rest/product_service.py",

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -3668,7 +3668,7 @@
       },
       {
         "name": "TestApplicationContainerBotCreation::test_create_bot_includes_notification_service",
-        "line": 54,
+        "line": 52,
         "markers": [
           "unit"
         ],
@@ -5150,7 +5150,7 @@
     "tests/unit/gpt_trader/backtesting/metrics/test_report_generate_backtest_report.py": [
       {
         "name": "TestGenerateBacktestReportFunction::test_returns_backtest_result",
-        "line": 20,
+        "line": 23,
         "markers": [
           "unit"
         ],
@@ -13008,7 +13008,7 @@
     "tests/unit/gpt_trader/features/brokerages/coinbase/rest/test_base_find_existing_order_by_client_id.py": [
       {
         "name": "TestCoinbaseRestServiceCoreFindExistingOrderByClientId::test_find_existing_order_by_client_id_success",
-        "line": 15,
+        "line": 18,
         "markers": [
           "unit"
         ],
@@ -13017,7 +13017,7 @@
       },
       {
         "name": "TestCoinbaseRestServiceCoreFindExistingOrderByClientId::test_find_existing_order_by_client_id_no_client_id",
-        "line": 35,
+        "line": 39,
         "markers": [
           "unit"
         ],
@@ -13026,7 +13026,7 @@
       },
       {
         "name": "TestCoinbaseRestServiceCoreFindExistingOrderByClientId::test_find_existing_order_by_client_id_no_matches",
-        "line": 41,
+        "line": 45,
         "markers": [
           "unit"
         ],
@@ -13035,7 +13035,7 @@
       },
       {
         "name": "TestCoinbaseRestServiceCoreFindExistingOrderByClientId::test_find_existing_order_by_client_id_multiple_matches",
-        "line": 48,
+        "line": 52,
         "markers": [
           "unit"
         ],
@@ -13044,7 +13044,7 @@
       },
       {
         "name": "TestCoinbaseRestServiceCoreFindExistingOrderByClientId::test_find_existing_order_by_client_id_api_error",
-        "line": 72,
+        "line": 77,
         "markers": [
           "unit"
         ],
@@ -13053,7 +13053,7 @@
       },
       {
         "name": "TestCoinbaseRestServiceCoreFindExistingOrderByClientId::test_find_existing_order_by_client_id_network_error",
-        "line": 79,
+        "line": 84,
         "markers": [
           "unit"
         ],
@@ -13062,7 +13062,7 @@
       },
       {
         "name": "TestCoinbaseRestServiceCoreFindExistingOrderByClientId::test_find_existing_order_by_client_id_value_error",
-        "line": 86,
+        "line": 91,
         "markers": [
           "unit"
         ],
@@ -13293,7 +13293,7 @@
     "tests/unit/gpt_trader/features/brokerages/coinbase/rest/test_contract_suite_order_service_queries_and_fills.py": [
       {
         "name": "TestCoinbaseRestContractSuiteOrderServiceQueriesAndFills::test_list_orders_with_pagination",
-        "line": 17,
+        "line": 18,
         "markers": [
           "unit"
         ],
@@ -13320,7 +13320,7 @@
       },
       {
         "name": "TestCoinbaseRestContractSuiteOrderServiceQueriesAndFills::test_get_order_not_found",
-        "line": 53,
+        "line": 50,
         "markers": [
           "unit"
         ],
@@ -13329,7 +13329,7 @@
       },
       {
         "name": "TestCoinbaseRestContractSuiteOrderServiceQueriesAndFills::test_list_fills_with_pagination",
-        "line": 60,
+        "line": 57,
         "markers": [
           "unit"
         ],
@@ -13338,7 +13338,7 @@
       },
       {
         "name": "TestCoinbaseRestContractSuiteOrderServiceQueriesAndFills::test_list_fills_error_handling",
-        "line": 71,
+        "line": 68,
         "markers": [
           "unit"
         ],
@@ -18367,7 +18367,7 @@
     "tests/unit/gpt_trader/features/brokerages/coinbase/test_ws_reconnection_reset.py": [
       {
         "name": "TestWebSocketReconnectionReset::test_attempts_reset_after_stable_period",
-        "line": 14,
+        "line": 16,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
Swaps `patch(...)` usage to `monkeypatch` in backtest report generation tests and regenerates inventory artifacts.

- `tests/unit/gpt_trader/backtesting/metrics/test_report_generate_backtest_report.py`
- `var/agents/testing/test_inventory.json`
- `var/agents/testing/source_test_map.json`

Validation:
- `uv run pytest -q tests/unit/gpt_trader/backtesting/metrics/test_report_generate_backtest_report.py`
- `uv run python scripts/ci/check_test_hygiene.py`
- `uv run python scripts/ci/check_legacy_test_triage.py`
- `uv run python scripts/agents/generate_test_inventory.py`