### PR TITLE
Fix dedupe manifest for PR #346

### DIFF
--- a/tests/_triage/dedupe_candidates.yaml
+++ b/tests/_triage/dedupe_candidates.yaml
@@ -1415,12 +1415,10 @@ clusters:
     source_modules: []
     decision: merge
     target_location: tests/unit/gpt_trader/tui/services/test_alert_manager.py
-    expected_file_delta: -1
+    expected_file_delta: -4
     priority: low
-    rationale: Consolidated fill model coverage into fewer cohesive modules
-    status: done
-    owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/346
+    rationale: Consolidate 5 test files into single parametrized file
+    status: pending
     added: '2026-01-21'
   1ddeaae0a707:
     type: similar_names
@@ -1434,12 +1432,10 @@ clusters:
     source_modules: []
     decision: merge
     target_location: tests/unit/gpt_trader/features/brokerages/paper/test_hybrid_paper.py
-    expected_file_delta: -1
+    expected_file_delta: -4
     priority: low
-    rationale: Consolidated fill model coverage into fewer cohesive modules
-    status: done
-    owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/346
+    rationale: Consolidate 5 test files into single parametrized file
+    status: pending
     added: '2026-01-21'
   52946e567f9f:
     type: similar_names
@@ -1538,10 +1534,12 @@ clusters:
     source_modules: []
     decision: merge
     target_location: tests/unit/gpt_trader/backtesting/simulation/test_fill_model.py
-    expected_file_delta: -4
+    expected_file_delta: -1
     priority: low
-    rationale: Consolidate 5 test files into single parametrized file
-    status: pending
+    rationale: Consolidated fill model coverage into fewer cohesive modules
+    status: done
+    owner: codex
+    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/346
     added: '2026-01-21'
   033123dabd72:
     type: similar_names


### PR DESCRIPTION
Corrects a bad manifest edit introduced in #346:
- Reverts accidental status/pr_url updates on the alert_manager + hybrid_paper clusters
- Marks the intended fill_model cluster (cc5aea60ee1b) as done with PR #346

No code/test changes.