### PR TITLE
test(preflight): replace patch.object/dict with monkeypatch

### DIFF
--- a/tests/unit/gpt_trader/preflight/test_checks_connectivity_api_connectivity.py
+++ b/tests/unit/gpt_trader/preflight/test_checks_connectivity_api_connectivity.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -11,22 +11,31 @@ from gpt_trader.preflight.checks.connectivity import check_api_connectivity
 from gpt_trader.preflight.core import PreflightCheck
 
 
+def _set_env(monkeypatch: pytest.MonkeyPatch, env: dict[str, str], *, clear: bool = True) -> None:
+    if clear:
+        for key in list(os.environ):
+            monkeypatch.delenv(key, raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+
+
 class TestCheckApiConnectivity:
     """Test API connectivity checks."""
 
-    def test_skips_when_remote_checks_bypassed(self) -> None:
+    def test_skips_when_remote_checks_bypassed(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Should skip and succeed when remote checks are bypassed."""
         checker = PreflightCheck(profile="dev")
 
         # Use env var to skip remote checks
         env = {"COINBASE_PREFLIGHT_SKIP_REMOTE": "1"}
-        with patch.dict(os.environ, env, clear=True):
+        with monkeypatch.context() as mp:
+            _set_env(mp, env, clear=True)
             result = check_api_connectivity(checker)
 
         assert result is True
         assert any("bypassed" in s for s in checker.successes)
 
-    def test_fails_when_client_build_fails(self) -> None:
+    def test_fails_when_client_build_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Should fail when CDP client cannot be built."""
         checker = PreflightCheck(profile="prod")
 
@@ -35,12 +44,13 @@ class TestCheckApiConnectivity:
             "COINBASE_PREFLIGHT_FORCE_REMOTE": "1",
             "COINBASE_ENABLE_DERIVATIVES": "1",
         }
-        with patch.dict(os.environ, env, clear=True):
+        with monkeypatch.context() as mp:
+            _set_env(mp, env, clear=True)
             result = check_api_connectivity(checker)
 
         assert result is False
 
-    def test_fails_on_jwt_generation_error(self) -> None:
+    def test_fails_on_jwt_generation_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Should fail when JWT generation fails."""
         checker = PreflightCheck(profile="prod")
 
@@ -52,16 +62,16 @@ class TestCheckApiConnectivity:
             "COINBASE_PREFLIGHT_FORCE_REMOTE": "1",
             "COINBASE_ENABLE_DERIVATIVES": "1",
         }
-        with (
-            patch.dict(os.environ, env, clear=True),
-            patch.object(checker, "_build_cdp_client", return_value=(mock_client, mock_auth)),
-        ):
+        with monkeypatch.context() as mp:
+            _set_env(mp, env, clear=True)
+            build_client_mock = MagicMock(return_value=(mock_client, mock_auth))
+            mp.setattr(checker, "_build_cdp_client", build_client_mock)
             result = check_api_connectivity(checker)
 
         assert result is False
         assert any("JWT generation failed" in e for e in checker.errors)
 
-    def test_passes_with_successful_api_calls(self) -> None:
+    def test_passes_with_successful_api_calls(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Should pass when all API calls succeed."""
         checker = PreflightCheck(profile="prod")
 
@@ -75,10 +85,10 @@ class TestCheckApiConnectivity:
             "COINBASE_PREFLIGHT_FORCE_REMOTE": "1",
             "COINBASE_ENABLE_DERIVATIVES": "1",
         }
-        with (
-            patch.dict(os.environ, env, clear=True),
-            patch.object(checker, "_build_cdp_client", return_value=(mock_client, mock_auth)),
-        ):
+        with monkeypatch.context() as mp:
+            _set_env(mp, env, clear=True)
+            build_client_mock = MagicMock(return_value=(mock_client, mock_auth))
+            mp.setattr(checker, "_build_cdp_client", build_client_mock)
             result = check_api_connectivity(checker)
 
         assert result is True
@@ -86,7 +96,7 @@ class TestCheckApiConnectivity:
         assert any("Accounts: OK" in s for s in checker.successes)
         assert any("Products: OK" in s for s in checker.successes)
 
-    def test_warns_on_empty_response(self) -> None:
+    def test_warns_on_empty_response(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Should warn when API returns empty response."""
         checker = PreflightCheck(profile="prod")
 
@@ -100,15 +110,15 @@ class TestCheckApiConnectivity:
             "COINBASE_PREFLIGHT_FORCE_REMOTE": "1",
             "COINBASE_ENABLE_DERIVATIVES": "1",
         }
-        with (
-            patch.dict(os.environ, env, clear=True),
-            patch.object(checker, "_build_cdp_client", return_value=(mock_client, mock_auth)),
-        ):
+        with monkeypatch.context() as mp:
+            _set_env(mp, env, clear=True)
+            build_client_mock = MagicMock(return_value=(mock_client, mock_auth))
+            mp.setattr(checker, "_build_cdp_client", build_client_mock)
             check_api_connectivity(checker)
 
         assert any("Empty response" in w for w in checker.warnings)
 
-    def test_fails_on_api_error(self) -> None:
+    def test_fails_on_api_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Should fail when API call raises exception."""
         checker = PreflightCheck(profile="prod")
 
@@ -119,15 +129,15 @@ class TestCheckApiConnectivity:
         mock_client.list_products.return_value = [{"product_id": "BTC-PERP"}]
 
         env = {"COINBASE_PREFLIGHT_FORCE_REMOTE": "1"}
-        with (
-            patch.dict(os.environ, env, clear=True),
-            patch.object(checker, "_build_cdp_client", return_value=(mock_client, mock_auth)),
-        ):
+        with monkeypatch.context() as mp:
+            _set_env(mp, env, clear=True)
+            build_client_mock = MagicMock(return_value=(mock_client, mock_auth))
+            mp.setattr(checker, "_build_cdp_client", build_client_mock)
             result = check_api_connectivity(checker)
 
         assert result is False
 
-    def test_fails_when_no_perps_found(self) -> None:
+    def test_fails_when_no_perps_found(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Should fail when no perpetual products found."""
         checker = PreflightCheck(profile="prod")
 
@@ -144,16 +154,16 @@ class TestCheckApiConnectivity:
             "COINBASE_PREFLIGHT_FORCE_REMOTE": "1",
             "COINBASE_ENABLE_DERIVATIVES": "1",
         }
-        with (
-            patch.dict(os.environ, env, clear=True),
-            patch.object(checker, "_build_cdp_client", return_value=(mock_client, mock_auth)),
-        ):
+        with monkeypatch.context() as mp:
+            _set_env(mp, env, clear=True)
+            build_client_mock = MagicMock(return_value=(mock_client, mock_auth))
+            mp.setattr(checker, "_build_cdp_client", build_client_mock)
             result = check_api_connectivity(checker)
 
         assert result is False
         assert any("No perpetual products" in e for e in checker.errors)
 
-    def test_logs_perp_count_when_found(self) -> None:
+    def test_logs_perp_count_when_found(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Should log count of perpetual products found."""
         checker = PreflightCheck(profile="prod")
 
@@ -168,16 +178,18 @@ class TestCheckApiConnectivity:
         ]
 
         env = {"COINBASE_PREFLIGHT_FORCE_REMOTE": "1"}
-        with (
-            patch.dict(os.environ, env, clear=True),
-            patch.object(checker, "_build_cdp_client", return_value=(mock_client, mock_auth)),
-        ):
+        with monkeypatch.context() as mp:
+            _set_env(mp, env, clear=True)
+            build_client_mock = MagicMock(return_value=(mock_client, mock_auth))
+            mp.setattr(checker, "_build_cdp_client", build_client_mock)
             result = check_api_connectivity(checker)
 
         assert result is True
         assert any("3 perpetual products" in s for s in checker.successes)
 
-    def test_logs_perp_names_when_verbose(self, capsys: pytest.CaptureFixture) -> None:
+    def test_logs_perp_names_when_verbose(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
         """Should log perpetual product names when verbose."""
         checker = PreflightCheck(profile="prod", verbose=True)
 
@@ -191,21 +203,24 @@ class TestCheckApiConnectivity:
         ]
 
         env = {"COINBASE_PREFLIGHT_FORCE_REMOTE": "1"}
-        with (
-            patch.dict(os.environ, env, clear=True),
-            patch.object(checker, "_build_cdp_client", return_value=(mock_client, mock_auth)),
-        ):
+        with monkeypatch.context() as mp:
+            _set_env(mp, env, clear=True)
+            build_client_mock = MagicMock(return_value=(mock_client, mock_auth))
+            mp.setattr(checker, "_build_cdp_client", build_client_mock)
             check_api_connectivity(checker)
 
         captured = capsys.readouterr()
         assert "BTC-PERP" in captured.out
 
-    def test_prints_section_header(self, capsys: pytest.CaptureFixture) -> None:
+    def test_prints_section_header(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
         """Should print section header."""
         checker = PreflightCheck(profile="dev")
 
         env = {"COINBASE_PREFLIGHT_SKIP_REMOTE": "1"}
-        with patch.dict(os.environ, env, clear=True):
+        with monkeypatch.context() as mp:
+            _set_env(mp, env, clear=True)
             check_api_connectivity(checker)
 
         captured = capsys.readouterr()

--- a/tests/unit/gpt_trader/preflight/test_checks_connectivity_key_permissions_core.py
+++ b/tests/unit/gpt_trader/preflight/test_checks_connectivity_key_permissions_core.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -11,31 +11,41 @@ from gpt_trader.preflight.checks.connectivity import check_key_permissions
 from gpt_trader.preflight.core import PreflightCheck
 
 
+def _set_env(monkeypatch: pytest.MonkeyPatch, env: dict[str, str], *, clear: bool = True) -> None:
+    if clear:
+        for key in list(os.environ):
+            monkeypatch.delenv(key, raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+
+
 class TestCheckKeyPermissionsCore:
     """Test key permissions checks (core scenarios)."""
 
-    def test_skips_when_remote_checks_bypassed(self) -> None:
+    def test_skips_when_remote_checks_bypassed(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Should skip and succeed when remote checks are bypassed."""
         checker = PreflightCheck(profile="dev")
 
         env = {"COINBASE_PREFLIGHT_SKIP_REMOTE": "1"}
-        with patch.dict(os.environ, env, clear=True):
+        with monkeypatch.context() as mp:
+            _set_env(mp, env, clear=True)
             result = check_key_permissions(checker)
 
         assert result is True
         assert any("bypassed" in s for s in checker.successes)
 
-    def test_fails_when_client_build_fails(self) -> None:
+    def test_fails_when_client_build_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Should fail when CDP client cannot be built."""
         checker = PreflightCheck(profile="prod")
 
         env = {"COINBASE_PREFLIGHT_FORCE_REMOTE": "1"}
-        with patch.dict(os.environ, env, clear=True):
+        with monkeypatch.context() as mp:
+            _set_env(mp, env, clear=True)
             result = check_key_permissions(checker)
 
         assert result is False
 
-    def test_passes_with_full_permissions(self) -> None:
+    def test_passes_with_full_permissions(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Should pass when key has trade and view permissions."""
         checker = PreflightCheck(profile="prod")
 
@@ -48,17 +58,22 @@ class TestCheckKeyPermissionsCore:
         }
 
         env = {"COINBASE_PREFLIGHT_FORCE_REMOTE": "1"}
-        with (
-            patch.dict(os.environ, env, clear=True),
-            patch.object(checker, "_build_cdp_client", return_value=(mock_client, mock_auth)),
-        ):
+        with monkeypatch.context() as mp:
+            _set_env(mp, env, clear=True)
+            mp.setattr(
+                checker,
+                "_build_cdp_client",
+                MagicMock(return_value=(mock_client, mock_auth)),
+            )
             result = check_key_permissions(checker)
 
         assert result is True
         assert any("view permission" in s for s in checker.successes)
         assert any("trade permission" in s for s in checker.successes)
 
-    def test_fails_without_trade_permission_when_derivatives_enabled(self) -> None:
+    def test_fails_without_trade_permission_when_derivatives_enabled(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Should fail when key lacks trade permission and derivatives are enabled."""
         checker = PreflightCheck(profile="prod")
 
@@ -74,16 +89,19 @@ class TestCheckKeyPermissionsCore:
             "COINBASE_PREFLIGHT_FORCE_REMOTE": "1",
             "COINBASE_ENABLE_DERIVATIVES": "1",
         }
-        with (
-            patch.dict(os.environ, env, clear=True),
-            patch.object(checker, "_build_cdp_client", return_value=(mock_client, mock_auth)),
-        ):
+        with monkeypatch.context() as mp:
+            _set_env(mp, env, clear=True)
+            mp.setattr(
+                checker,
+                "_build_cdp_client",
+                MagicMock(return_value=(mock_client, mock_auth)),
+            )
             result = check_key_permissions(checker)
 
         assert result is False
         assert any("missing trade permission" in e for e in checker.errors)
 
-    def test_fails_without_view_permission(self) -> None:
+    def test_fails_without_view_permission(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Should fail when key lacks view permission."""
         checker = PreflightCheck(profile="prod")
 
@@ -95,17 +113,20 @@ class TestCheckKeyPermissionsCore:
         }
 
         env = {"COINBASE_PREFLIGHT_FORCE_REMOTE": "1"}
-        with (
-            patch.dict(os.environ, env, clear=True),
-            patch.object(checker, "_build_cdp_client", return_value=(mock_client, mock_auth)),
-        ):
+        with monkeypatch.context() as mp:
+            _set_env(mp, env, clear=True)
+            mp.setattr(
+                checker,
+                "_build_cdp_client",
+                MagicMock(return_value=(mock_client, mock_auth)),
+            )
             result = check_key_permissions(checker)
 
         assert result is False
         assert any("missing portfolio view permission" in e for e in checker.errors)
 
     def test_passes_with_view_only_key_when_live_orders_not_intended(
-        self, capsys: pytest.CaptureFixture
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
     ) -> None:
         """Should pass with view-only key when no live orders are intended."""
         checker = PreflightCheck(profile="prod", verbose=True)
@@ -123,10 +144,13 @@ class TestCheckKeyPermissionsCore:
             "COINBASE_ENABLE_DERIVATIVES": "0",
             "DRY_RUN": "1",
         }
-        with (
-            patch.dict(os.environ, env, clear=True),
-            patch.object(checker, "_build_cdp_client", return_value=(mock_client, mock_auth)),
-        ):
+        with monkeypatch.context() as mp:
+            _set_env(mp, env, clear=True)
+            mp.setattr(
+                checker,
+                "_build_cdp_client",
+                MagicMock(return_value=(mock_client, mock_auth)),
+            )
             result = check_key_permissions(checker)
 
         assert result is True
@@ -135,7 +159,9 @@ class TestCheckKeyPermissionsCore:
         captured = capsys.readouterr()
         assert "view-only" in captured.out
 
-    def test_fails_with_view_only_key_when_live_spot_orders_intended(self) -> None:
+    def test_fails_with_view_only_key_when_live_spot_orders_intended(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Should fail with view-only key when live spot orders are intended."""
         checker = PreflightCheck(profile="prod")
 
@@ -151,16 +177,19 @@ class TestCheckKeyPermissionsCore:
             "COINBASE_ENABLE_DERIVATIVES": "0",
             "TRADING_MODES": "spot",
         }
-        with (
-            patch.dict(os.environ, env, clear=True),
-            patch.object(checker, "_build_cdp_client", return_value=(mock_client, mock_auth)),
-        ):
+        with monkeypatch.context() as mp:
+            _set_env(mp, env, clear=True)
+            mp.setattr(
+                checker,
+                "_build_cdp_client",
+                MagicMock(return_value=(mock_client, mock_auth)),
+            )
             result = check_key_permissions(checker)
 
         assert result is False
         assert any("missing trade permission" in e for e in checker.errors)
 
-    def test_warns_when_portfolio_uuid_missing(self) -> None:
+    def test_warns_when_portfolio_uuid_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Should warn when portfolio UUID is not returned."""
         checker = PreflightCheck(profile="prod")
 
@@ -173,21 +202,27 @@ class TestCheckKeyPermissionsCore:
         }
 
         env = {"COINBASE_PREFLIGHT_FORCE_REMOTE": "1"}
-        with (
-            patch.dict(os.environ, env, clear=True),
-            patch.object(checker, "_build_cdp_client", return_value=(mock_client, mock_auth)),
-        ):
+        with monkeypatch.context() as mp:
+            _set_env(mp, env, clear=True)
+            mp.setattr(
+                checker,
+                "_build_cdp_client",
+                MagicMock(return_value=(mock_client, mock_auth)),
+            )
             result = check_key_permissions(checker)
 
         assert result is True
         assert any("Portfolio UUID not returned" in w for w in checker.warnings)
 
-    def test_prints_section_header(self, capsys: pytest.CaptureFixture) -> None:
+    def test_prints_section_header(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
         """Should print section header."""
         checker = PreflightCheck(profile="dev")
 
         env = {"COINBASE_PREFLIGHT_SKIP_REMOTE": "1"}
-        with patch.dict(os.environ, env, clear=True):
+        with monkeypatch.context() as mp:
+            _set_env(mp, env, clear=True)
             check_key_permissions(checker)
 
         captured = capsys.readouterr()

--- a/tests/unit/gpt_trader/preflight/test_checks_connectivity_key_permissions_intx.py
+++ b/tests/unit/gpt_trader/preflight/test_checks_connectivity_key_permissions_intx.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -11,8 +11,18 @@ from gpt_trader.preflight.checks.connectivity import check_key_permissions
 from gpt_trader.preflight.core import PreflightCheck
 
 
+def _set_env(monkeypatch: pytest.MonkeyPatch, env: dict[str, str], *, clear: bool = True) -> None:
+    if clear:
+        for key in list(os.environ):
+            monkeypatch.delenv(key, raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+
+
 class TestCheckKeyPermissionsIntx:
-    def test_passes_intx_check_when_derivatives_enabled(self) -> None:
+    def test_passes_intx_check_when_derivatives_enabled(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Should pass INTX check when derivatives enabled and portfolio is INTX."""
         checker = PreflightCheck(profile="prod")
 
@@ -28,16 +38,21 @@ class TestCheckKeyPermissionsIntx:
             "COINBASE_PREFLIGHT_FORCE_REMOTE": "1",
             "COINBASE_ENABLE_DERIVATIVES": "1",
         }
-        with (
-            patch.dict(os.environ, env, clear=True),
-            patch.object(checker, "_build_cdp_client", return_value=(mock_client, mock_auth)),
-        ):
+        with monkeypatch.context() as mp:
+            _set_env(mp, env, clear=True)
+            mp.setattr(
+                checker,
+                "_build_cdp_client",
+                MagicMock(return_value=(mock_client, mock_auth)),
+            )
             result = check_key_permissions(checker)
 
         assert result is True
         assert any("INTX portfolio detected" in s for s in checker.successes)
 
-    def test_fails_intx_check_when_wrong_portfolio_type(self) -> None:
+    def test_fails_intx_check_when_wrong_portfolio_type(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Should fail when derivatives enabled but not INTX portfolio."""
         checker = PreflightCheck(profile="prod")
 
@@ -53,16 +68,21 @@ class TestCheckKeyPermissionsIntx:
             "COINBASE_PREFLIGHT_FORCE_REMOTE": "1",
             "COINBASE_ENABLE_DERIVATIVES": "1",
         }
-        with (
-            patch.dict(os.environ, env, clear=True),
-            patch.object(checker, "_build_cdp_client", return_value=(mock_client, mock_auth)),
-        ):
+        with monkeypatch.context() as mp:
+            _set_env(mp, env, clear=True)
+            mp.setattr(
+                checker,
+                "_build_cdp_client",
+                MagicMock(return_value=(mock_client, mock_auth)),
+            )
             result = check_key_permissions(checker)
 
         assert result is False
         assert any("INTX gating check failed" in e for e in checker.errors)
 
-    def test_logs_intx_available_when_disabled(self, capsys: pytest.CaptureFixture) -> None:
+    def test_logs_intx_available_when_disabled(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
         """Should log INTX available when derivatives disabled but INTX portfolio."""
         checker = PreflightCheck(profile="prod", verbose=True)
 
@@ -78,10 +98,13 @@ class TestCheckKeyPermissionsIntx:
             "COINBASE_PREFLIGHT_FORCE_REMOTE": "1",
             "COINBASE_ENABLE_DERIVATIVES": "0",
         }
-        with (
-            patch.dict(os.environ, env, clear=True),
-            patch.object(checker, "_build_cdp_client", return_value=(mock_client, mock_auth)),
-        ):
+        with monkeypatch.context() as mp:
+            _set_env(mp, env, clear=True)
+            mp.setattr(
+                checker,
+                "_build_cdp_client",
+                MagicMock(return_value=(mock_client, mock_auth)),
+            )
             result = check_key_permissions(checker)
 
         assert result is True

--- a/tests/unit/gpt_trader/preflight/test_checks_environment.py
+++ b/tests/unit/gpt_trader/preflight/test_checks_environment.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-from unittest.mock import patch
 
 import pytest
 
@@ -11,10 +10,18 @@ from gpt_trader.preflight.checks.environment import check_environment_variables
 from gpt_trader.preflight.core import PreflightCheck
 
 
+def _set_env(monkeypatch: pytest.MonkeyPatch, env: dict[str, str], *, clear: bool = True) -> None:
+    if clear:
+        for key in list(os.environ):
+            monkeypatch.delenv(key, raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+
+
 class TestCheckEnvironmentVariables:
     """Test environment variable validation."""
 
-    def test_passes_with_correct_prod_config(self, capsys: pytest.CaptureFixture) -> None:
+    def test_passes_with_correct_prod_config(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Should pass with correct production configuration."""
         checker = PreflightCheck(profile="prod")
 
@@ -27,7 +34,8 @@ class TestCheckEnvironmentVariables:
             "COINBASE_CDP_PRIVATE_KEY": "-----BEGIN EC PRIVATE KEY-----\ntest\n-----END EC PRIVATE KEY-----",
         }
 
-        with patch.dict(os.environ, env, clear=True):
+        with monkeypatch.context() as mp:
+            _set_env(mp, env, clear=True)
             result = check_environment_variables(checker)
 
         assert result is True
@@ -35,7 +43,7 @@ class TestCheckEnvironmentVariables:
         assert any("source=" in s for s in checker.successes)
         assert any("CDP private key found" in s for s in checker.successes)
 
-    def test_fails_with_wrong_broker(self, capsys: pytest.CaptureFixture) -> None:
+    def test_fails_with_wrong_broker(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Should fail when BROKER is not coinbase."""
         checker = PreflightCheck(profile="prod")
 
@@ -46,13 +54,14 @@ class TestCheckEnvironmentVariables:
             "COINBASE_ENABLE_DERIVATIVES": "1",
         }
 
-        with patch.dict(os.environ, env, clear=True):
+        with monkeypatch.context() as mp:
+            _set_env(mp, env, clear=True)
             result = check_environment_variables(checker)
 
         assert result is False
         assert any("BROKER=kraken" in e for e in checker.errors)
 
-    def test_fails_with_sandbox_in_prod(self, capsys: pytest.CaptureFixture) -> None:
+    def test_fails_with_sandbox_in_prod(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Should fail when sandbox enabled in prod profile."""
         checker = PreflightCheck(profile="prod")
 
@@ -63,13 +72,14 @@ class TestCheckEnvironmentVariables:
             "COINBASE_ENABLE_DERIVATIVES": "1",
         }
 
-        with patch.dict(os.environ, env, clear=True):
+        with monkeypatch.context() as mp:
+            _set_env(mp, env, clear=True)
             result = check_environment_variables(checker)
 
         assert result is False
         assert any("COINBASE_SANDBOX" in e for e in checker.errors)
 
-    def test_warns_with_wrong_config_in_dev(self, capsys: pytest.CaptureFixture) -> None:
+    def test_warns_with_wrong_config_in_dev(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Should warn (not fail) for non-strict vars in dev profile."""
         checker = PreflightCheck(profile="dev")
 
@@ -78,7 +88,8 @@ class TestCheckEnvironmentVariables:
             "COINBASE_SANDBOX": "0",  # Expected "1" in dev but not strict
         }
 
-        with patch.dict(os.environ, env, clear=True):
+        with monkeypatch.context() as mp:
+            _set_env(mp, env, clear=True)
             check_environment_variables(checker)
 
         # Should still pass because COINBASE_SANDBOX is not strict in dev
@@ -86,7 +97,7 @@ class TestCheckEnvironmentVariables:
         # Let's check warnings are logged
         assert any("COINBASE_SANDBOX" in w for w in checker.warnings)
 
-    def test_validates_cdp_api_key_format(self, capsys: pytest.CaptureFixture) -> None:
+    def test_validates_cdp_api_key_format(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Should validate CDP API key format."""
         checker = PreflightCheck(profile="prod")
 
@@ -99,13 +110,14 @@ class TestCheckEnvironmentVariables:
             "COINBASE_CDP_PRIVATE_KEY": "-----BEGIN EC PRIVATE KEY-----\ntest\n-----END EC PRIVATE KEY-----",
         }
 
-        with patch.dict(os.environ, env, clear=True):
+        with monkeypatch.context() as mp:
+            _set_env(mp, env, clear=True)
             result = check_environment_variables(checker)
 
         assert result is False
         assert any("Invalid CDP API key format" in e for e in checker.errors)
 
-    def test_validates_private_key_format(self, capsys: pytest.CaptureFixture) -> None:
+    def test_validates_private_key_format(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Should validate CDP private key format."""
         checker = PreflightCheck(profile="prod")
 
@@ -118,13 +130,14 @@ class TestCheckEnvironmentVariables:
             "COINBASE_CDP_PRIVATE_KEY": "not-a-valid-key",  # Invalid format
         }
 
-        with patch.dict(os.environ, env, clear=True):
+        with monkeypatch.context() as mp:
+            _set_env(mp, env, clear=True)
             result = check_environment_variables(checker)
 
         assert result is False
         assert any("Invalid private key format" in e for e in checker.errors)
 
-    def test_warns_about_missing_credentials_in_dev(self, capsys: pytest.CaptureFixture) -> None:
+    def test_warns_about_missing_credentials_in_dev(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Should warn (not fail) about missing credentials in dev profile."""
         checker = PreflightCheck(profile="dev")
 
@@ -133,13 +146,16 @@ class TestCheckEnvironmentVariables:
             # No CDP credentials
         }
 
-        with patch.dict(os.environ, env, clear=True):
+        with monkeypatch.context() as mp:
+            _set_env(mp, env, clear=True)
             check_environment_variables(checker)
 
         # In dev without credentials, should warn but not fail
         assert any("remote connectivity checks will be skipped" in w for w in checker.warnings)
 
-    def test_validates_risk_variables_in_range(self, capsys: pytest.CaptureFixture) -> None:
+    def test_validates_risk_variables_in_range(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
         """Should validate risk variables are in acceptable range."""
         checker = PreflightCheck(profile="dev", verbose=True)
 
@@ -150,13 +166,14 @@ class TestCheckEnvironmentVariables:
             "RISK_MAX_POSITION_PCT_PER_SYMBOL": "0.1",  # Within 0.01-0.5
         }
 
-        with patch.dict(os.environ, env, clear=True):
+        with monkeypatch.context() as mp:
+            _set_env(mp, env, clear=True)
             check_environment_variables(checker)
 
         captured = capsys.readouterr()
         assert "within safe range" in captured.out
 
-    def test_warns_about_out_of_range_risk_variables(self, capsys: pytest.CaptureFixture) -> None:
+    def test_warns_about_out_of_range_risk_variables(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Should warn about risk variables outside recommended range."""
         checker = PreflightCheck(profile="dev")
 
@@ -165,12 +182,13 @@ class TestCheckEnvironmentVariables:
             "RISK_MAX_LEVERAGE": "20",  # Outside 1-10
         }
 
-        with patch.dict(os.environ, env, clear=True):
+        with monkeypatch.context() as mp:
+            _set_env(mp, env, clear=True)
             check_environment_variables(checker)
 
         assert any("outside recommended range" in w for w in checker.warnings)
 
-    def test_fails_on_invalid_risk_variable_format(self, capsys: pytest.CaptureFixture) -> None:
+    def test_fails_on_invalid_risk_variable_format(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Should fail on non-numeric risk variable."""
         checker = PreflightCheck(profile="dev")
 
@@ -179,13 +197,14 @@ class TestCheckEnvironmentVariables:
             "RISK_MAX_LEVERAGE": "not-a-number",
         }
 
-        with patch.dict(os.environ, env, clear=True):
+        with monkeypatch.context() as mp:
+            _set_env(mp, env, clear=True)
             result = check_environment_variables(checker)
 
         assert result is False
         assert any("not a valid number" in e for e in checker.errors)
 
-    def test_warns_about_missing_risk_variables(self, capsys: pytest.CaptureFixture) -> None:
+    def test_warns_about_missing_risk_variables(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Should warn about missing risk variables."""
         checker = PreflightCheck(profile="dev")
 
@@ -194,16 +213,20 @@ class TestCheckEnvironmentVariables:
             # No risk variables set
         }
 
-        with patch.dict(os.environ, env, clear=True):
+        with monkeypatch.context() as mp:
+            _set_env(mp, env, clear=True)
             check_environment_variables(checker)
 
         assert any("using defaults" in w for w in checker.warnings)
 
-    def test_prints_section_header(self, capsys: pytest.CaptureFixture) -> None:
+    def test_prints_section_header(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
         """Should print section header."""
         checker = PreflightCheck(profile="dev")
 
-        with patch.dict(os.environ, {"BROKER": "coinbase"}, clear=True):
+        with monkeypatch.context() as mp:
+            _set_env(mp, {"BROKER": "coinbase"}, clear=True)
             check_environment_variables(checker)
 
         captured = capsys.readouterr()

--- a/tests/unit/gpt_trader/preflight/test_context_credentials.py
+++ b/tests/unit/gpt_trader/preflight/test_context_credentials.py
@@ -3,26 +3,36 @@
 from __future__ import annotations
 
 import os
-from unittest.mock import patch
+
+import pytest
 
 from gpt_trader.preflight.context import PreflightContext
+
+
+def _set_env(monkeypatch: pytest.MonkeyPatch, env: dict[str, str], *, clear: bool = True) -> None:
+    if clear:
+        for key in list(os.environ):
+            monkeypatch.delenv(key, raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
 
 
 class TestPreflightContextCredentials:
     """Test CDP credential resolution."""
 
-    def test_resolve_cdp_credentials_from_prod_env(self) -> None:
+    def test_resolve_cdp_credentials_from_prod_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Should prefer PROD env vars."""
-        with patch.dict(
-            os.environ,
-            {
-                "COINBASE_PROD_CDP_API_KEY": "prod_key",
-                "COINBASE_PROD_CDP_PRIVATE_KEY": "prod_private",
-                "COINBASE_CDP_API_KEY": "fallback_key",
-                "COINBASE_CDP_PRIVATE_KEY": "fallback_private",
-            },
-            clear=False,
-        ):
+        with monkeypatch.context() as mp:
+            _set_env(
+                mp,
+                {
+                    "COINBASE_PROD_CDP_API_KEY": "prod_key",
+                    "COINBASE_PROD_CDP_PRIVATE_KEY": "prod_private",
+                    "COINBASE_CDP_API_KEY": "fallback_key",
+                    "COINBASE_CDP_PRIVATE_KEY": "fallback_private",
+                },
+                clear=False,
+            )
             ctx = PreflightContext()
             api_key, private_key = ctx.resolve_cdp_credentials()
             resolved = ctx.resolve_cdp_credentials_info()
@@ -33,16 +43,17 @@ class TestPreflightContextCredentials:
             assert resolved.key_name == "prod_key"
             assert resolved.private_key == "prod_private"
 
-    def test_resolve_cdp_credentials_fallback(self) -> None:
+    def test_resolve_cdp_credentials_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Should fall back to non-PROD env vars."""
-        with patch.dict(
-            os.environ,
-            {
-                "COINBASE_CDP_API_KEY": "fallback_key",
-                "COINBASE_CDP_PRIVATE_KEY": "fallback_private",
-            },
-            clear=True,
-        ):
+        with monkeypatch.context() as mp:
+            _set_env(
+                mp,
+                {
+                    "COINBASE_CDP_API_KEY": "fallback_key",
+                    "COINBASE_CDP_PRIVATE_KEY": "fallback_private",
+                },
+                clear=True,
+            )
             ctx = PreflightContext()
             api_key, private_key = ctx.resolve_cdp_credentials()
             resolved = ctx.resolve_cdp_credentials_info()
@@ -53,9 +64,12 @@ class TestPreflightContextCredentials:
             assert resolved.key_name == "fallback_key"
             assert resolved.private_key == "fallback_private"
 
-    def test_resolve_cdp_credentials_returns_none_when_missing(self) -> None:
+    def test_resolve_cdp_credentials_returns_none_when_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Should return None when credentials not set."""
-        with patch.dict(os.environ, {}, clear=True):
+        with monkeypatch.context() as mp:
+            _set_env(mp, {}, clear=True)
             ctx = PreflightContext()
             api_key, private_key = ctx.resolve_cdp_credentials()
             resolved = ctx.resolve_cdp_credentials_info()
@@ -64,47 +78,55 @@ class TestPreflightContextCredentials:
             assert private_key is None
             assert resolved is None
 
-    def test_has_real_cdp_credentials_valid(self) -> None:
+    def test_has_real_cdp_credentials_valid(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Should return True for valid CDP credentials."""
-        with patch.dict(
-            os.environ,
-            {
-                "COINBASE_CDP_API_KEY": "organizations/abc/apiKeys/xyz",
-                "COINBASE_CDP_PRIVATE_KEY": "-----BEGIN EC PRIVATE KEY-----\ntest\n-----END EC PRIVATE KEY-----",
-            },
-            clear=True,
-        ):
+        with monkeypatch.context() as mp:
+            _set_env(
+                mp,
+                {
+                    "COINBASE_CDP_API_KEY": "organizations/abc/apiKeys/xyz",
+                    "COINBASE_CDP_PRIVATE_KEY": "-----BEGIN EC PRIVATE KEY-----\ntest\n-----END EC PRIVATE KEY-----",
+                },
+                clear=True,
+            )
             ctx = PreflightContext()
             assert ctx.has_real_cdp_credentials() is True
 
-    def test_has_real_cdp_credentials_invalid_key_format(self) -> None:
+    def test_has_real_cdp_credentials_invalid_key_format(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Should return False for invalid key format."""
-        with patch.dict(
-            os.environ,
-            {
-                "COINBASE_CDP_API_KEY": "invalid_format",
-                "COINBASE_CDP_PRIVATE_KEY": "-----BEGIN EC PRIVATE KEY-----\ntest\n-----END EC PRIVATE KEY-----",
-            },
-            clear=True,
-        ):
+        with monkeypatch.context() as mp:
+            _set_env(
+                mp,
+                {
+                    "COINBASE_CDP_API_KEY": "invalid_format",
+                    "COINBASE_CDP_PRIVATE_KEY": "-----BEGIN EC PRIVATE KEY-----\ntest\n-----END EC PRIVATE KEY-----",
+                },
+                clear=True,
+            )
             ctx = PreflightContext()
             assert ctx.has_real_cdp_credentials() is False
 
-    def test_has_real_cdp_credentials_invalid_private_key_format(self) -> None:
+    def test_has_real_cdp_credentials_invalid_private_key_format(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Should return False for invalid private key format."""
-        with patch.dict(
-            os.environ,
-            {
-                "COINBASE_CDP_API_KEY": "organizations/abc/apiKeys/xyz",
-                "COINBASE_CDP_PRIVATE_KEY": "not-a-valid-key",
-            },
-            clear=True,
-        ):
+        with monkeypatch.context() as mp:
+            _set_env(
+                mp,
+                {
+                    "COINBASE_CDP_API_KEY": "organizations/abc/apiKeys/xyz",
+                    "COINBASE_CDP_PRIVATE_KEY": "not-a-valid-key",
+                },
+                clear=True,
+            )
             ctx = PreflightContext()
             assert ctx.has_real_cdp_credentials() is False
 
-    def test_has_real_cdp_credentials_missing(self) -> None:
+    def test_has_real_cdp_credentials_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Should return False when credentials missing."""
-        with patch.dict(os.environ, {}, clear=True):
+        with monkeypatch.context() as mp:
+            _set_env(mp, {}, clear=True)
             ctx = PreflightContext()
             assert ctx.has_real_cdp_credentials() is False

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -38216,7 +38216,7 @@
     "tests/unit/gpt_trader/preflight/test_checks_connectivity_api_connectivity.py": [
       {
         "name": "TestCheckApiConnectivity::test_skips_when_remote_checks_bypassed",
-        "line": 17,
+        "line": 25,
         "markers": [
           "unit"
         ],
@@ -38225,7 +38225,7 @@
       },
       {
         "name": "TestCheckApiConnectivity::test_fails_when_client_build_fails",
-        "line": 29,
+        "line": 38,
         "markers": [
           "unit"
         ],
@@ -38234,7 +38234,7 @@
       },
       {
         "name": "TestCheckApiConnectivity::test_fails_on_jwt_generation_error",
-        "line": 43,
+        "line": 53,
         "markers": [
           "unit"
         ],
@@ -38243,7 +38243,7 @@
       },
       {
         "name": "TestCheckApiConnectivity::test_passes_with_successful_api_calls",
-        "line": 64,
+        "line": 74,
         "markers": [
           "unit"
         ],
@@ -38252,7 +38252,7 @@
       },
       {
         "name": "TestCheckApiConnectivity::test_warns_on_empty_response",
-        "line": 89,
+        "line": 99,
         "markers": [
           "unit"
         ],
@@ -38261,7 +38261,7 @@
       },
       {
         "name": "TestCheckApiConnectivity::test_fails_on_api_error",
-        "line": 111,
+        "line": 121,
         "markers": [
           "unit"
         ],
@@ -38270,7 +38270,7 @@
       },
       {
         "name": "TestCheckApiConnectivity::test_fails_when_no_perps_found",
-        "line": 130,
+        "line": 140,
         "markers": [
           "unit"
         ],
@@ -38279,7 +38279,7 @@
       },
       {
         "name": "TestCheckApiConnectivity::test_logs_perp_count_when_found",
-        "line": 156,
+        "line": 166,
         "markers": [
           "unit"
         ],
@@ -38288,7 +38288,7 @@
       },
       {
         "name": "TestCheckApiConnectivity::test_logs_perp_names_when_verbose",
-        "line": 180,
+        "line": 190,
         "markers": [
           "unit"
         ],
@@ -38297,7 +38297,7 @@
       },
       {
         "name": "TestCheckApiConnectivity::test_prints_section_header",
-        "line": 203,
+        "line": 215,
         "markers": [
           "unit"
         ],
@@ -38308,7 +38308,7 @@
     "tests/unit/gpt_trader/preflight/test_checks_connectivity_key_permissions_core.py": [
       {
         "name": "TestCheckKeyPermissionsCore::test_skips_when_remote_checks_bypassed",
-        "line": 17,
+        "line": 27,
         "markers": [
           "unit"
         ],
@@ -38317,7 +38317,7 @@
       },
       {
         "name": "TestCheckKeyPermissionsCore::test_fails_when_client_build_fails",
-        "line": 28,
+        "line": 41,
         "markers": [
           "unit"
         ],
@@ -38326,7 +38326,7 @@
       },
       {
         "name": "TestCheckKeyPermissionsCore::test_passes_with_full_permissions",
-        "line": 38,
+        "line": 52,
         "markers": [
           "unit"
         ],
@@ -38335,7 +38335,7 @@
       },
       {
         "name": "TestCheckKeyPermissionsCore::test_fails_without_trade_permission_when_derivatives_enabled",
-        "line": 61,
+        "line": 78,
         "markers": [
           "unit"
         ],
@@ -38344,7 +38344,7 @@
       },
       {
         "name": "TestCheckKeyPermissionsCore::test_fails_without_view_permission",
-        "line": 86,
+        "line": 108,
         "markers": [
           "unit"
         ],
@@ -38353,7 +38353,7 @@
       },
       {
         "name": "TestCheckKeyPermissionsCore::test_passes_with_view_only_key_when_live_orders_not_intended",
-        "line": 107,
+        "line": 132,
         "markers": [
           "unit"
         ],
@@ -38362,7 +38362,7 @@
       },
       {
         "name": "TestCheckKeyPermissionsCore::test_fails_with_view_only_key_when_live_spot_orders_intended",
-        "line": 138,
+        "line": 166,
         "markers": [
           "unit"
         ],
@@ -38371,7 +38371,7 @@
       },
       {
         "name": "TestCheckKeyPermissionsCore::test_warns_when_portfolio_uuid_missing",
-        "line": 163,
+        "line": 196,
         "markers": [
           "unit"
         ],
@@ -38380,7 +38380,7 @@
       },
       {
         "name": "TestCheckKeyPermissionsCore::test_prints_section_header",
-        "line": 185,
+        "line": 223,
         "markers": [
           "unit"
         ],
@@ -38391,7 +38391,7 @@
     "tests/unit/gpt_trader/preflight/test_checks_connectivity_key_permissions_intx.py": [
       {
         "name": "TestCheckKeyPermissionsIntx::test_passes_intx_check_when_derivatives_enabled",
-        "line": 15,
+        "line": 25,
         "markers": [
           "unit"
         ],
@@ -38400,7 +38400,7 @@
       },
       {
         "name": "TestCheckKeyPermissionsIntx::test_fails_intx_check_when_wrong_portfolio_type",
-        "line": 40,
+        "line": 55,
         "markers": [
           "unit"
         ],
@@ -38409,7 +38409,7 @@
       },
       {
         "name": "TestCheckKeyPermissionsIntx::test_logs_intx_available_when_disabled",
-        "line": 65,
+        "line": 85,
         "markers": [
           "unit"
         ],
@@ -38467,7 +38467,7 @@
       },
       {
         "name": "TestCheckDependencies::test_fails_when_package_missing",
-        "line": 38,
+        "line": 41,
         "markers": [
           "unit"
         ],
@@ -38476,7 +38476,7 @@
       },
       {
         "name": "TestCheckDependencies::test_logs_found_packages_when_verbose",
-        "line": 56,
+        "line": 62,
         "markers": [
           "unit"
         ],
@@ -38485,7 +38485,7 @@
       },
       {
         "name": "TestCheckDependencies::test_prints_section_header",
-        "line": 76,
+        "line": 85,
         "markers": [
           "unit"
         ],
@@ -38494,7 +38494,7 @@
       },
       {
         "name": "TestCheckDependencies::test_checks_gpt_trader_package",
-        "line": 95,
+        "line": 107,
         "markers": [
           "unit"
         ],
@@ -38503,7 +38503,7 @@
       },
       {
         "name": "TestCheckDependencies::test_checks_cryptography_package",
-        "line": 114,
+        "line": 129,
         "markers": [
           "unit"
         ],
@@ -38627,7 +38627,7 @@
     "tests/unit/gpt_trader/preflight/test_checks_environment.py": [
       {
         "name": "TestCheckEnvironmentVariables::test_passes_with_correct_prod_config",
-        "line": 17,
+        "line": 24,
         "markers": [
           "unit"
         ],
@@ -38636,7 +38636,7 @@
       },
       {
         "name": "TestCheckEnvironmentVariables::test_fails_with_wrong_broker",
-        "line": 38,
+        "line": 46,
         "markers": [
           "unit"
         ],
@@ -38645,7 +38645,7 @@
       },
       {
         "name": "TestCheckEnvironmentVariables::test_fails_with_sandbox_in_prod",
-        "line": 55,
+        "line": 64,
         "markers": [
           "unit"
         ],
@@ -38654,7 +38654,7 @@
       },
       {
         "name": "TestCheckEnvironmentVariables::test_warns_with_wrong_config_in_dev",
-        "line": 72,
+        "line": 82,
         "markers": [
           "unit"
         ],
@@ -38663,7 +38663,7 @@
       },
       {
         "name": "TestCheckEnvironmentVariables::test_validates_cdp_api_key_format",
-        "line": 89,
+        "line": 100,
         "markers": [
           "unit"
         ],
@@ -38672,7 +38672,7 @@
       },
       {
         "name": "TestCheckEnvironmentVariables::test_validates_private_key_format",
-        "line": 108,
+        "line": 120,
         "markers": [
           "unit"
         ],
@@ -38681,7 +38681,7 @@
       },
       {
         "name": "TestCheckEnvironmentVariables::test_warns_about_missing_credentials_in_dev",
-        "line": 127,
+        "line": 140,
         "markers": [
           "unit"
         ],
@@ -38690,7 +38690,7 @@
       },
       {
         "name": "TestCheckEnvironmentVariables::test_validates_risk_variables_in_range",
-        "line": 142,
+        "line": 156,
         "markers": [
           "unit"
         ],
@@ -38699,7 +38699,7 @@
       },
       {
         "name": "TestCheckEnvironmentVariables::test_warns_about_out_of_range_risk_variables",
-        "line": 159,
+        "line": 176,
         "markers": [
           "unit"
         ],
@@ -38708,7 +38708,7 @@
       },
       {
         "name": "TestCheckEnvironmentVariables::test_fails_on_invalid_risk_variable_format",
-        "line": 173,
+        "line": 191,
         "markers": [
           "unit"
         ],
@@ -38717,7 +38717,7 @@
       },
       {
         "name": "TestCheckEnvironmentVariables::test_warns_about_missing_risk_variables",
-        "line": 188,
+        "line": 207,
         "markers": [
           "unit"
         ],
@@ -38726,7 +38726,7 @@
       },
       {
         "name": "TestCheckEnvironmentVariables::test_prints_section_header",
-        "line": 202,
+        "line": 222,
         "markers": [
           "unit"
         ],
@@ -39488,7 +39488,7 @@
     "tests/unit/gpt_trader/preflight/test_context_credentials.py": [
       {
         "name": "TestPreflightContextCredentials::test_resolve_cdp_credentials_from_prod_env",
-        "line": 14,
+        "line": 25,
         "markers": [
           "unit"
         ],
@@ -39497,7 +39497,7 @@
       },
       {
         "name": "TestPreflightContextCredentials::test_resolve_cdp_credentials_fallback",
-        "line": 36,
+        "line": 50,
         "markers": [
           "unit"
         ],
@@ -39506,7 +39506,7 @@
       },
       {
         "name": "TestPreflightContextCredentials::test_resolve_cdp_credentials_returns_none_when_missing",
-        "line": 56,
+        "line": 73,
         "markers": [
           "unit"
         ],
@@ -39515,7 +39515,7 @@
       },
       {
         "name": "TestPreflightContextCredentials::test_has_real_cdp_credentials_valid",
-        "line": 67,
+        "line": 87,
         "markers": [
           "unit"
         ],
@@ -39524,7 +39524,7 @@
       },
       {
         "name": "TestPreflightContextCredentials::test_has_real_cdp_credentials_invalid_key_format",
-        "line": 80,
+        "line": 101,
         "markers": [
           "unit"
         ],
@@ -39533,7 +39533,7 @@
       },
       {
         "name": "TestPreflightContextCredentials::test_has_real_cdp_credentials_invalid_private_key_format",
-        "line": 93,
+        "line": 117,
         "markers": [
           "unit"
         ],
@@ -39542,7 +39542,7 @@
       },
       {
         "name": "TestPreflightContextCredentials::test_has_real_cdp_credentials_missing",
-        "line": 106,
+        "line": 133,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
- Replace patch.object/patch.dict patterns with pytest monkeypatch in the highest-density preflight suites:
  - tests/unit/gpt_trader/preflight/test_checks_connectivity_api_connectivity.py
  - tests/unit/gpt_trader/preflight/test_checks_connectivity_key_permissions_core.py
  - tests/unit/gpt_trader/preflight/test_checks_connectivity_key_permissions_intx.py
  - tests/unit/gpt_trader/preflight/test_checks_environment.py
  - tests/unit/gpt_trader/preflight/test_context_credentials.py
  - tests/unit/gpt_trader/preflight/test_checks_dependencies.py
- Regenerate var/agents/testing/test_inventory.json