### PR TITLE
Add dedicated executor option for bounded to_thread

### DIFF
--- a/src/gpt_trader/utilities/async_tools/bounded_to_thread.py
+++ b/src/gpt_trader/utilities/async_tools/bounded_to_thread.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+import functools
 from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any, TypeVar
 
 from .rate_limit import AsyncRateLimiter
@@ -17,6 +19,7 @@ class BoundedToThread:
     This is a thin wrapper over ``asyncio.to_thread`` that adds:
     - An ``asyncio.Semaphore`` to cap concurrent in-flight calls
     - Optional async token-bucket rate limiting
+    - Optional dedicated ``ThreadPoolExecutor`` for isolation
 
     Intended usage is for sync broker clients (requests/time.sleep) from async code.
     """
@@ -28,11 +31,15 @@ class BoundedToThread:
         rate_limit_per_sec: float | None = None,
         burst_limit: int = 1,
         limiter: AsyncRateLimiter | None = None,
+        executor: ThreadPoolExecutor | None = None,
+        use_dedicated_executor: bool = False,
     ) -> None:
         if max_concurrency < 1:
             raise ValueError("max_concurrency must be at least 1")
         if rate_limit_per_sec is not None and rate_limit_per_sec <= 0:
             raise ValueError("rate_limit_per_sec must be positive when provided")
+        if executor is not None and use_dedicated_executor:
+            raise ValueError("Provide executor or set use_dedicated_executor, not both")
 
         self._semaphore = asyncio.Semaphore(max_concurrency)
         self._limiter = limiter or (
@@ -40,16 +47,39 @@ class BoundedToThread:
             if rate_limit_per_sec is not None
             else None
         )
+        self._owns_executor = False
+        if executor is not None:
+            self._executor: ThreadPoolExecutor | None = executor
+        elif use_dedicated_executor:
+            self._executor = ThreadPoolExecutor(max_workers=max_concurrency)
+            self._owns_executor = True
+        else:
+            self._executor = None
+
+    async def _run_in_thread(self, func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
+        if self._executor is None:
+            return await asyncio.to_thread(func, *args, **kwargs)
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            self._executor,
+            functools.partial(func, *args, **kwargs),
+        )
 
     async def run(self, func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
         async with self._semaphore:
             if self._limiter is None:
-                return await asyncio.to_thread(func, *args, **kwargs)
+                return await self._run_in_thread(func, *args, **kwargs)
             async with self._limiter:
-                return await asyncio.to_thread(func, *args, **kwargs)
+                return await self._run_in_thread(func, *args, **kwargs)
 
     async def __call__(self, func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
         return await self.run(func, *args, **kwargs)
+
+    def shutdown(self) -> None:
+        """Shutdown the dedicated executor if this instance owns it."""
+        if self._executor is not None and self._owns_executor:
+            self._executor.shutdown(wait=True)
+            self._executor = None
 
 
 __all__ = ["BoundedToThread"]


### PR DESCRIPTION
## Summary\n- add optional dedicated ThreadPoolExecutor support to BoundedToThread with shutdown\n- cover custom/dedicated executor paths in concurrency tests\n\n## Testing\n- uv run pytest -q tests/unit/gpt_trader/utilities/test_async_utils_concurrency.py