### PR TITLE
Fix headless command bar timer

### DIFF
--- a/src/gpt_trader/tui/widgets/shell.py
+++ b/src/gpt_trader/tui/widgets/shell.py
@@ -42,8 +42,10 @@ class CommandBar(Static):
         self._onboarding = get_onboarding_service()
 
     def on_mount(self) -> None:
-        self.set_interval(1.0, self.update_time)
         self.update_time()
+        # Avoid timer-driven updates in headless/test runs to keep snapshots stable.
+        if not getattr(self.app, "is_headless", False):
+            self.set_interval(1.0, self.update_time)
         if hasattr(self.app, "state_registry"):
             self.app.state_registry.register(self)
 


### PR DESCRIPTION
This branch was produced by an automated Codex run and appears to address a TUI bug (headless command bar timer) in src/gpt_trader/tui/widgets/shell.py.

Opening for review/triage. If this is not desired, feel free to close and we can delete the branch.