### PR TITLE
fix(agents): ensure output dirs exist

### DIFF
--- a/scripts/agents/dependency_graph.py
+++ b/scripts/agents/dependency_graph.py
@@ -418,6 +418,7 @@ def main() -> int:
         output = json.dumps(graph, indent=2)
 
     if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
         args.output.write_text(output)
         print(f"Graph written to: {args.output}", file=sys.stderr)
     else:

--- a/scripts/agents/generate_reasoning_artifacts.py
+++ b/scripts/agents/generate_reasoning_artifacts.py
@@ -2042,8 +2042,8 @@ def _timestamp() -> str:
     return "1970-01-01T00:00:00+00:00"
 
 
-def _ensure_output_dir() -> None:
-    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+def _ensure_output_dir(output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
 
 
 def _write_json(path: Path, payload: dict[str, Any]) -> None:
@@ -2921,7 +2921,7 @@ def generate(
     validate: bool = False,
     strict: bool = False,
 ) -> dict[str, Path]:
-    _ensure_output_dir()
+    _ensure_output_dir(output_dir)
     flow_payloads: list[tuple[str, dict[str, Any]]] = []
 
     def _load_flow(

--- a/scripts/agents/health_report.py
+++ b/scripts/agents/health_report.py
@@ -79,6 +79,10 @@ def _parse_profile(value: str) -> Profile:
         raise ValueError(f"Unknown profile: {value}") from exc
 
 
+def _ensure_parent_dir(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
 def _run_quality_checks(
     *,
     checks: list[str],
@@ -804,6 +808,7 @@ def main() -> int:
     if args.schema:
         output = json.dumps(build_schema(), indent=2)
         if args.output:
+            _ensure_parent_dir(args.output)
             args.output.write_text(output)
         else:
             print(output)
@@ -812,6 +817,7 @@ def main() -> int:
     if args.example:
         output = json.dumps(build_example(), indent=2)
         if args.output:
+            _ensure_parent_dir(args.output)
             args.output.write_text(output)
         else:
             print(output)
@@ -874,6 +880,7 @@ def main() -> int:
     output = json.dumps(report, indent=2) if args.format == "json" else format_text_report(report)
 
     if args.output:
+        _ensure_parent_dir(args.output)
         args.output.write_text(output)
     else:
         print(output)
@@ -885,6 +892,7 @@ def main() -> int:
         text_output = args.output.with_name("health_report.txt")
 
     if text_output:
+        _ensure_parent_dir(text_output)
         text_output.write_text(format_text_report(report))
 
     exit_code = 1 if report["status"] == "failed" else 0

--- a/scripts/agents/quality_gate.py
+++ b/scripts/agents/quality_gate.py
@@ -509,6 +509,7 @@ def main() -> int:
         output = json.dumps(report, indent=2)
 
     if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
         args.output.write_text(output)
         print(f"Report written to: {args.output}", file=sys.stderr)
     else:

--- a/scripts/agents/query_risk_config.py
+++ b/scripts/agents/query_risk_config.py
@@ -266,6 +266,7 @@ def main() -> int:
         schema = generate_schema()
         output = json.dumps(schema, indent=2)
         if args.output:
+            args.output.parent.mkdir(parents=True, exist_ok=True)
             args.output.write_text(output)
             print(f"Schema written to: {args.output}")
         else:
@@ -296,6 +297,7 @@ def main() -> int:
         output = json.dumps(config, indent=2, default=str)
 
     if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
         args.output.write_text(output)
         print(f"Config written to: {args.output}")
     else:


### PR DESCRIPTION
Closes #446

Ensures agent scripts create parent directories before writing --output files, so 'uv run agent-map' and 'uv run agent-health' work from a fresh clone.