### PR TITLE
ci: decouple agent artifacts freshness from PR merges

### DIFF
--- a/.github/workflows/agent-artifacts-refresh.yml
+++ b/.github/workflows/agent-artifacts-refresh.yml
@@ -1,0 +1,57 @@
+name: Agent Artifacts Refresh
+
+on:
+  schedule:
+    # Every 6 hours, offset to avoid common top-of-hour spikes.
+    - cron: "17 */6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  refresh:
+    name: Refresh var/agents artifacts
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: ".python-version"
+
+      - name: Install dependencies
+        run: uv sync --all-extras --dev
+
+      - name: Regenerate agent artifacts
+        run: |
+          set -euo pipefail
+          uv run agent-regenerate
+
+      - name: Create or update pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: refresh agent artifacts"
+          title: "chore: refresh agent artifacts"
+          body: |
+            Automated refresh of generated agent context under `var/agents/`.
+
+            - Trigger: scheduled workflow
+            - Command: `uv run agent-regenerate`
+
+            If this PR is large or noisy, consider narrowing generators or moving high-churn outputs out of the repo.
+          branch: automation/agent-artifacts-refresh
+          base: main
+          delete-branch: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [main, develop]
   pull_request:
     branches: [main, develop]
+  merge_group:
+    branches: [main, develop]
   workflow_dispatch:
 
 concurrency:
@@ -220,7 +222,10 @@ jobs:
           status=$?
           set +o pipefail
           set -e
+
+          EVENT_NAME="${{ github.event_name }}"
           echo "exit_code=$status" >> $GITHUB_OUTPUT
+
           if [ $status -ne 0 ]; then
             echo "::error::Agent artifacts are stale; run uv run agent-regenerate and commit the changes"
             echo "Fix command: uv run agent-regenerate"
@@ -233,16 +238,28 @@ jobs:
               echo "No working tree changes detected; diffstat:"
               git diff --stat
             fi
+
+            # Non-blocking on PRs: signal in summary, but don't stall merges.
+            if [ "$EVENT_NAME" = "pull_request" ]; then
+              echo "::warning::Agent artifacts are stale (non-blocking on pull_request); a scheduled refresh workflow will update these on main."
+              exit 0
+            fi
           fi
+
           exit $status
 
       - name: Add freshness summary
         if: always()
         run: |
+          EVENT_NAME="${{ github.event_name }}"
           echo "## Agent Artifacts Freshness" >> $GITHUB_STEP_SUMMARY
           if [ "${{ steps.verify.outputs.exit_code }}" != "0" ]; then
-            echo "Status: STALE (run \`uv run agent-regenerate\`)" >> $GITHUB_STEP_SUMMARY
-            echo "Fix: \`uv run agent-regenerate\`" >> $GITHUB_STEP_SUMMARY
+            if [ "$EVENT_NAME" = "pull_request" ]; then
+              echo "Status: STALE (non-blocking on PR; scheduled refresh will update on main)" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "Status: STALE (run \`uv run agent-regenerate\`)" >> $GITHUB_STEP_SUMMARY
+              echo "Fix: \`uv run agent-regenerate\`" >> $GITHUB_STEP_SUMMARY
+            fi
             echo "Verify log: \`var/agents/health/agent_regenerate_verify.txt\`" >> $GITHUB_STEP_SUMMARY
           else
             echo "Status: OK" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## What\n- Make "Agent Artifacts Freshness" non-blocking on pull requests (still reports STALE in the summary)\n- Keep strict failures on non-PR events (push / merge_group)\n- Add a scheduled workflow that runs `uv run agent-regenerate` and opens/updates a PR with refreshed `var/agents/*` artifacts\n\n## Why\nRegenerating and committing `var/agents/*` on every PR has been a repeated source of merge conflicts and automation stalls. This keeps the benefit (fresh agent context) while removing the per-PR merge tax.\n\n## Follow-ups\n- If you want, we can further reduce churn by teaching the CI-fixer to only run `agent-regenerate` when generator inputs change.