### PR TITLE
Route UI coordinator broker calls through broker_calls

### DIFF
--- a/tests/unit/gpt_trader/tui/test_ui_coordinator_broker_calls.py
+++ b/tests/unit/gpt_trader/tui/test_ui_coordinator_broker_calls.py
@@ -1,0 +1,61 @@
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from gpt_trader.tui.managers.ui_coordinator import UICoordinator
+
+
+class _BrokerCallsSpy:
+    def __init__(self) -> None:
+        self.calls: list[object] = []
+
+    async def __call__(self, func, *args, **kwargs):
+        self.calls.append(func)
+        return func(*args, **kwargs)
+
+
+class _TestClient:
+    def get_product_book(self, product_id: str, limit: int = 1) -> dict[str, list[dict[str, str]]]:
+        return {
+            "bids": [{"price": "100"}],
+            "asks": [{"price": "101"}],
+        }
+
+    def get_resilience_status(self) -> dict[str, str]:
+        return {"status": "ok"}
+
+
+def _make_app(client: _TestClient, broker_calls: _BrokerCallsSpy) -> SimpleNamespace:
+    broker = SimpleNamespace(_client=client)
+    context = SimpleNamespace(broker=broker, broker_calls=broker_calls)
+    engine = SimpleNamespace(context=context)
+    bot = SimpleNamespace(engine=engine)
+    market_data = SimpleNamespace(prices={"BTC-USD": Decimal("20000")}, spreads={})
+    tui_state = SimpleNamespace(market_data=market_data, update_resilience_data=Mock())
+    return SimpleNamespace(bot=bot, tui_state=tui_state)
+
+
+@pytest.mark.asyncio
+async def test_collect_spread_data_uses_broker_calls() -> None:
+    broker_calls = _BrokerCallsSpy()
+    app = _make_app(_TestClient(), broker_calls)
+    coordinator = UICoordinator(app)
+
+    await coordinator._collect_spread_data()
+
+    assert broker_calls.calls
+    assert app.tui_state.market_data.spreads["BTC-USD"] > 0
+
+
+@pytest.mark.asyncio
+async def test_collect_resilience_metrics_uses_broker_calls() -> None:
+    broker_calls = _BrokerCallsSpy()
+    app = _make_app(_TestClient(), broker_calls)
+    coordinator = UICoordinator(app)
+
+    await coordinator._collect_resilience_metrics()
+
+    assert broker_calls.calls
+    app.tui_state.update_resilience_data.assert_called_once_with({"status": "ok"})

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,8 +7,8 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6038,
-    "total_files": 715,
+    "total_tests": 6040,
+    "total_files": 716,
     "markers_used": 16
   },
   "quick_commands": {

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,8 +95,8 @@
     ]
   },
   "counts": {
-    "unit": 5873,
-    "asyncio": 351,
+    "unit": 5875,
+    "asyncio": 353,
     "parametrize": 153,
     "property": 82,
     "integration": 79,

--- a/var/agents/testing/source_test_map.json
+++ b/var/agents/testing/source_test_map.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "summary": {
-    "tests_scanned": 656,
+    "tests_scanned": 657,
     "source_modules": 353,
     "unresolved_modules": 3
   },
@@ -1568,7 +1568,8 @@
     ],
     "gpt_trader.tui.managers.ui_coordinator": [
       "tests/unit/gpt_trader/tui/services/test_state_registry.py",
-      "tests/unit/gpt_trader/tui/test_degraded_mode.py"
+      "tests/unit/gpt_trader/tui/test_degraded_mode.py",
+      "tests/unit/gpt_trader/tui/test_ui_coordinator_broker_calls.py"
     ],
     "gpt_trader.tui.mixins": [
       "tests/unit/gpt_trader/tui/mixins/test_event_handlers.py",
@@ -4271,6 +4272,9 @@
     ],
     "tests/unit/gpt_trader/tui/test_trade_matcher_matching.py": [
       "gpt_trader.tui.trade_matcher"
+    ],
+    "tests/unit/gpt_trader/tui/test_ui_coordinator_broker_calls.py": [
+      "gpt_trader.tui.managers.ui_coordinator"
     ],
     "tests/unit/gpt_trader/tui/test_widget_interactions_keyboard.py": [
       "gpt_trader.tui.app"

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,8 +2,8 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6038,
-    "total_files": 715,
+    "total_tests": 6040,
+    "total_files": 716,
     "markers_used": 16
   },
   "marker_definitions": {
@@ -102,8 +102,8 @@
     ]
   },
   "marker_counts": {
-    "unit": 5873,
-    "asyncio": 351,
+    "unit": 5875,
+    "asyncio": 353,
     "parametrize": 153,
     "property": 82,
     "integration": 79,
@@ -739,6 +739,7 @@
       "tests/unit/gpt_trader/tui/test_trade_matcher_edge_cases.py",
       "tests/unit/gpt_trader/tui/test_trade_matcher_matching.py",
       "tests/unit/gpt_trader/tui/test_tui_factories.py",
+      "tests/unit/gpt_trader/tui/test_ui_coordinator_broker_calls.py",
       "tests/unit/gpt_trader/tui/test_widget_interactions_keyboard.py",
       "tests/unit/gpt_trader/tui/utilities/test_pnl_formatting.py",
       "tests/unit/gpt_trader/tui/utilities/test_table_formatting.py",
@@ -42354,7 +42355,7 @@
       },
       {
         "name": "TestCredentialValidatorConnectivity::test_jwt_generation_failure",
-        "line": 193,
+        "line": 195,
         "markers": [
           "asyncio",
           "unit"
@@ -47718,6 +47719,26 @@
         ],
         "docstring": "",
         "class": "TestTuiStateFactory"
+      }
+    ],
+    "tests/unit/gpt_trader/tui/test_ui_coordinator_broker_calls.py": [
+      {
+        "name": "test_collect_spread_data_uses_broker_calls",
+        "line": 41,
+        "markers": [
+          "asyncio",
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_collect_resilience_metrics_uses_broker_calls",
+        "line": 53,
+        "markers": [
+          "asyncio",
+          "unit"
+        ],
+        "docstring": ""
       }
     ],
     "tests/unit/gpt_trader/tui/test_widget_interactions_keyboard.py": [


### PR DESCRIPTION
- Route UICoordinator resilience and spread collection through app context broker_calls when available (fallback to asyncio.to_thread).
- Fix heartbeat loop to await async resilience collection hook.
- Add targeted unit coverage for broker_calls usage and regenerate testing inventory artifacts.

Tests:
- uv run pytest -q tests/unit/gpt_trader/tui/test_ui_coordinator_broker_calls.py
- uv run python scripts/ci/check_test_hygiene.py
- uv run python scripts/ci/check_legacy_test_triage.py
- uv run python scripts/ci/check_dedupe_manifest.py
- uv run agent-regenerate --only testing