### PR TITLE
test(coinbase/client): reduce patch density in client tests

### DIFF
--- a/tests/unit/gpt_trader/features/brokerages/coinbase/client/test_base_perform_http_request_and_lifecycle.py
+++ b/tests/unit/gpt_trader/features/brokerages/coinbase/client/test_base_perform_http_request_and_lifecycle.py
@@ -1,7 +1,7 @@
 """Tests for CoinbaseClientBase low-level HTTP + lifecycle helpers."""
 
 import time
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock
 
 import pytest
 import requests
@@ -93,13 +93,14 @@ class TestCoinbaseClientBasePerformHttpRequestAndLifecycle:
 
         client.close.assert_called_once()
 
-    def test_close_handles_session_error(self) -> None:
+    def test_close_handles_session_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test close logs warning on session close error."""
         client = CoinbaseClientBase(base_url=self.base_url, auth=self.auth)
         client.session.close = Mock(side_effect=RuntimeError("boom"))
+        mock_logger = MagicMock()
+        monkeypatch.setattr(base_module, "logger", mock_logger)
 
-        with patch("gpt_trader.features.brokerages.coinbase.client.base.logger") as mock_logger:
-            client.close()
+        client.close()
 
         mock_logger.warning.assert_called_once()
 

--- a/tests/unit/gpt_trader/features/brokerages/coinbase/client/test_base_request_happy_path.py
+++ b/tests/unit/gpt_trader/features/brokerages/coinbase/client/test_base_request_happy_path.py
@@ -1,8 +1,11 @@
 """Tests for CoinbaseClientBase request happy-path behavior."""
 
 import json
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
+import pytest
+
+import gpt_trader.features.brokerages.coinbase.client.base as base_module
 from gpt_trader.features.brokerages.coinbase.auth import SimpleAuth
 from gpt_trader.features.brokerages.coinbase.client.base import CoinbaseClientBase
 
@@ -72,10 +75,9 @@ class TestCoinbaseClientBaseRequestHappyPath:
         headers = call_args[0][2]
         assert "Authorization" not in headers
 
-    @patch("gpt_trader.features.brokerages.coinbase.client.base.get_correlation_id")
-    def test_request_with_correlation_id(self, mock_get_correlation_id: Mock) -> None:
+    def test_request_with_correlation_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test request with correlation ID."""
-        mock_get_correlation_id.return_value = "test-correlation-123"
+        monkeypatch.setattr(base_module, "get_correlation_id", lambda: "test-correlation-123")
         client = CoinbaseClientBase(base_url=self.base_url, auth=self.auth)
         mock_transport = Mock()
         mock_transport.return_value = (200, {}, '{"success": true}')

--- a/var/agents/testing/source_test_map.json
+++ b/var/agents/testing/source_test_map.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "summary": {
     "tests_scanned": 918,
-    "source_modules": 352,
+    "source_modules": 353,
     "unresolved_modules": 3
   },
   "source_to_tests": {
@@ -591,6 +591,9 @@
       "tests/unit/gpt_trader/features/brokerages/coinbase/client/test_circuit_breaker_core.py",
       "tests/unit/gpt_trader/features/brokerages/coinbase/client/test_circuit_breaker_error.py",
       "tests/unit/gpt_trader/features/brokerages/coinbase/client/test_circuit_breaker_registry.py"
+    ],
+    "gpt_trader.features.brokerages.coinbase.client.client": [
+      "tests/unit/gpt_trader/features/brokerages/coinbase/client/test_coinbase_client.py"
     ],
     "gpt_trader.features.brokerages.coinbase.client.market": [
       "tests/unit/gpt_trader/features/brokerages/coinbase/client/test_coinbase_client.py",
@@ -3116,6 +3119,7 @@
     ],
     "tests/unit/gpt_trader/features/brokerages/coinbase/client/test_coinbase_client.py": [
       "gpt_trader.features.brokerages.coinbase.client",
+      "gpt_trader.features.brokerages.coinbase.client.client",
       "gpt_trader.features.brokerages.coinbase.client.market",
       "gpt_trader.features.brokerages.coinbase.errors"
     ],
@@ -5923,6 +5927,7 @@
     "gpt_trader.features.brokerages.coinbase.client.response_cache": "src/gpt_trader/features/brokerages/coinbase/client/response_cache.py",
     "gpt_trader.features.brokerages.coinbase.client.circuit_breaker": "src/gpt_trader/features/brokerages/coinbase/client/circuit_breaker.py",
     "gpt_trader.features.brokerages.coinbase.client.priority": "src/gpt_trader/features/brokerages/coinbase/client/priority.py",
+    "gpt_trader.features.brokerages.coinbase.client.client": "src/gpt_trader/features/brokerages/coinbase/client/client.py",
     "gpt_trader.features.brokerages.coinbase.client.market": "src/gpt_trader/features/brokerages/coinbase/client/market.py",
     "gpt_trader.features.brokerages.coinbase.client.orders": "src/gpt_trader/features/brokerages/coinbase/client/orders.py",
     "gpt_trader.features.brokerages.coinbase.client.portfolio": "src/gpt_trader/features/brokerages/coinbase/client/portfolio.py",

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -5150,7 +5150,7 @@
     "tests/unit/gpt_trader/backtesting/metrics/test_report_generate_backtest_report.py": [
       {
         "name": "TestGenerateBacktestReportFunction::test_returns_backtest_result",
-        "line": 23,
+        "line": 22,
         "markers": [
           "unit"
         ],
@@ -11484,7 +11484,7 @@
       },
       {
         "name": "TestCoinbaseClientBasePerformHttpRequestAndLifecycle::test_del_suppresses_close_errors",
-        "line": 106,
+        "line": 107,
         "markers": [
           "unit"
         ],
@@ -11636,7 +11636,7 @@
     "tests/unit/gpt_trader/features/brokerages/coinbase/client/test_base_request_happy_path.py": [
       {
         "name": "TestCoinbaseClientBaseRequestHappyPath::test_request_success",
-        "line": 18,
+        "line": 21,
         "markers": [
           "unit"
         ],
@@ -11645,7 +11645,7 @@
       },
       {
         "name": "TestCoinbaseClientBaseRequestHappyPath::test_request_with_body",
-        "line": 40,
+        "line": 43,
         "markers": [
           "unit"
         ],
@@ -11654,7 +11654,7 @@
       },
       {
         "name": "TestCoinbaseClientBaseRequestHappyPath::test_request_no_auth",
-        "line": 61,
+        "line": 64,
         "markers": [
           "unit"
         ],
@@ -11663,7 +11663,7 @@
       },
       {
         "name": "TestCoinbaseClientBaseRequestHappyPath::test_request_with_correlation_id",
-        "line": 76,
+        "line": 78,
         "markers": [
           "unit"
         ],
@@ -11889,7 +11889,7 @@
     "tests/unit/gpt_trader/features/brokerages/coinbase/client/test_coinbase_client.py": [
       {
         "name": "test_list_positions_filters_zero_and_maps_side",
-        "line": 21,
+        "line": 22,
         "markers": [
           "unit"
         ],
@@ -11897,7 +11897,7 @@
       },
       {
         "name": "test_list_balances_warns_when_accounts_missing",
-        "line": 64,
+        "line": 65,
         "markers": [
           "unit"
         ],
@@ -11905,7 +11905,7 @@
       },
       {
         "name": "test_list_balances_maps_totals",
-        "line": 75,
+        "line": 76,
         "markers": [
           "unit"
         ],
@@ -11913,7 +11913,7 @@
       },
       {
         "name": "test_warn_public_market_fallback_only_once",
-        "line": 101,
+        "line": 102,
         "markers": [
           "unit"
         ],
@@ -11929,7 +11929,7 @@
       },
       {
         "name": "test_get_ticker_invalid_request_falls_back_to_authenticated",
-        "line": 132,
+        "line": 133,
         "markers": [
           "unit"
         ],
@@ -11937,7 +11937,7 @@
       },
       {
         "name": "test_get_ticker_normalizes_from_trades_and_best_bid_ask",
-        "line": 154,
+        "line": 149,
         "markers": [
           "unit"
         ],
@@ -11945,7 +11945,7 @@
       },
       {
         "name": "test_get_ticker_auth_error_raises_in_non_advanced",
-        "line": 172,
+        "line": 171,
         "markers": [
           "unit"
         ],
@@ -11953,7 +11953,7 @@
       },
       {
         "name": "test_get_candles_permission_denied_falls_back_to_public",
-        "line": 180,
+        "line": 183,
         "markers": [
           "unit"
         ],
@@ -11961,7 +11961,7 @@
       },
       {
         "name": "test_get_candles_permission_denied_raises_in_non_advanced",
-        "line": 201,
+        "line": 204,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary
- Convert `@patch` decorators and context managers to `monkeypatch.setattr()` in Coinbase client tests
- Files converted:
  - `test_base_perform_http_request_and_lifecycle.py` (1 patch)
  - `test_base_request_happy_path.py` (1 patch)
  - `test_coinbase_client.py` (8 patches)
- Total patches converted: 10

## Test plan
- [x] `uv run pytest tests/unit/gpt_trader/features/brokerages/coinbase/client/test_base_perform_http_request_and_lifecycle.py tests/unit/gpt_trader/features/brokerages/coinbase/client/test_base_request_happy_path.py tests/unit/gpt_trader/features/brokerages/coinbase/client/test_coinbase_client.py -v` (20 passed)
- [x] `uv run python scripts/ci/check_test_hygiene.py` (passed)
- [x] `uv run python scripts/ci/check_legacy_test_triage.py` (passed)
- [x] `uv run python scripts/agents/generate_test_inventory.py` (regenerated)