### PR TITLE
test(tui): reduce patch density in TUI tests

### DIFF
--- a/tests/unit/gpt_trader/tui/screens/test_alert_history.py
+++ b/tests/unit/gpt_trader/tui/screens/test_alert_history.py
@@ -1,7 +1,7 @@
 """Tests for AlertHistoryScreen."""
 
 from datetime import datetime
-from unittest.mock import MagicMock, PropertyMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -48,29 +48,29 @@ class TestAlertHistoryScreen:
         assert "y" in binding_keys  # Copy row
         assert "r" in binding_keys  # Reset cooldowns
 
-    def test_action_clear_history_clears_alerts(self, mock_app):
+    def test_action_clear_history_clears_alerts(self, mock_app, monkeypatch: pytest.MonkeyPatch):
         """Test that clear history action calls alert manager."""
         screen = AlertHistoryScreen()
 
-        with patch.object(type(screen), "app", new_callable=PropertyMock, return_value=mock_app):
-            # Mock _refresh_table since DataTable isn't mounted
-            with patch.object(screen, "_refresh_table"):
-                screen.action_clear_history()
+        monkeypatch.setattr(type(screen), "app", property(lambda self: mock_app))
+        # Mock _refresh_table since DataTable isn't mounted
+        monkeypatch.setattr(screen, "_refresh_table", lambda: None)
+        screen.action_clear_history()
 
         mock_app.alert_manager.clear_history.assert_called_once()
         mock_app.notify.assert_called()
 
-    def test_action_reset_cooldowns_resets_alerts(self, mock_app):
+    def test_action_reset_cooldowns_resets_alerts(self, mock_app, monkeypatch: pytest.MonkeyPatch):
         """Test that reset cooldowns action calls alert manager."""
         screen = AlertHistoryScreen()
 
-        with patch.object(type(screen), "app", new_callable=PropertyMock, return_value=mock_app):
-            screen.action_reset_cooldowns()
+        monkeypatch.setattr(type(screen), "app", property(lambda self: mock_app))
+        screen.action_reset_cooldowns()
 
         mock_app.alert_manager.reset_cooldowns.assert_called_once()
         mock_app.notify.assert_called()
 
-    def test_button_pressed_clear_btn(self, mock_app):
+    def test_button_pressed_clear_btn(self, mock_app, monkeypatch: pytest.MonkeyPatch):
         """Test clear button calls action_clear_history."""
         screen = AlertHistoryScreen()
 
@@ -79,12 +79,13 @@ class TestAlertHistoryScreen:
         event = MagicMock()
         event.button = mock_button
 
-        with patch.object(type(screen), "app", new_callable=PropertyMock, return_value=mock_app):
-            with patch.object(screen, "action_clear_history") as mock_action:
-                screen.on_button_pressed(event)
-                mock_action.assert_called_once()
+        monkeypatch.setattr(type(screen), "app", property(lambda self: mock_app))
+        mock_action = MagicMock()
+        monkeypatch.setattr(screen, "action_clear_history", mock_action)
+        screen.on_button_pressed(event)
+        mock_action.assert_called_once()
 
-    def test_button_pressed_reset_btn(self, mock_app):
+    def test_button_pressed_reset_btn(self, mock_app, monkeypatch: pytest.MonkeyPatch):
         """Test reset button calls action_reset_cooldowns."""
         screen = AlertHistoryScreen()
 
@@ -93,12 +94,13 @@ class TestAlertHistoryScreen:
         event = MagicMock()
         event.button = mock_button
 
-        with patch.object(type(screen), "app", new_callable=PropertyMock, return_value=mock_app):
-            with patch.object(screen, "action_reset_cooldowns") as mock_action:
-                screen.on_button_pressed(event)
-                mock_action.assert_called_once()
+        monkeypatch.setattr(type(screen), "app", property(lambda self: mock_app))
+        mock_action = MagicMock()
+        monkeypatch.setattr(screen, "action_reset_cooldowns", mock_action)
+        screen.on_button_pressed(event)
+        mock_action.assert_called_once()
 
-    def test_button_pressed_close_btn(self, mock_app):
+    def test_button_pressed_close_btn(self, mock_app, monkeypatch: pytest.MonkeyPatch):
         """Test close button pops screen."""
         screen = AlertHistoryScreen()
 
@@ -107,20 +109,20 @@ class TestAlertHistoryScreen:
         event = MagicMock()
         event.button = mock_button
 
-        with patch.object(type(screen), "app", new_callable=PropertyMock, return_value=mock_app):
-            screen.on_button_pressed(event)
-            mock_app.pop_screen.assert_called_once()
+        monkeypatch.setattr(type(screen), "app", property(lambda self: mock_app))
+        screen.on_button_pressed(event)
+        mock_app.pop_screen.assert_called_once()
 
-    def test_no_alert_manager_graceful_handling(self):
+    def test_no_alert_manager_graceful_handling(self, monkeypatch: pytest.MonkeyPatch):
         """Test screen handles missing alert_manager gracefully."""
         screen = AlertHistoryScreen()
         mock_app = MagicMock(spec=[])  # Empty spec means no alert_manager attribute
 
-        with patch.object(type(screen), "app", new_callable=PropertyMock, return_value=mock_app):
-            # Should not raise
-            screen.action_clear_history()
-            screen.action_reset_cooldowns()
-            assert mock_app.method_calls == []
+        monkeypatch.setattr(type(screen), "app", property(lambda self: mock_app))
+        # Should not raise
+        screen.action_clear_history()
+        screen.action_reset_cooldowns()
+        assert mock_app.method_calls == []
 
 
 class TestAlertHistoryFilterActions:
@@ -134,37 +136,42 @@ class TestAlertHistoryFilterActions:
         mock_app.notify = MagicMock()
         return screen, mock_app
 
-    def test_cycle_filter_cycles_through_all_filters(self, screen_with_mocks):
+    def test_cycle_filter_cycles_through_all_filters(
+        self, screen_with_mocks, monkeypatch: pytest.MonkeyPatch
+    ):
         """Test 'f' key cycles through all filter options."""
         screen, mock_app = screen_with_mocks
 
-        with patch.object(type(screen), "app", new_callable=PropertyMock, return_value=mock_app):
-            with patch.object(screen, "_set_filter") as mock_set_filter:
-                # Start at 'all', should cycle to 'trade'
-                screen._current_filter = "all"
-                screen.action_cycle_filter()
-                mock_set_filter.assert_called_with("trade")
+        monkeypatch.setattr(type(screen), "app", property(lambda self: mock_app))
+        mock_set_filter = MagicMock()
+        monkeypatch.setattr(screen, "_set_filter", mock_set_filter)
+        # Start at 'all', should cycle to 'trade'
+        screen._current_filter = "all"
+        screen.action_cycle_filter()
+        mock_set_filter.assert_called_with("trade")
 
-    def test_cycle_filter_wraps_around(self, screen_with_mocks):
+    def test_cycle_filter_wraps_around(self, screen_with_mocks, monkeypatch: pytest.MonkeyPatch):
         """Test filter cycling wraps from last to first."""
         screen, mock_app = screen_with_mocks
 
-        with patch.object(type(screen), "app", new_callable=PropertyMock, return_value=mock_app):
-            with patch.object(screen, "_set_filter") as mock_set_filter:
-                # At 'error' (last), should wrap to 'all'
-                screen._current_filter = "error"
-                screen.action_cycle_filter()
-                mock_set_filter.assert_called_with("all")
+        monkeypatch.setattr(type(screen), "app", property(lambda self: mock_app))
+        mock_set_filter = MagicMock()
+        monkeypatch.setattr(screen, "_set_filter", mock_set_filter)
+        # At 'error' (last), should wrap to 'all'
+        screen._current_filter = "error"
+        screen.action_cycle_filter()
+        mock_set_filter.assert_called_with("all")
 
-    def test_clear_filter_resets_to_all(self, screen_with_mocks):
+    def test_clear_filter_resets_to_all(self, screen_with_mocks, monkeypatch: pytest.MonkeyPatch):
         """Test 'F' key resets filter to 'all'."""
         screen, mock_app = screen_with_mocks
 
-        with patch.object(type(screen), "app", new_callable=PropertyMock, return_value=mock_app):
-            with patch.object(screen, "_set_filter") as mock_set_filter:
-                screen._current_filter = "risk"
-                screen.action_clear_filter()
-                mock_set_filter.assert_called_with("all")
+        monkeypatch.setattr(type(screen), "app", property(lambda self: mock_app))
+        mock_set_filter = MagicMock()
+        monkeypatch.setattr(screen, "_set_filter", mock_set_filter)
+        screen._current_filter = "risk"
+        screen.action_clear_filter()
+        mock_set_filter.assert_called_with("all")
 
     def test_filter_bindings_present(self):
         """Test 'f' and 'F' keybinds are present."""

--- a/tests/unit/gpt_trader/tui/widgets/test_trading_stats.py
+++ b/tests/unit/gpt_trader/tui/widgets/test_trading_stats.py
@@ -1,6 +1,8 @@
 """Tests for TradingStatsWidget."""
 
-from unittest.mock import MagicMock, PropertyMock, patch
+from unittest.mock import MagicMock
+
+import pytest
 
 from gpt_trader.tui.services.focus_manager import FocusManager
 from gpt_trader.tui.widgets.trading_stats import TradingStatsWidget
@@ -44,7 +46,7 @@ class TestTradingStatsWidgetModes:
 class TestTradingStatsWidgetActions:
     """Tests for TradingStatsWidget action methods."""
 
-    def test_action_cycle_window_calls_service(self):
+    def test_action_cycle_window_calls_service(self, monkeypatch: pytest.MonkeyPatch):
         """Test action_cycle_window uses the service."""
         widget = TradingStatsWidget()
         mock_app = MagicMock()
@@ -53,15 +55,14 @@ class TestTradingStatsWidgetActions:
         mock_state_registry.get_state.return_value = None
         mock_app.state_registry = mock_state_registry
 
-        with patch.object(type(widget), "app", new_callable=PropertyMock, return_value=mock_app):
-            with patch.object(
-                widget._service, "cycle_window", return_value=(5, "Last 5 min")
-            ) as mock_cycle:
-                with patch.object(widget, "_update_window_chips"):
-                    widget.action_cycle_window()
-                    mock_cycle.assert_called_once()
+        monkeypatch.setattr(type(widget), "app", property(lambda self: mock_app))
+        mock_cycle = MagicMock(return_value=(5, "Last 5 min"))
+        monkeypatch.setattr(widget._service, "cycle_window", mock_cycle)
+        monkeypatch.setattr(widget, "_update_window_chips", lambda: None)
+        widget.action_cycle_window()
+        mock_cycle.assert_called_once()
 
-    def test_action_reset_window_calls_service(self):
+    def test_action_reset_window_calls_service(self, monkeypatch: pytest.MonkeyPatch):
         """Test action_reset_window uses the service."""
         widget = TradingStatsWidget()
         mock_app = MagicMock()
@@ -70,13 +71,12 @@ class TestTradingStatsWidgetActions:
         mock_state_registry.get_state.return_value = None
         mock_app.state_registry = mock_state_registry
 
-        with patch.object(type(widget), "app", new_callable=PropertyMock, return_value=mock_app):
-            with patch.object(
-                widget._service, "reset_window", return_value=(0, "All Session")
-            ) as mock_reset:
-                with patch.object(widget, "_update_window_chips"):
-                    widget.action_reset_window()
-                    mock_reset.assert_called_once()
+        monkeypatch.setattr(type(widget), "app", property(lambda self: mock_app))
+        mock_reset = MagicMock(return_value=(0, "All Session"))
+        monkeypatch.setattr(widget._service, "reset_window", mock_reset)
+        monkeypatch.setattr(widget, "_update_window_chips", lambda: None)
+        widget.action_reset_window()
+        mock_reset.assert_called_once()
 
 
 class TestTradingStatsWidgetStateUpdates:

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -38308,7 +38308,7 @@
     "tests/unit/gpt_trader/preflight/test_checks_connectivity_key_permissions_core.py": [
       {
         "name": "TestCheckKeyPermissionsCore::test_skips_when_remote_checks_bypassed",
-        "line": 27,
+        "line": 25,
         "markers": [
           "unit"
         ],
@@ -38317,7 +38317,7 @@
       },
       {
         "name": "TestCheckKeyPermissionsCore::test_fails_when_client_build_fails",
-        "line": 41,
+        "line": 37,
         "markers": [
           "unit"
         ],
@@ -38326,7 +38326,7 @@
       },
       {
         "name": "TestCheckKeyPermissionsCore::test_passes_with_full_permissions",
-        "line": 52,
+        "line": 48,
         "markers": [
           "unit"
         ],
@@ -38335,7 +38335,7 @@
       },
       {
         "name": "TestCheckKeyPermissionsCore::test_fails_without_trade_permission_when_derivatives_enabled",
-        "line": 78,
+        "line": 74,
         "markers": [
           "unit"
         ],
@@ -38344,7 +38344,7 @@
       },
       {
         "name": "TestCheckKeyPermissionsCore::test_fails_without_view_permission",
-        "line": 108,
+        "line": 104,
         "markers": [
           "unit"
         ],
@@ -38353,7 +38353,7 @@
       },
       {
         "name": "TestCheckKeyPermissionsCore::test_passes_with_view_only_key_when_live_orders_not_intended",
-        "line": 132,
+        "line": 128,
         "markers": [
           "unit"
         ],
@@ -38362,7 +38362,7 @@
       },
       {
         "name": "TestCheckKeyPermissionsCore::test_fails_with_view_only_key_when_live_spot_orders_intended",
-        "line": 166,
+        "line": 162,
         "markers": [
           "unit"
         ],
@@ -38371,7 +38371,7 @@
       },
       {
         "name": "TestCheckKeyPermissionsCore::test_warns_when_portfolio_uuid_missing",
-        "line": 196,
+        "line": 192,
         "markers": [
           "unit"
         ],
@@ -38380,7 +38380,7 @@
       },
       {
         "name": "TestCheckKeyPermissionsCore::test_prints_section_header",
-        "line": 223,
+        "line": 217,
         "markers": [
           "unit"
         ],
@@ -38391,7 +38391,7 @@
     "tests/unit/gpt_trader/preflight/test_checks_connectivity_key_permissions_intx.py": [
       {
         "name": "TestCheckKeyPermissionsIntx::test_passes_intx_check_when_derivatives_enabled",
-        "line": 25,
+        "line": 23,
         "markers": [
           "unit"
         ],
@@ -38400,7 +38400,7 @@
       },
       {
         "name": "TestCheckKeyPermissionsIntx::test_fails_intx_check_when_wrong_portfolio_type",
-        "line": 55,
+        "line": 53,
         "markers": [
           "unit"
         ],
@@ -38409,7 +38409,7 @@
       },
       {
         "name": "TestCheckKeyPermissionsIntx::test_logs_intx_available_when_disabled",
-        "line": 85,
+        "line": 83,
         "markers": [
           "unit"
         ],
@@ -39488,7 +39488,7 @@
     "tests/unit/gpt_trader/preflight/test_context_credentials.py": [
       {
         "name": "TestPreflightContextCredentials::test_resolve_cdp_credentials_from_prod_env",
-        "line": 25,
+        "line": 23,
         "markers": [
           "unit"
         ],
@@ -39497,7 +39497,7 @@
       },
       {
         "name": "TestPreflightContextCredentials::test_resolve_cdp_credentials_fallback",
-        "line": 50,
+        "line": 46,
         "markers": [
           "unit"
         ],
@@ -39506,7 +39506,7 @@
       },
       {
         "name": "TestPreflightContextCredentials::test_resolve_cdp_credentials_returns_none_when_missing",
-        "line": 73,
+        "line": 67,
         "markers": [
           "unit"
         ],
@@ -39515,7 +39515,7 @@
       },
       {
         "name": "TestPreflightContextCredentials::test_has_real_cdp_credentials_valid",
-        "line": 87,
+        "line": 81,
         "markers": [
           "unit"
         ],
@@ -39524,7 +39524,7 @@
       },
       {
         "name": "TestPreflightContextCredentials::test_has_real_cdp_credentials_invalid_key_format",
-        "line": 101,
+        "line": 95,
         "markers": [
           "unit"
         ],
@@ -39533,7 +39533,7 @@
       },
       {
         "name": "TestPreflightContextCredentials::test_has_real_cdp_credentials_invalid_private_key_format",
-        "line": 117,
+        "line": 111,
         "markers": [
           "unit"
         ],
@@ -39542,7 +39542,7 @@
       },
       {
         "name": "TestPreflightContextCredentials::test_has_real_cdp_credentials_missing",
-        "line": 133,
+        "line": 127,
         "markers": [
           "unit"
         ],
@@ -43280,7 +43280,7 @@
       },
       {
         "name": "TestAlertHistoryScreen::test_action_reset_cooldowns_resets_alerts",
-        "line": 63,
+        "line": 65,
         "markers": [
           "unit"
         ],
@@ -43289,7 +43289,7 @@
       },
       {
         "name": "TestAlertHistoryScreen::test_button_pressed_clear_btn",
-        "line": 73,
+        "line": 77,
         "markers": [
           "unit"
         ],
@@ -43298,7 +43298,7 @@
       },
       {
         "name": "TestAlertHistoryScreen::test_button_pressed_reset_btn",
-        "line": 87,
+        "line": 92,
         "markers": [
           "unit"
         ],
@@ -43307,7 +43307,7 @@
       },
       {
         "name": "TestAlertHistoryScreen::test_button_pressed_close_btn",
-        "line": 101,
+        "line": 107,
         "markers": [
           "unit"
         ],
@@ -43316,7 +43316,7 @@
       },
       {
         "name": "TestAlertHistoryScreen::test_no_alert_manager_graceful_handling",
-        "line": 114,
+        "line": 120,
         "markers": [
           "unit"
         ],
@@ -43325,7 +43325,7 @@
       },
       {
         "name": "TestAlertHistoryFilterActions::test_cycle_filter_cycles_through_all_filters",
-        "line": 137,
+        "line": 143,
         "markers": [
           "unit"
         ],
@@ -43334,7 +43334,7 @@
       },
       {
         "name": "TestAlertHistoryFilterActions::test_cycle_filter_wraps_around",
-        "line": 148,
+        "line": 157,
         "markers": [
           "unit"
         ],
@@ -43343,7 +43343,7 @@
       },
       {
         "name": "TestAlertHistoryFilterActions::test_clear_filter_resets_to_all",
-        "line": 159,
+        "line": 171,
         "markers": [
           "unit"
         ],
@@ -43352,7 +43352,7 @@
       },
       {
         "name": "TestAlertHistoryFilterActions::test_filter_bindings_present",
-        "line": 169,
+        "line": 184,
         "markers": [
           "unit"
         ],
@@ -43361,7 +43361,7 @@
       },
       {
         "name": "TestAlertHistoryFilterActions::test_number_filter_bindings_present",
-        "line": 176,
+        "line": 191,
         "markers": [
           "unit"
         ],
@@ -53930,7 +53930,7 @@
     "tests/unit/gpt_trader/tui/widgets/test_trading_stats.py": [
       {
         "name": "TestTradingStatsWidgetBindings::test_window_bindings_present",
-        "line": 12,
+        "line": 14,
         "markers": [
           "unit"
         ],
@@ -53939,7 +53939,7 @@
       },
       {
         "name": "TestTradingStatsWidgetBindings::test_window_binding_actions_exist",
-        "line": 20,
+        "line": 22,
         "markers": [
           "unit"
         ],
@@ -53948,7 +53948,7 @@
       },
       {
         "name": "TestTradingStatsWidgetModes::test_compact_mode_initialization",
-        "line": 33,
+        "line": 35,
         "markers": [
           "unit"
         ],
@@ -53957,7 +53957,7 @@
       },
       {
         "name": "TestTradingStatsWidgetModes::test_default_mode_is_expanded",
-        "line": 38,
+        "line": 40,
         "markers": [
           "unit"
         ],
@@ -53966,7 +53966,7 @@
       },
       {
         "name": "TestTradingStatsWidgetActions::test_action_cycle_window_calls_service",
-        "line": 47,
+        "line": 49,
         "markers": [
           "unit"
         ],
@@ -53975,7 +53975,7 @@
       },
       {
         "name": "TestTradingStatsWidgetActions::test_action_reset_window_calls_service",
-        "line": 64,
+        "line": 65,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary
- Convert `patch.object` to pytest `monkeypatch` in 2 TUI test files
- 21 patches converted total
- 24 tests pass

## Test plan
- [x] All 24 tests pass
- [x] Pre-commit hooks pass (black, ruff, test-hygiene, naming-standards)