### PR TITLE
Offload file notification connection check

### DIFF
--- a/src/gpt_trader/monitoring/notifications/backends.py
+++ b/src/gpt_trader/monitoring/notifications/backends.py
@@ -290,8 +290,11 @@ class FileNotificationBackend:
             return False
 
         try:
-            with open(self.file_path, "a"):
-                pass  # Just test if we can open for append
+            await asyncio.to_thread(self._check_file_writable)
             return True
         except Exception:
             return False
+
+    def _check_file_writable(self) -> None:
+        with open(self.file_path, "a"):
+            pass  # Just test if we can open for append

--- a/tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_core.py
+++ b/tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_core.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import tempfile
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 from gpt_trader.monitoring.alert_types import Alert, AlertSeverity
+from gpt_trader.monitoring.notifications import backends as backends_module
 from gpt_trader.monitoring.notifications.backends import (
     ConsoleNotificationBackend,
     FileNotificationBackend,
@@ -105,6 +107,30 @@ class TestFileNotificationBackend:
             backend = FileNotificationBackend(file_path=file_path)
             result = await backend.test_connection()
             assert result is True
+        finally:
+            Path(file_path).unlink(missing_ok=True)
+
+    @pytest.mark.asyncio
+    async def test_test_connection_offloads_file_check_to_thread(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[tuple[Any, tuple[Any, ...]]] = []
+
+        async def fake_to_thread(func, /, *args, **kwargs):
+            calls.append((func, args))
+            return func(*args, **kwargs)
+
+        monkeypatch.setattr(backends_module.asyncio, "to_thread", fake_to_thread)
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
+            file_path = f.name
+
+        try:
+            backend = FileNotificationBackend(file_path=file_path)
+            result = await backend.test_connection()
+
+            assert result is True
+            assert calls == [(backend._check_file_writable, ())]
         finally:
             Path(file_path).unlink(missing_ok=True)
 


### PR DESCRIPTION
## Summary
- move `FileNotificationBackend.test_connection`'s file-open writability probe into `asyncio.to_thread`
- add a focused unit test to pin the offload behavior
- keep the change scoped to the file notification backend

## Tests
- `uv run pytest tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_core.py tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_edges.py -q` → 14 passed in 0.18s
- `uv run ruff check src/gpt_trader/monitoring/notifications/backends.py tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_core.py tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_edges.py` → All checks passed!
- `uv run black --check src/gpt_trader/monitoring/notifications/backends.py tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_core.py tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_edges.py` → 3 files would be left unchanged.
- `uv run local-ci --profile quick` → Local CI passed; 6780 passed, 8 skipped in 36.11s

## Notes
- Draft PR opened under standing RJ-owned repo collaboration authority.
- No merge/release/settings/secret/deploy/trading action requested or taken.
