### PR TITLE
Extract Coinbase price-validation order-type set

### DIFF
--- a/src/gpt_trader/features/brokerages/coinbase/specs.py
+++ b/src/gpt_trader/features/brokerages/coinbase/specs.py
@@ -23,6 +23,8 @@ from gpt_trader.utilities.quantization import quantize_price_side_aware
 
 logger = get_logger(__name__, component="coinbase_specs")
 
+PRICE_VALIDATED_ORDER_TYPES = frozenset({"LIMIT", "STOP_LIMIT"})
+
 
 class ProductSpec:
     """Product specification with quantization rules."""
@@ -218,7 +220,7 @@ class SpecsService:
             return result
 
         # Validate price if provided (for limit/stop orders)
-        if price is not None and order_type.upper() in ["LIMIT", "STOP_LIMIT"]:
+        if price is not None and order_type.upper() in PRICE_VALIDATED_ORDER_TYPES:
             price_decimal = Decimal(str(price))
             quantized_price = self.quantize_price_side_aware(product_id, side, price)
 

--- a/tests/unit/gpt_trader/features/brokerages/coinbase/test_specs_order.py
+++ b/tests/unit/gpt_trader/features/brokerages/coinbase/test_specs_order.py
@@ -4,7 +4,16 @@ from __future__ import annotations
 
 from decimal import Decimal
 
-from gpt_trader.features.brokerages.coinbase.specs import SpecsService
+from gpt_trader.features.brokerages.coinbase.specs import (
+    PRICE_VALIDATED_ORDER_TYPES,
+    SpecsService,
+)
+
+
+def test_price_validated_order_types_are_constant_membership_set():
+    """Price validation order types use a reusable constant set."""
+
+    assert PRICE_VALIDATED_ORDER_TYPES == frozenset({"LIMIT", "STOP_LIMIT"})
 
 
 class TestSpecsServiceCalculateSafePositionSize:


### PR DESCRIPTION
## Summary
- add a reusable `PRICE_VALIDATED_ORDER_TYPES` frozenset for Coinbase order validation
- replace inline list membership in price validation with the constant
- add a focused unit check documenting the constant contents

## Tests
- `uv run pytest tests/unit/gpt_trader/features/brokerages/coinbase/test_specs_order.py tests/unit/gpt_trader/features/brokerages/coinbase/test_specs_validation.py -q` → 19 passed in 0.23s
- `uv run ruff check src/gpt_trader/features/brokerages/coinbase/specs.py tests/unit/gpt_trader/features/brokerages/coinbase/test_specs_order.py` → All checks passed!
- `uv run black --check src/gpt_trader/features/brokerages/coinbase/specs.py tests/unit/gpt_trader/features/brokerages/coinbase/test_specs_order.py` → 2 files would be left unchanged.
- `uv run local-ci --profile quick` → Local CI passed; 6780 passed, 8 skipped in 27.16s

## Notes
- Draft PR opened under standing RJ-owned repo collaboration authority.
- No merge/release/settings/secret/deploy/trading action requested or taken.
