### PR TITLE
test(tui): reduce patch density in TUI tests

### DIFF
--- a/tests/unit/gpt_trader/tui/mixins/test_event_handlers_custom_overrides.py
+++ b/tests/unit/gpt_trader/tui/mixins/test_event_handlers_custom_overrides.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import MagicMock
 
+import pytest
 from textual.widgets import Static
 
+import gpt_trader.tui.mixins.event_handlers as event_handlers_module
 from gpt_trader.tui.events import BotStateChanged
 from gpt_trader.tui.mixins import EventHandlerMixin
 
@@ -13,9 +15,10 @@ from gpt_trader.tui.mixins import EventHandlerMixin
 class TestCustomEventHandlers:
     """Test that custom handlers can override defaults."""
 
-    @patch("gpt_trader.tui.mixins.event_handlers.logger")
-    def test_custom_handler_overrides_default(self, mock_logger):
+    def test_custom_handler_overrides_default(self, monkeypatch: pytest.MonkeyPatch):
         """Test that custom handler can override mixin default."""
+        mock_logger = MagicMock()
+        monkeypatch.setattr(event_handlers_module, "logger", mock_logger)
 
         class CustomWidget(EventHandlerMixin, Static):
             def __init__(self):

--- a/tests/unit/gpt_trader/tui/services/test_performance_service_core.py
+++ b/tests/unit/gpt_trader/tui/services/test_performance_service_core.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import time
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
+import gpt_trader.tui.services.performance_service as perf_service_module
 from gpt_trader.tui.services.performance_service import (
     FrameMetrics,
     TuiPerformanceService,
@@ -164,8 +165,7 @@ class TestTuiPerformanceService:
         assert snapshot.throttler_batch_size == 2.5
         assert snapshot.throttler_queue_depth == 3
 
-    @patch("gpt_trader.tui.services.performance_service.get_resource_monitor")
-    def test_snapshot_memory_metrics(self, mock_get_monitor) -> None:
+    def test_snapshot_memory_metrics(self, monkeypatch: pytest.MonkeyPatch) -> None:
         mock_monitor = MagicMock()
         mock_monitor.is_available.return_value = True
         mock_monitor.get_memory_usage.return_value = {
@@ -173,7 +173,7 @@ class TestTuiPerformanceService:
             "percent": 25.0,
         }
         mock_monitor.get_cpu_usage.return_value = {"cpu_percent": 15.0}
-        mock_get_monitor.return_value = mock_monitor
+        monkeypatch.setattr(perf_service_module, "get_resource_monitor", lambda: mock_monitor)
 
         service = TuiPerformanceService(app=None, enabled=True)
         snapshot = service.get_snapshot()

--- a/tests/unit/gpt_trader/tui/test_screen_flows_log_focus.py
+++ b/tests/unit/gpt_trader/tui/test_screen_flows_log_focus.py
@@ -6,10 +6,11 @@ Tests navigation flows between TUI screens using Textual's Pilot API.
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import MagicMock
 
 import pytest
 
+import gpt_trader.tui.services.action_dispatcher as action_dispatcher_module
 from gpt_trader.tui.app import TraderApp
 
 
@@ -17,8 +18,10 @@ class TestLogFocusFlow:
     """Tests for log widget focus navigation."""
 
     @pytest.mark.asyncio
-    async def test_logs_focus_on_l(self, mock_bot_with_status):
+    async def test_logs_focus_on_l(self, mock_bot_with_status, monkeypatch: pytest.MonkeyPatch):
         """Test that pressing 'l' focuses the logs widget."""
+        mock_notify = MagicMock()
+        monkeypatch.setattr(action_dispatcher_module, "notify_warning", mock_notify)
         app = TraderApp(bot=mock_bot_with_status)
 
         async with app.run_test() as pilot:
@@ -32,15 +35,14 @@ class TestLogFocusFlow:
                     break
             assert isinstance(app.screen, MainScreen)
 
-            with patch("gpt_trader.tui.services.action_dispatcher.notify_warning") as mock_notify:
-                await pilot.press("l")
-                await pilot.pause()
+            await pilot.press("l")
+            await pilot.pause()
 
-                try:
-                    log_widget = app.query_one("#dash-logs")
-                except NoMatches:
-                    mock_notify.assert_called_once()
-                    return
+            try:
+                log_widget = app.query_one("#dash-logs")
+            except NoMatches:
+                mock_notify.assert_called_once()
+                return
 
-                assert log_widget.has_focus
-                mock_notify.assert_not_called()
+            assert log_widget.has_focus
+            mock_notify.assert_not_called()

--- a/tests/unit/gpt_trader/tui/utilities/test_table_formatting_clipboard.py
+++ b/tests/unit/gpt_trader/tui/utilities/test_table_formatting_clipboard.py
@@ -1,6 +1,9 @@
 """Tests for DataTable clipboard utilities."""
 
-from unittest.mock import patch
+import subprocess
+from unittest.mock import MagicMock
+
+import pytest
 
 from gpt_trader.tui.utilities.table_formatting import copy_to_clipboard
 
@@ -8,10 +11,11 @@ from gpt_trader.tui.utilities.table_formatting import copy_to_clipboard
 class TestCopyToClipboard:
     """Tests for copy_to_clipboard function."""
 
-    @patch("subprocess.run")
-    def test_copy_on_macos(self, mock_run) -> None:
+    def test_copy_on_macos(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test clipboard copy on macOS."""
+        mock_run = MagicMock()
         mock_run.return_value.returncode = 0
+        monkeypatch.setattr(subprocess, "run", mock_run)
         # This test is platform-dependent, so we just verify no crash
         result = copy_to_clipboard("test text")
         # Result depends on platform and available tools

--- a/tests/unit/gpt_trader/tui/widgets/test_config_modal.py
+++ b/tests/unit/gpt_trader/tui/widgets/test_config_modal.py
@@ -1,40 +1,41 @@
 from __future__ import annotations
 
-from unittest.mock import MagicMock, PropertyMock, patch
+from unittest.mock import MagicMock
 
+import pytest
+from textual.widget import Widget
 from textual.widgets import Input
 
 from gpt_trader.tui.widgets.config import ConfigModal
 
 
-def test_config_modal_save_updates_risk_config(mock_bot) -> None:
+def test_config_modal_save_updates_risk_config(mock_bot, monkeypatch: pytest.MonkeyPatch) -> None:
     mock_bot.config.risk = MagicMock()
     mock_bot.config.risk.max_leverage = 1.0
     mock_bot.config.risk.daily_loss_limit_pct = 0.02
 
     modal = ConfigModal(mock_bot.config)
 
-    with patch("textual.widget.Widget.app", new_callable=PropertyMock) as mock_app_prop:
-        mock_app = MagicMock()
-        mock_app_prop.return_value = mock_app
+    mock_app = MagicMock()
+    monkeypatch.setattr(Widget, "app", property(lambda self: mock_app))
 
-        input_leverage = MagicMock(spec=Input)
-        input_leverage.value = "5.0"
+    input_leverage = MagicMock(spec=Input)
+    input_leverage.value = "5.0"
 
-        input_loss = MagicMock(spec=Input)
-        input_loss.value = "0.05"
+    input_loss = MagicMock(spec=Input)
+    input_loss.value = "0.05"
 
-        def query_side_effect(selector: str, type: type | None = None):
-            if "leverage" in selector:
-                return input_leverage
-            if "loss" in selector:
-                return input_loss
-            return MagicMock()
+    def query_side_effect(selector: str, type: type | None = None):
+        if "leverage" in selector:
+            return input_leverage
+        if "loss" in selector:
+            return input_loss
+        return MagicMock()
 
-        modal.query_one = MagicMock(side_effect=query_side_effect)
+    modal.query_one = MagicMock(side_effect=query_side_effect)
 
-        modal._save_config()
+    modal._save_config()
 
-        assert mock_bot.config.risk.max_leverage == 5.0
-        assert mock_bot.config.risk.daily_loss_limit_pct == 0.05
-        mock_app.notify.assert_called_with("Configuration updated successfully.", title="Config")
+    assert mock_bot.config.risk.max_leverage == 5.0
+    assert mock_bot.config.risk.daily_loss_limit_pct == 0.05
+    mock_app.notify.assert_called_with("Configuration updated successfully.", title="Config")

--- a/tests/unit/gpt_trader/tui/widgets/test_logs.py
+++ b/tests/unit/gpt_trader/tui/widgets/test_logs.py
@@ -1,8 +1,12 @@
 """Tests for LogWidget filter functionality."""
 
 import logging
-from unittest.mock import MagicMock, PropertyMock, patch
+from unittest.mock import MagicMock
 
+import pytest
+from textual.widget import Widget
+
+import gpt_trader.tui.log_manager as log_manager_module
 from gpt_trader.tui.widgets.logs import LogWidget
 
 
@@ -22,90 +26,104 @@ class TestLogWidgetFilterChips:
         assert "f" in binding_keys  # Cycle filter
         assert "F" in binding_keys  # Clear filter
 
-    def test_action_filter_all_sets_debug_level(self):
+    def test_action_filter_all_sets_debug_level(self, monkeypatch: pytest.MonkeyPatch):
         """Test '1' key sets DEBUG level (show all)."""
         widget = LogWidget()
         mock_app = MagicMock()
         mock_app.notify = MagicMock()
+        monkeypatch.setattr(Widget, "app", property(lambda self: mock_app))
+        mock_set = MagicMock()
+        monkeypatch.setattr(widget, "_set_level_filter", mock_set)
 
-        with patch.object(type(widget), "app", new_callable=PropertyMock, return_value=mock_app):
-            with patch.object(widget, "_set_level_filter") as mock_set:
-                widget.action_filter_all()
-                mock_set.assert_called_once_with(logging.DEBUG, "all")
+        widget.action_filter_all()
 
-    def test_action_filter_error_sets_error_level(self):
+        mock_set.assert_called_once_with(logging.DEBUG, "all")
+
+    def test_action_filter_error_sets_error_level(self, monkeypatch: pytest.MonkeyPatch):
         """Test '2' key sets ERROR level."""
         widget = LogWidget()
         mock_app = MagicMock()
         mock_app.notify = MagicMock()
+        monkeypatch.setattr(Widget, "app", property(lambda self: mock_app))
+        mock_set = MagicMock()
+        monkeypatch.setattr(widget, "_set_level_filter", mock_set)
 
-        with patch.object(type(widget), "app", new_callable=PropertyMock, return_value=mock_app):
-            with patch.object(widget, "_set_level_filter") as mock_set:
-                widget.action_filter_error()
-                mock_set.assert_called_once_with(logging.ERROR, "error")
+        widget.action_filter_error()
 
-    def test_action_filter_warning_sets_warning_level(self):
+        mock_set.assert_called_once_with(logging.ERROR, "error")
+
+    def test_action_filter_warning_sets_warning_level(self, monkeypatch: pytest.MonkeyPatch):
         """Test '3' key sets WARNING level."""
         widget = LogWidget()
         mock_app = MagicMock()
         mock_app.notify = MagicMock()
+        monkeypatch.setattr(Widget, "app", property(lambda self: mock_app))
+        mock_set = MagicMock()
+        monkeypatch.setattr(widget, "_set_level_filter", mock_set)
 
-        with patch.object(type(widget), "app", new_callable=PropertyMock, return_value=mock_app):
-            with patch.object(widget, "_set_level_filter") as mock_set:
-                widget.action_filter_warning()
-                mock_set.assert_called_once_with(logging.WARNING, "warn")
+        widget.action_filter_warning()
 
-    def test_action_filter_info_sets_info_level(self):
+        mock_set.assert_called_once_with(logging.WARNING, "warn")
+
+    def test_action_filter_info_sets_info_level(self, monkeypatch: pytest.MonkeyPatch):
         """Test '4' key sets INFO level."""
         widget = LogWidget()
         mock_app = MagicMock()
         mock_app.notify = MagicMock()
+        monkeypatch.setattr(Widget, "app", property(lambda self: mock_app))
+        mock_set = MagicMock()
+        monkeypatch.setattr(widget, "_set_level_filter", mock_set)
 
-        with patch.object(type(widget), "app", new_callable=PropertyMock, return_value=mock_app):
-            with patch.object(widget, "_set_level_filter") as mock_set:
-                widget.action_filter_info()
-                mock_set.assert_called_once_with(logging.INFO, "info")
+        widget.action_filter_info()
 
-    def test_action_filter_debug_sets_debug_level(self):
+        mock_set.assert_called_once_with(logging.INFO, "info")
+
+    def test_action_filter_debug_sets_debug_level(self, monkeypatch: pytest.MonkeyPatch):
         """Test '5' key sets DEBUG level."""
         widget = LogWidget()
         mock_app = MagicMock()
         mock_app.notify = MagicMock()
+        monkeypatch.setattr(Widget, "app", property(lambda self: mock_app))
+        mock_set = MagicMock()
+        monkeypatch.setattr(widget, "_set_level_filter", mock_set)
 
-        with patch.object(type(widget), "app", new_callable=PropertyMock, return_value=mock_app):
-            with patch.object(widget, "_set_level_filter") as mock_set:
-                widget.action_filter_debug()
-                mock_set.assert_called_once_with(logging.DEBUG, "debug")
+        widget.action_filter_debug()
+
+        mock_set.assert_called_once_with(logging.DEBUG, "debug")
 
 
 class TestLogWidgetCycleFilter:
     """Tests for LogWidget filter cycling (aligned with AlertHistory pattern)."""
 
-    def test_cycle_level_filter_cycles_through_levels(self):
+    def test_cycle_level_filter_cycles_through_levels(self, monkeypatch: pytest.MonkeyPatch):
         """Test 'f' key cycles through filter levels."""
         widget = LogWidget()
         mock_app = MagicMock()
         mock_app.notify = MagicMock()
+        monkeypatch.setattr(Widget, "app", property(lambda self: mock_app))
+        mock_set = MagicMock()
+        monkeypatch.setattr(widget, "_set_level_filter", mock_set)
 
-        with patch.object(type(widget), "app", new_callable=PropertyMock, return_value=mock_app):
-            with patch.object(widget, "_set_level_filter") as mock_set:
-                # Start at info, should cycle to warn
-                widget._current_level_filter = "info"
-                widget.action_cycle_level_filter()
-                mock_set.assert_called_once_with(logging.WARNING, "warn")
+        # Start at info, should cycle to warn
+        widget._current_level_filter = "info"
+        widget.action_cycle_level_filter()
 
-    def test_cycle_level_filter_wraps_around(self):
+        mock_set.assert_called_once_with(logging.WARNING, "warn")
+
+    def test_cycle_level_filter_wraps_around(self, monkeypatch: pytest.MonkeyPatch):
         """Test filter cycling wraps from last to first."""
         widget = LogWidget()
         mock_app = MagicMock()
         mock_app.notify = MagicMock()
+        monkeypatch.setattr(Widget, "app", property(lambda self: mock_app))
+        mock_set = MagicMock()
+        monkeypatch.setattr(widget, "_set_level_filter", mock_set)
 
-        with patch.object(type(widget), "app", new_callable=PropertyMock, return_value=mock_app):
-            with patch.object(widget, "_set_level_filter") as mock_set:
-                # At 'all' (last), should wrap to 'info'
-                widget._current_level_filter = "all"
-                widget.action_cycle_level_filter()
-                mock_set.assert_called_once_with(logging.INFO, "info")
+        # At 'all' (last), should wrap to 'info'
+        widget._current_level_filter = "all"
+        widget.action_cycle_level_filter()
+
+        mock_set.assert_called_once_with(logging.INFO, "info")
 
     def test_clear_filters_binding_exists(self):
         """Test 'F' key binding exists for clear filters."""
@@ -117,7 +135,7 @@ class TestLogWidgetCycleFilter:
         assert hasattr(widget, "action_clear_filters")
         assert callable(widget.action_clear_filters)
 
-    def test_clear_filters_resets_state(self):
+    def test_clear_filters_resets_state(self, monkeypatch: pytest.MonkeyPatch):
         """Test action_clear_filters sets expected state values."""
         widget = LogWidget()
         widget._min_level = logging.ERROR
@@ -126,35 +144,23 @@ class TestLogWidgetCycleFilter:
 
         mock_app = MagicMock()
         mock_app.notify = MagicMock()
+        monkeypatch.setattr(Widget, "app", property(lambda self: mock_app))
 
         # Create mock handler
         mock_handler = MagicMock()
+        monkeypatch.setattr(log_manager_module, "get_tui_log_handler", lambda: mock_handler)
+        monkeypatch.setattr(widget, "_update_level_chips", MagicMock())
 
-        with patch.object(type(widget), "app", new_callable=PropertyMock, return_value=mock_app):
-            with patch.object(widget, "_update_level_chips"):
-                with patch.object(widget, "query_one") as mock_query:
-                    # Set up query_one to return mocks for different queries
-                    mock_input = MagicMock()
-                    mock_log_stream = MagicMock()
-                    mock_query.side_effect = [mock_input, mock_log_stream, mock_log_stream]
+        # Set up query_one to return mocks for different queries
+        mock_input = MagicMock()
+        mock_log_stream = MagicMock()
+        monkeypatch.setattr(
+            widget,
+            "query_one",
+            MagicMock(side_effect=[mock_input, mock_log_stream, mock_log_stream]),
+        )
 
-                    # Patch the import inside the method
-                    with patch(
-                        "gpt_trader.tui.widgets.logs.get_tui_log_handler",
-                        create=True,
-                    ) as mock_get_handler:
-                        mock_get_handler.return_value = mock_handler
-                        # Import and patch directly in the module's namespace
-                        import gpt_trader.tui.widgets.logs as logs_module
-
-                        original = getattr(logs_module, "get_tui_log_handler", None)
-                        try:
-                            # Manually inject the mock
-                            logs_module.get_tui_log_handler = lambda: mock_handler
-                            widget.action_clear_filters()
-                        finally:
-                            if original:
-                                logs_module.get_tui_log_handler = original
+        widget.action_clear_filters()
 
         # Verify state was reset
         assert widget._min_level == logging.INFO
@@ -165,15 +171,17 @@ class TestLogWidgetCycleFilter:
 class TestLogWidgetSetLevel:
     """Tests for LogWidget.set_level method."""
 
-    def test_set_level_delegates_to_set_level_filter(self):
+    def test_set_level_delegates_to_set_level_filter(self, monkeypatch: pytest.MonkeyPatch):
         """Test set_level uses _set_level_filter internally."""
         widget = LogWidget()
+        mock_set = MagicMock()
+        monkeypatch.setattr(widget, "_set_level_filter", mock_set)
 
-        with patch.object(widget, "_set_level_filter") as mock_set:
-            widget.set_level(logging.WARNING)
-            mock_set.assert_called_once_with(logging.WARNING, "warn")
+        widget.set_level(logging.WARNING)
 
-    def test_set_level_maps_all_standard_levels(self):
+        mock_set.assert_called_once_with(logging.WARNING, "warn")
+
+    def test_set_level_maps_all_standard_levels(self, monkeypatch: pytest.MonkeyPatch):
         """Test set_level maps all standard logging levels correctly."""
         widget = LogWidget()
 
@@ -185,6 +193,7 @@ class TestLogWidgetSetLevel:
         ]
 
         for level, expected_name in level_map:
-            with patch.object(widget, "_set_level_filter") as mock_set:
-                widget.set_level(level)
-                mock_set.assert_called_once_with(level, expected_name)
+            mock_set = MagicMock()
+            monkeypatch.setattr(widget, "_set_level_filter", mock_set)
+            widget.set_level(level)
+            mock_set.assert_called_once_with(level, expected_name)

--- a/var/agents/testing/source_test_map.json
+++ b/var/agents/testing/source_test_map.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "summary": {
     "tests_scanned": 919,
-    "source_modules": 353,
+    "source_modules": 354,
     "unresolved_modules": 3
   },
   "source_to_tests": {
@@ -1837,6 +1837,9 @@
       "tests/unit/gpt_trader/tui/test_widget_interactions_keyboard.py",
       "tests/unit/gpt_trader/tui/test_widget_interactions_widgets.py"
     ],
+    "gpt_trader.tui.app_lifecycle": [
+      "tests/unit/gpt_trader/tui/test_app_resource_cleanup.py"
+    ],
     "gpt_trader.tui.demo.demo_bot": [
       "tests/unit/gpt_trader/tui/demo/test_mock_data.py"
     ],
@@ -1866,7 +1869,8 @@
       "tests/unit/gpt_trader/tui/test_log_manager_formatters_structured.py",
       "tests/unit/gpt_trader/tui/test_log_manager_handler_emit.py",
       "tests/unit/gpt_trader/tui/test_log_manager_handler_message_safety.py",
-      "tests/unit/gpt_trader/tui/test_log_manager_handler_widget_controls.py"
+      "tests/unit/gpt_trader/tui/test_log_manager_handler_widget_controls.py",
+      "tests/unit/gpt_trader/tui/widgets/test_logs.py"
     ],
     "gpt_trader.tui.managers.ui_coordinator": [
       "tests/unit/gpt_trader/tui/services/test_state_registry.py",
@@ -1879,6 +1883,7 @@
       "tests/unit/gpt_trader/tui/mixins/test_event_handlers_utilities_and_docs.py"
     ],
     "gpt_trader.tui.mixins.event_handlers": [
+      "tests/unit/gpt_trader/tui/mixins/test_event_handlers_custom_overrides.py",
       "tests/unit/gpt_trader/tui/mixins/test_event_handlers_default_handlers.py",
       "tests/unit/gpt_trader/tui/mixins/test_event_handlers_utilities_and_docs.py"
     ],
@@ -1927,7 +1932,8 @@
     ],
     "gpt_trader.tui.services.action_dispatcher": [
       "tests/unit/gpt_trader/tui/services/test_action_dispatcher_core.py",
-      "tests/unit/gpt_trader/tui/services/test_action_dispatcher_refresh.py"
+      "tests/unit/gpt_trader/tui/services/test_action_dispatcher_refresh.py",
+      "tests/unit/gpt_trader/tui/test_screen_flows_log_focus.py"
     ],
     "gpt_trader.tui.services.alert_manager": [
       "tests/unit/gpt_trader/tui/screens/test_alert_history.py",
@@ -5040,7 +5046,8 @@
     ],
     "tests/unit/gpt_trader/tui/mixins/test_event_handlers_custom_overrides.py": [
       "gpt_trader.tui.events",
-      "gpt_trader.tui.mixins"
+      "gpt_trader.tui.mixins",
+      "gpt_trader.tui.mixins.event_handlers"
     ],
     "tests/unit/gpt_trader/tui/mixins/test_event_handlers_default_handlers.py": [
       "gpt_trader.tui.events",
@@ -5244,6 +5251,7 @@
       "gpt_trader.features.brokerages.coinbase.client.base",
       "gpt_trader.features.brokerages.coinbase.ws",
       "gpt_trader.tui.app",
+      "gpt_trader.tui.app_lifecycle",
       "gpt_trader.tui.services.performance_service"
     ],
     "tests/unit/gpt_trader/tui/test_app_widgets.py": [
@@ -5347,7 +5355,8 @@
     ],
     "tests/unit/gpt_trader/tui/test_screen_flows_log_focus.py": [
       "gpt_trader.tui.app",
-      "gpt_trader.tui.screens"
+      "gpt_trader.tui.screens",
+      "gpt_trader.tui.services.action_dispatcher"
     ],
     "tests/unit/gpt_trader/tui/test_screen_flows_quick_navigation_and_state.py": [
       "gpt_trader.tui.app",
@@ -5528,6 +5537,7 @@
       "gpt_trader.tui.widgets.execution_issues_modal"
     ],
     "tests/unit/gpt_trader/tui/widgets/test_logs.py": [
+      "gpt_trader.tui.log_manager",
       "gpt_trader.tui.widgets.logs"
     ],
     "tests/unit/gpt_trader/tui/widgets/test_order_detail_modal.py": [
@@ -6147,6 +6157,7 @@
     "gpt_trader.tui.state_management.delta_updater": "src/gpt_trader/tui/state_management/delta_updater.py",
     "gpt_trader.tui.state_management.validators": "src/gpt_trader/tui/state_management/validators.py",
     "gpt_trader.tui.app": "src/gpt_trader/tui/app.py",
+    "gpt_trader.tui.app_lifecycle": "src/gpt_trader/tui/app_lifecycle.py",
     "gpt_trader.tui.log_manager": "src/gpt_trader/tui/log_manager.py",
     "gpt_trader.tui.widgets": "src/gpt_trader/tui/widgets/__init__.py",
     "gpt_trader.tui.widgets.error_indicator": "src/gpt_trader/tui/widgets/error_indicator.py",

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -43085,7 +43085,7 @@
     "tests/unit/gpt_trader/tui/mixins/test_event_handlers_custom_overrides.py": [
       {
         "name": "TestCustomEventHandlers::test_custom_handler_overrides_default",
-        "line": 17,
+        "line": 18,
         "markers": [
           "unit"
         ],
@@ -43094,7 +43094,7 @@
       },
       {
         "name": "TestCustomEventHandlers::test_custom_handler_without_super_call",
-        "line": 37,
+        "line": 40,
         "markers": [
           "unit"
         ],
@@ -45871,7 +45871,7 @@
     "tests/unit/gpt_trader/tui/services/test_performance_service_core.py": [
       {
         "name": "TestTuiPerformanceService::test_init_enabled",
-        "line": 37,
+        "line": 38,
         "markers": [
           "unit"
         ],
@@ -45880,7 +45880,7 @@
       },
       {
         "name": "TestTuiPerformanceService::test_init_disabled",
-        "line": 41,
+        "line": 42,
         "markers": [
           "unit"
         ],
@@ -45889,7 +45889,7 @@
       },
       {
         "name": "TestTuiPerformanceService::test_time_operation_enabled",
-        "line": 44,
+        "line": 45,
         "markers": [
           "unit"
         ],
@@ -45898,7 +45898,7 @@
       },
       {
         "name": "TestTuiPerformanceService::test_time_operation_disabled",
-        "line": 54,
+        "line": 55,
         "markers": [
           "unit"
         ],
@@ -45907,7 +45907,7 @@
       },
       {
         "name": "TestTuiPerformanceService::test_record_frame",
-        "line": 58,
+        "line": 59,
         "markers": [
           "unit"
         ],
@@ -45916,7 +45916,7 @@
       },
       {
         "name": "TestTuiPerformanceService::test_record_frame_disabled",
-        "line": 71,
+        "line": 72,
         "markers": [
           "unit"
         ],
@@ -45925,7 +45925,7 @@
       },
       {
         "name": "TestTuiPerformanceService::test_fps_calculation",
-        "line": 78,
+        "line": 79,
         "markers": [
           "unit"
         ],
@@ -45934,7 +45934,7 @@
       },
       {
         "name": "TestTuiPerformanceService::test_frame_time_statistics",
-        "line": 92,
+        "line": 93,
         "markers": [
           "unit"
         ],
@@ -45943,7 +45943,7 @@
       },
       {
         "name": "TestTuiPerformanceService::test_slow_operation_tracking",
-        "line": 108,
+        "line": 109,
         "markers": [
           "unit"
         ],
@@ -45952,7 +45952,7 @@
       },
       {
         "name": "TestTuiPerformanceService::test_slow_operation_not_tracked_below_threshold",
-        "line": 117,
+        "line": 118,
         "markers": [
           "unit"
         ],
@@ -45961,7 +45961,7 @@
       },
       {
         "name": "TestTuiPerformanceService::test_slow_operation_disabled",
-        "line": 126,
+        "line": 127,
         "markers": [
           "unit"
         ],
@@ -45970,7 +45970,7 @@
       },
       {
         "name": "TestTuiPerformanceService::test_get_operation_stats",
-        "line": 131,
+        "line": 132,
         "markers": [
           "unit"
         ],
@@ -45979,7 +45979,7 @@
       },
       {
         "name": "TestTuiPerformanceService::test_reset",
-        "line": 141,
+        "line": 142,
         "markers": [
           "unit"
         ],
@@ -45988,7 +45988,7 @@
       },
       {
         "name": "TestTuiPerformanceService::test_snapshot_with_app_reference",
-        "line": 154,
+        "line": 155,
         "markers": [
           "unit"
         ],
@@ -47121,7 +47121,7 @@
     "tests/unit/gpt_trader/tui/test_app_resource_cleanup.py": [
       {
         "name": "TestResourceCleanup::test_coinbase_client_has_close_method",
-        "line": 9,
+        "line": 12,
         "markers": [
           "unit"
         ],
@@ -47130,7 +47130,7 @@
       },
       {
         "name": "TestResourceCleanup::test_coinbase_client_context_manager",
-        "line": 19,
+        "line": 22,
         "markers": [
           "unit"
         ],
@@ -47139,7 +47139,7 @@
       },
       {
         "name": "TestResourceCleanup::test_websocket_has_close_method",
-        "line": 25,
+        "line": 28,
         "markers": [
           "unit"
         ],
@@ -47148,7 +47148,7 @@
       },
       {
         "name": "TestResourceCleanup::test_websocket_close_is_idempotent",
-        "line": 36,
+        "line": 39,
         "markers": [
           "unit"
         ],
@@ -47157,7 +47157,7 @@
       },
       {
         "name": "TestResourceCleanup::test_performance_service_cleanup",
-        "line": 47,
+        "line": 50,
         "markers": [
           "unit"
         ],
@@ -47166,7 +47166,7 @@
       },
       {
         "name": "TestResourceCleanup::test_app_cleanup_bot_resources_closes_client",
-        "line": 66,
+        "line": 69,
         "markers": [
           "unit"
         ],
@@ -47175,7 +47175,7 @@
       },
       {
         "name": "TestResourceCleanup::test_app_cleanup_bot_resources_closes_websocket",
-        "line": 75,
+        "line": 78,
         "markers": [
           "unit"
         ],
@@ -47184,7 +47184,7 @@
       },
       {
         "name": "TestResourceCleanup::test_app_cleanup_bot_resources_closes_engine_client",
-        "line": 84,
+        "line": 87,
         "markers": [
           "unit"
         ],
@@ -47193,7 +47193,7 @@
       },
       {
         "name": "TestResourceCleanup::test_app_cleanup_handles_missing_resources",
-        "line": 93,
+        "line": 96,
         "markers": [
           "unit"
         ],
@@ -47202,7 +47202,7 @@
       },
       {
         "name": "TestResourceCleanup::test_app_cleanup_handles_close_errors",
-        "line": 104,
+        "line": 107,
         "markers": [
           "unit"
         ],
@@ -47211,7 +47211,7 @@
       },
       {
         "name": "TestResourceCleanup::test_websocket_reconnect_limit_configurable",
-        "line": 114,
+        "line": 121,
         "markers": [
           "unit"
         ],
@@ -48840,7 +48840,7 @@
     "tests/unit/gpt_trader/tui/test_screen_flows_log_focus.py": [
       {
         "name": "TestLogFocusFlow::test_logs_focus_on_l",
-        "line": 20,
+        "line": 21,
         "markers": [
           "asyncio",
           "unit"
@@ -51084,7 +51084,7 @@
     "tests/unit/gpt_trader/tui/utilities/test_table_formatting_clipboard.py": [
       {
         "name": "TestCopyToClipboard::test_copy_on_macos",
-        "line": 12,
+        "line": 14,
         "markers": [
           "unit"
         ],
@@ -51093,7 +51093,7 @@
       },
       {
         "name": "TestCopyToClipboard::test_copy_empty_string",
-        "line": 20,
+        "line": 24,
         "markers": [
           "unit"
         ],
@@ -51924,7 +51924,7 @@
     "tests/unit/gpt_trader/tui/widgets/test_config_modal.py": [
       {
         "name": "test_config_modal_save_updates_risk_config",
-        "line": 10,
+        "line": 12,
         "markers": [
           "unit"
         ],
@@ -52118,7 +52118,7 @@
     "tests/unit/gpt_trader/tui/widgets/test_logs.py": [
       {
         "name": "TestLogWidgetFilterChips::test_filter_bindings_present",
-        "line": 12,
+        "line": 16,
         "markers": [
           "unit"
         ],
@@ -52127,7 +52127,7 @@
       },
       {
         "name": "TestLogWidgetFilterChips::test_action_filter_all_sets_debug_level",
-        "line": 25,
+        "line": 29,
         "markers": [
           "unit"
         ],
@@ -52136,7 +52136,7 @@
       },
       {
         "name": "TestLogWidgetFilterChips::test_action_filter_error_sets_error_level",
-        "line": 36,
+        "line": 42,
         "markers": [
           "unit"
         ],
@@ -52145,7 +52145,7 @@
       },
       {
         "name": "TestLogWidgetFilterChips::test_action_filter_warning_sets_warning_level",
-        "line": 47,
+        "line": 55,
         "markers": [
           "unit"
         ],
@@ -52154,7 +52154,7 @@
       },
       {
         "name": "TestLogWidgetFilterChips::test_action_filter_info_sets_info_level",
-        "line": 58,
+        "line": 68,
         "markers": [
           "unit"
         ],
@@ -52163,7 +52163,7 @@
       },
       {
         "name": "TestLogWidgetFilterChips::test_action_filter_debug_sets_debug_level",
-        "line": 69,
+        "line": 81,
         "markers": [
           "unit"
         ],
@@ -52172,7 +52172,7 @@
       },
       {
         "name": "TestLogWidgetCycleFilter::test_cycle_level_filter_cycles_through_levels",
-        "line": 84,
+        "line": 98,
         "markers": [
           "unit"
         ],
@@ -52181,7 +52181,7 @@
       },
       {
         "name": "TestLogWidgetCycleFilter::test_cycle_level_filter_wraps_around",
-        "line": 97,
+        "line": 113,
         "markers": [
           "unit"
         ],
@@ -52190,7 +52190,7 @@
       },
       {
         "name": "TestLogWidgetCycleFilter::test_clear_filters_binding_exists",
-        "line": 110,
+        "line": 128,
         "markers": [
           "unit"
         ],
@@ -52199,7 +52199,7 @@
       },
       {
         "name": "TestLogWidgetCycleFilter::test_clear_filters_resets_state",
-        "line": 120,
+        "line": 138,
         "markers": [
           "unit"
         ],
@@ -52208,7 +52208,7 @@
       },
       {
         "name": "TestLogWidgetSetLevel::test_set_level_delegates_to_set_level_filter",
-        "line": 168,
+        "line": 174,
         "markers": [
           "unit"
         ],
@@ -52217,7 +52217,7 @@
       },
       {
         "name": "TestLogWidgetSetLevel::test_set_level_maps_all_standard_levels",
-        "line": 176,
+        "line": 184,
         "markers": [
           "unit"
         ],
@@ -52629,7 +52629,7 @@
     "tests/unit/gpt_trader/tui/widgets/test_performance_dashboard_watch_snapshot.py": [
       {
         "name": "TestPerformanceDashboardWidgetWatchSnapshot::test_watch_snapshot_none",
-        "line": 12,
+        "line": 15,
         "markers": [
           "unit"
         ],
@@ -52638,7 +52638,7 @@
       },
       {
         "name": "TestPerformanceDashboardWidgetWatchSnapshot::test_watch_snapshot_updates_cached_labels",
-        "line": 23,
+        "line": 26,
         "markers": [
           "unit"
         ],
@@ -52647,7 +52647,7 @@
       },
       {
         "name": "TestPerformanceDashboardWidgetWatchSnapshot::test_watch_snapshot_applies_warning_classes",
-        "line": 56,
+        "line": 59,
         "markers": [
           "unit"
         ],
@@ -52656,7 +52656,7 @@
       },
       {
         "name": "TestPerformanceDashboardWidgetWatchSnapshot::test_watch_snapshot_applies_bad_classes",
-        "line": 84,
+        "line": 87,
         "markers": [
           "unit"
         ],
@@ -52665,7 +52665,7 @@
       },
       {
         "name": "TestPerformanceDashboardWidgetWatchSnapshot::test_refresh_metrics_gets_snapshot",
-        "line": 112,
+        "line": 115,
         "markers": [
           "unit"
         ],
@@ -52674,7 +52674,7 @@
       },
       {
         "name": "TestPerformanceDashboardWidgetWatchSnapshot::test_compact_mode_skips_expanded_metrics",
-        "line": 135,
+        "line": 136,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary
- Convert `@patch` decorators and context managers to `monkeypatch.setattr()` in TUI tests
- Files converted (8 files):
  - `test_event_handlers_custom_overrides.py` (1 patch)
  - `test_performance_service_core.py` (1 patch)
  - `test_app_resource_cleanup.py` (1 patch)
  - `test_screen_flows_log_focus.py` (1 patch)
  - `test_table_formatting_clipboard.py` (1 patch)
  - `test_config_modal.py` (1 patch)
  - `test_logs.py` (12 patches)
  - `test_performance_dashboard_watch_snapshot.py` (1 patch)
- Total patches converted: 19

## Test plan
- [x] `uv run pytest <all 8 files> -v` (52 passed)
- [x] `uv run python scripts/ci/check_test_hygiene.py` (passed)
- [x] `uv run python scripts/ci/check_legacy_test_triage.py` (passed)
- [x] `uv run python scripts/agents/generate_test_inventory.py` (regenerated)