### PR TITLE
[tests] Add regression coverage for TimeProvider usage in health checks

### DIFF
--- a/src/gpt_trader/monitoring/health_checks.py
+++ b/src/gpt_trader/monitoring/health_checks.py
@@ -905,12 +905,14 @@ def _ratio_or_zero(numerator: int | float, denominator: int | float) -> float:
 def check_ws_staleness_signal(
     broker: BrokerProtocol,
     thresholds: HealthThresholds | None = None,
+    time_provider: TimeProvider | None = None,
 ) -> HealthSignal:
     """Check WebSocket staleness as a health signal.
 
     Args:
         broker: Broker protocol instance.
         thresholds: Optional custom thresholds.
+        time_provider: Optional time provider for deterministic staleness checks.
 
     Returns:
         HealthSignal for WebSocket staleness.
@@ -949,7 +951,8 @@ def check_ws_staleness_signal(
                 details={"ws_not_initialized": True},
             )
 
-        now = time.time()
+        clock = time_provider or get_clock()
+        now = clock.time()
         raw_last_message_ts = health.get("last_message_ts", 0)
         message_ts, staleness = age_since_timestamp_seconds(
             raw_last_message_ts,


### PR DESCRIPTION
Fixes #615

(Automated PR created by OpenClaw PR finisher)
Branch: codex/615-tests-add-regression-coverage-for-timepr
Commit: 452fe96d847965c40df80690aead3b30c5bf3e87