### PR TITLE
feat: add trade-idea service, approval policy, and renegotiable risk budget

### DIFF
--- a/docs/OPERATING_RUBRIC.md
+++ b/docs/OPERATING_RUBRIC.md
@@ -1,0 +1,94 @@
+# Operating Rubric
+
+---
+status: current
+last-updated: 2026-06-11
+---
+
+This rubric defines what the bot must be able to do to "run successfully" as an
+autonomous trading entity, and what evidence earns each capability more
+autonomy. It complements the
+[Pre-Migration Decision Framework](PRE_MIGRATION_DECISION_FRAMEWORK.md) (which
+gates *whether* to build execution paths) by describing *what good operation
+looks like* once they exist.
+
+Grade work against this rubric before adding new feature surface: if a change
+does not advance a listed capability or its evidence, it is probably scope
+creep.
+
+## Risk Philosophy (owner-accepted, 2026-06-11)
+
+1. **Principal is fully at risk.** The owner funds the bot with a lump sum he
+   is prepared to lose entirely. Loss of principal is an acceptable outcome;
+   timidity that prevents the system from ever demonstrating skill is the
+   bigger failure. Seeded budgets are therefore aggressive.
+2. **Realized gains are not principal.** Tripling the portfolio and then
+   riding it back to zero is explicitly the *worst* outcome — worse than
+   losing the original stake outright. Drawdown-from-peak matters more than
+   drawdown-from-principal. High-water-mark tracking, profit-taking, and
+   rebalancing are first-class capabilities, not enhancements.
+3. **Limits exist to bound system failure, not to second-guess the agent.**
+   Budget levers cap the blast radius of bugs, bad data, venue outages, and
+   compromised credentials. They are designed to be *renegotiated by the
+   agents themselves* through the audited budget workflow — handed over
+   progressively as track record accumulates, never silently removed.
+4. **Every grant of autonomy is earned, recorded, and reversible.** Autonomy
+   expansions ride the same append-only audit trail as trades.
+
+## Capability Rubric
+
+Each capability lists the evidence ("graduation evidence") that it works.
+A stage is complete when every capability in it has its evidence.
+
+### Stage 0 — Rails (in progress)
+
+| Capability | Evidence |
+|------------|----------|
+| Broker-neutral trade-idea record with thesis, invalidation, max loss, sizing, expiry | Unit-tested round-trip + record hashing (`features/trade_ideas/models.py`) |
+| Workflow where execution is impossible without approval | State-machine tests prove `submitted` is reachable only from `approved` |
+| Append-only audit trail pinning every action to a record version | Audit log rejects out-of-order or conflicting appends |
+| Eligibility gate encoding automatic rejection conditions | Ineligible ideas cannot be approved |
+| Versioned risk budget that agents can later renegotiate | Budget changes append to their own audited log; current budget is always derivable |
+| Policy module that encodes the autonomy mode | Approval by a non-human actor is refused in `human_approved_execution` mode |
+
+### Stage 1 — Human-approved loop
+
+| Capability | Evidence |
+|------------|----------|
+| A proposer that generates complete, eligible trade ideas from market data | ≥ 90% of proposed ideas pass the eligibility gate without human edits |
+| Reviewer tooling (CLI first; TUI screen optional) | Owner can list, inspect, approve, and reject ideas end to end |
+| Approved tickets executed in paper mode | Paper fills recorded back onto the idea's audit trail |
+| Outcome attribution | Every closed idea records whether thesis, invalidation, or expiry resolved it, and realized PnL vs. max-loss estimate |
+| Expiry sweep | Stale ideas expire automatically; nothing waits on a human to notice |
+| Track-record report | One command summarizes proposal quality, approval rate, and outcome accuracy over time |
+
+### Stage 2 — Bounded autonomy
+
+| Capability | Evidence |
+|------------|----------|
+| Auto-approval inside the budget envelope | Ideas within budget auto-approve; outside it they queue for human review; both paths audited |
+| High-water-mark protection | Equity peak is tracked; a configured share of peak gains is defended by de-risking or halting (the "triple then zero" guard) |
+| Profit-taking and rebalancing policies | Gains are systematically skimmed/rebalanced per recorded policy, visible in the audit trail |
+| Kill switch | A single owner action halts proposing, approving, and submitting; verified by drill, not assumption |
+| Budget renegotiation by agents | An agent proposes a budget change with rationale; human approves; new version takes effect — exercised at least once |
+| Daily-loss circuit breaker enforced at runtime | Breach halts submission the same day, demonstrated in paper or canary |
+
+### Stage 3 — Self-directed entity
+
+| Capability | Evidence |
+|------------|----------|
+| Capital allocation across multiple concurrent strategies | Allocation decisions are recorded with the same rigor as trade ideas |
+| Self-adjusted budgets within a meta-envelope | Agent-initiated budget changes auto-approve inside owner-set meta-limits |
+| Scheduled self-review | The system periodically evaluates its own track record and adjusts behavior, leaving an auditable review note |
+| Owner reporting cadence | Owner receives a periodic plain-language report: positions, PnL vs. high-water mark, budget changes, notable decisions |
+
+## Non-negotiables (every stage)
+
+- Append-only audit trail for every state change, budget change, and autonomy grant.
+- A reachable kill switch once anything can submit orders.
+- No secrets or credentials in records, logs, or reports.
+- Blast-radius caps always exist — they may be wide, but never absent.
+- Tooling serves three audiences equally: the owner, agents developing the
+  project, and agents operating it. Every operator action must be available
+  as a library call with identity stamping; CLIs/TUIs/MCP servers are thin
+  adapters over that.

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ When adding a new doc, link it below in the best-fit section.
 | [Live Operations Guide](production.md) | Readiness-gated live operations, rollback, and emergency procedures |
 | [Readiness Checklist](READINESS.md) | Gates to move from paper to live trading |
 | [Pre-Migration Decision Framework](PRE_MIGRATION_DECISION_FRAMEWORK.md) | AI-assisted trading autonomy, product, venue, approval, and audit gates |
+| [Operating Rubric](OPERATING_RUBRIC.md) | Staged capabilities and graduation evidence for the autonomous entity |
 | [Reliability Guide](RELIABILITY.md) | Guard stack, degradation responses, chaos testing |
 | [TUI Guide](TUI_GUIDE.md) | Launching and operating the terminal UI |
 | [TUI Style Guide](TUI_STYLE_GUIDE.md) | Visual standards for TUI components |

--- a/src/gpt_trader/features/trade_ideas/__init__.py
+++ b/src/gpt_trader/features/trade_ideas/__init__.py
@@ -14,6 +14,13 @@ from gpt_trader.features.trade_ideas.audit import (
     TradeIdeaAuditLog,
     new_event_id,
 )
+from gpt_trader.features.trade_ideas.budget import (
+    DEFAULT_RISK_BUDGET,
+    BudgetIntegrityError,
+    BudgetLogEntry,
+    RiskBudget,
+    RiskBudgetLog,
+)
 from gpt_trader.features.trade_ideas.eligibility import evaluate_eligibility, is_eligible
 from gpt_trader.features.trade_ideas.models import (
     AutonomyMode,
@@ -30,6 +37,13 @@ from gpt_trader.features.trade_ideas.models import (
     TradeDirection,
     TradeIdea,
 )
+from gpt_trader.features.trade_ideas.policy import ApprovalPolicy, PolicyViolationError
+from gpt_trader.features.trade_ideas.service import (
+    TradeIdeaService,
+    TradeIdeaView,
+    UnknownTradeIdeaError,
+)
+from gpt_trader.features.trade_ideas.store import TradeIdeaStore
 from gpt_trader.features.trade_ideas.workflow import (
     ALLOWED_TRANSITIONS,
     TERMINAL_STATES,
@@ -40,19 +54,26 @@ from gpt_trader.features.trade_ideas.workflow import (
 
 __all__ = [
     "ALLOWED_TRANSITIONS",
+    "DEFAULT_RISK_BUDGET",
     "TERMINAL_STATES",
     "ActorType",
+    "ApprovalPolicy",
     "AuditAction",
     "AuditEvent",
     "AuditIntegrityError",
     "AutonomyMode",
     "BrokerTicket",
+    "BudgetIntegrityError",
+    "BudgetLogEntry",
     "Confidence",
     "ConfidenceLabel",
     "EntryZone",
     "InvalidTransitionError",
     "MaxLoss",
+    "PolicyViolationError",
     "ProductType",
+    "RiskBudget",
+    "RiskBudgetLog",
     "SizingRecommendation",
     "TicketStatus",
     "TicketVenue",
@@ -60,7 +81,11 @@ __all__ = [
     "TradeDirection",
     "TradeIdea",
     "TradeIdeaAuditLog",
+    "TradeIdeaService",
     "TradeIdeaState",
+    "TradeIdeaStore",
+    "TradeIdeaView",
+    "UnknownTradeIdeaError",
     "evaluate_eligibility",
     "is_eligible",
     "new_event_id",

--- a/src/gpt_trader/features/trade_ideas/budget.py
+++ b/src/gpt_trader/features/trade_ideas/budget.py
@@ -1,0 +1,164 @@
+"""Versioned, renegotiable risk budget for trade-idea workflows.
+
+The budget is the lever-handover mechanism from the accepted direction: limits
+are explicit data that agents can propose changes to through the same audited
+workflow as everything else. They are never silently removed — each version is
+appended to its own log with the actor and rationale that produced it.
+
+Seeded defaults reflect the owner's accepted risk philosophy
+(docs/OPERATING_RUBRIC.md): principal is fully at risk, so per-idea and daily
+caps are aggressive; realized gains are not principal, so a gain-retention
+floor defends a share of peak gains once the account is above its
+high-water mark.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+from gpt_trader.errors import ValidationError
+from gpt_trader.features.trade_ideas.audit import ActorType
+
+
+class BudgetIntegrityError(ValidationError):
+    """Raised when a budget append would break version sequencing."""
+
+
+@dataclass(frozen=True, slots=True)
+class RiskBudget:
+    """One immutable version of the risk budget."""
+
+    version: int
+    max_loss_per_idea_pct: Decimal
+    max_daily_loss_pct: Decimal
+    max_open_notional_pct: Decimal
+    max_concurrent_approved_tickets: int
+    max_review_latency_hours: int
+    sizing_capped_by_budget: bool
+    gain_retention_floor_pct: Decimal
+    allow_futures_leverage: bool
+    allow_naked_shorts: bool
+    reason: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "version": self.version,
+            "max_loss_per_idea_pct": str(self.max_loss_per_idea_pct),
+            "max_daily_loss_pct": str(self.max_daily_loss_pct),
+            "max_open_notional_pct": str(self.max_open_notional_pct),
+            "max_concurrent_approved_tickets": self.max_concurrent_approved_tickets,
+            "max_review_latency_hours": self.max_review_latency_hours,
+            "sizing_capped_by_budget": self.sizing_capped_by_budget,
+            "gain_retention_floor_pct": str(self.gain_retention_floor_pct),
+            "allow_futures_leverage": self.allow_futures_leverage,
+            "allow_naked_shorts": self.allow_naked_shorts,
+            "reason": self.reason,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> RiskBudget:
+        return cls(
+            version=int(payload["version"]),
+            max_loss_per_idea_pct=Decimal(payload["max_loss_per_idea_pct"]),
+            max_daily_loss_pct=Decimal(payload["max_daily_loss_pct"]),
+            max_open_notional_pct=Decimal(payload["max_open_notional_pct"]),
+            max_concurrent_approved_tickets=int(payload["max_concurrent_approved_tickets"]),
+            max_review_latency_hours=int(payload["max_review_latency_hours"]),
+            sizing_capped_by_budget=bool(payload["sizing_capped_by_budget"]),
+            gain_retention_floor_pct=Decimal(payload["gain_retention_floor_pct"]),
+            allow_futures_leverage=bool(payload["allow_futures_leverage"]),
+            allow_naked_shorts=bool(payload["allow_naked_shorts"]),
+            reason=payload.get("reason", ""),
+        )
+
+
+DEFAULT_RISK_BUDGET = RiskBudget(
+    version=1,
+    max_loss_per_idea_pct=Decimal("5"),
+    max_daily_loss_pct=Decimal("10"),
+    max_open_notional_pct=Decimal("100"),
+    max_concurrent_approved_tickets=5,
+    max_review_latency_hours=72,
+    sizing_capped_by_budget=True,
+    gain_retention_floor_pct=Decimal("50"),
+    allow_futures_leverage=False,
+    allow_naked_shorts=False,
+    reason=(
+        "Seeded aggressive defaults accepted 2026-06-11: principal fully at risk, "
+        "gain-retention floor defends 50% of peak gains above the high-water mark"
+    ),
+)
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetLogEntry:
+    """One appended budget version plus the actor and time that produced it."""
+
+    timestamp: datetime
+    actor_type: ActorType
+    actor_id: str
+    budget: RiskBudget
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "timestamp": self.timestamp.isoformat(),
+            "actor_type": self.actor_type.value,
+            "actor_id": self.actor_id,
+            "budget": self.budget.to_dict(),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> BudgetLogEntry:
+        return cls(
+            timestamp=datetime.fromisoformat(payload["timestamp"]),
+            actor_type=ActorType(payload["actor_type"]),
+            actor_id=payload["actor_id"],
+            budget=RiskBudget.from_dict(payload["budget"]),
+        )
+
+
+class RiskBudgetLog:
+    """Append-only JSONL log of budget versions; the last entry is current."""
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def append(self, entry: BudgetLogEntry) -> None:
+        current = self.current()
+        expected_version = 1 if current is None else current.version + 1
+        if entry.budget.version != expected_version:
+            raise BudgetIntegrityError(
+                f"Budget version must be {expected_version}, got {entry.budget.version}",
+                field="version",
+                value=entry.budget.version,
+            )
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(entry.to_dict(), sort_keys=True, separators=(",", ":"))
+        with self._path.open("a", encoding="utf-8") as handle:
+            handle.write(line + "\n")
+
+    def history(self) -> list[BudgetLogEntry]:
+        if not self._path.exists():
+            return []
+        entries: list[BudgetLogEntry] = []
+        with self._path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if line:
+                    entries.append(BudgetLogEntry.from_dict(json.loads(line)))
+        return entries
+
+    def current(self) -> RiskBudget | None:
+        entries = self.history()
+        if not entries:
+            return None
+        return entries[-1].budget

--- a/src/gpt_trader/features/trade_ideas/policy.py
+++ b/src/gpt_trader/features/trade_ideas/policy.py
@@ -1,0 +1,99 @@
+"""Approval policy: encodes the autonomy mode as enforceable checks.
+
+This module is the seam where autonomy is handed over. Moving up the ladder
+(human approval -> bounded autonomy) means changing policy data and rules
+here — never the service plumbing or the audit trail. In the current accepted
+mode (``human_approved_execution``), only a human actor can move an idea to
+``approved``, and approvals must clear the eligibility gate and the current
+risk budget.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from gpt_trader.errors import ValidationError
+from gpt_trader.features.trade_ideas.audit import ActorType
+from gpt_trader.features.trade_ideas.budget import RiskBudget
+from gpt_trader.features.trade_ideas.eligibility import evaluate_eligibility
+from gpt_trader.features.trade_ideas.models import AutonomyMode, TradeIdea
+
+
+class PolicyViolationError(ValidationError):
+    """Raised when an action violates the active approval policy."""
+
+    def __init__(self, message: str, violations: list[str] | None = None) -> None:
+        super().__init__(message)
+        self.violations = violations or []
+
+
+class ApprovalPolicy:
+    """Checks workflow actions against the active autonomy mode and budget."""
+
+    def __init__(self, autonomy_mode: AutonomyMode = AutonomyMode.HUMAN_APPROVED_EXECUTION) -> None:
+        self._autonomy_mode = autonomy_mode
+
+    @property
+    def autonomy_mode(self) -> AutonomyMode:
+        return self._autonomy_mode
+
+    def approval_violations(
+        self,
+        idea: TradeIdea,
+        actor_type: ActorType,
+        budget: RiskBudget,
+        open_approved_count: int,
+        now: datetime,
+    ) -> list[str]:
+        """Return every reason this approval must be refused; empty means allowed."""
+        violations: list[str] = []
+
+        if self._autonomy_mode is AutonomyMode.RESEARCH_ONLY:
+            violations.append("Autonomy mode 'research_only' does not permit approvals")
+        elif self._autonomy_mode is AutonomyMode.HUMAN_APPROVED_EXECUTION:
+            if actor_type is not ActorType.HUMAN:
+                violations.append(
+                    "Autonomy mode 'human_approved_execution' requires a human approver; "
+                    f"got actor_type '{actor_type.value}'"
+                )
+
+        violations.extend(evaluate_eligibility(idea))
+
+        percent = idea.max_loss.percent_of_account
+        if percent is None:
+            violations.append(
+                "max_loss.percent_of_account is required to verify the idea against the budget"
+            )
+        elif percent > budget.max_loss_per_idea_pct:
+            violations.append(
+                f"max_loss {percent}% exceeds budget cap of "
+                f"{budget.max_loss_per_idea_pct}% per idea"
+            )
+
+        if open_approved_count >= budget.max_concurrent_approved_tickets:
+            violations.append(
+                f"{open_approved_count} tickets already approved; budget allows "
+                f"{budget.max_concurrent_approved_tickets} concurrent approved tickets"
+            )
+
+        expires_at = idea.time_horizon.expires_at
+        if expires_at is not None and expires_at <= now:
+            violations.append(f"Idea expired at {expires_at.isoformat()}; approve nothing stale")
+
+        return violations
+
+    def budget_change_violations(self, actor_type: ActorType) -> list[str]:
+        """Budget renegotiation rules for the current autonomy mode.
+
+        Agents may *propose* budget changes at any stage; in the current modes
+        only a human can enact one. Bounded autonomy will relax this within a
+        meta-envelope.
+        """
+        if self._autonomy_mode is AutonomyMode.BOUNDED_AUTONOMY:
+            return []
+        if actor_type is not ActorType.HUMAN:
+            return [
+                f"Autonomy mode '{self._autonomy_mode.value}' requires a human to enact "
+                f"budget changes; got actor_type '{actor_type.value}'"
+            ]
+        return []

--- a/src/gpt_trader/features/trade_ideas/service.py
+++ b/src/gpt_trader/features/trade_ideas/service.py
@@ -1,0 +1,337 @@
+"""Trade-idea lifecycle service: the one audited code path for every actor.
+
+Humans, development agents, and (eventually) operating agents all act through
+this service. Every action is identity-stamped, checked against the approval
+policy, and appended to the audit log; interfaces such as CLI, TUI, or MCP
+servers must stay thin adapters over these methods.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from gpt_trader.errors import ValidationError
+from gpt_trader.features.trade_ideas.audit import (
+    ActorType,
+    AuditAction,
+    AuditEvent,
+    TradeIdeaAuditLog,
+    new_event_id,
+)
+from gpt_trader.features.trade_ideas.budget import (
+    DEFAULT_RISK_BUDGET,
+    BudgetLogEntry,
+    RiskBudget,
+    RiskBudgetLog,
+)
+from gpt_trader.features.trade_ideas.models import TradeIdea
+from gpt_trader.features.trade_ideas.policy import ApprovalPolicy, PolicyViolationError
+from gpt_trader.features.trade_ideas.store import TradeIdeaStore
+from gpt_trader.features.trade_ideas.workflow import TradeIdeaState
+
+
+class UnknownTradeIdeaError(ValidationError):
+    """Raised when a decision_id has no stored record."""
+
+
+@dataclass(frozen=True, slots=True)
+class TradeIdeaView:
+    """A record plus its derived workflow state and full history."""
+
+    idea: TradeIdea
+    state: TradeIdeaState
+    events: tuple[AuditEvent, ...]
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+class TradeIdeaService:
+    def __init__(
+        self,
+        root: Path,
+        *,
+        policy: ApprovalPolicy | None = None,
+        now_factory: Callable[[], datetime] = _utc_now,
+    ) -> None:
+        self._store = TradeIdeaStore(root / "records")
+        self._audit = TradeIdeaAuditLog(root / "audit.jsonl")
+        self._budget_log = RiskBudgetLog(root / "risk_budget.jsonl")
+        self._policy = policy or ApprovalPolicy()
+        self._now = now_factory
+
+    @property
+    def audit_log(self) -> TradeIdeaAuditLog:
+        return self._audit
+
+    # -- budget ----------------------------------------------------------
+
+    def current_budget(self) -> RiskBudget:
+        """Return the active budget, seeding the accepted defaults on first use."""
+        budget = self._budget_log.current()
+        if budget is not None:
+            return budget
+        self._budget_log.append(
+            BudgetLogEntry(
+                timestamp=self._now(),
+                actor_type=ActorType.SYSTEM,
+                actor_id="seed-defaults",
+                budget=DEFAULT_RISK_BUDGET,
+            )
+        )
+        return DEFAULT_RISK_BUDGET
+
+    def update_budget(self, budget: RiskBudget, actor_type: ActorType, actor_id: str) -> None:
+        """Enact a new budget version, subject to the autonomy-mode policy."""
+        violations = self._policy.budget_change_violations(actor_type)
+        if violations:
+            raise PolicyViolationError(
+                "Budget change refused: " + "; ".join(violations), violations
+            )
+        self.current_budget()  # ensure the seed entry exists so versions stay contiguous
+        self._budget_log.append(
+            BudgetLogEntry(
+                timestamp=self._now(),
+                actor_type=actor_type,
+                actor_id=actor_id,
+                budget=budget,
+            )
+        )
+
+    # -- lifecycle actions -------------------------------------------------
+
+    def propose(
+        self,
+        idea: TradeIdea,
+        actor_id: str,
+        actor_type: ActorType = ActorType.AI,
+        reason: str = "New trade idea proposed",
+        evidence: tuple[str, ...] = (),
+    ) -> TradeIdeaView:
+        self._store.save(idea)
+        self._append(
+            idea,
+            action=AuditAction.PROPOSED,
+            after_state=TradeIdeaState.PROPOSED,
+            actor_type=actor_type,
+            actor_id=actor_id,
+            reason=reason,
+            evidence=evidence,
+        )
+        return self.get(idea.decision_id)
+
+    def request_changes(self, decision_id: str, actor_id: str, reason: str) -> TradeIdeaView:
+        idea = self._require_idea(decision_id)
+        self._append(
+            idea,
+            action=AuditAction.CHANGED,
+            after_state=TradeIdeaState.NEEDS_CHANGES,
+            actor_type=ActorType.HUMAN,
+            actor_id=actor_id,
+            reason=reason,
+        )
+        return self.get(decision_id)
+
+    def resubmit(
+        self,
+        idea: TradeIdea,
+        actor_id: str,
+        actor_type: ActorType = ActorType.AI,
+        reason: str = "Revised after requested changes",
+    ) -> TradeIdeaView:
+        self._require_idea(idea.decision_id)
+        self._store.save(idea)
+        self._append(
+            idea,
+            action=AuditAction.PROPOSED,
+            after_state=TradeIdeaState.PROPOSED,
+            actor_type=actor_type,
+            actor_id=actor_id,
+            reason=reason,
+        )
+        return self.get(idea.decision_id)
+
+    def approve(self, decision_id: str, actor_id: str, reason: str) -> TradeIdeaView:
+        idea = self._require_idea(decision_id)
+        violations = self._policy.approval_violations(
+            idea,
+            actor_type=ActorType.HUMAN,
+            budget=self.current_budget(),
+            open_approved_count=self.open_approved_count(),
+            now=self._now(),
+        )
+        if violations:
+            raise PolicyViolationError(
+                f"Approval of '{decision_id}' refused: " + "; ".join(violations), violations
+            )
+        self._append(
+            idea,
+            action=AuditAction.APPROVED,
+            after_state=TradeIdeaState.APPROVED,
+            actor_type=ActorType.HUMAN,
+            actor_id=actor_id,
+            reason=reason,
+        )
+        return self.get(decision_id)
+
+    def reject(
+        self,
+        decision_id: str,
+        actor_id: str,
+        reason: str,
+        actor_type: ActorType = ActorType.HUMAN,
+    ) -> TradeIdeaView:
+        idea = self._require_idea(decision_id)
+        self._append(
+            idea,
+            action=AuditAction.REJECTED,
+            after_state=TradeIdeaState.REJECTED,
+            actor_type=actor_type,
+            actor_id=actor_id,
+            reason=reason,
+        )
+        return self.get(decision_id)
+
+    def cancel(
+        self,
+        decision_id: str,
+        actor_id: str,
+        reason: str,
+        actor_type: ActorType = ActorType.HUMAN,
+    ) -> TradeIdeaView:
+        idea = self._require_idea(decision_id)
+        self._append(
+            idea,
+            action=AuditAction.CANCELLED,
+            after_state=TradeIdeaState.CANCELLED,
+            actor_type=actor_type,
+            actor_id=actor_id,
+            reason=reason,
+        )
+        return self.get(decision_id)
+
+    def expire(
+        self,
+        decision_id: str,
+        actor_id: str = "expiry-sweep",
+        reason: str = "Idea passed its review or execution deadline",
+        actor_type: ActorType = ActorType.SYSTEM,
+    ) -> TradeIdeaView:
+        idea = self._require_idea(decision_id)
+        self._append(
+            idea,
+            action=AuditAction.EXPIRED,
+            after_state=TradeIdeaState.EXPIRED,
+            actor_type=actor_type,
+            actor_id=actor_id,
+            reason=reason,
+        )
+        return self.get(decision_id)
+
+    def record_submission(
+        self,
+        decision_id: str,
+        actor_id: str,
+        venue: str,
+        external_order_id: str = "",
+        reason: str = "Approved ticket submitted",
+        actor_type: ActorType = ActorType.SYSTEM,
+    ) -> TradeIdeaView:
+        idea = self._require_idea(decision_id)
+        self._append(
+            idea,
+            action=AuditAction.SUBMITTED,
+            after_state=TradeIdeaState.SUBMITTED,
+            actor_type=actor_type,
+            actor_id=actor_id,
+            reason=reason,
+            venue=venue,
+            external_order_id=external_order_id,
+        )
+        return self.get(decision_id)
+
+    def record_fill(
+        self,
+        decision_id: str,
+        actor_id: str,
+        venue: str,
+        external_order_id: str = "",
+        reason: str = "Venue confirmed fill",
+        actor_type: ActorType = ActorType.VENUE,
+    ) -> TradeIdeaView:
+        idea = self._require_idea(decision_id)
+        self._append(
+            idea,
+            action=AuditAction.FILLED,
+            after_state=TradeIdeaState.FILLED,
+            actor_type=actor_type,
+            actor_id=actor_id,
+            reason=reason,
+            venue=venue,
+            external_order_id=external_order_id,
+        )
+        return self.get(decision_id)
+
+    # -- queries -----------------------------------------------------------
+
+    def get(self, decision_id: str) -> TradeIdeaView:
+        idea = self._require_idea(decision_id)
+        events = tuple(self._audit.read_events(decision_id))
+        state = events[-1].after_state if events else TradeIdeaState.PROPOSED
+        return TradeIdeaView(idea=idea, state=state, events=events)
+
+    def list_views(self, state: TradeIdeaState | None = None) -> list[TradeIdeaView]:
+        views = [self.get(decision_id) for decision_id in self._store.list_decision_ids()]
+        if state is None:
+            return views
+        return [view for view in views if view.state is state]
+
+    def open_approved_count(self) -> int:
+        return len(self.list_views(TradeIdeaState.APPROVED))
+
+    # -- internals -----------------------------------------------------------
+
+    def _require_idea(self, decision_id: str) -> TradeIdea:
+        idea = self._store.load_latest(decision_id)
+        if idea is None:
+            raise UnknownTradeIdeaError(
+                f"No trade idea stored for decision_id '{decision_id}'",
+                field="decision_id",
+                value=decision_id,
+            )
+        return idea
+
+    def _append(
+        self,
+        idea: TradeIdea,
+        *,
+        action: AuditAction,
+        after_state: TradeIdeaState,
+        actor_type: ActorType,
+        actor_id: str,
+        reason: str,
+        evidence: tuple[str, ...] = (),
+        venue: str = "",
+        external_order_id: str = "",
+    ) -> None:
+        self._audit.append(
+            AuditEvent(
+                event_id=new_event_id(),
+                timestamp=self._now(),
+                decision_id=idea.decision_id,
+                actor_type=actor_type,
+                actor_id=actor_id,
+                action=action,
+                before_state=self._audit.current_state(idea.decision_id),
+                after_state=after_state,
+                reason=reason,
+                record_hash=idea.record_hash(),
+                evidence=evidence,
+                venue=venue,
+                external_order_id=external_order_id,
+            )
+        )

--- a/src/gpt_trader/features/trade_ideas/store.py
+++ b/src/gpt_trader/features/trade_ideas/store.py
@@ -1,0 +1,58 @@
+"""Versioned persistence for trade-idea records.
+
+Every saved version is kept under its record hash so audit events can always
+be resolved back to the exact record content they acted on; ``latest.json``
+tracks the current version for convenience.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from gpt_trader.features.trade_ideas.models import TradeIdea
+
+
+class TradeIdeaStore:
+    """Filesystem store: one directory per decision, one file per version."""
+
+    def __init__(self, root: Path) -> None:
+        self._root = root
+
+    @property
+    def root(self) -> Path:
+        return self._root
+
+    def _decision_dir(self, decision_id: str) -> Path:
+        return self._root / decision_id
+
+    def save(self, idea: TradeIdea) -> str:
+        """Persist a record version; returns its record hash."""
+        record_hash = idea.record_hash()
+        directory = self._decision_dir(idea.decision_id)
+        directory.mkdir(parents=True, exist_ok=True)
+        payload = json.dumps(idea.to_dict(), sort_keys=True, indent=2)
+        (directory / f"{record_hash}.json").write_text(payload, encoding="utf-8")
+        (directory / "latest.json").write_text(payload, encoding="utf-8")
+        return record_hash
+
+    def load_latest(self, decision_id: str) -> TradeIdea | None:
+        path = self._decision_dir(decision_id) / "latest.json"
+        if not path.exists():
+            return None
+        return TradeIdea.from_dict(json.loads(path.read_text(encoding="utf-8")))
+
+    def load_version(self, decision_id: str, record_hash: str) -> TradeIdea | None:
+        path = self._decision_dir(decision_id) / f"{record_hash}.json"
+        if not path.exists():
+            return None
+        return TradeIdea.from_dict(json.loads(path.read_text(encoding="utf-8")))
+
+    def list_decision_ids(self) -> list[str]:
+        if not self._root.exists():
+            return []
+        return sorted(
+            entry.name
+            for entry in self._root.iterdir()
+            if entry.is_dir() and (entry / "latest.json").exists()
+        )

--- a/tests/unit/gpt_trader/features/trade_ideas/test_budget.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_budget.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from gpt_trader.features.trade_ideas import (
+    DEFAULT_RISK_BUDGET,
+    ActorType,
+    BudgetIntegrityError,
+    BudgetLogEntry,
+    RiskBudget,
+    RiskBudgetLog,
+)
+
+
+def build_entry(budget: RiskBudget, minute: int = 0) -> BudgetLogEntry:
+    return BudgetLogEntry(
+        timestamp=datetime(2026, 6, 12, 9, minute, tzinfo=UTC),
+        actor_type=ActorType.HUMAN,
+        actor_id="rj",
+        budget=budget,
+    )
+
+
+@pytest.fixture
+def budget_log(tmp_path: Path) -> RiskBudgetLog:
+    return RiskBudgetLog(tmp_path / "risk_budget.jsonl")
+
+
+def test_seeded_defaults_reflect_accepted_risk_philosophy() -> None:
+    assert DEFAULT_RISK_BUDGET.version == 1
+    assert DEFAULT_RISK_BUDGET.max_loss_per_idea_pct == Decimal("5")
+    assert DEFAULT_RISK_BUDGET.max_daily_loss_pct == Decimal("10")
+    assert DEFAULT_RISK_BUDGET.gain_retention_floor_pct == Decimal("50")
+    assert DEFAULT_RISK_BUDGET.sizing_capped_by_budget is True
+    assert DEFAULT_RISK_BUDGET.allow_futures_leverage is False
+
+
+def test_budget_round_trip() -> None:
+    restored = RiskBudget.from_dict(DEFAULT_RISK_BUDGET.to_dict())
+
+    assert restored == DEFAULT_RISK_BUDGET
+    assert isinstance(restored.max_loss_per_idea_pct, Decimal)
+
+
+def test_empty_log_has_no_current_budget(budget_log: RiskBudgetLog) -> None:
+    assert budget_log.current() is None
+    assert budget_log.history() == []
+
+
+def test_append_and_current(budget_log: RiskBudgetLog) -> None:
+    budget_log.append(build_entry(DEFAULT_RISK_BUDGET))
+
+    assert budget_log.current() == DEFAULT_RISK_BUDGET
+    assert len(budget_log.history()) == 1
+
+
+def test_versions_must_be_contiguous(budget_log: RiskBudgetLog) -> None:
+    budget_log.append(build_entry(DEFAULT_RISK_BUDGET))
+    skipped = RiskBudget.from_dict({**DEFAULT_RISK_BUDGET.to_dict(), "version": 3})
+
+    with pytest.raises(BudgetIntegrityError):
+        budget_log.append(build_entry(skipped, minute=1))
+
+
+def test_renegotiated_budget_becomes_current(budget_log: RiskBudgetLog) -> None:
+    budget_log.append(build_entry(DEFAULT_RISK_BUDGET))
+    widened = RiskBudget.from_dict(
+        {
+            **DEFAULT_RISK_BUDGET.to_dict(),
+            "version": 2,
+            "max_loss_per_idea_pct": "8",
+            "reason": "Earned after 90 days of accurate max-loss estimates",
+        }
+    )
+
+    budget_log.append(build_entry(widened, minute=1))
+
+    assert budget_log.current() == widened
+    assert [entry.budget.version for entry in budget_log.history()] == [1, 2]

--- a/tests/unit/gpt_trader/features/trade_ideas/test_policy.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_policy.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+
+from tests.unit.gpt_trader.features.trade_ideas.conftest import build_trade_idea
+
+from gpt_trader.features.trade_ideas import (
+    DEFAULT_RISK_BUDGET,
+    ActorType,
+    ApprovalPolicy,
+    AutonomyMode,
+    MaxLoss,
+    TradeIdea,
+)
+
+NOW = datetime(2026, 6, 12, 10, 0, tzinfo=UTC)
+
+
+def violations(
+    idea: TradeIdea,
+    *,
+    policy: ApprovalPolicy | None = None,
+    actor_type: ActorType = ActorType.HUMAN,
+    open_approved_count: int = 0,
+) -> list[str]:
+    active = policy or ApprovalPolicy()
+    return active.approval_violations(
+        idea,
+        actor_type=actor_type,
+        budget=DEFAULT_RISK_BUDGET,
+        open_approved_count=open_approved_count,
+        now=NOW,
+    )
+
+
+def test_eligible_idea_with_human_approver_passes(trade_idea: TradeIdea) -> None:
+    assert violations(trade_idea) == []
+
+
+def test_ai_actor_cannot_approve_in_human_approved_mode(trade_idea: TradeIdea) -> None:
+    found = violations(trade_idea, actor_type=ActorType.AI)
+
+    assert any("requires a human approver" in violation for violation in found)
+
+
+def test_research_only_mode_blocks_all_approvals(trade_idea: TradeIdea) -> None:
+    policy = ApprovalPolicy(AutonomyMode.RESEARCH_ONLY)
+
+    found = violations(trade_idea, policy=policy)
+
+    assert any("research_only" in violation for violation in found)
+
+
+def test_ineligible_idea_cannot_be_approved() -> None:
+    idea = build_trade_idea(invalidation="")
+
+    assert any("invalidation" in violation for violation in violations(idea))
+
+
+def test_max_loss_above_budget_cap_is_refused() -> None:
+    idea = build_trade_idea(
+        max_loss=MaxLoss(amount=Decimal("900"), percent_of_account=Decimal("9"))
+    )
+
+    found = violations(idea)
+
+    assert any("exceeds budget cap" in violation for violation in found)
+
+
+def test_missing_percent_cannot_be_verified() -> None:
+    idea = build_trade_idea(max_loss=MaxLoss(amount=Decimal("250")))
+
+    found = violations(idea)
+
+    assert any("percent_of_account is required" in violation for violation in found)
+
+
+def test_concurrent_approved_cap_is_enforced(trade_idea: TradeIdea) -> None:
+    found = violations(
+        trade_idea,
+        open_approved_count=DEFAULT_RISK_BUDGET.max_concurrent_approved_tickets,
+    )
+
+    assert any("concurrent approved tickets" in violation for violation in found)
+
+
+def test_stale_idea_cannot_be_approved(trade_idea: TradeIdea) -> None:
+    policy = ApprovalPolicy()
+
+    found = policy.approval_violations(
+        trade_idea,
+        actor_type=ActorType.HUMAN,
+        budget=DEFAULT_RISK_BUDGET,
+        open_approved_count=0,
+        now=datetime(2026, 7, 1, tzinfo=UTC),
+    )
+
+    assert any("expired" in violation for violation in found)
+
+
+def test_budget_changes_require_human_below_bounded_autonomy() -> None:
+    policy = ApprovalPolicy()
+
+    assert policy.budget_change_violations(ActorType.HUMAN) == []
+    assert policy.budget_change_violations(ActorType.AI) != []
+
+
+def test_bounded_autonomy_lets_agents_change_budgets() -> None:
+    policy = ApprovalPolicy(AutonomyMode.BOUNDED_AUTONOMY)
+
+    assert policy.budget_change_violations(ActorType.AI) == []

--- a/tests/unit/gpt_trader/features/trade_ideas/test_service.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_service.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+from tests.unit.gpt_trader.features.trade_ideas.conftest import build_trade_idea
+
+from gpt_trader.features.trade_ideas import (
+    DEFAULT_RISK_BUDGET,
+    ActorType,
+    AuditAction,
+    MaxLoss,
+    PolicyViolationError,
+    RiskBudget,
+    TradeIdeaService,
+    TradeIdeaState,
+    UnknownTradeIdeaError,
+)
+
+
+@pytest.fixture
+def service(tmp_path: Path) -> TradeIdeaService:
+    return TradeIdeaService(
+        tmp_path / "trade_ideas",
+        now_factory=lambda: datetime(2026, 6, 12, 10, 0, tzinfo=UTC),
+    )
+
+
+def test_propose_creates_proposed_view(service: TradeIdeaService) -> None:
+    view = service.propose(build_trade_idea(), actor_id="idea-generator-v1")
+
+    assert view.state is TradeIdeaState.PROPOSED
+    assert view.events[0].actor_type is ActorType.AI
+    assert view.events[0].record_hash == view.idea.record_hash()
+
+
+def test_full_lifecycle_to_fill(service: TradeIdeaService) -> None:
+    idea = build_trade_idea()
+    service.propose(idea, actor_id="idea-generator-v1")
+    service.approve(idea.decision_id, actor_id="rj", reason="Thesis and risk verified")
+    service.record_submission(idea.decision_id, actor_id="executor", venue="coinbase")
+    view = service.record_fill(
+        idea.decision_id, actor_id="coinbase", venue="coinbase", external_order_id="abc-123"
+    )
+
+    assert view.state is TradeIdeaState.FILLED
+    assert [event.action for event in view.events] == [
+        AuditAction.PROPOSED,
+        AuditAction.APPROVED,
+        AuditAction.SUBMITTED,
+        AuditAction.FILLED,
+    ]
+
+
+def test_changes_loop_keeps_every_record_version(service: TradeIdeaService) -> None:
+    idea = build_trade_idea()
+    service.propose(idea, actor_id="idea-generator-v1")
+    service.request_changes(idea.decision_id, actor_id="rj", reason="Tighten the invalidation")
+    revised = build_trade_idea(invalidation="Daily close below 59000")
+    view = service.resubmit(revised, actor_id="idea-generator-v1")
+
+    assert view.state is TradeIdeaState.PROPOSED
+    assert view.idea.invalidation == "Daily close below 59000"
+    hashes = {event.record_hash for event in view.events}
+    assert idea.record_hash() in hashes
+    assert revised.record_hash() in hashes
+
+
+def test_approval_refused_for_budget_violation(service: TradeIdeaService) -> None:
+    idea = build_trade_idea(
+        max_loss=MaxLoss(amount=Decimal("900"), percent_of_account=Decimal("9"))
+    )
+    service.propose(idea, actor_id="idea-generator-v1")
+
+    with pytest.raises(PolicyViolationError) as exc_info:
+        service.approve(idea.decision_id, actor_id="rj", reason="Looks fine")
+
+    assert any("exceeds budget cap" in violation for violation in exc_info.value.violations)
+    assert service.get(idea.decision_id).state is TradeIdeaState.PROPOSED
+
+
+def test_unknown_decision_id_is_an_error(service: TradeIdeaService) -> None:
+    with pytest.raises(UnknownTradeIdeaError):
+        service.approve("trade-missing", actor_id="rj", reason="?")
+
+
+def test_list_views_filters_by_state(service: TradeIdeaService) -> None:
+    first = build_trade_idea(decision_id="trade-20260612-001")
+    second = build_trade_idea(decision_id="trade-20260612-002")
+    service.propose(first, actor_id="idea-generator-v1")
+    service.propose(second, actor_id="idea-generator-v1")
+    service.approve(first.decision_id, actor_id="rj", reason="Verified")
+
+    approved = service.list_views(TradeIdeaState.APPROVED)
+
+    assert [view.idea.decision_id for view in approved] == ["trade-20260612-001"]
+    assert service.open_approved_count() == 1
+
+
+def test_budget_seeds_defaults_on_first_use(service: TradeIdeaService) -> None:
+    assert service.current_budget() == DEFAULT_RISK_BUDGET
+
+
+def test_human_can_renegotiate_budget(service: TradeIdeaService) -> None:
+    widened = RiskBudget.from_dict(
+        {**DEFAULT_RISK_BUDGET.to_dict(), "version": 2, "max_loss_per_idea_pct": "8"}
+    )
+
+    service.update_budget(widened, actor_type=ActorType.HUMAN, actor_id="rj")
+
+    assert service.current_budget().max_loss_per_idea_pct == Decimal("8")
+
+
+def test_agent_budget_change_refused_in_current_mode(service: TradeIdeaService) -> None:
+    widened = RiskBudget.from_dict(
+        {**DEFAULT_RISK_BUDGET.to_dict(), "version": 2, "max_loss_per_idea_pct": "8"}
+    )
+
+    with pytest.raises(PolicyViolationError):
+        service.update_budget(widened, actor_type=ActorType.AI, actor_id="idea-generator-v1")
+
+    assert service.current_budget() == DEFAULT_RISK_BUDGET
+
+
+def test_expire_is_a_system_action(service: TradeIdeaService) -> None:
+    idea = build_trade_idea()
+    service.propose(idea, actor_id="idea-generator-v1")
+
+    view = service.expire(idea.decision_id)
+
+    assert view.state is TradeIdeaState.EXPIRED
+    assert view.events[-1].actor_type is ActorType.SYSTEM

--- a/tests/unit/gpt_trader/features/trade_ideas/test_store.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_store.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+from tests.unit.gpt_trader.features.trade_ideas.conftest import build_trade_idea
+
+from gpt_trader.features.trade_ideas import MaxLoss, TradeIdeaStore
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> TradeIdeaStore:
+    return TradeIdeaStore(tmp_path / "records")
+
+
+def test_save_and_load_latest(store: TradeIdeaStore) -> None:
+    idea = build_trade_idea()
+    store.save(idea)
+
+    assert store.load_latest(idea.decision_id) == idea
+
+
+def test_missing_decision_returns_none(store: TradeIdeaStore) -> None:
+    assert store.load_latest("trade-unknown") is None
+    assert store.load_version("trade-unknown", "deadbeef") is None
+
+
+def test_every_version_stays_retrievable_by_hash(store: TradeIdeaStore) -> None:
+    original = build_trade_idea()
+    first_hash = store.save(original)
+    amended = build_trade_idea(max_loss=MaxLoss(amount=Decimal("300")))
+    second_hash = store.save(amended)
+
+    assert store.load_version(original.decision_id, first_hash) == original
+    assert store.load_version(original.decision_id, second_hash) == amended
+    assert store.load_latest(original.decision_id) == amended
+
+
+def test_list_decision_ids_sorted(store: TradeIdeaStore) -> None:
+    store.save(build_trade_idea(decision_id="trade-20260612-002"))
+    store.save(build_trade_idea(decision_id="trade-20260612-001"))
+
+    assert store.list_decision_ids() == ["trade-20260612-001", "trade-20260612-002"]
+
+
+def test_empty_store_lists_nothing(store: TradeIdeaStore) -> None:
+    assert store.list_decision_ids() == []

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,8 +7,8 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6513,
-    "total_files": 766,
+    "total_tests": 6544,
+    "total_files": 770,
     "markers_used": 16
   },
   "quick_commands": {

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6348,
+    "unit": 6379,
     "asyncio": 372,
     "parametrize": 173,
     "endpoints": 83,

--- a/var/agents/testing/source_test_map.json
+++ b/var/agents/testing/source_test_map.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "summary": {
-    "tests_scanned": 686,
+    "tests_scanned": 690,
     "source_modules": 367,
     "unresolved_modules": 3
   },
@@ -1235,8 +1235,12 @@
     ],
     "gpt_trader.features.trade_ideas": [
       "tests/unit/gpt_trader/features/trade_ideas/test_audit.py",
+      "tests/unit/gpt_trader/features/trade_ideas/test_budget.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_eligibility.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_models.py",
+      "tests/unit/gpt_trader/features/trade_ideas/test_policy.py",
+      "tests/unit/gpt_trader/features/trade_ideas/test_service.py",
+      "tests/unit/gpt_trader/features/trade_ideas/test_store.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_workflow.py"
     ],
     "gpt_trader.logging.correlation": [
@@ -3752,10 +3756,22 @@
     "tests/unit/gpt_trader/features/trade_ideas/test_audit.py": [
       "gpt_trader.features.trade_ideas"
     ],
+    "tests/unit/gpt_trader/features/trade_ideas/test_budget.py": [
+      "gpt_trader.features.trade_ideas"
+    ],
     "tests/unit/gpt_trader/features/trade_ideas/test_eligibility.py": [
       "gpt_trader.features.trade_ideas"
     ],
     "tests/unit/gpt_trader/features/trade_ideas/test_models.py": [
+      "gpt_trader.features.trade_ideas"
+    ],
+    "tests/unit/gpt_trader/features/trade_ideas/test_policy.py": [
+      "gpt_trader.features.trade_ideas"
+    ],
+    "tests/unit/gpt_trader/features/trade_ideas/test_service.py": [
+      "gpt_trader.features.trade_ideas"
+    ],
+    "tests/unit/gpt_trader/features/trade_ideas/test_store.py": [
       "gpt_trader.features.trade_ideas"
     ],
     "tests/unit/gpt_trader/features/trade_ideas/test_workflow.py": [

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,8 +2,8 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6513,
-    "total_files": 766,
+    "total_tests": 6544,
+    "total_files": 770,
     "markers_used": 16
   },
   "marker_definitions": {
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6348,
+    "unit": 6379,
     "asyncio": 372,
     "parametrize": 173,
     "endpoints": 83,
@@ -520,8 +520,12 @@
       "tests/unit/gpt_trader/features/strategy_tools/test_strategy_enhancements_edges.py",
       "tests/unit/gpt_trader/features/strategy_tools/test_strategy_tools_import.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_audit.py",
+      "tests/unit/gpt_trader/features/trade_ideas/test_budget.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_eligibility.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_models.py",
+      "tests/unit/gpt_trader/features/trade_ideas/test_policy.py",
+      "tests/unit/gpt_trader/features/trade_ideas/test_service.py",
+      "tests/unit/gpt_trader/features/trade_ideas/test_store.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_workflow.py"
     ],
     "fixtures": [
@@ -31476,6 +31480,56 @@
         "docstring": ""
       }
     ],
+    "tests/unit/gpt_trader/features/trade_ideas/test_budget.py": [
+      {
+        "name": "test_seeded_defaults_reflect_accepted_risk_philosophy",
+        "line": 33,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_budget_round_trip",
+        "line": 42,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_empty_log_has_no_current_budget",
+        "line": 49,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_append_and_current",
+        "line": 54,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_versions_must_be_contiguous",
+        "line": 61,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_renegotiated_budget_becomes_current",
+        "line": 69,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      }
+    ],
     "tests/unit/gpt_trader/features/trade_ideas/test_eligibility.py": [
       {
         "name": "test_fully_specified_idea_is_eligible",
@@ -31602,6 +31656,212 @@
       {
         "name": "test_optional_value_objects_round_trip_when_empty",
         "line": 55,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      }
+    ],
+    "tests/unit/gpt_trader/features/trade_ideas/test_policy.py": [
+      {
+        "name": "test_eligible_idea_with_human_approver_passes",
+        "line": 37,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_ai_actor_cannot_approve_in_human_approved_mode",
+        "line": 41,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_research_only_mode_blocks_all_approvals",
+        "line": 47,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_ineligible_idea_cannot_be_approved",
+        "line": 55,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_max_loss_above_budget_cap_is_refused",
+        "line": 61,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_missing_percent_cannot_be_verified",
+        "line": 71,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_concurrent_approved_cap_is_enforced",
+        "line": 79,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_stale_idea_cannot_be_approved",
+        "line": 88,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_budget_changes_require_human_below_bounded_autonomy",
+        "line": 102,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_bounded_autonomy_lets_agents_change_budgets",
+        "line": 109,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      }
+    ],
+    "tests/unit/gpt_trader/features/trade_ideas/test_service.py": [
+      {
+        "name": "test_propose_creates_proposed_view",
+        "line": 31,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_full_lifecycle_to_fill",
+        "line": 39,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_changes_loop_keeps_every_record_version",
+        "line": 57,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_approval_refused_for_budget_violation",
+        "line": 71,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_unknown_decision_id_is_an_error",
+        "line": 84,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_list_views_filters_by_state",
+        "line": 89,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_budget_seeds_defaults_on_first_use",
+        "line": 102,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_human_can_renegotiate_budget",
+        "line": 106,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_agent_budget_change_refused_in_current_mode",
+        "line": 116,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_expire_is_a_system_action",
+        "line": 127,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      }
+    ],
+    "tests/unit/gpt_trader/features/trade_ideas/test_store.py": [
+      {
+        "name": "test_save_and_load_latest",
+        "line": 17,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_missing_decision_returns_none",
+        "line": 24,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_every_version_stays_retrievable_by_hash",
+        "line": 29,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_list_decision_ids_sorted",
+        "line": 40,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_empty_store_lists_nothing",
+        "line": 47,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary

Builds the service + policy core agreed in the direction discussion, plus the operating rubric.

**`docs/OPERATING_RUBRIC.md`** — what "running successfully" means: the owner-accepted risk philosophy (principal fully at risk; realized gains are not principal; limits bound system failure and are designed to be handed to agents) and a staged capability rubric (Rails → Human-approved loop → Bounded autonomy → Self-directed entity), each with graduation evidence.

**`features/trade_ideas/` additions:**
- `service.py` — `TradeIdeaService`, the one audited code path for every actor (propose, request changes, resubmit, approve, reject, cancel, expire, record submission/fill, queries). Identity-stamped; CLI/TUI/MCP must stay thin adapters.
- `policy.py` — `ApprovalPolicy` encodes the autonomy mode: human-only approval in `human_approved_execution`, eligibility + budget checks, stale-idea refusal. Moving up the autonomy ladder changes policy here, never plumbing.
- `budget.py` — `RiskBudget`: versioned, append-only, renegotiable by agents through the same workflow (human-enacted below bounded autonomy). Seeded aggressive defaults per owner acceptance: 5% max loss/idea, 10% daily circuit breaker, 100% open notional (no leverage), 5 concurrent tickets, 72h review latency, **50% gain-retention floor** above the high-water mark (the "tripled then zero is the worst outcome" guard).
- `store.py` — versioned record persistence; every record version stays retrievable by its hash so audit events always resolve to exact content.

## Verification

- 83 slice tests (31 new); full suite 6,795 passed, 8 skipped
- ruff, black, mypy, agent-naming, docs audits, agent-regenerate — clean