### PR TITLE
test(cli,config): reduce patch density in optimize/env tests

### DIFF
--- a/tests/unit/gpt_trader/cli/commands/optimize/test_commands_execution.py
+++ b/tests/unit/gpt_trader/cli/commands/optimize/test_commands_execution.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from argparse import Namespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
+
+import pytest
 
 from gpt_trader.cli.commands.optimize import apply, compare, export, run, view
 from gpt_trader.cli.commands.optimize import list as list_cmd
@@ -39,18 +41,18 @@ class TestRunCommand:
 class TestListCommand:
     """Test list command functionality."""
 
-    def test_execute_with_no_runs(self, tmp_path, monkeypatch):
+    def test_execute_with_no_runs(self, tmp_path, monkeypatch: pytest.MonkeyPatch):
         """Test list command with no runs."""
         mock_storage = MagicMock()
         mock_storage.list_runs.return_value = []
 
-        with patch.object(list_cmd, "OptimizationStorage", return_value=mock_storage):
-            args = Namespace(format="text", limit=20, study=None)
-            result = list_cmd.execute(args)
+        monkeypatch.setattr(list_cmd, "OptimizationStorage", MagicMock(return_value=mock_storage))
+        args = Namespace(format="text", limit=20, study=None)
+        result = list_cmd.execute(args)
 
         assert result == 0
 
-    def test_execute_with_runs(self, monkeypatch):
+    def test_execute_with_runs(self, monkeypatch: pytest.MonkeyPatch):
         """Test list command with runs."""
         mock_storage = MagicMock()
         mock_storage.list_runs.return_value = [
@@ -62,9 +64,9 @@ class TestListCommand:
             }
         ]
 
-        with patch.object(list_cmd, "OptimizationStorage", return_value=mock_storage):
-            args = Namespace(format="text", limit=20, study=None)
-            result = list_cmd.execute(args)
+        monkeypatch.setattr(list_cmd, "OptimizationStorage", MagicMock(return_value=mock_storage))
+        args = Namespace(format="text", limit=20, study=None)
+        result = list_cmd.execute(args)
 
         assert result == 0
 
@@ -72,16 +74,16 @@ class TestListCommand:
 class TestViewCommand:
     """Test view command functionality."""
 
-    def test_execute_with_missing_run(self, monkeypatch):
+    def test_execute_with_missing_run(self, monkeypatch: pytest.MonkeyPatch):
         """Test view command with missing run."""
         mock_storage = MagicMock()
         mock_storage.list_runs.return_value = []
 
-        with patch.object(view, "OptimizationStorage", return_value=mock_storage):
-            args = Namespace(
-                run_id="latest", format="text", trials=10, show_params=False, summary_only=False
-            )
-            result = view.execute(args)
+        monkeypatch.setattr(view, "OptimizationStorage", MagicMock(return_value=mock_storage))
+        args = Namespace(
+            run_id="latest", format="text", trials=10, show_params=False, summary_only=False
+        )
+        result = view.execute(args)
 
         assert result == 1  # Error: no runs found
 
@@ -99,20 +101,20 @@ class TestCompareCommand:
 class TestExportCommand:
     """Test export command functionality."""
 
-    def test_execute_with_missing_run(self, monkeypatch):
+    def test_execute_with_missing_run(self, monkeypatch: pytest.MonkeyPatch):
         """Test export command with missing run."""
         mock_storage = MagicMock()
         mock_storage.list_runs.return_value = []
 
-        with patch.object(export, "OptimizationStorage", return_value=mock_storage):
-            args = Namespace(
-                run_id="latest",
-                format="json",
-                output=None,
-                best_only=False,
-                include_trials=False,
-            )
-            result = export.execute(args)
+        monkeypatch.setattr(export, "OptimizationStorage", MagicMock(return_value=mock_storage))
+        args = Namespace(
+            run_id="latest",
+            format="json",
+            output=None,
+            best_only=False,
+            include_trials=False,
+        )
+        result = export.execute(args)
 
         assert result == 1  # Error: no runs found
 
@@ -120,20 +122,20 @@ class TestExportCommand:
 class TestApplyCommand:
     """Test apply command functionality."""
 
-    def test_execute_with_missing_run(self, monkeypatch):
+    def test_execute_with_missing_run(self, monkeypatch: pytest.MonkeyPatch):
         """Test apply command with missing run."""
         mock_storage = MagicMock()
         mock_storage.list_runs.return_value = []
 
-        with patch.object(apply, "OptimizationStorage", return_value=mock_storage):
-            args = Namespace(
-                run_id="latest",
-                output=None,
-                profile="optimized",
-                base_config=None,
-                strategy_only=False,
-                dry_run=False,
-            )
-            result = apply.execute(args)
+        monkeypatch.setattr(apply, "OptimizationStorage", MagicMock(return_value=mock_storage))
+        args = Namespace(
+            run_id="latest",
+            output=None,
+            profile="optimized",
+            base_config=None,
+            strategy_only=False,
+            dry_run=False,
+        )
+        result = apply.execute(args)
 
         assert result == 1  # Error: no runs found

--- a/tests/unit/gpt_trader/config/test_bot_config_env_aliasing.py
+++ b/tests/unit/gpt_trader/config/test_bot_config_env_aliasing.py
@@ -2,42 +2,44 @@
 
 from __future__ import annotations
 
-import os
 from decimal import Decimal
-from unittest import mock
+
+import pytest
 
 
 class TestBotConfigEnvAliasing:
     """Tests for RISK_* prefixed environment variable support."""
 
-    def test_risk_max_leverage_with_prefix(self) -> None:
+    def test_risk_max_leverage_with_prefix(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test RISK_MAX_LEVERAGE is read correctly."""
-        with mock.patch.dict(os.environ, {"RISK_MAX_LEVERAGE": "7"}, clear=False):
-            from gpt_trader.app.config.bot_config import BotConfig
+        monkeypatch.setenv("RISK_MAX_LEVERAGE", "7")
+        from gpt_trader.app.config.bot_config import BotConfig
 
-            config = BotConfig.from_env()
-            assert config.risk.max_leverage == 7
+        config = BotConfig.from_env()
+        assert config.risk.max_leverage == 7
 
-    def test_risk_position_fraction_from_pct_per_symbol(self) -> None:
+    def test_risk_position_fraction_from_pct_per_symbol(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Test RISK_MAX_POSITION_PCT_PER_SYMBOL maps to position_fraction."""
-        with mock.patch.dict(os.environ, {"RISK_MAX_POSITION_PCT_PER_SYMBOL": "0.15"}, clear=False):
-            from gpt_trader.app.config.bot_config import BotConfig
+        monkeypatch.setenv("RISK_MAX_POSITION_PCT_PER_SYMBOL", "0.15")
+        from gpt_trader.app.config.bot_config import BotConfig
 
-            config = BotConfig.from_env()
-            assert config.risk.position_fraction == Decimal("0.15")
+        config = BotConfig.from_env()
+        assert config.risk.position_fraction == Decimal("0.15")
 
-    def test_risk_daily_loss_limit_pct(self) -> None:
+    def test_risk_daily_loss_limit_pct(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test RISK_DAILY_LOSS_LIMIT_PCT is read correctly."""
-        with mock.patch.dict(os.environ, {"RISK_DAILY_LOSS_LIMIT_PCT": "0.08"}, clear=False):
-            from gpt_trader.app.config.bot_config import BotConfig
+        monkeypatch.setenv("RISK_DAILY_LOSS_LIMIT_PCT", "0.08")
+        from gpt_trader.app.config.bot_config import BotConfig
 
-            config = BotConfig.from_env()
-            assert config.risk.daily_loss_limit_pct == 0.08
+        config = BotConfig.from_env()
+        assert config.risk.daily_loss_limit_pct == 0.08
 
-    def test_trading_symbols_alias(self) -> None:
+    def test_trading_symbols_alias(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test TRADING_SYMBOLS is read correctly."""
-        with mock.patch.dict(os.environ, {"TRADING_SYMBOLS": "BTC-USD,SOL-USD"}, clear=False):
-            from gpt_trader.app.config.bot_config import BotConfig
+        monkeypatch.setenv("TRADING_SYMBOLS", "BTC-USD,SOL-USD")
+        from gpt_trader.app.config.bot_config import BotConfig
 
-            config = BotConfig.from_env()
-            assert config.symbols == ["BTC-USD", "SOL-USD"]
+        config = BotConfig.from_env()
+        assert config.symbols == ["BTC-USD", "SOL-USD"]

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -8706,7 +8706,7 @@
     "tests/unit/gpt_trader/cli/commands/optimize/test_commands_execution.py": [
       {
         "name": "TestRunCommand::test_dry_run_returns_success",
-        "line": 15,
+        "line": 17,
         "markers": [
           "unit"
         ],
@@ -8715,7 +8715,7 @@
       },
       {
         "name": "TestListCommand::test_execute_with_no_runs",
-        "line": 42,
+        "line": 44,
         "markers": [
           "unit"
         ],
@@ -8724,7 +8724,7 @@
       },
       {
         "name": "TestListCommand::test_execute_with_runs",
-        "line": 53,
+        "line": 55,
         "markers": [
           "unit"
         ],
@@ -8733,7 +8733,7 @@
       },
       {
         "name": "TestViewCommand::test_execute_with_missing_run",
-        "line": 75,
+        "line": 77,
         "markers": [
           "unit"
         ],
@@ -8742,7 +8742,7 @@
       },
       {
         "name": "TestCompareCommand::test_execute_requires_two_runs",
-        "line": 92,
+        "line": 94,
         "markers": [
           "unit"
         ],
@@ -8751,7 +8751,7 @@
       },
       {
         "name": "TestExportCommand::test_execute_with_missing_run",
-        "line": 102,
+        "line": 104,
         "markers": [
           "unit"
         ],
@@ -8760,7 +8760,7 @@
       },
       {
         "name": "TestApplyCommand::test_execute_with_missing_run",
-        "line": 123,
+        "line": 125,
         "markers": [
           "unit"
         ],
@@ -9703,7 +9703,7 @@
       },
       {
         "name": "TestBotConfigEnvAliasing::test_risk_daily_loss_limit_pct",
-        "line": 29,
+        "line": 31,
         "markers": [
           "unit"
         ],
@@ -9712,7 +9712,7 @@
       },
       {
         "name": "TestBotConfigEnvAliasing::test_trading_symbols_alias",
-        "line": 37,
+        "line": 39,
         "markers": [
           "unit"
         ],

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -22382,7 +22382,7 @@
       },
       {
         "name": "test_safe_run_runtime_guards_reduce_only_failure",
-        "line": 121,
+        "line": 119,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary
- Convert 9 patch usages to pytest `monkeypatch` fixtures
- **test_commands_execution.py**: 5 `patch.object` (OptimizationStorage mocking)
- **test_bot_config_env_aliasing.py**: 4 `patch.dict` (os.environ mocking)

## Metrics
- **Before**: 36 patch.object/patch.dict usages
- **After**: 27 usages
- **Reduction**: 9 patches (25%)

## Test plan
- [x] All 11 unit tests pass
- [x] Pre-commit hooks pass (test-hygiene, legacy-test-triage, naming-standards)
- [x] Test inventory regenerated