### PR TITLE
Improve data-loader performance and harden monitoring/execution regressions

### DIFF
--- a/src/gpt_trader/monitoring/status_reporter.py
+++ b/src/gpt_trader/monitoring/status_reporter.py
@@ -965,12 +965,20 @@ class StatusReporter:
                 if isinstance(guard, GuardStatus):
                     normalized.append(guard)
                 elif isinstance(guard, dict):
+                    try:
+                        last_triggered = float(guard.get("last_triggered", 0.0) or 0.0)
+                    except (TypeError, ValueError):
+                        last_triggered = 0.0
+                    try:
+                        triggered_count = int(guard.get("triggered_count", 0) or 0)
+                    except (TypeError, ValueError):
+                        triggered_count = 0
                     normalized.append(
                         GuardStatus(
                             name=str(guard.get("name", "")),
                             severity=str(guard.get("severity", "MEDIUM")),
-                            last_triggered=float(guard.get("last_triggered", 0.0) or 0.0),
-                            triggered_count=int(guard.get("triggered_count", 0) or 0),
+                            last_triggered=last_triggered,
+                            triggered_count=triggered_count,
                             description=str(guard.get("description", "") or ""),
                         )
                     )

--- a/tests/unit/gpt_trader/features/brokerages/coinbase/test_market_data_service.py
+++ b/tests/unit/gpt_trader/features/brokerages/coinbase/test_market_data_service.py
@@ -6,6 +6,7 @@ from gpt_trader.features.brokerages.coinbase.market_data_service import (
     CoinbaseTickerService,
     MarketDataService,
     Ticker,
+    TickerCache,
 )
 from gpt_trader.utilities.datetime_helpers import utc_now
 
@@ -166,6 +167,15 @@ class TestCoinbaseTickerService:
         service.set_symbols([])
 
         assert service._symbols == []
+
+    def test_get_last_ticker_timestamp_reads_from_cache(self) -> None:
+        """Service should expose the latest timestamp tracked by its cache."""
+        cache = TickerCache()
+        latest = utc_now()
+        cache.update(Ticker(symbol="BTC-USD", bid=1.0, ask=2.0, last=1.5, ts=latest))
+        service = CoinbaseTickerService(symbols=["BTC-USD"], ticker_cache=cache)
+
+        assert service.get_last_ticker_timestamp() == latest
 
     def test_multiple_start_stop_cycles(self) -> None:
         """Test multiple start/stop cycles."""

--- a/tests/unit/gpt_trader/monitoring/test_health_checks_market_data_feed_staleness.py
+++ b/tests/unit/gpt_trader/monitoring/test_health_checks_market_data_feed_staleness.py
@@ -1,0 +1,65 @@
+"""Tests for market data feed staleness health check wrapper."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from gpt_trader.monitoring.health_checks import check_market_data_feed_staleness
+from gpt_trader.utilities.time_provider import FakeClock
+
+
+class TestCheckMarketDataFeedStaleness:
+    """Tests for check_market_data_feed_staleness wrapper behavior."""
+
+    def test_unknown_signal_is_treated_as_skipped(self) -> None:
+        healthy, details = check_market_data_feed_staleness(None)
+
+        assert healthy is True
+        assert details["status"] == "UNKNOWN"
+        assert details["skipped"] is True
+        assert details["reason"] == "market_data_timestamp_unavailable"
+
+    @pytest.mark.parametrize(
+        ("age_seconds", "expected_healthy", "expected_status", "expected_severity"),
+        [
+            (5.0, True, "OK", "ok"),
+            (20.0, False, "WARN", "warning"),
+            (40.0, False, "CRIT", "critical"),
+        ],
+    )
+    def test_status_and_severity_follow_staleness_thresholds(
+        self,
+        age_seconds: float,
+        expected_healthy: bool,
+        expected_status: str,
+        expected_severity: str,
+    ) -> None:
+        from gpt_trader.monitoring.health_signals import HealthThresholds
+
+        class TimestampService:
+            def __init__(self, last_update: datetime) -> None:
+                self._last_update = last_update
+
+            def get_last_ticker_timestamp(self) -> datetime:
+                return self._last_update
+
+        clock = FakeClock(start_time=1000.0)
+        service = TimestampService(
+            datetime.fromtimestamp(clock.time() - age_seconds, tz=timezone.utc)
+        )
+        thresholds = HealthThresholds(
+            market_data_staleness_seconds_warn=10.0,
+            market_data_staleness_seconds_crit=30.0,
+        )
+
+        healthy, details = check_market_data_feed_staleness(
+            service,
+            thresholds=thresholds,
+            time_provider=clock,
+        )
+
+        assert healthy is expected_healthy
+        assert details["status"] == expected_status
+        assert details["severity"] == expected_severity

--- a/tests/unit/gpt_trader/monitoring/test_status_reporter.py
+++ b/tests/unit/gpt_trader/monitoring/test_status_reporter.py
@@ -228,6 +228,18 @@ class TestStatusReporterUpdates:
         reporter.set_heartbeat_service(mock_heartbeat)
         assert reporter._heartbeat_service is mock_heartbeat
 
+    def test_add_and_remove_observer(self) -> None:
+        reporter = StatusReporter()
+
+        def observer(status: BotStatus) -> None:
+            _ = status
+
+        reporter.add_observer(observer)
+        assert observer in reporter._observers
+
+        reporter.remove_observer(observer)
+        assert observer not in reporter._observers
+
 
 class TestStatusReporterStop:
 


### PR DESCRIPTION
## Summary
- optimize symbol loading path to avoid full table scans in backtesting data loader
- add targeted regression coverage for high-churn monitoring and execution paths
- harden `StatusReporter.update_risk()` guard normalization to safely coerce invalid `last_triggered` / `triggered_count` values
- add market-data timestamp consistency tests for `TickerCache` and `CoinbaseTickerService`

## Validation
- `uv run pytest tests/unit/gpt_trader/monitoring tests/unit/gpt_trader/features/live_trade/execution tests/unit/gpt_trader/features/brokerages/coinbase/test_market_data_service.py tests/unit/gpt_trader/features/brokerages/coinbase/test_market_data_ticker_cache.py -q`
- `uv run ruff check src/gpt_trader/monitoring/status_reporter.py tests/unit/gpt_trader/features/brokerages/coinbase/test_market_data_service.py tests/unit/gpt_trader/features/brokerages/coinbase/test_market_data_ticker_cache.py tests/unit/gpt_trader/features/live_trade/execution/test_order_submission_core.py tests/unit/gpt_trader/features/live_trade/execution/test_router_execute_async.py tests/unit/gpt_trader/monitoring/test_health_checks.py tests/unit/gpt_trader/monitoring/test_health_checks_market_data_feed_staleness.py tests/unit/gpt_trader/monitoring/test_health_checks_websocket.py tests/unit/gpt_trader/monitoring/test_status_reporter.py tests/unit/gpt_trader/monitoring/test_status_reporter_file_output.py tests/unit/gpt_trader/monitoring/test_status_reporter_health.py`
