### PR TITLE
docs(architecture): boundaries + entrypoints

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,8 @@ last-updated: 2026-01-24
 
 ### Architecture & Design
 - [System Architecture](ARCHITECTURE.md) - Component overview and vertical slices
+- [Module Boundaries](architecture/BOUNDARIES.md) - Dependency direction and layer rules
+- [Canonical Entrypoints](architecture/ENTRYPOINTS.md) - Supported entrypoints and wiring
 - [DI Policy](DI_POLICY.md) - Dependency injection patterns and container usage
 
 ### Trading Operations

--- a/docs/architecture/BOUNDARIES.md
+++ b/docs/architecture/BOUNDARIES.md
@@ -1,0 +1,67 @@
+# Module Boundaries
+
+---
+status: current
+last-updated: 2026-01-31
+---
+
+This document defines the module boundaries for GPT-Trader. Keep dependency
+flow one-way to preserve testability, avoid circular imports, and keep slices
+independent.
+
+## Layer Map (Top to Bottom)
+
+```
+Entry points (scripts/, gpt_trader.cli, gpt_trader.tui, gpt_trader.preflight)
+    v
+Composition root (gpt_trader.app)
+    v
+Domain slices (gpt_trader.features.*, gpt_trader.backtesting)
+    v
+Shared platform (gpt_trader.core, errors, monitoring, validation, persistence,
+                 security, logging, observability, config, utilities)
+    v
+Stdlib + third-party libraries
+```
+
+### Responsibilities by Layer
+
+- Entry points: argument parsing, environment loading, process orchestration.
+  No business rules. Hand off to application services quickly.
+- Composition root: `ApplicationContainer` wiring, configuration assembly,
+  lifecycle hooks. This is the only place that should import multiple slices
+  to stitch them together.
+- Domain slices: trading features and integrations. Each slice owns its
+  internal modules and tests and should be independently testable.
+- Shared platform: cross-cutting services and abstractions (errors, validation,
+  logging, persistence). These should not depend on feature slices.
+
+## Allowed Import Directions
+
+| From | Allowed to import | Avoid importing |
+|------|-------------------|----------------|
+| Entry points | `gpt_trader.app`, feature slices, shared platform, stdlib/third-party | None (but keep logic thin) |
+| `gpt_trader.app` | Feature slices, shared platform, stdlib/third-party | Entry points |
+| Feature slices | Same slice, shared platform, `gpt_trader.app.config` types | Other feature slices, `ApplicationContainer` |
+| Shared platform | Other shared platform packages, stdlib/third-party | Feature slices, `gpt_trader.app` |
+| Tests | Any module | N/A |
+
+### Cross-slice collaboration
+
+- Prefer shared abstractions (protocols, data models) in the shared platform
+  and have slices depend on those instead of importing each other.
+- If two slices need shared logic, extract it to
+  `gpt_trader.features.strategy_tools` (when strategy-focused) or a new shared
+  platform package, then wire it in `ApplicationContainer`.
+
+## Decision Tree (Where Should New Code Live?)
+
+1. Is it a user entrypoint, CLI flag, or TUI wiring? -> `gpt_trader.cli`,
+   `gpt_trader.tui`, or `scripts/`.
+2. Is it dependency wiring or lifecycle setup? -> `gpt_trader.app`.
+3. Is it a trading capability, integration, or feature-specific behavior? ->
+   `gpt_trader.features/<slice>/` (or `gpt_trader.backtesting` for backtests).
+4. Is it shared across slices (errors, validation, persistence, monitoring)? ->
+   `gpt_trader/<shared-package>/`.
+5. Still unsure? Start in `docs/DEVELOPMENT_GUIDELINES.md` or ask for guidance
+   before creating a new top-level package.

--- a/docs/architecture/ENTRYPOINTS.md
+++ b/docs/architecture/ENTRYPOINTS.md
@@ -1,0 +1,49 @@
+# Canonical Entrypoints
+
+---
+status: current
+last-updated: 2026-01-31
+---
+
+This document lists the supported entrypoints and the wiring they activate.
+Use these paths when documenting or invoking the system.
+
+## gpt-trader (Primary CLI)
+
+**Definition**
+- `pyproject.toml` `[project.scripts]`: `gpt-trader = "gpt_trader.cli:main"`
+
+**Wiring**
+- `gpt_trader.cli:main`
+- `gpt_trader.cli.commands.*` (command routing)
+- `gpt_trader.cli.services.instantiate_bot`
+- `gpt_trader.app.container.create_application_container`
+- `ApplicationContainer.create_bot()` -> `TradingBot`
+
+**Module entrypoint**
+- `python -m gpt_trader.cli` -> `gpt_trader.cli.__main__` -> `gpt_trader.cli:main`
+
+## Preflight CLI
+
+**Definition**
+- Script entrypoint: `scripts/production_preflight.py`
+
+**Wiring**
+- `scripts/production_preflight.py:main`
+- `gpt_trader.preflight.run_preflight_cli`
+- `gpt_trader.preflight.cli:main`
+- `gpt_trader.preflight.core.PreflightCheck` -> `gpt_trader.preflight.checks.*`
+
+**Notes**
+- This is a standalone CLI; it is not a `gpt-trader` subcommand.
+
+## TUI Demo (Module Entrypoint)
+
+**Definition**
+- Module entrypoint: `python -m gpt_trader.tui.demo`
+
+**Wiring**
+- `gpt_trader.tui.demo.__main__:main`
+- `gpt_trader.logging.setup.configure_logging(tui_mode=True)`
+- `gpt_trader.tui.demo.demo_bot.DemoBot`
+- `gpt_trader.tui.app.TraderApp` -> `gpt_trader.tui.helpers.run_tui_app_with_cleanup`


### PR DESCRIPTION
Closes #445

Adds docs/architecture/BOUNDARIES.md and docs/architecture/ENTRYPOINTS.md to clarify module layering and canonical entrypoints.