### PR TITLE
test(live_trade): reduce patch density in chaos/guard tests

### DIFF
--- a/tests/unit/gpt_trader/features/live_trade/execution/test_guard_manager_cancel_and_safe_run.py
+++ b/tests/unit/gpt_trader/features/live_trade/execution/test_guard_manager_cancel_and_safe_run.py
@@ -1,6 +1,8 @@
 """Tests for GuardManager order cancellation and safe-run wrapper."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
+
+import pytest
 
 from gpt_trader.features.live_trade.execution.guard_manager import GuardManager
 from gpt_trader.features.live_trade.guard_errors import (
@@ -68,50 +70,60 @@ def test_cancel_all_orders_uses_broker_list_orders(guard_manager, mock_broker):
     assert guard_manager.open_orders == []
 
 
-def test_safe_run_runtime_guards_success(guard_manager):
-    with patch.object(guard_manager, "run_runtime_guards") as mock_run:
-        guard_manager.safe_run_runtime_guards()
-        mock_run.assert_called_once_with(force_full=False)
+def test_safe_run_runtime_guards_success(guard_manager, monkeypatch: pytest.MonkeyPatch):
+    mock_run = MagicMock()
+    monkeypatch.setattr(guard_manager, "run_runtime_guards", mock_run)
+    guard_manager.safe_run_runtime_guards()
+    mock_run.assert_called_once_with(force_full=False)
 
 
-def test_safe_run_runtime_guards_force_full(guard_manager):
-    with patch.object(guard_manager, "run_runtime_guards") as mock_run:
-        guard_manager.safe_run_runtime_guards(force_full=True)
-        mock_run.assert_called_once_with(force_full=True)
+def test_safe_run_runtime_guards_force_full(guard_manager, monkeypatch: pytest.MonkeyPatch):
+    mock_run = MagicMock()
+    monkeypatch.setattr(guard_manager, "run_runtime_guards", mock_run)
+    guard_manager.safe_run_runtime_guards(force_full=True)
+    mock_run.assert_called_once_with(force_full=True)
 
 
-def test_safe_run_runtime_guards_recoverable_error(guard_manager, mock_risk_manager):
+def test_safe_run_runtime_guards_recoverable_error(
+    guard_manager, mock_risk_manager, monkeypatch: pytest.MonkeyPatch
+):
     error = RiskGuardTelemetryError(guard_name="test", message="Recoverable", details={})
 
-    with patch.object(guard_manager, "run_runtime_guards", side_effect=error):
-        guard_manager.safe_run_runtime_guards()
+    mock_run = MagicMock(side_effect=error)
+    monkeypatch.setattr(guard_manager, "run_runtime_guards", mock_run)
+    guard_manager.safe_run_runtime_guards()
 
     mock_risk_manager.set_reduce_only_mode.assert_not_called()
 
 
-def test_safe_run_runtime_guards_unrecoverable_error(guard_manager, mock_risk_manager):
+def test_safe_run_runtime_guards_unrecoverable_error(
+    guard_manager, mock_risk_manager, monkeypatch: pytest.MonkeyPatch
+):
     error = RiskGuardActionError(guard_name="test", message="Fatal", details={})
 
-    with patch.object(guard_manager, "run_runtime_guards", side_effect=error):
-        guard_manager.safe_run_runtime_guards()
+    mock_run = MagicMock(side_effect=error)
+    monkeypatch.setattr(guard_manager, "run_runtime_guards", mock_run)
+    guard_manager.safe_run_runtime_guards()
 
     mock_risk_manager.set_reduce_only_mode.assert_called_with(True, reason="guard_failure")
     guard_manager._invalidate_cache_callback.assert_called()
 
 
-def test_safe_run_runtime_guards_unexpected_error(guard_manager):
-    with patch.object(
-        guard_manager, "run_runtime_guards", side_effect=ValueError("Unexpected")
-    ) as mock_run:
-        guard_manager.safe_run_runtime_guards()
+def test_safe_run_runtime_guards_unexpected_error(guard_manager, monkeypatch: pytest.MonkeyPatch):
+    mock_run = MagicMock(side_effect=ValueError("Unexpected"))
+    monkeypatch.setattr(guard_manager, "run_runtime_guards", mock_run)
+    guard_manager.safe_run_runtime_guards()
     mock_run.assert_called_once_with(force_full=False)
 
 
-def test_safe_run_runtime_guards_reduce_only_failure(guard_manager, mock_risk_manager):
+def test_safe_run_runtime_guards_reduce_only_failure(
+    guard_manager, mock_risk_manager, monkeypatch: pytest.MonkeyPatch
+):
     error = RiskGuardActionError(guard_name="test", message="Fatal", details={})
     mock_risk_manager.set_reduce_only_mode.side_effect = Exception("Failed")
 
-    with patch.object(guard_manager, "run_runtime_guards", side_effect=error):
-        guard_manager.safe_run_runtime_guards()
+    mock_run = MagicMock(side_effect=error)
+    monkeypatch.setattr(guard_manager, "run_runtime_guards", mock_run)
+    guard_manager.safe_run_runtime_guards()
 
     guard_manager._invalidate_cache_callback.assert_called()

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -20492,7 +20492,7 @@
       },
       {
         "name": "TestGuardFailureDegradation::test_api_outage_scenario_triggers_degradation",
-        "line": 41,
+        "line": 44,
         "markers": [
           "asyncio",
           "unit"
@@ -20502,7 +20502,7 @@
       },
       {
         "name": "TestGuardFailureDegradation::test_api_health_guard_emits_api_error_event",
-        "line": 69,
+        "line": 73,
         "markers": [
           "asyncio",
           "unit"
@@ -20512,7 +20512,7 @@
       },
       {
         "name": "test_kill_switch_blocks_submission",
-        "line": 87,
+        "line": 91,
         "markers": [
           "asyncio",
           "unit"
@@ -20649,7 +20649,7 @@
       },
       {
         "name": "TestWSHealthDegradation::test_ws_stale_heartbeat_triggers_pause",
-        "line": 55,
+        "line": 56,
         "markers": [
           "asyncio",
           "unit"
@@ -20659,7 +20659,7 @@
       },
       {
         "name": "TestWSHealthDegradation::test_ws_reconnect_triggers_pause_for_sync",
-        "line": 81,
+        "line": 83,
         "markers": [
           "asyncio",
           "unit"
@@ -20669,7 +20669,7 @@
       },
       {
         "name": "TestWSHealthDegradation::test_ws_disconnect_with_stale_timestamps_triggers_degradation",
-        "line": 111,
+        "line": 114,
         "markers": [
           "asyncio",
           "unit"
@@ -20679,7 +20679,7 @@
       },
       {
         "name": "TestWSHealthDegradation::test_ws_gap_count_tracked_in_status",
-        "line": 136,
+        "line": 140,
         "markers": [
           "asyncio",
           "unit"
@@ -20689,7 +20689,7 @@
       },
       {
         "name": "TestWSHealthDegradation::test_no_degradation_when_broker_lacks_ws_health",
-        "line": 168,
+        "line": 173,
         "markers": [
           "asyncio",
           "unit"
@@ -20699,7 +20699,7 @@
       },
       {
         "name": "TestWSHealthDegradation::test_ws_health_exception_handled_gracefully",
-        "line": 191,
+        "line": 197,
         "markers": [
           "asyncio",
           "unit"
@@ -22302,7 +22302,7 @@
     "tests/unit/gpt_trader/features/live_trade/execution/test_guard_manager_cancel_and_safe_run.py": [
       {
         "name": "test_cancel_all_orders_success",
-        "line": 12,
+        "line": 14,
         "markers": [
           "unit"
         ],
@@ -22310,7 +22310,7 @@
       },
       {
         "name": "test_cancel_all_orders_partial_failure",
-        "line": 23,
+        "line": 25,
         "markers": [
           "unit"
         ],
@@ -22318,7 +22318,7 @@
       },
       {
         "name": "test_cancel_all_orders_none_cancelled",
-        "line": 33,
+        "line": 35,
         "markers": [
           "unit"
         ],
@@ -22326,7 +22326,7 @@
       },
       {
         "name": "test_cancel_all_orders_empty_list",
-        "line": 42,
+        "line": 44,
         "markers": [
           "unit"
         ],
@@ -22334,7 +22334,7 @@
       },
       {
         "name": "test_cancel_all_orders_uses_broker_list_orders",
-        "line": 57,
+        "line": 59,
         "markers": [
           "unit"
         ],
@@ -22342,7 +22342,7 @@
       },
       {
         "name": "test_safe_run_runtime_guards_success",
-        "line": 71,
+        "line": 73,
         "markers": [
           "unit"
         ],
@@ -22350,7 +22350,7 @@
       },
       {
         "name": "test_safe_run_runtime_guards_force_full",
-        "line": 77,
+        "line": 80,
         "markers": [
           "unit"
         ],
@@ -22358,7 +22358,7 @@
       },
       {
         "name": "test_safe_run_runtime_guards_recoverable_error",
-        "line": 83,
+        "line": 87,
         "markers": [
           "unit"
         ],
@@ -22366,7 +22366,7 @@
       },
       {
         "name": "test_safe_run_runtime_guards_unrecoverable_error",
-        "line": 92,
+        "line": 99,
         "markers": [
           "unit"
         ],
@@ -22374,7 +22374,7 @@
       },
       {
         "name": "test_safe_run_runtime_guards_unexpected_error",
-        "line": 102,
+        "line": 112,
         "markers": [
           "unit"
         ],
@@ -22382,7 +22382,7 @@
       },
       {
         "name": "test_safe_run_runtime_guards_reduce_only_failure",
-        "line": 110,
+        "line": 121,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary
- Convert 15 `patch.object` usages to pytest `monkeypatch` fixtures in Live Trade tests
- **test_strategy_engine_chaos_ws_health.py**: 7 patches (asyncio.sleep mocking)
- **test_guard_manager_cancel_and_safe_run.py**: 6 patches (run_runtime_guards mocking)
- **test_strategy_engine_chaos_guard_failures.py**: 2 patches (asyncio.sleep mocking)

## Metrics
- **Before**: 36 patch.object/patch.dict usages
- **After**: 21 usages
- **Reduction**: 15 patches (42%)

## Test plan
- [x] All 22 unit tests pass
- [x] Pre-commit hooks pass (test-hygiene, legacy-test-triage, naming-standards)
- [x] Test inventory regenerated