### PR TITLE
feat: add point-in-time market snapshots and deterministic baseline proposer

### DIFF
--- a/src/gpt_trader/features/trade_ideas/__init__.py
+++ b/src/gpt_trader/features/trade_ideas/__init__.py
@@ -14,6 +14,10 @@ from gpt_trader.features.trade_ideas.audit import (
     TradeIdeaAuditLog,
     new_event_id,
 )
+from gpt_trader.features.trade_ideas.baseline import (
+    BaselineProposer,
+    BaselineProposerConfig,
+)
 from gpt_trader.features.trade_ideas.budget import (
     DEFAULT_RISK_BUDGET,
     BudgetIntegrityError,
@@ -38,10 +42,16 @@ from gpt_trader.features.trade_ideas.models import (
     TradeIdea,
 )
 from gpt_trader.features.trade_ideas.policy import ApprovalPolicy, PolicyViolationError
+from gpt_trader.features.trade_ideas.proposer import Proposer
 from gpt_trader.features.trade_ideas.service import (
     TradeIdeaService,
     TradeIdeaView,
     UnknownTradeIdeaError,
+)
+from gpt_trader.features.trade_ideas.snapshot import (
+    MarketSnapshot,
+    SnapshotIntegrityError,
+    SymbolSeries,
 )
 from gpt_trader.features.trade_ideas.store import TradeIdeaStore
 from gpt_trader.features.trade_ideas.workflow import (
@@ -62,6 +72,8 @@ __all__ = [
     "AuditEvent",
     "AuditIntegrityError",
     "AutonomyMode",
+    "BaselineProposer",
+    "BaselineProposerConfig",
     "BrokerTicket",
     "BudgetIntegrityError",
     "BudgetLogEntry",
@@ -69,12 +81,16 @@ __all__ = [
     "ConfidenceLabel",
     "EntryZone",
     "InvalidTransitionError",
+    "MarketSnapshot",
     "MaxLoss",
     "PolicyViolationError",
     "ProductType",
+    "Proposer",
     "RiskBudget",
     "RiskBudgetLog",
     "SizingRecommendation",
+    "SnapshotIntegrityError",
+    "SymbolSeries",
     "TicketStatus",
     "TicketVenue",
     "TimeHorizon",

--- a/src/gpt_trader/features/trade_ideas/baseline.py
+++ b/src/gpt_trader/features/trade_ideas/baseline.py
@@ -1,0 +1,180 @@
+"""Deterministic baseline proposer: the benchmark every fancier proposer must beat.
+
+Long-only moving-average crossover on point-in-time snapshots. Intentionally
+simple and fully deterministic — identical snapshots produce byte-identical
+records (stable decision ids and record hashes), which makes replay scoring
+and proposer-vs-proposer comparison trivial. If a future LLM proposer cannot
+outscore this on the same replayed snapshots, it is noise.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from datetime import timedelta
+from decimal import Decimal
+
+from gpt_trader.errors import ValidationError
+from gpt_trader.features.trade_ideas.eligibility import evaluate_eligibility
+from gpt_trader.features.trade_ideas.models import (
+    AutonomyMode,
+    Confidence,
+    ConfidenceLabel,
+    EntryZone,
+    MaxLoss,
+    ProductType,
+    SizingRecommendation,
+    TimeHorizon,
+    TradeDirection,
+    TradeIdea,
+)
+from gpt_trader.features.trade_ideas.snapshot import MarketSnapshot, SymbolSeries
+
+
+@dataclass(frozen=True, slots=True)
+class BaselineProposerConfig:
+    short_window: int = 10
+    long_window: int = 50
+    crossover_lookback: int = 3
+    risk_per_idea_pct: Decimal = Decimal("2")
+    entry_band_pct: Decimal = Decimal("1")
+    reward_multiple: Decimal = Decimal("2")
+    expiry_hours: int = 48
+    expected_hold: str = "5-15 days"
+    price_precision: Decimal = Decimal("0.01")
+
+
+def _moving_average(closes: list[Decimal], window: int, end_index: int) -> Decimal:
+    start = end_index - window + 1
+    return sum(closes[start : end_index + 1], Decimal("0")) / Decimal(window)
+
+
+class BaselineProposer:
+    """Long-only MA-crossover proposer over spot symbols in a snapshot."""
+
+    def __init__(self, config: BaselineProposerConfig | None = None) -> None:
+        self._config = config or BaselineProposerConfig()
+
+    @property
+    def proposer_id(self) -> str:
+        return f"baseline-ma-{self._config.short_window}-{self._config.long_window}"
+
+    def propose(self, snapshot: MarketSnapshot) -> list[TradeIdea]:
+        ideas: list[TradeIdea] = []
+        for series in snapshot.series:
+            idea = self._propose_for_series(snapshot, series)
+            if idea is not None:
+                ideas.append(idea)
+        return ideas
+
+    def _propose_for_series(
+        self, snapshot: MarketSnapshot, series: SymbolSeries
+    ) -> TradeIdea | None:
+        config = self._config
+        required = config.long_window + config.crossover_lookback
+        if len(series.candles) < required:
+            return None
+
+        closes = [candle.close for candle in series.candles]
+        last = len(closes) - 1
+        short_now = _moving_average(closes, config.short_window, last)
+        long_now = _moving_average(closes, config.long_window, last)
+        if short_now <= long_now:
+            return None
+
+        crossed_recently = any(
+            _moving_average(closes, config.short_window, last - offset)
+            <= _moving_average(closes, config.long_window, last - offset)
+            for offset in range(1, config.crossover_lookback + 1)
+        )
+        if not crossed_recently:
+            return None
+
+        close = closes[-1]
+        stop_level = long_now.quantize(config.price_precision)
+        if close <= stop_level:
+            return None
+
+        entry_lower = (close * (1 - config.entry_band_pct / 100)).quantize(config.price_precision)
+        entry_upper = (close * (1 + config.entry_band_pct / 100)).quantize(config.price_precision)
+        target = (close + config.reward_multiple * (close - stop_level)).quantize(
+            config.price_precision
+        )
+        stop_distance_pct = ((close - stop_level) / close * 100).quantize(Decimal("0.01"))
+
+        volumes = [candle.volume for candle in series.candles[-config.long_window :]]
+        average_volume = sum(volumes, Decimal("0")) / Decimal(len(volumes))
+        volume_confirmed = series.candles[-1].volume > average_volume
+        confidence = Confidence(
+            label=ConfidenceLabel.MEDIUM if volume_confirmed else ConfidenceLabel.LOW,
+            rationale=(
+                "Latest volume is above the long-window average, supporting the move"
+                if volume_confirmed
+                else "Crossover lacks volume confirmation; treat as a weaker signal"
+            ),
+        )
+
+        idea = TradeIdea(
+            decision_id=self._decision_id(snapshot, series.symbol),
+            autonomy_mode=AutonomyMode.HUMAN_APPROVED_EXECUTION,
+            thesis=(
+                f"{series.symbol} {config.short_window}-bar average crossed above the "
+                f"{config.long_window}-bar average within the last "
+                f"{config.crossover_lookback} bars and closed at {close} above the "
+                f"long-term average {stop_level}, signalling upward momentum"
+            ),
+            instrument=series.symbol,
+            product_type=ProductType.SPOT,
+            direction=TradeDirection.LONG,
+            entry_zone=EntryZone(lower=entry_lower, upper=entry_upper),
+            invalidation=f"Close below the {config.long_window}-bar average ({stop_level})",
+            target_exit=(
+                f"Take profit near {target} ({config.reward_multiple}R) or exit at expiry"
+            ),
+            max_loss=MaxLoss(
+                percent_of_account=config.risk_per_idea_pct,
+                assumptions=(
+                    f"Position sized so a stop-out at {stop_level} costs "
+                    f"{config.risk_per_idea_pct}% of account equity",
+                    f"Stop distance is {stop_distance_pct}% from the last close",
+                ),
+            ),
+            sizing_recommendation=SizingRecommendation(
+                rationale=(
+                    f"Size = ({config.risk_per_idea_pct}% of equity) / "
+                    f"({stop_distance_pct}% stop distance) in notional terms"
+                ),
+            ),
+            time_horizon=TimeHorizon(
+                expected_hold=config.expected_hold,
+                expires_at=snapshot.as_of + timedelta(hours=config.expiry_hours),
+            ),
+            data_used=(
+                f"{snapshot.source}:{series.symbol}:{series.granularity}"
+                f":as_of={snapshot.as_of.isoformat()}",
+            ),
+            confidence=confidence,
+            failure_mode=(
+                "False breakout: the short-term average rolls back below the "
+                "long-term average shortly after entry"
+            ),
+            do_not_trade_if=(
+                f"Price has already moved above {entry_upper} before entry",
+                "The crossover has reversed on the most recent completed bar",
+            ),
+        )
+
+        gaps = evaluate_eligibility(idea)
+        if gaps:
+            raise ValidationError(
+                f"BaselineProposer produced an ineligible idea for '{series.symbol}': "
+                + "; ".join(gaps)
+            )
+        return idea
+
+    def _decision_id(self, snapshot: MarketSnapshot, symbol: str) -> str:
+        digest = hashlib.sha256(
+            f"{self.proposer_id}|{symbol}|{snapshot.as_of.isoformat()}".encode()
+        ).hexdigest()[:8]
+        symbol_slug = symbol.lower().replace("-", "")
+        return f"trade-{snapshot.as_of:%Y%m%d}-{symbol_slug}-{digest}"

--- a/src/gpt_trader/features/trade_ideas/proposer.py
+++ b/src/gpt_trader/features/trade_ideas/proposer.py
@@ -1,0 +1,29 @@
+"""Proposer protocol: snapshot in, complete trade-idea records out.
+
+Every proposer — deterministic baseline or future LLM-backed — implements the
+same contract, so all of them can be replayed over historical snapshots and
+scored against each other on identical inputs. Proposers never see "the
+present", only a :class:`MarketSnapshot`, and they never submit anything; their
+output enters the workflow through ``TradeIdeaService.propose``.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from gpt_trader.features.trade_ideas.models import TradeIdea
+from gpt_trader.features.trade_ideas.snapshot import MarketSnapshot
+
+
+@runtime_checkable
+class Proposer(Protocol):
+    """Generates eligible trade-idea records from a point-in-time snapshot."""
+
+    @property
+    def proposer_id(self) -> str:
+        """Stable actor identifier recorded on every proposed idea."""
+        ...
+
+    def propose(self, snapshot: MarketSnapshot) -> list[TradeIdea]:
+        """Return zero or more complete, eligibility-passing records."""
+        ...

--- a/src/gpt_trader/features/trade_ideas/snapshot.py
+++ b/src/gpt_trader/features/trade_ideas/snapshot.py
@@ -1,0 +1,84 @@
+"""Point-in-time market snapshots: the only input a proposer may see.
+
+A snapshot is frozen "as of" a moment. Construction rejects any candle that
+starts at or after ``as_of``, which makes look-ahead bias structurally
+impossible rather than a discipline: a proposer fed snapshots from last year
+cannot peek at what happened next, so the same proposer is replayable over
+history for calibration scoring.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from gpt_trader.core import Candle
+from gpt_trader.errors import ValidationError
+
+
+class SnapshotIntegrityError(ValidationError):
+    """Raised when snapshot data violates point-in-time guarantees."""
+
+
+@dataclass(frozen=True, slots=True)
+class SymbolSeries:
+    """Ordered candle history for one symbol at one granularity."""
+
+    symbol: str
+    granularity: str
+    candles: tuple[Candle, ...]
+
+    def __post_init__(self) -> None:
+        for earlier, later in zip(self.candles, self.candles[1:], strict=False):
+            if later.ts <= earlier.ts:
+                raise SnapshotIntegrityError(
+                    f"Candles for '{self.symbol}' must be strictly ascending by timestamp; "
+                    f"{later.ts.isoformat()} follows {earlier.ts.isoformat()}",
+                    field="candles",
+                )
+
+    @property
+    def closes(self) -> tuple[Candle, ...]:
+        return self.candles
+
+    def last_close(self) -> Candle:
+        if not self.candles:
+            raise SnapshotIntegrityError(
+                f"Series for '{self.symbol}' has no candles", field="candles"
+            )
+        return self.candles[-1]
+
+
+@dataclass(frozen=True, slots=True)
+class MarketSnapshot:
+    """Frozen view of market data as of a single moment."""
+
+    as_of: datetime
+    source: str
+    series: tuple[SymbolSeries, ...]
+
+    def __post_init__(self) -> None:
+        seen: set[str] = set()
+        for symbol_series in self.series:
+            if symbol_series.symbol in seen:
+                raise SnapshotIntegrityError(
+                    f"Duplicate series for symbol '{symbol_series.symbol}'", field="series"
+                )
+            seen.add(symbol_series.symbol)
+            for candle in symbol_series.candles:
+                if candle.ts >= self.as_of:
+                    raise SnapshotIntegrityError(
+                        f"Candle for '{symbol_series.symbol}' starting {candle.ts.isoformat()} "
+                        f"is not strictly before snapshot as_of {self.as_of.isoformat()}; "
+                        "future or incomplete bars are look-ahead data",
+                        field="as_of",
+                    )
+
+    def symbols(self) -> tuple[str, ...]:
+        return tuple(symbol_series.symbol for symbol_series in self.series)
+
+    def series_for(self, symbol: str) -> SymbolSeries | None:
+        for symbol_series in self.series:
+            if symbol_series.symbol == symbol:
+                return symbol_series
+        return None

--- a/tests/unit/gpt_trader/features/trade_ideas/test_baseline_proposer.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_baseline_proposer.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+
+from gpt_trader.core import Candle
+from gpt_trader.features.trade_ideas import (
+    BaselineProposer,
+    BaselineProposerConfig,
+    MarketSnapshot,
+    Proposer,
+    SymbolSeries,
+    TradeDirection,
+    evaluate_eligibility,
+)
+
+AS_OF = datetime(2026, 6, 12, 0, 0, tzinfo=UTC)
+CONFIG = BaselineProposerConfig(short_window=5, long_window=20, crossover_lookback=3)
+
+
+def make_series(
+    closes: list[str], symbol: str = "BTC-USD", last_volume: str = "1000"
+) -> SymbolSeries:
+    candles = []
+    for index, close in enumerate(closes):
+        price = Decimal(close)
+        volume = Decimal(last_volume) if index == len(closes) - 1 else Decimal("1000")
+        candles.append(
+            Candle(
+                ts=AS_OF - timedelta(days=len(closes) - index),
+                open=price,
+                high=price,
+                low=price,
+                close=price,
+                volume=volume,
+            )
+        )
+    return SymbolSeries(symbol=symbol, granularity="1d", candles=tuple(candles))
+
+
+def snapshot_of(*series: SymbolSeries) -> MarketSnapshot:
+    return MarketSnapshot(as_of=AS_OF, source="coinbase:candles", series=series)
+
+
+GOLDEN_CROSS = ["100"] * 28 + ["102", "104"]
+FLAT = ["100"] * 30
+DOWNTREND = [str(130 - i) for i in range(30)]
+
+
+def test_satisfies_proposer_protocol() -> None:
+    assert isinstance(BaselineProposer(CONFIG), Proposer)
+
+
+def test_fresh_golden_cross_produces_long_idea() -> None:
+    ideas = BaselineProposer(CONFIG).propose(snapshot_of(make_series(GOLDEN_CROSS)))
+
+    assert len(ideas) == 1
+    idea = ideas[0]
+    assert idea.direction is TradeDirection.LONG
+    assert idea.instrument == "BTC-USD"
+    assert evaluate_eligibility(idea) == []
+
+
+def test_idea_records_are_complete_and_pinned() -> None:
+    idea = BaselineProposer(CONFIG).propose(snapshot_of(make_series(GOLDEN_CROSS)))[0]
+
+    assert idea.time_horizon.expires_at == AS_OF + timedelta(hours=CONFIG.expiry_hours)
+    assert idea.data_used == (f"coinbase:candles:BTC-USD:1d:as_of={AS_OF.isoformat()}",)
+    assert idea.max_loss.percent_of_account == CONFIG.risk_per_idea_pct
+    assert idea.entry_zone.lower is not None
+    assert idea.entry_zone.upper is not None
+    assert idea.entry_zone.lower < idea.entry_zone.upper
+
+
+def test_flat_market_produces_nothing() -> None:
+    assert BaselineProposer(CONFIG).propose(snapshot_of(make_series(FLAT))) == []
+
+
+def test_downtrend_produces_nothing() -> None:
+    assert BaselineProposer(CONFIG).propose(snapshot_of(make_series(DOWNTREND))) == []
+
+
+def test_stale_crossover_outside_lookback_produces_nothing() -> None:
+    stale = ["100"] * 20 + [str(102 + 2 * i) for i in range(10)]
+
+    assert BaselineProposer(CONFIG).propose(snapshot_of(make_series(stale))) == []
+
+
+def test_insufficient_history_produces_nothing() -> None:
+    short_history = ["100"] * 10 + ["102", "104"]
+
+    assert BaselineProposer(CONFIG).propose(snapshot_of(make_series(short_history))) == []
+
+
+def test_identical_snapshots_produce_identical_records() -> None:
+    proposer = BaselineProposer(CONFIG)
+
+    first = proposer.propose(snapshot_of(make_series(GOLDEN_CROSS)))[0]
+    second = proposer.propose(snapshot_of(make_series(GOLDEN_CROSS)))[0]
+
+    assert first.record_hash() == second.record_hash()
+    assert first.decision_id == second.decision_id
+
+
+def test_volume_confirmation_raises_confidence() -> None:
+    confirmed = BaselineProposer(CONFIG).propose(
+        snapshot_of(make_series(GOLDEN_CROSS, last_volume="5000"))
+    )[0]
+    unconfirmed = BaselineProposer(CONFIG).propose(
+        snapshot_of(make_series(GOLDEN_CROSS, last_volume="1000"))
+    )[0]
+
+    assert confirmed.confidence.label.value == "medium"
+    assert unconfirmed.confidence.label.value == "low"
+
+
+def test_multi_symbol_snapshot_only_signals_where_warranted() -> None:
+    snapshot = snapshot_of(
+        make_series(GOLDEN_CROSS, symbol="BTC-USD"),
+        make_series(FLAT, symbol="ETH-USD"),
+    )
+
+    ideas = BaselineProposer(CONFIG).propose(snapshot)
+
+    assert [idea.instrument for idea in ideas] == ["BTC-USD"]
+    assert "btcusd" in ideas[0].decision_id
+
+
+@pytest.mark.parametrize("symbol", ["BTC-USD", "ETH-USD"])
+def test_decision_ids_are_distinct_per_symbol(symbol: str) -> None:
+    idea = BaselineProposer(CONFIG).propose(snapshot_of(make_series(GOLDEN_CROSS, symbol=symbol)))[
+        0
+    ]
+
+    assert symbol.lower().replace("-", "") in idea.decision_id

--- a/tests/unit/gpt_trader/features/trade_ideas/test_snapshot.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_snapshot.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+
+from gpt_trader.core import Candle
+from gpt_trader.features.trade_ideas import (
+    MarketSnapshot,
+    SnapshotIntegrityError,
+    SymbolSeries,
+)
+
+AS_OF = datetime(2026, 6, 12, 0, 0, tzinfo=UTC)
+
+
+def make_candle(days_before_as_of: int, close: str = "100") -> Candle:
+    price = Decimal(close)
+    return Candle(
+        ts=AS_OF - timedelta(days=days_before_as_of),
+        open=price,
+        high=price,
+        low=price,
+        close=price,
+        volume=Decimal("1000"),
+    )
+
+
+def test_valid_snapshot_construction() -> None:
+    series = SymbolSeries(
+        symbol="BTC-USD",
+        granularity="1d",
+        candles=(make_candle(3), make_candle(2), make_candle(1)),
+    )
+
+    snapshot = MarketSnapshot(as_of=AS_OF, source="coinbase:candles", series=(series,))
+
+    assert snapshot.symbols() == ("BTC-USD",)
+    assert snapshot.series_for("BTC-USD") is series
+    assert snapshot.series_for("ETH-USD") is None
+
+
+def test_candle_at_or_after_as_of_is_rejected() -> None:
+    series = SymbolSeries(
+        symbol="BTC-USD",
+        granularity="1d",
+        candles=(make_candle(1), make_candle(0)),
+    )
+
+    with pytest.raises(SnapshotIntegrityError, match="look-ahead"):
+        MarketSnapshot(as_of=AS_OF, source="coinbase:candles", series=(series,))
+
+
+def test_unordered_candles_are_rejected() -> None:
+    with pytest.raises(SnapshotIntegrityError, match="ascending"):
+        SymbolSeries(
+            symbol="BTC-USD",
+            granularity="1d",
+            candles=(make_candle(1), make_candle(2)),
+        )
+
+
+def test_duplicate_symbols_are_rejected() -> None:
+    series = SymbolSeries(symbol="BTC-USD", granularity="1d", candles=(make_candle(1),))
+
+    with pytest.raises(SnapshotIntegrityError, match="Duplicate"):
+        MarketSnapshot(as_of=AS_OF, source="coinbase:candles", series=(series, series))
+
+
+def test_empty_series_has_no_last_close() -> None:
+    series = SymbolSeries(symbol="BTC-USD", granularity="1d", candles=())
+
+    with pytest.raises(SnapshotIntegrityError, match="no candles"):
+        series.last_close()

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,8 +7,8 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6544,
-    "total_files": 770,
+    "total_tests": 6560,
+    "total_files": 772,
     "markers_used": 16
   },
   "quick_commands": {

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,9 +95,9 @@
     ]
   },
   "counts": {
-    "unit": 6379,
+    "unit": 6395,
     "asyncio": 372,
-    "parametrize": 173,
+    "parametrize": 174,
     "endpoints": 83,
     "property": 82,
     "integration": 79,

--- a/var/agents/testing/source_test_map.json
+++ b/var/agents/testing/source_test_map.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "summary": {
-    "tests_scanned": 690,
+    "tests_scanned": 692,
     "source_modules": 367,
     "unresolved_modules": 3
   },
@@ -434,6 +434,8 @@
       "tests/unit/gpt_trader/features/live_trade/test_bot_flatten_and_stop.py",
       "tests/unit/gpt_trader/features/live_trade/test_risk.py",
       "tests/unit/gpt_trader/features/live_trade/test_risk_time_windows.py",
+      "tests/unit/gpt_trader/features/trade_ideas/test_baseline_proposer.py",
+      "tests/unit/gpt_trader/features/trade_ideas/test_snapshot.py",
       "tests/unit/gpt_trader/tui/test_app_bootstrap_snapshot.py"
     ],
     "gpt_trader.core.account": [
@@ -1235,11 +1237,13 @@
     ],
     "gpt_trader.features.trade_ideas": [
       "tests/unit/gpt_trader/features/trade_ideas/test_audit.py",
+      "tests/unit/gpt_trader/features/trade_ideas/test_baseline_proposer.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_budget.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_eligibility.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_models.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_policy.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_service.py",
+      "tests/unit/gpt_trader/features/trade_ideas/test_snapshot.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_store.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_workflow.py"
     ],
@@ -3756,6 +3760,10 @@
     "tests/unit/gpt_trader/features/trade_ideas/test_audit.py": [
       "gpt_trader.features.trade_ideas"
     ],
+    "tests/unit/gpt_trader/features/trade_ideas/test_baseline_proposer.py": [
+      "gpt_trader.core",
+      "gpt_trader.features.trade_ideas"
+    ],
     "tests/unit/gpt_trader/features/trade_ideas/test_budget.py": [
       "gpt_trader.features.trade_ideas"
     ],
@@ -3769,6 +3777,10 @@
       "gpt_trader.features.trade_ideas"
     ],
     "tests/unit/gpt_trader/features/trade_ideas/test_service.py": [
+      "gpt_trader.features.trade_ideas"
+    ],
+    "tests/unit/gpt_trader/features/trade_ideas/test_snapshot.py": [
+      "gpt_trader.core",
       "gpt_trader.features.trade_ideas"
     ],
     "tests/unit/gpt_trader/features/trade_ideas/test_store.py": [

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,8 +2,8 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6544,
-    "total_files": 770,
+    "total_tests": 6560,
+    "total_files": 772,
     "markers_used": 16
   },
   "marker_definitions": {
@@ -102,9 +102,9 @@
     ]
   },
   "marker_counts": {
-    "unit": 6379,
+    "unit": 6395,
     "asyncio": 372,
-    "parametrize": 173,
+    "parametrize": 174,
     "endpoints": 83,
     "property": 82,
     "integration": 79,
@@ -520,11 +520,13 @@
       "tests/unit/gpt_trader/features/strategy_tools/test_strategy_enhancements_edges.py",
       "tests/unit/gpt_trader/features/strategy_tools/test_strategy_tools_import.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_audit.py",
+      "tests/unit/gpt_trader/features/trade_ideas/test_baseline_proposer.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_budget.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_eligibility.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_models.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_policy.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_service.py",
+      "tests/unit/gpt_trader/features/trade_ideas/test_snapshot.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_store.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_workflow.py"
     ],
@@ -31480,6 +31482,97 @@
         "docstring": ""
       }
     ],
+    "tests/unit/gpt_trader/features/trade_ideas/test_baseline_proposer.py": [
+      {
+        "name": "test_satisfies_proposer_protocol",
+        "line": 52,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_fresh_golden_cross_produces_long_idea",
+        "line": 56,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_idea_records_are_complete_and_pinned",
+        "line": 66,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_flat_market_produces_nothing",
+        "line": 77,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_downtrend_produces_nothing",
+        "line": 81,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_stale_crossover_outside_lookback_produces_nothing",
+        "line": 85,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_insufficient_history_produces_nothing",
+        "line": 91,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_identical_snapshots_produce_identical_records",
+        "line": 97,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_volume_confirmation_raises_confidence",
+        "line": 107,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_multi_symbol_snapshot_only_signals_where_warranted",
+        "line": 119,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_decision_ids_are_distinct_per_symbol",
+        "line": 132,
+        "markers": [
+          "parametrize",
+          "unit"
+        ],
+        "docstring": ""
+      }
+    ],
     "tests/unit/gpt_trader/features/trade_ideas/test_budget.py": [
       {
         "name": "test_seeded_defaults_reflect_accepted_risk_philosophy",
@@ -31820,6 +31913,48 @@
       {
         "name": "test_expire_is_a_system_action",
         "line": 127,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      }
+    ],
+    "tests/unit/gpt_trader/features/trade_ideas/test_snapshot.py": [
+      {
+        "name": "test_valid_snapshot_construction",
+        "line": 30,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_candle_at_or_after_as_of_is_rejected",
+        "line": 44,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_unordered_candles_are_rejected",
+        "line": 55,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_duplicate_symbols_are_rejected",
+        "line": 64,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_empty_series_has_no_last_close",
+        "line": 71,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary

Bricks 1–2 of the proposer path agreed in the direction discussion (see `docs/OPERATING_RUBRIC.md`, Stage 1).

**`snapshot.py` — `MarketSnapshot` + `SymbolSeries`:** a frozen point-in-time view of market data. Construction rejects any candle at or after `as_of`, so look-ahead bias is structurally impossible rather than a discipline — the same proposer can be replayed over historical snapshots for calibration scoring. Reuses the canonical `gpt_trader.core.Candle`.

**`proposer.py` — `Proposer` protocol:** snapshot in, eligible records out. Deterministic baseline and future LLM proposers implement the same contract so they can be scored head-to-head on identical inputs. Proposers never see "the present" and never submit anything.

**`baseline.py` — `BaselineProposer`:** long-only MA-crossover benchmark. Fully deterministic — identical snapshots produce byte-identical records (stable decision ids + record hashes). Emits complete `TradeIdea` records: thesis with numbers, entry band, invalidation at the long average, 2R target, risk-pct max loss with stop-distance assumptions, volume-confirmation confidence, pinned `data_used` provenance, 48h expiry. Raises rather than emit an ineligible idea. This is the benchmark every fancier proposer must beat.

## Verification

- 100 slice tests (17 new: snapshot integrity, golden cross fires, flat/downtrend/stale-cross/short-history produce nothing, determinism, eligibility, volume confirmation, multi-symbol)
- Full suite: 6,812 passed, 8 skipped
- ruff, black, mypy, agent-naming, agent-regenerate — clean