### PR TITLE
test(config): reduce patch density in config tests

### DIFF
--- a/tests/unit/gpt_trader/config/test_config_utilities.py
+++ b/tests/unit/gpt_trader/config/test_config_utilities.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 from decimal import Decimal
-from unittest.mock import patch
 
 import pytest
 
@@ -18,78 +17,80 @@ from gpt_trader.config.config_utilities import (
 )
 
 
-def test_parse_list_env_success():
-    with patch.dict(os.environ, {"TEST_LIST": "alpha,beta,gamma"}, clear=True):
-        result = parse_list_env("TEST_LIST", str)
+@pytest.fixture
+def clean_env(monkeypatch: pytest.MonkeyPatch):
+    """Clear all environment variables for isolated tests."""
+    for key in list(os.environ.keys()):
+        monkeypatch.delenv(key, raising=False)
+    return monkeypatch
+
+
+def test_parse_list_env_success(clean_env: pytest.MonkeyPatch):
+    clean_env.setenv("TEST_LIST", "alpha,beta,gamma")
+    result = parse_list_env("TEST_LIST", str)
     assert result == ["alpha", "beta", "gamma"]
 
 
-def test_parse_mapping_env_wraps_errors():
-    with patch.dict(os.environ, {"BAD_MAP": "value-without-key"}, clear=True):
-        with pytest.raises(ValidationError) as exc:
-            parse_mapping_env("BAD_MAP", int)
+def test_parse_mapping_env_wraps_errors(clean_env: pytest.MonkeyPatch):
+    clean_env.setenv("BAD_MAP", "value-without-key")
+    with pytest.raises(ValidationError) as exc:
+        parse_mapping_env("BAD_MAP", int)
     assert "Failed to parse BAD_MAP" in str(exc.value)
 
 
-def test_numeric_env_helpers_handle_defaults():
-    with patch.dict(
-        os.environ,
-        {
-            "BOOL_FLAG": "true",
-            "DECIMAL_VALUE": "1.5",
-            "INT_VALUE": "7",
-            "FLOAT_VALUE": "2.75",
-        },
-        clear=True,
-    ):
-        assert parse_bool_env("BOOL_FLAG", default=False) is True
-        assert parse_decimal_env("DECIMAL_VALUE") == Decimal("1.5")
-        assert parse_int_env("INT_VALUE") == 7
-        assert parse_float_env("FLOAT_VALUE") == 2.75
+def test_numeric_env_helpers_handle_defaults(clean_env: pytest.MonkeyPatch):
+    clean_env.setenv("BOOL_FLAG", "true")
+    clean_env.setenv("DECIMAL_VALUE", "1.5")
+    clean_env.setenv("INT_VALUE", "7")
+    clean_env.setenv("FLOAT_VALUE", "2.75")
+
+    assert parse_bool_env("BOOL_FLAG", default=False) is True
+    assert parse_decimal_env("DECIMAL_VALUE") == Decimal("1.5")
+    assert parse_int_env("INT_VALUE") == 7
+    assert parse_float_env("FLOAT_VALUE") == 2.75
 
 
-def test_validate_required_env_raises_when_missing():
-    with patch.dict(os.environ, {}, clear=True):
-        with pytest.raises(ValidationError):
-            validate_required_env(["MISSING_VAR"])
+def test_validate_required_env_raises_when_missing(clean_env: pytest.MonkeyPatch):
+    with pytest.raises(ValidationError):
+        validate_required_env(["MISSING_VAR"])
 
 
-def test_validate_required_env_passes_when_present():
-    with patch.dict(os.environ, {"PRESENT_VAR": "value"}, clear=True):
-        result = validate_required_env(["PRESENT_VAR"])
+def test_validate_required_env_passes_when_present(clean_env: pytest.MonkeyPatch):
+    clean_env.setenv("PRESENT_VAR", "value")
+    result = validate_required_env(["PRESENT_VAR"])
     assert result is None
 
 
-def test_parse_list_env_with_invalid_cast():
-    with patch.dict(os.environ, {"TEST_LIST": "a,b,c"}, clear=True):
-        with pytest.raises(ValidationError) as exc:
-            parse_list_env("TEST_LIST", int)
-        assert "Failed to parse TEST_LIST" in str(exc.value)
+def test_parse_list_env_with_invalid_cast(clean_env: pytest.MonkeyPatch):
+    clean_env.setenv("TEST_LIST", "a,b,c")
+    with pytest.raises(ValidationError) as exc:
+        parse_list_env("TEST_LIST", int)
+    assert "Failed to parse TEST_LIST" in str(exc.value)
 
 
-def test_parse_bool_env_with_invalid_value():
-    with patch.dict(os.environ, {"BAD_BOOL": "not_a_bool"}, clear=True):
-        with pytest.raises(ValidationError) as exc:
-            parse_bool_env("BAD_BOOL")
-        assert "Failed to parse BAD_BOOL" in str(exc.value)
+def test_parse_bool_env_with_invalid_value(clean_env: pytest.MonkeyPatch):
+    clean_env.setenv("BAD_BOOL", "not_a_bool")
+    with pytest.raises(ValidationError) as exc:
+        parse_bool_env("BAD_BOOL")
+    assert "Failed to parse BAD_BOOL" in str(exc.value)
 
 
-def test_parse_decimal_env_with_invalid_value():
-    with patch.dict(os.environ, {"BAD_DECIMAL": "not_a_decimal"}, clear=True):
-        with pytest.raises(ValidationError) as exc:
-            parse_decimal_env("BAD_DECIMAL")
-        assert "Failed to parse BAD_DECIMAL" in str(exc.value)
+def test_parse_decimal_env_with_invalid_value(clean_env: pytest.MonkeyPatch):
+    clean_env.setenv("BAD_DECIMAL", "not_a_decimal")
+    with pytest.raises(ValidationError) as exc:
+        parse_decimal_env("BAD_DECIMAL")
+    assert "Failed to parse BAD_DECIMAL" in str(exc.value)
 
 
-def test_parse_int_env_with_invalid_value():
-    with patch.dict(os.environ, {"BAD_INT": "not_an_int"}, clear=True):
-        with pytest.raises(ValidationError) as exc:
-            parse_int_env("BAD_INT")
-        assert "Failed to parse BAD_INT" in str(exc.value)
+def test_parse_int_env_with_invalid_value(clean_env: pytest.MonkeyPatch):
+    clean_env.setenv("BAD_INT", "not_an_int")
+    with pytest.raises(ValidationError) as exc:
+        parse_int_env("BAD_INT")
+    assert "Failed to parse BAD_INT" in str(exc.value)
 
 
-def test_parse_float_env_with_invalid_value():
-    with patch.dict(os.environ, {"BAD_FLOAT": "not_a_float"}, clear=True):
-        with pytest.raises(ValidationError) as exc:
-            parse_float_env("BAD_FLOAT")
-        assert "Failed to parse BAD_FLOAT" in str(exc.value)
+def test_parse_float_env_with_invalid_value(clean_env: pytest.MonkeyPatch):
+    clean_env.setenv("BAD_FLOAT", "not_a_float")
+    with pytest.raises(ValidationError) as exc:
+        parse_float_env("BAD_FLOAT")
+    assert "Failed to parse BAD_FLOAT" in str(exc.value)

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2713,7 +2713,7 @@
     "tests/unit/gpt_trader/app/config/test_bot_config.py": [
       {
         "name": "TestEnableShortsCanonical::test_active_enable_shorts_from_baseline_strategy",
-        "line": 19,
+        "line": 26,
         "markers": [
           "unit"
         ],
@@ -2722,7 +2722,7 @@
       },
       {
         "name": "TestEnableShortsCanonical::test_active_enable_shorts_from_mean_reversion",
-        "line": 31,
+        "line": 38,
         "markers": [
           "unit"
         ],
@@ -2731,7 +2731,7 @@
       },
       {
         "name": "TestEnableShortsCanonical::test_sync_warning_on_mismatch",
-        "line": 41,
+        "line": 48,
         "markers": [
           "unit"
         ],
@@ -2740,7 +2740,7 @@
       },
       {
         "name": "TestEnableShortsCanonical::test_no_warning_when_synced",
-        "line": 58,
+        "line": 65,
         "markers": [
           "unit"
         ],
@@ -2749,7 +2749,7 @@
       },
       {
         "name": "TestEnableShortsCanonical::test_warning_only_once_per_process",
-        "line": 73,
+        "line": 80,
         "markers": [
           "unit"
         ],
@@ -2758,7 +2758,7 @@
       },
       {
         "name": "TestMockBrokerEnvParsing::test_mock_broker_env_true",
-        "line": 98,
+        "line": 105,
         "markers": [
           "unit"
         ],
@@ -2767,7 +2767,7 @@
       },
       {
         "name": "TestMockBrokerEnvParsing::test_mock_broker_env_default_false",
-        "line": 104,
+        "line": 111,
         "markers": [
           "unit"
         ],
@@ -2776,7 +2776,7 @@
       },
       {
         "name": "TestReduceOnlyModeEnvParsing::test_risk_prefixed_enabled",
-        "line": 114,
+        "line": 120,
         "markers": [
           "unit"
         ],
@@ -2785,7 +2785,7 @@
       },
       {
         "name": "TestReduceOnlyModeEnvParsing::test_default_false",
-        "line": 124,
+        "line": 127,
         "markers": [
           "unit"
         ],
@@ -2794,7 +2794,7 @@
       },
       {
         "name": "TestDerivativesEnvParsing::test_derivatives_enabled_prefers_intx_perps_flag",
-        "line": 134,
+        "line": 137,
         "markers": [
           "unit"
         ],
@@ -2803,7 +2803,7 @@
       },
       {
         "name": "TestDerivativesEnvParsing::test_derivatives_enabled_intx_perps_can_disable_legacy",
-        "line": 144,
+        "line": 146,
         "markers": [
           "unit"
         ],
@@ -2812,7 +2812,7 @@
       },
       {
         "name": "TestDerivativesEnvParsing::test_derivatives_enabled_falls_back_to_legacy",
-        "line": 154,
+        "line": 155,
         "markers": [
           "unit"
         ],
@@ -9857,7 +9857,7 @@
     "tests/unit/gpt_trader/config/test_config_utilities.py": [
       {
         "name": "test_parse_list_env_success",
-        "line": 21,
+        "line": 28,
         "markers": [
           "unit"
         ],
@@ -9865,14 +9865,6 @@
       },
       {
         "name": "test_parse_mapping_env_wraps_errors",
-        "line": 27,
-        "markers": [
-          "unit"
-        ],
-        "docstring": ""
-      },
-      {
-        "name": "test_numeric_env_helpers_handle_defaults",
         "line": 34,
         "markers": [
           "unit"
@@ -9880,8 +9872,16 @@
         "docstring": ""
       },
       {
+        "name": "test_numeric_env_helpers_handle_defaults",
+        "line": 41,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
         "name": "test_validate_required_env_raises_when_missing",
-        "line": 51,
+        "line": 53,
         "markers": [
           "unit"
         ],
@@ -9889,7 +9889,7 @@
       },
       {
         "name": "test_validate_required_env_passes_when_present",
-        "line": 57,
+        "line": 58,
         "markers": [
           "unit"
         ],
@@ -9897,7 +9897,7 @@
       },
       {
         "name": "test_parse_list_env_with_invalid_cast",
-        "line": 63,
+        "line": 64,
         "markers": [
           "unit"
         ],
@@ -9905,7 +9905,7 @@
       },
       {
         "name": "test_parse_bool_env_with_invalid_value",
-        "line": 70,
+        "line": 71,
         "markers": [
           "unit"
         ],
@@ -9913,7 +9913,7 @@
       },
       {
         "name": "test_parse_decimal_env_with_invalid_value",
-        "line": 77,
+        "line": 78,
         "markers": [
           "unit"
         ],
@@ -9921,7 +9921,7 @@
       },
       {
         "name": "test_parse_int_env_with_invalid_value",
-        "line": 84,
+        "line": 85,
         "markers": [
           "unit"
         ],
@@ -9929,7 +9929,7 @@
       },
       {
         "name": "test_parse_float_env_with_invalid_value",
-        "line": 91,
+        "line": 92,
         "markers": [
           "unit"
         ],
@@ -38308,7 +38308,7 @@
     "tests/unit/gpt_trader/preflight/test_checks_connectivity_key_permissions_core.py": [
       {
         "name": "TestCheckKeyPermissionsCore::test_skips_when_remote_checks_bypassed",
-        "line": 27,
+        "line": 25,
         "markers": [
           "unit"
         ],
@@ -38317,7 +38317,7 @@
       },
       {
         "name": "TestCheckKeyPermissionsCore::test_fails_when_client_build_fails",
-        "line": 41,
+        "line": 37,
         "markers": [
           "unit"
         ],
@@ -38326,7 +38326,7 @@
       },
       {
         "name": "TestCheckKeyPermissionsCore::test_passes_with_full_permissions",
-        "line": 52,
+        "line": 48,
         "markers": [
           "unit"
         ],
@@ -38335,7 +38335,7 @@
       },
       {
         "name": "TestCheckKeyPermissionsCore::test_fails_without_trade_permission_when_derivatives_enabled",
-        "line": 78,
+        "line": 74,
         "markers": [
           "unit"
         ],
@@ -38344,7 +38344,7 @@
       },
       {
         "name": "TestCheckKeyPermissionsCore::test_fails_without_view_permission",
-        "line": 108,
+        "line": 104,
         "markers": [
           "unit"
         ],
@@ -38353,7 +38353,7 @@
       },
       {
         "name": "TestCheckKeyPermissionsCore::test_passes_with_view_only_key_when_live_orders_not_intended",
-        "line": 132,
+        "line": 128,
         "markers": [
           "unit"
         ],
@@ -38362,7 +38362,7 @@
       },
       {
         "name": "TestCheckKeyPermissionsCore::test_fails_with_view_only_key_when_live_spot_orders_intended",
-        "line": 166,
+        "line": 162,
         "markers": [
           "unit"
         ],
@@ -38371,7 +38371,7 @@
       },
       {
         "name": "TestCheckKeyPermissionsCore::test_warns_when_portfolio_uuid_missing",
-        "line": 196,
+        "line": 192,
         "markers": [
           "unit"
         ],
@@ -38380,7 +38380,7 @@
       },
       {
         "name": "TestCheckKeyPermissionsCore::test_prints_section_header",
-        "line": 223,
+        "line": 217,
         "markers": [
           "unit"
         ],
@@ -38391,7 +38391,7 @@
     "tests/unit/gpt_trader/preflight/test_checks_connectivity_key_permissions_intx.py": [
       {
         "name": "TestCheckKeyPermissionsIntx::test_passes_intx_check_when_derivatives_enabled",
-        "line": 25,
+        "line": 23,
         "markers": [
           "unit"
         ],
@@ -38400,7 +38400,7 @@
       },
       {
         "name": "TestCheckKeyPermissionsIntx::test_fails_intx_check_when_wrong_portfolio_type",
-        "line": 55,
+        "line": 53,
         "markers": [
           "unit"
         ],
@@ -38409,7 +38409,7 @@
       },
       {
         "name": "TestCheckKeyPermissionsIntx::test_logs_intx_available_when_disabled",
-        "line": 85,
+        "line": 83,
         "markers": [
           "unit"
         ],
@@ -39488,7 +39488,7 @@
     "tests/unit/gpt_trader/preflight/test_context_credentials.py": [
       {
         "name": "TestPreflightContextCredentials::test_resolve_cdp_credentials_from_prod_env",
-        "line": 25,
+        "line": 23,
         "markers": [
           "unit"
         ],
@@ -39497,7 +39497,7 @@
       },
       {
         "name": "TestPreflightContextCredentials::test_resolve_cdp_credentials_fallback",
-        "line": 50,
+        "line": 46,
         "markers": [
           "unit"
         ],
@@ -39506,7 +39506,7 @@
       },
       {
         "name": "TestPreflightContextCredentials::test_resolve_cdp_credentials_returns_none_when_missing",
-        "line": 73,
+        "line": 67,
         "markers": [
           "unit"
         ],
@@ -39515,7 +39515,7 @@
       },
       {
         "name": "TestPreflightContextCredentials::test_has_real_cdp_credentials_valid",
-        "line": 87,
+        "line": 81,
         "markers": [
           "unit"
         ],
@@ -39524,7 +39524,7 @@
       },
       {
         "name": "TestPreflightContextCredentials::test_has_real_cdp_credentials_invalid_key_format",
-        "line": 101,
+        "line": 95,
         "markers": [
           "unit"
         ],
@@ -39533,7 +39533,7 @@
       },
       {
         "name": "TestPreflightContextCredentials::test_has_real_cdp_credentials_invalid_private_key_format",
-        "line": 117,
+        "line": 111,
         "markers": [
           "unit"
         ],
@@ -39542,7 +39542,7 @@
       },
       {
         "name": "TestPreflightContextCredentials::test_has_real_cdp_credentials_missing",
-        "line": 133,
+        "line": 127,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary
- Convert `patch.dict(os.environ, ...)` to pytest `monkeypatch.setenv` in 2 config test files
- 18 patches converted total
- 23 tests pass

## Test plan
- [x] All 23 tests pass
- [x] Pre-commit hooks pass (black, ruff, test-hygiene, naming-standards)