### PR TITLE
Cleanup Closeout: Docs + README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,7 @@ That's it! Now, every time you run `git commit`, the pre-commit hooks will run a
 3. Snapshot test discovery: `uv run pytest --collect-only`.
 4. Run the full unit suite: `uv run pytest tests/unit -q`.
 5. Execute slice-specific suites relevant to your change set (examples below).
+6. Validate docs links: `make agent-docs-links` (runs `scripts/maintenance/docs_link_audit.py`).
 
 ### Recommended Commands
 
@@ -111,7 +112,10 @@ Before branching, make sure to:
 - Descriptive test names that explain what's being tested
 - One assertion per test when possible
 - Use fixtures for shared setup
-- Mock external dependencies
+- Use pytest `monkeypatch` for mocks; patch-style helpers are blocked in `tests/`
+- Keep test modules <= 240 lines unless allowlisted by `scripts/ci/check_test_hygiene.py`
+- Avoid `time.sleep`; prefer deterministic `fake_clock`
+- Match marker conventions to folder (integration/contract/real_api)
 
 ### Resilience Testing
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,19 @@ uv run pytest tests/property -q
 uv run pytest tests/unit/gpt_trader/tui/test_snapshots_*.py -q
 ```
 
+### Test Guardrails
+
+- Keep `test_*.py` modules <= 240 lines unless allowlisted.
+- Patch-style mocking is blocked in `tests/`; use `monkeypatch.setattr`.
+- Avoid `time.sleep` in tests; use the `fake_clock` fixture for deterministic time.
+- Marker conventions are enforced by folder (unit/integration/contract/real_api).
+
+When you rename or move tests, regenerate the testing inventory:
+
+```bash
+uv run agent-regenerate --only testing
+```
+
 ### Agent Tools
 
 Commands for AI-assisted development:

--- a/docs/FEATURE_FLAGS.md
+++ b/docs/FEATURE_FLAGS.md
@@ -44,6 +44,8 @@ Configuration values follow this precedence (highest to lowest):
 |------|------------------|---------|-----|---------|-------|
 | `enable_order_preview` | `BotConfig` | `ORDER_PREVIEW_ENABLED` | `--enable-preview` | `False` | Pre-trade validation |
 | `reduce_only_mode` | `BotConfig` | `RISK_REDUCE_ONLY_MODE` | `--reduce-only` | `False` | Only allow reducing positions |
+| `order_submission_retries_enabled` | `BotConfig` | `ORDER_SUBMISSION_RETRIES_ENABLED` | - | `False` | Retry order submissions on transient failures (off by default) |
+| `broker_calls_use_dedicated_executor` | `BotConfig` | `BROKER_CALLS_USE_DEDICATED_EXECUTOR` | - | `False` | Use a dedicated thread pool for broker calls |
 
 ### Strategy Flags
 
@@ -85,6 +87,21 @@ These flags are **canonicalized on strategy config** based on `strategy_type`:
 | Rate Limit Usage | `RISK_API_RATE_LIMIT_USAGE_THRESHOLD` | `0.9` | 90% triggers guard |
 | Vol Reduce-Only | `RISK_VOL_REDUCE_ONLY_THRESH` | `0.22` | 22% triggers reduce-only |
 | Vol Kill Switch | `RISK_VOL_KILL_SWITCH_THRESH` | `0.26` | 26% triggers kill switch |
+
+### Health Thresholds
+
+| Setting | Env Var | Default | Notes |
+|---------|---------|---------|-------|
+| Order Error Rate Warn | `HEALTH_ORDER_ERROR_RATE_WARN` | `0.05` | Warning threshold for order errors |
+| Order Error Rate Crit | `HEALTH_ORDER_ERROR_RATE_CRIT` | `0.15` | Critical threshold for order errors |
+| Order Retry Rate Warn | `HEALTH_ORDER_RETRY_RATE_WARN` | `0.10` | Warning threshold for retry rate |
+| Order Retry Rate Crit | `HEALTH_ORDER_RETRY_RATE_CRIT` | `0.25` | Critical threshold for retry rate |
+| Broker Latency Warn (ms) | `HEALTH_BROKER_LATENCY_MS_WARN` | `1000.0` | Warning threshold for broker latency |
+| Broker Latency Crit (ms) | `HEALTH_BROKER_LATENCY_MS_CRIT` | `3000.0` | Critical threshold for broker latency |
+| WS Staleness Warn (s) | `HEALTH_WS_STALENESS_SECONDS_WARN` | `30.0` | Warning threshold for WebSocket staleness |
+| WS Staleness Crit (s) | `HEALTH_WS_STALENESS_SECONDS_CRIT` | `60.0` | Critical threshold for WebSocket staleness |
+| Guard Trip Count Warn | `HEALTH_GUARD_TRIP_COUNT_WARN` | `3` | Warning threshold for guard trip count |
+| Guard Trip Count Crit | `HEALTH_GUARD_TRIP_COUNT_CRIT` | `10` | Critical threshold for guard trip count |
 
 ## Deprecated Flags
 

--- a/docs/RELIABILITY.md
+++ b/docs/RELIABILITY.md
@@ -31,6 +31,7 @@ Implementation references:
 | Validation infra failure | ValidationFailureTracker escalation | Reduce-only + global pause | `RISK_VALIDATION_FAILURE_COOLDOWN_SECONDS` |
 | Preview failures | Preview exceptions reach threshold | Disable preview for the session | `RISK_PREVIEW_FAILURE_DISABLE_AFTER` |
 | Broker read failures | Consecutive balance/position read failures | Global pause (reduce-only allowed) | `RISK_BROKER_OUTAGE_MAX_FAILURES`, `RISK_BROKER_OUTAGE_COOLDOWN_SECONDS` |
+| Order reconciliation drift | Broker open orders include bot-owned IDs missing from open_orders/orders_store | Reduce-only + global pause after 3 consecutive detections; attempt cancels; alert operator | `ORDER_RECONCILIATION_DRIFT_MAX_FAILURES` (constant), `RISK_API_HEALTH_COOLDOWN_SECONDS` |
 | WS max reconnect | WebSocket exceeds max reconnection attempts | Global pause + callback for degradation | `GPT_TRADER_WS_RECONNECT_MAX_ATTEMPTS`, `GPT_TRADER_WS_RECONNECT_PAUSE_SECONDS` |
 
 Notes:
@@ -93,6 +94,13 @@ Health Monitoring:
 | Env Var | Default | Purpose |
 | --- | --- | --- |
 | `GPT_TRADER_HEALTH_CHECK_INTERVAL` | `30.0` | Seconds between health check runner cycles |
+
+Execution Resilience:
+
+| Env Var | Default | Purpose |
+| --- | --- | --- |
+| `ORDER_SUBMISSION_RETRIES_ENABLED` | `0` | Enable broker submission retries (off by default) |
+| `BROKER_CALLS_USE_DEDICATED_EXECUTOR` | `0` | Run broker calls in a dedicated thread pool |
 
 ## Metrics
 


### PR DESCRIPTION
## Summary
- align README/CONTRIBUTING/testing guide with enforced test hygiene guardrails
- document new reliability/feature-flag knobs (retries, broker executor, health thresholds)
- add order reconciliation drift behavior and hygiene/dedupe commands

## Testing
- make agent-docs-links
