### PR TITLE
test(live_trade): convert patches to monkeypatch (Packet W)

### DIFF
--- a/tests/unit/gpt_trader/features/live_trade/engines/test_telemetry_streaming_emit_and_enable.py
+++ b/tests/unit/gpt_trader/features/live_trade/engines/test_telemetry_streaming_emit_and_enable.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock
 
+import pytest
+
+import gpt_trader.utilities.telemetry as telemetry_module
 from gpt_trader.features.live_trade.engines.telemetry_streaming import (
     _emit_metric,
     _should_enable_streaming,
@@ -13,9 +16,11 @@ from gpt_trader.features.live_trade.engines.telemetry_streaming import (
 class TestEmitMetric:
     """Tests for _emit_metric function."""
 
-    @patch("gpt_trader.utilities.telemetry.emit_metric")
-    def test_emit_metric_calls_utility(self, mock_emit: Mock) -> None:
+    def test_emit_metric_calls_utility(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test _emit_metric calls the utility emit_metric."""
+        mock_emit = MagicMock()
+        monkeypatch.setattr(telemetry_module, "emit_metric", mock_emit)
+
         event_store = Mock()
         bot_id = "test_bot"
         payload = {"event_type": "test"}

--- a/tests/unit/gpt_trader/features/live_trade/execution/test_broker_executor_execute_with_retry.py
+++ b/tests/unit/gpt_trader/features/live_trade/execution/test_broker_executor_execute_with_retry.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
+import gpt_trader.features.live_trade.execution.broker_executor as broker_executor_module
 from gpt_trader.features.live_trade.execution.broker_executor import (
     RetryPolicy,
     execute_with_retry,
@@ -99,9 +100,11 @@ class TestExecuteWithRetry:
         assert result == "success"
         assert func.call_count == 2
 
-    @patch("gpt_trader.features.live_trade.execution.broker_executor.logger")
-    def test_client_order_id_logged_consistently(self, mock_logger: MagicMock) -> None:
+    def test_client_order_id_logged_consistently(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test that the same client_order_id is used for all attempts."""
+        mock_logger = MagicMock()
+        monkeypatch.setattr(broker_executor_module, "logger", mock_logger)
+
         func = MagicMock(side_effect=[ConnectionError("fail"), "success"])
         policy = RetryPolicy(max_attempts=3, jitter=0)
 

--- a/tests/unit/gpt_trader/features/live_trade/execution/test_validation_flow.py
+++ b/tests/unit/gpt_trader/features/live_trade/execution/test_validation_flow.py
@@ -3,28 +3,34 @@
 from __future__ import annotations
 
 from decimal import Decimal
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
+import pytest
+
+import gpt_trader.features.live_trade.execution.validation as validation_module
 from gpt_trader.core import OrderSide, OrderType, Product
 from gpt_trader.features.live_trade.execution.validation import OrderValidator
 
 
 class TestValidationFlow:
-    @patch("gpt_trader.features.live_trade.execution.validation.spec_validate_order")
     def test_full_validation_flow(
         self,
-        mock_spec_validate: MagicMock,
         mock_broker: MagicMock,
         mock_risk_manager: MagicMock,
         mock_product: Product,
         mock_failure_tracker: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        mock_spec_validate.return_value = MagicMock(
-            ok=True,
-            reason=None,
-            adjusted_quantity=Decimal("1.001"),
-            adjusted_price=None,
+        mock_spec_validate = MagicMock(
+            return_value=MagicMock(
+                ok=True,
+                reason=None,
+                adjusted_quantity=Decimal("1.001"),
+                adjusted_price=None,
+            )
         )
+        monkeypatch.setattr(validation_module, "spec_validate_order", mock_spec_validate)
+
         mock_broker.get_market_snapshot.return_value = {
             "spread_bps": 5,
             "depth_l1": 100000000,

--- a/var/agents/testing/source_test_map.json
+++ b/var/agents/testing/source_test_map.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "summary": {
     "tests_scanned": 919,
-    "source_modules": 353,
+    "source_modules": 354,
     "unresolved_modules": 3
   },
   "source_to_tests": {
@@ -985,6 +985,7 @@
       "tests/unit/gpt_trader/features/live_trade/execution/test_api_health_guard.py",
       "tests/unit/gpt_trader/features/live_trade/execution/test_guard_manager_cache.py",
       "tests/unit/gpt_trader/features/live_trade/execution/test_guard_manager_cancel_and_safe_run.py",
+      "tests/unit/gpt_trader/features/live_trade/execution/test_guard_manager_runtime_and_orchestration.py",
       "tests/unit/gpt_trader/features/live_trade/execution/test_guard_manager_steps_and_telemetry.py"
     ],
     "gpt_trader.features.live_trade.execution.guards": [
@@ -1805,8 +1806,10 @@
       "tests/unit/gpt_trader/security/secrets_manager/test_vault_failures.py"
     ],
     "gpt_trader.security.security_validator": [
+      "tests/unit/gpt_trader/features/live_trade/engines/test_strategy_engine_order_flow.py",
       "tests/unit/gpt_trader/features/live_trade/engines/test_strategy_engine_order_guards.py",
       "tests/unit/gpt_trader/features/live_trade/engines/test_strategy_engine_reduce_only.py",
+      "tests/unit/gpt_trader/features/live_trade/engines/test_strategy_engine_risk_format.py",
       "tests/unit/gpt_trader/security/security_validator/test_convenience_wrappers.py"
     ],
     "gpt_trader.security.symbol_validator": [
@@ -2307,6 +2310,9 @@
     ],
     "gpt_trader.utilities.quantization": [
       "tests/unit/gpt_trader/utilities/test_quantization.py"
+    ],
+    "gpt_trader.utilities.telemetry": [
+      "tests/unit/gpt_trader/features/live_trade/engines/test_telemetry_streaming_emit_and_enable.py"
     ],
     "gpt_trader.validation": [
       "tests/unit/gpt_trader/security/security_validator/test_symbol_validation.py",
@@ -3719,7 +3725,8 @@
     ],
     "tests/unit/gpt_trader/features/live_trade/engines/test_strategy_engine_order_flow.py": [
       "gpt_trader.core",
-      "gpt_trader.features.live_trade.strategies.perps_baseline"
+      "gpt_trader.features.live_trade.strategies.perps_baseline",
+      "gpt_trader.security.security_validator"
     ],
     "tests/unit/gpt_trader/features/live_trade/engines/test_strategy_engine_order_guards.py": [
       "gpt_trader.core",
@@ -3740,7 +3747,8 @@
     ],
     "tests/unit/gpt_trader/features/live_trade/engines/test_strategy_engine_risk_format.py": [
       "gpt_trader.core",
-      "gpt_trader.features.live_trade.strategies.perps_baseline"
+      "gpt_trader.features.live_trade.strategies.perps_baseline",
+      "gpt_trader.security.security_validator"
     ],
     "tests/unit/gpt_trader/features/live_trade/engines/test_telemetry_health_edges.py": [
       "gpt_trader.features.brokerages.coinbase.market_data_features",
@@ -3759,7 +3767,8 @@
       "gpt_trader.features.live_trade.engines.telemetry_streaming"
     ],
     "tests/unit/gpt_trader/features/live_trade/engines/test_telemetry_streaming_emit_and_enable.py": [
-      "gpt_trader.features.live_trade.engines.telemetry_streaming"
+      "gpt_trader.features.live_trade.engines.telemetry_streaming",
+      "gpt_trader.utilities.telemetry"
     ],
     "tests/unit/gpt_trader/features/live_trade/engines/test_telemetry_streaming_run_loop.py": [
       "gpt_trader.features.live_trade.engines.telemetry_streaming"
@@ -3825,6 +3834,7 @@
       "gpt_trader.features.live_trade.guard_errors"
     ],
     "tests/unit/gpt_trader/features/live_trade/execution/test_guard_manager_runtime_and_orchestration.py": [
+      "gpt_trader.features.live_trade.execution.guard_manager",
       "gpt_trader.features.live_trade.guard_errors"
     ],
     "tests/unit/gpt_trader/features/live_trade/execution/test_guard_manager_state_collection.py": [
@@ -5986,6 +5996,7 @@
     "gpt_trader.features.live_trade.engines": "src/gpt_trader/features/live_trade/engines/__init__.py",
     "gpt_trader.features.live_trade.engines.telemetry_health": "src/gpt_trader/features/live_trade/engines/telemetry_health.py",
     "gpt_trader.features.live_trade.engines.telemetry_streaming": "src/gpt_trader/features/live_trade/engines/telemetry_streaming.py",
+    "gpt_trader.utilities.telemetry": "src/gpt_trader/utilities/telemetry.py",
     "gpt_trader.features.live_trade.execution.broker_executor": "src/gpt_trader/features/live_trade/execution/broker_executor.py",
     "gpt_trader.features.live_trade.execution.guards": "src/gpt_trader/features/live_trade/execution/guards/__init__.py",
     "gpt_trader.features.live_trade.execution.guards.daily_loss": "src/gpt_trader/features/live_trade/execution/guards/daily_loss.py",

--- a/var/agents/testing/source_test_map.json
+++ b/var/agents/testing/source_test_map.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "summary": {
     "tests_scanned": 919,
-    "source_modules": 354,
+    "source_modules": 355,
     "unresolved_modules": 3
   },
   "source_to_tests": {

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -20796,7 +20796,7 @@
     "tests/unit/gpt_trader/features/live_trade/engines/test_strategy_engine_order_flow.py": [
       {
         "name": "test_order_placed_with_dynamic_quantity",
-        "line": 15,
+        "line": 16,
         "markers": [
           "asyncio",
           "unit"
@@ -20901,7 +20901,7 @@
     "tests/unit/gpt_trader/features/live_trade/engines/test_strategy_engine_risk_format.py": [
       {
         "name": "test_positions_to_risk_format",
-        "line": 14,
+        "line": 15,
         "markers": [
           "unit"
         ],
@@ -20909,7 +20909,7 @@
       },
       {
         "name": "test_risk_manager_receives_dict_format",
-        "line": 36,
+        "line": 37,
         "markers": [
           "asyncio",
           "unit"
@@ -21426,7 +21426,7 @@
     "tests/unit/gpt_trader/features/live_trade/engines/test_telemetry_streaming_emit_and_enable.py": [
       {
         "name": "TestEmitMetric::test_emit_metric_calls_utility",
-        "line": 17,
+        "line": 19,
         "markers": [
           "unit"
         ],
@@ -21435,7 +21435,7 @@
       },
       {
         "name": "TestShouldEnableStreaming::test_returns_false_for_test_profile",
-        "line": 31,
+        "line": 36,
         "markers": [
           "unit"
         ],
@@ -21444,7 +21444,7 @@
       },
       {
         "name": "TestShouldEnableStreaming::test_returns_false_when_streaming_disabled",
-        "line": 40,
+        "line": 45,
         "markers": [
           "unit"
         ],
@@ -21453,7 +21453,7 @@
       },
       {
         "name": "TestShouldEnableStreaming::test_returns_true_for_prod_with_streaming_enabled",
-        "line": 49,
+        "line": 54,
         "markers": [
           "unit"
         ],
@@ -21462,7 +21462,7 @@
       },
       {
         "name": "TestShouldEnableStreaming::test_returns_true_for_canary_with_streaming_enabled",
-        "line": 58,
+        "line": 63,
         "markers": [
           "unit"
         ],
@@ -21471,7 +21471,7 @@
       },
       {
         "name": "TestShouldEnableStreaming::test_returns_false_for_dev_profile",
-        "line": 67,
+        "line": 72,
         "markers": [
           "unit"
         ],
@@ -21480,7 +21480,7 @@
       },
       {
         "name": "TestShouldEnableStreaming::test_handles_profile_with_value_attribute",
-        "line": 76,
+        "line": 81,
         "markers": [
           "unit"
         ],
@@ -21489,7 +21489,7 @@
       },
       {
         "name": "TestShouldEnableStreaming::test_handles_none_profile",
-        "line": 87,
+        "line": 92,
         "markers": [
           "unit"
         ],
@@ -21877,7 +21877,7 @@
     "tests/unit/gpt_trader/features/live_trade/execution/test_broker_executor_execute_with_retry.py": [
       {
         "name": "TestExecuteWithRetry::test_success_on_first_attempt",
-        "line": 18,
+        "line": 19,
         "markers": [
           "unit"
         ],
@@ -21886,7 +21886,7 @@
       },
       {
         "name": "TestExecuteWithRetry::test_retry_on_retryable_exception",
-        "line": 35,
+        "line": 36,
         "markers": [
           "unit"
         ],
@@ -21895,7 +21895,7 @@
       },
       {
         "name": "TestExecuteWithRetry::test_max_attempts_respected",
-        "line": 52,
+        "line": 53,
         "markers": [
           "unit"
         ],
@@ -21904,7 +21904,7 @@
       },
       {
         "name": "TestExecuteWithRetry::test_non_retryable_exception_not_retried",
-        "line": 69,
+        "line": 70,
         "markers": [
           "unit"
         ],
@@ -21913,7 +21913,7 @@
       },
       {
         "name": "TestExecuteWithRetry::test_timeout_error_is_retryable",
-        "line": 86,
+        "line": 87,
         "markers": [
           "unit"
         ],
@@ -22029,7 +22029,7 @@
     "tests/unit/gpt_trader/features/live_trade/execution/test_broker_executor_resilience_retry.py": [
       {
         "name": "TestBrokerExecutorResilienceRetry::test_retry_success_after_n_failures",
-        "line": 24,
+        "line": 25,
         "markers": [
           "unit"
         ],
@@ -22038,7 +22038,7 @@
       },
       {
         "name": "TestBrokerExecutorResilienceRetry::test_timeout_path_triggers_retry_with_classification",
-        "line": 63,
+        "line": 64,
         "markers": [
           "unit"
         ],
@@ -22047,7 +22047,7 @@
       },
       {
         "name": "TestBrokerExecutorResilienceRetry::test_non_retryable_error_short_circuits",
-        "line": 105,
+        "line": 108,
         "markers": [
           "unit"
         ],
@@ -22056,7 +22056,7 @@
       },
       {
         "name": "TestBrokerExecutorResilienceRetry::test_all_retries_exhausted_raises_last_exception",
-        "line": 142,
+        "line": 145,
         "markers": [
           "unit"
         ],
@@ -22392,7 +22392,7 @@
     "tests/unit/gpt_trader/features/live_trade/execution/test_guard_manager_runtime_and_orchestration.py": [
       {
         "name": "test_run_guards_for_state_calls_all_guards",
-        "line": 14,
+        "line": 15,
         "markers": [
           "unit"
         ],
@@ -22400,7 +22400,7 @@
       },
       {
         "name": "test_run_runtime_guards_first_run",
-        "line": 29,
+        "line": 34,
         "markers": [
           "unit"
         ],
@@ -22408,7 +22408,7 @@
       },
       {
         "name": "test_run_runtime_guards_incremental",
-        "line": 44,
+        "line": 48,
         "markers": [
           "unit"
         ],
@@ -22416,7 +22416,7 @@
       },
       {
         "name": "test_run_runtime_guards_force_full",
-        "line": 61,
+        "line": 66,
         "markers": [
           "unit"
         ],
@@ -22424,7 +22424,7 @@
       },
       {
         "name": "TestGuardManagerEdgeCases::test_data_unavailable_is_recorded_and_surfaces",
-        "line": 82,
+        "line": 86,
         "markers": [
           "unit"
         ],
@@ -22433,7 +22433,7 @@
       },
       {
         "name": "TestGuardManagerEdgeCases::test_guard_order_is_stable",
-        "line": 100,
+        "line": 106,
         "markers": [
           "unit"
         ],
@@ -22442,7 +22442,7 @@
       },
       {
         "name": "TestGuardManagerEdgeCases::test_run_guards_for_state_stops_on_unrecoverable_error",
-        "line": 114,
+        "line": 120,
         "markers": [
           "unit"
         ],
@@ -24146,7 +24146,7 @@
     "tests/unit/gpt_trader/features/live_trade/execution/test_validation_flow.py": [
       {
         "name": "TestValidationFlow::test_full_validation_flow",
-        "line": 14,
+        "line": 16,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary
- Convert 11 `patch` decorators/context managers to `monkeypatch.setattr()` across 7 live_trade test files
- Files updated:
  - `test_strategy_engine_order_flow.py` - security_validator.get_validator
  - `test_strategy_engine_risk_format.py` - security_validator.get_validator
  - `test_telemetry_streaming_emit_and_enable.py` - telemetry.emit_metric
  - `test_broker_executor_execute_with_retry.py` - logger
  - `test_broker_executor_resilience_retry.py` - _record_broker_call_latency
  - `test_guard_manager_runtime_and_orchestration.py` - patch.object + record_guard_failure
  - `test_validation_flow.py` - spec_validate_order
- All 30 tests pass
- Continues patch density reduction effort (34 → 23)

## Test plan
- [x] `pytest` passes on all 7 files (30 tests)
- [x] `check_test_hygiene.py` passes
- [x] `check_legacy_test_triage.py` passes
- [x] Test inventory regenerated