### PR TITLE
Wire dedicated broker-call executor

### DIFF
--- a/docs/RELIABILITY.md
+++ b/docs/RELIABILITY.md
@@ -353,6 +353,7 @@ The strategy engine parallelizes independent broker operations:
 - `_fetch_positions()` and `_audit_orders()` run concurrently via `asyncio.create_task()`
 - Per-symbol ticker and candles fetches are bounded by `asyncio.Semaphore` (default 5 concurrent calls)
 - Configurable via `config.max_concurrent_rest_calls` (defaults to 5)
+- Optional dedicated executor via `config.broker_calls_use_dedicated_executor` (defaults to `False`)
 
 This reduces cycle latency by overlapping I/O-bound operations while preventing API rate limit exhaustion.
 

--- a/src/gpt_trader/app/config/bot_config.py
+++ b/src/gpt_trader/app/config/bot_config.py
@@ -180,6 +180,7 @@ class BotConfig:
     use_limit_orders: bool = False
     market_order_fallback: bool = True
     account_telemetry_interval: int | None = None
+    broker_calls_use_dedicated_executor: bool = False
 
     # System
     log_level: str = "INFO"
@@ -408,6 +409,9 @@ class BotConfig:
             status_file=os.getenv("STATUS_FILE", "var/data/status.json"),
             status_interval=parse_int_env("STATUS_INTERVAL", 60) or 60,
             status_enabled=parse_bool_env("STATUS_ENABLED", default=True),
+            broker_calls_use_dedicated_executor=parse_bool_env(
+                "BROKER_CALLS_USE_DEDICATED_EXECUTOR", default=False
+            ),
             derivatives_enabled=derivatives_enabled,
             # Inherited from RuntimeSettings
             coinbase_default_quote=os.getenv("COINBASE_DEFAULT_QUOTE", "USD"),


### PR DESCRIPTION
## Summary\n- add BotConfig flag to opt into a dedicated broker-call executor\n- pass the flag into BoundedToThread wiring in TradingBot and TradingEngine fallback\n- shutdown broker-call executor during bot/engine shutdown\n- document the new flag in reliability notes\n\n## Testing\n- uv run pytest -q tests/unit/gpt_trader/utilities/test_async_utils_concurrency.py