### PR TITLE
Route TUI/telemetry broker calls through broker_calls

### DIFF
--- a/tests/unit/gpt_trader/features/live_trade/telemetry/test_account_telemetry_broker_calls.py
+++ b/tests/unit/gpt_trader/features/live_trade/telemetry/test_account_telemetry_broker_calls.py
@@ -1,0 +1,62 @@
+"""Tests for AccountTelemetryService broker_calls execution path."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import Mock
+
+import pytest
+
+from gpt_trader.features.live_trade.telemetry.account import AccountTelemetryService
+
+
+class _BrokerCallsSpy:
+    def __init__(self) -> None:
+        self.calls: list[object] = []
+
+    async def __call__(self, func, *args, **kwargs):
+        self.calls.append(func)
+        return func(*args, **kwargs)
+
+
+@pytest.mark.asyncio
+async def test_run_uses_broker_calls() -> None:
+    broker = Mock()
+    broker.get_key_permissions = Mock()
+    broker.get_fee_schedule = Mock()
+    broker.get_account_limits = Mock()
+    broker.get_transaction_summary = Mock()
+    broker.list_payment_methods = Mock()
+    broker.list_portfolios = Mock()
+    broker.get_server_time.return_value = None
+
+    account_manager = Mock()
+    account_manager.snapshot.return_value = {"balance": "1000"}
+
+    broker_calls = _BrokerCallsSpy()
+    service = AccountTelemetryService(
+        broker=broker,
+        account_manager=account_manager,
+        event_store=Mock(),
+        bot_id="test",
+        profile="default",
+        broker_calls=broker_calls,
+    )
+
+    published = asyncio.Event()
+
+    def _publish_snapshot(snapshot: dict) -> None:
+        published.set()
+
+    service._publish_snapshot = Mock(side_effect=_publish_snapshot)
+
+    task = asyncio.create_task(service.run(interval_seconds=10))
+    await asyncio.wait_for(published.wait(), timeout=0.2)
+    task.cancel()
+
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+    assert broker_calls.calls

--- a/tests/unit/gpt_trader/tui/test_app_bootstrap_snapshot.py
+++ b/tests/unit/gpt_trader/tui/test_app_bootstrap_snapshot.py
@@ -1,0 +1,87 @@
+from dataclasses import dataclass
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
+
+from gpt_trader.core import Balance
+from gpt_trader.tui.app import TraderApp
+
+
+@dataclass(frozen=True)
+class _BootstrapConfig:
+    symbols: list[str]
+
+
+class _BootstrapBroker:
+    def __init__(self) -> None:
+        self._tickers = {
+            "BTC-USD": {"price": "20000"},
+            "ETH-USD": {"price": "1000"},
+        }
+
+    def list_balances(self) -> list[Balance]:
+        return [
+            Balance(asset="USD", total=Decimal("100"), available=Decimal("100")),
+            Balance(asset="BTC", total=Decimal("0.5"), available=Decimal("0.5")),
+        ]
+
+    def get_ticker(self, product_id: str) -> dict:
+        return self._tickers.get(product_id, {"price": "0"})
+
+
+class _BootstrapEngine:
+    def __init__(self) -> None:
+        from gpt_trader.monitoring.status_reporter import StatusReporter
+
+        self.status_reporter = StatusReporter()
+        self.context = SimpleNamespace(runtime_state=None)
+
+
+class _BootstrapBot:
+    def __init__(self) -> None:
+        self.running = False
+        self.config = _BootstrapConfig(symbols=["BTC-USD", "ETH-USD"])
+        self.broker = _BootstrapBroker()
+        self.engine = _BootstrapEngine()
+
+
+class _BrokerCallsSpy:
+    def __init__(self) -> None:
+        self.calls: list[object] = []
+
+    async def __call__(self, func, *args, **kwargs):
+        self.calls.append(func)
+        return func(*args, **kwargs)
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_snapshot_populates_balances_and_equity():
+    bot = _BootstrapBot()
+    app = TraderApp(bot=bot)
+    app.data_source_mode = "paper"
+    app.tui_state.data_source_mode = "paper"
+
+    ok = await app.bootstrap_snapshot()
+    assert ok is True
+
+    assert any(b.asset == "USD" for b in app.tui_state.account_data.balances)
+    assert any(b.asset == "BTC" for b in app.tui_state.account_data.balances)
+
+    assert app.tui_state.position_data.equity == Decimal("10100")
+
+    assert app.tui_state.market_data.prices.get("BTC-USD") == Decimal("20000")
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_snapshot_uses_broker_calls():
+    bot = _BootstrapBot()
+    broker_calls = _BrokerCallsSpy()
+    bot.context = SimpleNamespace(broker_calls=broker_calls)
+    app = TraderApp(bot=bot)
+    app.data_source_mode = "paper"
+    app.tui_state.data_source_mode = "paper"
+
+    ok = await app.bootstrap_snapshot()
+    assert ok is True
+    assert len(broker_calls.calls) == 1

--- a/tests/unit/gpt_trader/tui/test_app_core.py
+++ b/tests/unit/gpt_trader/tui/test_app_core.py
@@ -1,12 +1,9 @@
-from dataclasses import dataclass
 from decimal import Decimal
-from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
 
 import gpt_trader.tui.app_lifecycle as app_lifecycle_module
-from gpt_trader.core import Balance
 from gpt_trader.monitoring.status_reporter import (
     AccountStatus,
     BotStatus,
@@ -57,62 +54,6 @@ async def test_app_sync_state(mock_bot):
 
     assert app.tui_state.running is True
     assert app.tui_state.position_data.equity == Decimal("999.00")
-
-
-@dataclass(frozen=True)
-class _BootstrapConfig:
-    symbols: list[str]
-
-
-class _BootstrapBroker:
-    def __init__(self) -> None:
-        self._tickers = {
-            "BTC-USD": {"price": "20000"},
-            "ETH-USD": {"price": "1000"},
-        }
-
-    def list_balances(self) -> list[Balance]:
-        return [
-            Balance(asset="USD", total=Decimal("100"), available=Decimal("100")),
-            Balance(asset="BTC", total=Decimal("0.5"), available=Decimal("0.5")),
-        ]
-
-    def get_ticker(self, product_id: str) -> dict:
-        return self._tickers.get(product_id, {"price": "0"})
-
-
-class _BootstrapEngine:
-    def __init__(self) -> None:
-        from gpt_trader.monitoring.status_reporter import StatusReporter
-
-        self.status_reporter = StatusReporter()
-        self.context = SimpleNamespace(runtime_state=None)
-
-
-class _BootstrapBot:
-    def __init__(self) -> None:
-        self.running = False
-        self.config = _BootstrapConfig(symbols=["BTC-USD", "ETH-USD"])
-        self.broker = _BootstrapBroker()
-        self.engine = _BootstrapEngine()
-
-
-@pytest.mark.asyncio
-async def test_bootstrap_snapshot_populates_balances_and_equity():
-    bot = _BootstrapBot()
-    app = TraderApp(bot=bot)
-    app.data_source_mode = "paper"
-    app.tui_state.data_source_mode = "paper"
-
-    ok = await app.bootstrap_snapshot()
-    assert ok is True
-
-    assert any(b.asset == "USD" for b in app.tui_state.account_data.balances)
-    assert any(b.asset == "BTC" for b in app.tui_state.account_data.balances)
-
-    assert app.tui_state.position_data.equity == Decimal("10100")
-
-    assert app.tui_state.market_data.prices.get("BTC-USD") == Decimal("20000")
 
 
 class TestResourceCleanup:

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,8 +7,8 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6031,
-    "total_files": 713,
+    "total_tests": 6038,
+    "total_files": 715,
     "markers_used": 16
   },
   "quick_commands": {

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,8 +95,8 @@
     ]
   },
   "counts": {
-    "unit": 5866,
-    "asyncio": 344,
+    "unit": 5873,
+    "asyncio": 351,
     "parametrize": 153,
     "property": 82,
     "integration": 79,

--- a/var/agents/testing/source_test_map.json
+++ b/var/agents/testing/source_test_map.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "summary": {
-    "tests_scanned": 654,
+    "tests_scanned": 656,
     "source_modules": 353,
     "unresolved_modules": 3
   },
@@ -386,7 +386,7 @@
       "tests/unit/gpt_trader/features/live_trade/test_bot_flatten_and_stop.py",
       "tests/unit/gpt_trader/features/live_trade/test_risk.py",
       "tests/unit/gpt_trader/features/live_trade/test_risk_time_windows.py",
-      "tests/unit/gpt_trader/tui/test_app_core.py"
+      "tests/unit/gpt_trader/tui/test_app_bootstrap_snapshot.py"
     ],
     "gpt_trader.core.account": [
       "tests/unit/gpt_trader/core/test_account_edges.py",
@@ -1084,6 +1084,7 @@
     ],
     "gpt_trader.features.live_trade.telemetry.account": [
       "tests/unit/gpt_trader/features/live_trade/telemetry/test_account_telemetry.py",
+      "tests/unit/gpt_trader/features/live_trade/telemetry/test_account_telemetry_broker_calls.py",
       "tests/unit/gpt_trader/features/live_trade/telemetry/test_account_telemetry_lifecycle.py"
     ],
     "gpt_trader.features.optimize.objectives.base": [
@@ -1355,6 +1356,7 @@
       "tests/unit/gpt_trader/monitoring/test_status_reporter.py",
       "tests/unit/gpt_trader/monitoring/test_status_reporter_file_output.py",
       "tests/unit/gpt_trader/monitoring/test_status_reporter_health.py",
+      "tests/unit/gpt_trader/tui/test_app_bootstrap_snapshot.py",
       "tests/unit/gpt_trader/tui/test_app_core.py",
       "tests/unit/gpt_trader/tui/test_state_resilience_and_performance.py",
       "tests/unit/gpt_trader/tui/test_state_update_from_bot_status.py"
@@ -1525,6 +1527,7 @@
       "tests/unit/gpt_trader/tui/test_degraded_mode.py"
     ],
     "gpt_trader.tui.app": [
+      "tests/unit/gpt_trader/tui/test_app_bootstrap_snapshot.py",
       "tests/unit/gpt_trader/tui/test_app_core.py",
       "tests/unit/gpt_trader/tui/test_screen_flows_help.py",
       "tests/unit/gpt_trader/tui/test_screen_flows_quick_navigation_and_state.py",
@@ -1866,6 +1869,7 @@
       "tests/unit/gpt_trader/utilities/test_logging_patterns_domain.py"
     ],
     "gpt_trader.utilities.async_tools": [
+      "tests/unit/gpt_trader/features/live_trade/engines/test_equity_calculator.py",
       "tests/unit/gpt_trader/utilities/test_async_utils_cache_and_retry.py",
       "tests/unit/gpt_trader/utilities/test_async_utils_concurrency.py",
       "tests/unit/gpt_trader/utilities/test_async_utils_gather.py",
@@ -2950,7 +2954,8 @@
     "tests/unit/gpt_trader/features/live_trade/engines/test_equity_calculator.py": [
       "gpt_trader.core",
       "gpt_trader.features.live_trade.degradation",
-      "gpt_trader.features.live_trade.engines.equity_calculator"
+      "gpt_trader.features.live_trade.engines.equity_calculator",
+      "gpt_trader.utilities.async_tools"
     ],
     "tests/unit/gpt_trader/features/live_trade/engines/test_price_tick_store_edges.py": [
       "gpt_trader.features.live_trade.engines.price_tick_store"
@@ -3327,6 +3332,9 @@
       "gpt_trader.features.live_trade.strategies.perps_baseline.strategy"
     ],
     "tests/unit/gpt_trader/features/live_trade/telemetry/test_account_telemetry.py": [
+      "gpt_trader.features.live_trade.telemetry.account"
+    ],
+    "tests/unit/gpt_trader/features/live_trade/telemetry/test_account_telemetry_broker_calls.py": [
       "gpt_trader.features.live_trade.telemetry.account"
     ],
     "tests/unit/gpt_trader/features/live_trade/telemetry/test_account_telemetry_lifecycle.py": [
@@ -4120,9 +4128,13 @@
     "tests/unit/gpt_trader/tui/state_management/test_validators_result.py": [
       "gpt_trader.tui.state_management.validators"
     ],
+    "tests/unit/gpt_trader/tui/test_app_bootstrap_snapshot.py": [
+      "gpt_trader.core",
+      "gpt_trader.monitoring.status_reporter",
+      "gpt_trader.tui.app"
+    ],
     "tests/unit/gpt_trader/tui/test_app_core.py": [
       "gpt_trader.config.constants",
-      "gpt_trader.core",
       "gpt_trader.features.brokerages.coinbase.client.base",
       "gpt_trader.features.brokerages.coinbase.ws",
       "gpt_trader.monitoring.status_reporter",
@@ -4661,6 +4673,7 @@
     "gpt_trader.features.live_trade.signals.protocol": "src/gpt_trader/features/live_trade/signals/protocol.py",
     "gpt_trader.features.live_trade.signals.types": "src/gpt_trader/features/live_trade/signals/types.py",
     "gpt_trader.features.live_trade.engines.equity_calculator": "src/gpt_trader/features/live_trade/engines/equity_calculator.py",
+    "gpt_trader.utilities.async_tools": "src/gpt_trader/utilities/async_tools/__init__.py",
     "gpt_trader.features.live_trade.engines.price_tick_store": "src/gpt_trader/features/live_trade/engines/price_tick_store.py",
     "gpt_trader.features.live_trade.execution.guard_manager": "src/gpt_trader/features/live_trade/execution/guard_manager.py",
     "gpt_trader.features.live_trade.execution.submission_result": "src/gpt_trader/features/live_trade/execution/submission_result.py",
@@ -4871,7 +4884,6 @@
     "gpt_trader.tui.widgets.validation_indicator": "src/gpt_trader/tui/widgets/validation_indicator.py",
     "gpt_trader.utilities.performance": "src/gpt_trader/utilities/performance/__init__.py",
     "gpt_trader.utilities.performance.metrics": "src/gpt_trader/utilities/performance/metrics.py",
-    "gpt_trader.utilities.async_tools": "src/gpt_trader/utilities/async_tools/__init__.py",
     "gpt_trader.utilities.console_logging": "src/gpt_trader/utilities/console_logging.py",
     "gpt_trader.utilities.iterators": "src/gpt_trader/utilities/iterators.py",
     "gpt_trader.utilities": "src/gpt_trader/utilities/__init__.py",

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,8 +2,8 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6031,
-    "total_files": 713,
+    "total_tests": 6038,
+    "total_files": 715,
     "markers_used": 16
   },
   "marker_definitions": {
@@ -102,8 +102,8 @@
     ]
   },
   "marker_counts": {
-    "unit": 5866,
-    "asyncio": 344,
+    "unit": 5873,
+    "asyncio": 351,
     "parametrize": 153,
     "property": 82,
     "integration": 79,
@@ -443,6 +443,7 @@
       "tests/unit/gpt_trader/features/live_trade/strategies/test_stateful_indicators_algorithm.py",
       "tests/unit/gpt_trader/features/live_trade/strategies/test_stateful_perps_baseline_edges.py",
       "tests/unit/gpt_trader/features/live_trade/telemetry/test_account_telemetry.py",
+      "tests/unit/gpt_trader/features/live_trade/telemetry/test_account_telemetry_broker_calls.py",
       "tests/unit/gpt_trader/features/live_trade/telemetry/test_account_telemetry_lifecycle.py",
       "tests/unit/gpt_trader/features/live_trade/test_bot_engine_delegation.py",
       "tests/unit/gpt_trader/features/live_trade/test_bot_flatten_and_stop.py",
@@ -701,6 +702,7 @@
       "tests/unit/gpt_trader/tui/state_management/test_validators_market.py",
       "tests/unit/gpt_trader/tui/state_management/test_validators_orders_and_trades.py",
       "tests/unit/gpt_trader/tui/state_management/test_validators_result.py",
+      "tests/unit/gpt_trader/tui/test_app_bootstrap_snapshot.py",
       "tests/unit/gpt_trader/tui/test_app_core.py",
       "tests/unit/gpt_trader/tui/test_credential_cache.py",
       "tests/unit/gpt_trader/tui/test_degraded_mode.py",
@@ -18507,7 +18509,7 @@
     "tests/unit/gpt_trader/features/live_trade/engines/test_equity_calculator.py": [
       {
         "name": "test_equity_calculator_skips_missing_pairs_using_product_list",
-        "line": 15,
+        "line": 17,
         "markers": [
           "asyncio",
           "unit"
@@ -18516,7 +18518,16 @@
       },
       {
         "name": "test_equity_calculator_handles_dict_product_list",
-        "line": 38,
+        "line": 40,
+        "markers": [
+          "asyncio",
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_equity_calculator_uses_broker_calls_executor",
+        "line": 63,
         "markers": [
           "asyncio",
           "unit"
@@ -21806,7 +21817,7 @@
     "tests/unit/gpt_trader/features/live_trade/execution/test_validation_async.py": [
       {
         "name": "test_maybe_preview_order_async_success",
-        "line": 35,
+        "line": 44,
         "markers": [
           "asyncio",
           "unit"
@@ -21815,7 +21826,7 @@
       },
       {
         "name": "test_maybe_preview_order_async_validation_error",
-        "line": 79,
+        "line": 88,
         "markers": [
           "asyncio",
           "unit"
@@ -21824,7 +21835,7 @@
       },
       {
         "name": "test_maybe_preview_order_async_generic_error",
-        "line": 112,
+        "line": 121,
         "markers": [
           "asyncio",
           "unit"
@@ -21833,12 +21844,21 @@
       },
       {
         "name": "test_maybe_preview_order_async_disabled",
-        "line": 148,
+        "line": 157,
         "markers": [
           "asyncio",
           "unit"
         ],
         "docstring": "Test that disabled preview is skipped in async."
+      },
+      {
+        "name": "test_maybe_preview_order_async_uses_broker_calls",
+        "line": 188,
+        "markers": [
+          "asyncio",
+          "unit"
+        ],
+        "docstring": ""
       }
     ],
     "tests/unit/gpt_trader/features/live_trade/execution/test_validation_exchange.py": [
@@ -25002,6 +25022,17 @@
         ],
         "docstring": "Test collect_snapshot when both account_manager and server_time fail.",
         "class": "TestAccountTelemetrySnapshotEdgeCases"
+      }
+    ],
+    "tests/unit/gpt_trader/features/live_trade/telemetry/test_account_telemetry_broker_calls.py": [
+      {
+        "name": "test_run_uses_broker_calls",
+        "line": 23,
+        "markers": [
+          "asyncio",
+          "unit"
+        ],
+        "docstring": ""
       }
     ],
     "tests/unit/gpt_trader/features/live_trade/telemetry/test_account_telemetry_lifecycle.py": [
@@ -42256,7 +42287,7 @@
     "tests/unit/gpt_trader/tui/services/test_credential_validator.py": [
       {
         "name": "TestCredentialValidatorKeyFormatAndConfiguration::test_demo_mode_skips_validation",
-        "line": 19,
+        "line": 29,
         "markers": [
           "asyncio",
           "unit"
@@ -42266,7 +42297,7 @@
       },
       {
         "name": "TestCredentialValidatorKeyFormatAndConfiguration::test_missing_credentials_fails",
-        "line": 31,
+        "line": 41,
         "markers": [
           "asyncio",
           "unit"
@@ -42276,7 +42307,7 @@
       },
       {
         "name": "TestCredentialValidatorKeyFormatAndConfiguration::test_valid_key_format",
-        "line": 46,
+        "line": 56,
         "markers": [
           "unit"
         ],
@@ -42285,7 +42316,7 @@
       },
       {
         "name": "TestCredentialValidatorKeyFormatAndConfiguration::test_invalid_key_format",
-        "line": 69,
+        "line": 79,
         "markers": [
           "unit"
         ],
@@ -42294,7 +42325,7 @@
       },
       {
         "name": "TestCredentialValidatorKeyFormatAndConfiguration::test_invalid_private_key_format",
-        "line": 91,
+        "line": 101,
         "markers": [
           "unit"
         ],
@@ -42303,7 +42334,7 @@
       },
       {
         "name": "TestCredentialValidatorConnectivity::test_connectivity_success",
-        "line": 113,
+        "line": 123,
         "markers": [
           "asyncio",
           "unit"
@@ -42312,8 +42343,18 @@
         "class": "TestCredentialValidatorConnectivity"
       },
       {
+        "name": "TestCredentialValidatorConnectivity::test_connectivity_uses_broker_calls",
+        "line": 158,
+        "markers": [
+          "asyncio",
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestCredentialValidatorConnectivity"
+      },
+      {
         "name": "TestCredentialValidatorConnectivity::test_jwt_generation_failure",
-        "line": 148,
+        "line": 193,
         "markers": [
           "asyncio",
           "unit"
@@ -44573,10 +44614,30 @@
         "class": "TestValidationResult"
       }
     ],
+    "tests/unit/gpt_trader/tui/test_app_bootstrap_snapshot.py": [
+      {
+        "name": "test_bootstrap_snapshot_populates_balances_and_equity",
+        "line": 59,
+        "markers": [
+          "asyncio",
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_bootstrap_snapshot_uses_broker_calls",
+        "line": 77,
+        "markers": [
+          "asyncio",
+          "unit"
+        ],
+        "docstring": ""
+      }
+    ],
     "tests/unit/gpt_trader/tui/test_app_core.py": [
       {
         "name": "test_app_instantiation",
-        "line": 25,
+        "line": 22,
         "markers": [
           "asyncio",
           "unit"
@@ -44585,16 +44646,7 @@
       },
       {
         "name": "test_app_sync_state",
-        "line": 34,
-        "markers": [
-          "asyncio",
-          "unit"
-        ],
-        "docstring": ""
-      },
-      {
-        "name": "test_bootstrap_snapshot_populates_balances_and_equity",
-        "line": 101,
+        "line": 31,
         "markers": [
           "asyncio",
           "unit"
@@ -44603,7 +44655,7 @@
       },
       {
         "name": "TestResourceCleanup::test_coinbase_client_has_close_method",
-        "line": 121,
+        "line": 62,
         "markers": [
           "unit"
         ],
@@ -44612,7 +44664,7 @@
       },
       {
         "name": "TestResourceCleanup::test_coinbase_client_context_manager",
-        "line": 131,
+        "line": 72,
         "markers": [
           "unit"
         ],
@@ -44621,7 +44673,7 @@
       },
       {
         "name": "TestResourceCleanup::test_websocket_has_close_method",
-        "line": 137,
+        "line": 78,
         "markers": [
           "unit"
         ],
@@ -44630,7 +44682,7 @@
       },
       {
         "name": "TestResourceCleanup::test_websocket_close_is_idempotent",
-        "line": 148,
+        "line": 89,
         "markers": [
           "unit"
         ],
@@ -44639,7 +44691,7 @@
       },
       {
         "name": "TestResourceCleanup::test_performance_service_cleanup",
-        "line": 159,
+        "line": 100,
         "markers": [
           "unit"
         ],
@@ -44648,7 +44700,7 @@
       },
       {
         "name": "TestResourceCleanup::test_app_cleanup_bot_resources_closes_client",
-        "line": 178,
+        "line": 119,
         "markers": [
           "unit"
         ],
@@ -44657,7 +44709,7 @@
       },
       {
         "name": "TestResourceCleanup::test_app_cleanup_bot_resources_closes_websocket",
-        "line": 187,
+        "line": 128,
         "markers": [
           "unit"
         ],
@@ -44666,7 +44718,7 @@
       },
       {
         "name": "TestResourceCleanup::test_app_cleanup_bot_resources_closes_engine_client",
-        "line": 196,
+        "line": 137,
         "markers": [
           "unit"
         ],
@@ -44675,7 +44727,7 @@
       },
       {
         "name": "TestResourceCleanup::test_app_cleanup_handles_missing_resources",
-        "line": 205,
+        "line": 146,
         "markers": [
           "unit"
         ],
@@ -44684,7 +44736,7 @@
       },
       {
         "name": "TestResourceCleanup::test_app_cleanup_handles_close_errors",
-        "line": 216,
+        "line": 157,
         "markers": [
           "unit"
         ],
@@ -44693,7 +44745,7 @@
       },
       {
         "name": "TestResourceCleanup::test_websocket_reconnect_limit_configurable",
-        "line": 228,
+        "line": 169,
         "markers": [
           "unit"
         ],
@@ -51537,7 +51589,7 @@
     "tests/unit/gpt_trader/utilities/test_async_utils_concurrency.py": [
       {
         "name": "TestBoundedToThread::test_invalid_concurrency",
-        "line": 21,
+        "line": 22,
         "markers": [
           "unit"
         ],
@@ -51546,7 +51598,27 @@
       },
       {
         "name": "TestBoundedToThread::test_concurrency_is_bounded",
-        "line": 26,
+        "line": 27,
+        "markers": [
+          "asyncio",
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestBoundedToThread"
+      },
+      {
+        "name": "TestBoundedToThread::test_custom_executor_path",
+        "line": 61,
+        "markers": [
+          "asyncio",
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestBoundedToThread"
+      },
+      {
+        "name": "TestBoundedToThread::test_dedicated_executor_shutdown",
+        "line": 84,
         "markers": [
           "asyncio",
           "unit"
@@ -51556,7 +51628,7 @@
       },
       {
         "name": "TestAsyncContextManager::test_async_context_manager_basic",
-        "line": 64,
+        "line": 98,
         "markers": [
           "asyncio",
           "unit"
@@ -51566,7 +51638,7 @@
       },
       {
         "name": "TestAsyncContextManager::test_async_context_manager_with_timeout",
-        "line": 76,
+        "line": 110,
         "markers": [
           "asyncio",
           "unit"
@@ -51576,7 +51648,7 @@
       },
       {
         "name": "TestAsyncTimeout::test_async_timeout_success",
-        "line": 88,
+        "line": 122,
         "markers": [
           "asyncio",
           "unit"
@@ -51586,7 +51658,7 @@
       },
       {
         "name": "TestAsyncTimeout::test_async_timeout_failure",
-        "line": 100,
+        "line": 134,
         "markers": [
           "asyncio",
           "unit"
@@ -51596,7 +51668,7 @@
       },
       {
         "name": "TestAsyncBatchProcessor::test_batch_processor_basic",
-        "line": 116,
+        "line": 150,
         "markers": [
           "asyncio",
           "unit"
@@ -51606,7 +51678,7 @@
       },
       {
         "name": "TestAsyncBatchProcessor::test_batch_processor_with_exceptions",
-        "line": 132,
+        "line": 166,
         "markers": [
           "asyncio",
           "unit"


### PR DESCRIPTION
- Use app context broker_calls when available for TUI bootstrap snapshot, credential validator connectivity/permissions checks, and account telemetry snapshot collection (fallback to asyncio.to_thread when absent).
- Add unit coverage for broker_calls usage and keep test modules under the 240-line hygiene cap by splitting bootstrap/account telemetry broker_calls tests into their own files.
- Regenerate testing inventory artifacts.