### PR TITLE
Add replay scoring foundation for broker-neutral trade ideas

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ When adding a new doc, link it below in the best-fit section.
 | [Live Operations Guide](production.md) | Readiness-gated live operations, rollback, and emergency procedures |
 | [Readiness Checklist](READINESS.md) | Gates to move from paper to live trading |
 | [Pre-Migration Decision Framework](PRE_MIGRATION_DECISION_FRAMEWORK.md) | AI-assisted trading autonomy, product, venue, approval, and audit gates |
+| [Trade-Idea Interface Design Notes](specs/TRADE_IDEA_INTERFACES_DESIGN_NOTES.md) | Proposed CLI/TUI workstreams for human-approved trade ideas |
 | [Operating Rubric](OPERATING_RUBRIC.md) | Staged capabilities and graduation evidence for the autonomous entity |
 | [Reliability Guide](RELIABILITY.md) | Guard stack, degradation responses, chaos testing |
 | [TUI Guide](TUI_GUIDE.md) | Launching and operating the terminal UI |

--- a/docs/specs/TRADE_IDEA_CLI_SPEC.md
+++ b/docs/specs/TRADE_IDEA_CLI_SPEC.md
@@ -1,0 +1,219 @@
+---
+status: draft
+last-updated: 2026-06-12
+workstream: 1 (see TRADE_IDEA_INTERFACES_DESIGN_NOTES.md)
+depends-on: Workstream 0 (service factory, error codes, actor resolution)
+---
+
+# Implementation Spec: `gpt-trader ideas` CLI Command Group
+
+## Goal
+
+A complete, scriptable CLI surface over `TradeIdeaService` so that AI agents
+can propose trade-idea records and humans can review them, with JSON output
+for programmatic use. This is the first working door into the staged-autonomy
+workflow.
+
+## Files
+
+| File | Action |
+|------|--------|
+| `src/gpt_trader/cli/commands/ideas.py` | New — command group |
+| `src/gpt_trader/cli/__init__.py` | Add `ideas.register(subparsers)` alongside existing registrations |
+| `src/gpt_trader/cli/response.py` | Add `POLICY_VIOLATION`, `IDEA_NOT_FOUND` to `CliErrorCode` |
+| `src/gpt_trader/features/trade_ideas/service.py` | Add `DEFAULT_IDEAS_ROOT`, `create_trade_idea_service()` factory |
+| `tests/unit/gpt_trader/cli/commands/test_ideas_*.py` | New tests (split by lifecycle/query/budget) |
+
+Follow the structure of `cli/commands/controls.py`: a `register(subparsers)`
+function, one `_handle_*` per subcommand returning `CliResponse`, with
+`options.add_output_options(parser)` on every subcommand.
+
+## Common options
+
+Every subcommand accepts:
+
+- `--format {text,json}` (via `options.add_output_options`)
+- `--ideas-root PATH` — override storage root (default: `GPT_TRADER_IDEAS_ROOT`
+  env, then `var/data/trade_ideas/`)
+
+Every mutating subcommand accepts:
+
+- `--actor ID` — actor identity (default: `GPT_TRADER_ACTOR` env, then OS user)
+
+## Command tree
+
+```
+gpt-trader ideas
+├── propose          --file PATH | --stdin   [--actor-type {ai,human}] [--reason TEXT]
+├── resubmit         --file PATH | --stdin   [--actor-type {ai,human}] [--reason TEXT]
+├── list             [--state STATE]
+├── show             DECISION_ID [--events]
+├── approve          DECISION_ID --reason TEXT
+├── reject           DECISION_ID --reason TEXT
+├── request-changes  DECISION_ID --reason TEXT
+├── cancel           DECISION_ID --reason TEXT
+├── expire           DECISION_ID [--reason TEXT] | --sweep
+├── mark-submitted   DECISION_ID --venue {coinbase,manual} [--external-order-id ID] [--reason TEXT]
+├── mark-filled      DECISION_ID --venue {coinbase,manual} [--external-order-id ID] [--reason TEXT]
+├── budget
+│   ├── show
+│   └── set          --reason TEXT [one flag per RiskBudget field]
+└── audit
+    ├── tail         [-n N] [--decision-id ID]
+    └── verify
+```
+
+### `ideas propose`
+
+- Input: a `TradeIdea` JSON document (the `to_dict` shape from
+  `features/trade_ideas/models.py`) from `--file` or stdin. `--file` and
+  `--stdin` are mutually exclusive; one is required.
+- Parse via `TradeIdea.from_dict`. `KeyError`/`ValueError` →
+  `INVALID_ARGUMENT` naming the missing/invalid field.
+- Call `service.propose(idea, actor_id=..., actor_type=...)`.
+- On success, `data` contains `decision_id`, `state`, `record_hash`, and the
+  eligibility preview: `violations` from
+  `ApprovalPolicy().approval_violations(...)` evaluated read-only with the
+  current budget, so the proposer immediately sees whether the idea could be
+  approved as-is. Preview violations are `warnings`, not errors — propose
+  still succeeds (rejection happens at review, per the framework).
+- Text: `✓ ideas propose OK (trade-20260612-001, state=proposed)` followed by
+  `⚠ would fail approval: <reason>` lines if any.
+
+### `ideas resubmit`
+
+Same input handling as `propose`; calls `service.resubmit`. The record must
+already exist (`IDEA_NOT_FOUND` otherwise). Service/audit layer enforces the
+`needs_changes → proposed` transition; surface `InvalidTransitionError` as
+`VALIDATION_ERROR`.
+
+### `ideas list`
+
+- `--state` choices = `TradeIdeaState` values. Calls
+  `service.list_views(state)`.
+- Text: aligned table — `DECISION_ID  STATE  INSTRUMENT  DIRECTION
+  MAX_LOSS%  EXPIRES_AT`. JSON: `data["ideas"]` = list of
+  `{decision_id, state, instrument, direction, max_loss_pct, expires_at,
+  confidence}`.
+- Empty store is success with an empty list, not an error.
+
+### `ideas show DECISION_ID`
+
+- Calls `service.get`. `data` = full `idea.to_dict()` plus `state`.
+- `--events` additionally includes the audit history
+  (`[e.to_dict() for e in view.events]`).
+- Text: field-per-line record rendering; with `--events`, a chronological
+  `timestamp  actor_type/actor_id  action  before→after  reason` table.
+
+### `ideas approve DECISION_ID --reason TEXT`
+
+- `actor_type` hard-coded `HUMAN`. `--reason` required and non-empty.
+- `PolicyViolationError` → exit 1, code `POLICY_VIOLATION`,
+  `data["violations"]` = full list. Text mode:
+
+  ```
+  ✗ ideas approve FAILED: approval refused (3 violations)
+    - max_loss 8% exceeds budget cap of 5% per idea
+    - 2 tickets already approved; budget allows 2 concurrent approved tickets
+    - Idea expired at 2026-06-11T20:00:00+00:00; approve nothing stale
+  ```
+
+### `ideas reject` / `request-changes` / `cancel`
+
+Thin wrappers over `service.reject` / `service.request_changes` /
+`service.cancel` with `actor_type=HUMAN` and required `--reason`.
+
+### `ideas expire`
+
+- `ideas expire DECISION_ID` — expire one idea (service defaults for
+  reason/actor unless overridden).
+- `ideas expire --sweep` — list all non-terminal views, expire each whose
+  `time_horizon.expires_at` is set and `<= now`. Report
+  `data["expired"]` = list of decision_ids; success even when zero matched
+  (`was_noop=True`). DECISION_ID and `--sweep` are mutually exclusive;
+  one is required.
+
+### `ideas mark-submitted` / `ideas mark-filled`
+
+- Wrap `service.record_submission` / `service.record_fill`.
+- **These record manually executed tickets; they never touch a broker API.**
+  Help text must say so.
+- `--venue` choices: `coinbase`, `manual` (no INTX-specific venue surface).
+
+### `ideas budget show` / `ideas budget set`
+
+- `show`: `data` = `service.current_budget().to_dict()` (this seeds defaults
+  on first use — acceptable and documented).
+- `set`: one optional flag per `RiskBudget` field
+  (`--max-loss-per-idea-pct`, `--max-daily-loss-pct`,
+  `--max-open-notional-pct`, `--max-concurrent-approved-tickets`,
+  `--max-review-latency-hours`, `--sizing-capped-by-budget {true,false}`,
+  `--gain-retention-floor-pct`, `--allow-futures-leverage {true,false}`,
+  `--allow-naked-shorts {true,false}`), plus required `--reason`. Build the
+  new `RiskBudget` by copying the current one with overrides and
+  `version = current.version + 1`; call
+  `service.update_budget(budget, ActorType.HUMAN, actor_id)`.
+  At least one field flag is required (`MISSING_ARGUMENT` otherwise).
+  `PolicyViolationError` → `POLICY_VIOLATION`.
+
+### `ideas audit tail` / `ideas audit verify`
+
+- `tail`: last N events (default 20) from
+  `service.audit_log.read_events(decision_id)`, newest last.
+- `verify`: full read of the audit log; `AuditIntegrityError` →
+  `✗ ideas audit verify FAILED: <reason>` with `OPERATION_FAILED`. Success
+  reports event count: `✓ ideas audit verify OK (142 events)`.
+
+## Output standards
+
+Per CLAUDE.md: text mode prints `✓ ideas <action> OK (<details>)` /
+`✗ ideas <action> FAILED: <error>`; exit 0 on success, 1 on failure; JSON
+mode returns the `CliResponse` envelope with `command="ideas <subcommand>"`.
+
+## Serialization notes
+
+- `Decimal` fields (`MaxLoss`, `RiskBudget`) serialize as strings via the
+  models' own `to_dict`; do not re-serialize with `float()`.
+- Timestamps render ISO-8601 UTC.
+- Never print secrets; the audit contract forbids credentials in any record.
+
+## Test plan (tests/unit/gpt_trader/cli/commands/)
+
+Use a `tmp_path`-rooted service via `--ideas-root` (no monkeypatching of
+globals needed; this is why the flag exists). Fixture helper builds a valid
+`TradeIdea` dict matching `eligibility` requirements.
+
+Required cases:
+
+1. `propose` from file and stdin → success, record on disk, audit event
+   appended, eligibility warnings surfaced for a non-compliant idea.
+2. `propose` with missing required field → `INVALID_ARGUMENT`, names field.
+3. `list` empty store → success, empty list. `list --state proposed` filters.
+4. `show` unknown id → `IDEA_NOT_FOUND`. `show --events` includes history.
+5. `approve` happy path → state `approved`, human actor in audit event.
+6. `approve` over-budget idea → exit 1, `POLICY_VIOLATION`, all violations in
+   `data["violations"]` (assert ≥2 violations both present).
+7. `request-changes` → `resubmit` (revised record) → `approve` full loop.
+8. `reject`, `cancel`, `expire` single, `expire --sweep` (one stale + one
+   fresh idea: only stale expires; `was_noop` when none).
+9. `mark-submitted` then `mark-filled` with venue/external id recorded in
+   audit events.
+10. `budget show` seeds defaults; `budget set --max-loss-per-idea-pct 2
+    --reason ...` bumps version; `budget set` with no field flags →
+    `MISSING_ARGUMENT`.
+11. `audit verify` OK path; tampered line in `audit.jsonl` → failure.
+12. JSON mode for at least propose/approve/list asserting the
+    `CliResponse` envelope per CLAUDE.md patterns
+    (`result.errors[0].code == CliErrorCode.POLICY_VIOLATION.value`).
+
+## Acceptance criteria
+
+- [ ] `gpt-trader ideas --help` lists all subcommands with accurate help text.
+- [ ] Full loop works on a clean checkout with no env vars:
+      propose → list → show → approve → mark-submitted → mark-filled,
+      and the audit log verifies afterward.
+- [ ] No import from `features/brokerages/` or `features/live_trade/` in
+      `ideas.py` (enforce by review; this surface must stay execution-free).
+- [ ] All policy violations reach the user; no first-error-only truncation.
+- [ ] `uv run agent-check`, `agent-naming`, `mypy`, `ruff`, `black` clean.
+- [ ] Test plan above implemented; `uv run pytest tests/unit -q` green.

--- a/docs/specs/TRADE_IDEA_INTERFACES_DESIGN_NOTES.md
+++ b/docs/specs/TRADE_IDEA_INTERFACES_DESIGN_NOTES.md
@@ -1,0 +1,154 @@
+---
+status: draft
+last-updated: 2026-06-12
+scope: Operator and agent interfaces over the trade_ideas slice
+audience: Implementation agents (Codex) and reviewers
+---
+
+# Trade-Idea Interfaces — Design Notes
+
+## Context
+
+The accepted direction (docs/PRE_MIGRATION_DECISION_FRAMEWORK.md) is staged
+autonomy: AI drafts complete trade-idea records, a human approves them, and
+every state change lands in an append-only audit log. The core slice for this
+already exists and is complete at the domain level:
+
+| Module | Provides |
+|--------|----------|
+| `features/trade_ideas/models.py` | `TradeIdea` record (frozen dataclass, `to_dict`/`from_dict`, `record_hash`) |
+| `features/trade_ideas/workflow.py` | `TradeIdeaState`, `ALLOWED_TRANSITIONS`, `validate_transition` |
+| `features/trade_ideas/service.py` | `TradeIdeaService` — the one audited code path for every actor |
+| `features/trade_ideas/policy.py` | `ApprovalPolicy` — autonomy mode as enforceable checks |
+| `features/trade_ideas/budget.py` | `RiskBudget`, versioned `RiskBudgetLog`, seeded defaults |
+| `features/trade_ideas/audit.py` | Append-only `TradeIdeaAuditLog` (JSONL), `AuditEvent` |
+| `features/trade_ideas/store.py` | `TradeIdeaStore` — versioned records under record hash |
+| `features/trade_ideas/baseline.py`, `replay.py` | Baseline proposer and replay scoring |
+
+**The gap:** no human or agent can reach this service today. There is no CLI
+command, no TUI screen, and `TradeIdeaService` is constructed nowhere in
+production code (only tests). The approval workflow exists but has no door.
+The service docstring states the intent explicitly: *"interfaces such as CLI,
+TUI, or MCP servers must stay thin adapters over these methods."*
+
+These notes define the two interface workstreams that close the gap, plus the
+shared wiring they both need.
+
+## Design Principles
+
+1. **Thin adapters only.** Interfaces parse input, resolve actor identity,
+   call one `TradeIdeaService` method, and render the result. No workflow,
+   policy, or budget logic in CLI/TUI code. If an interface needs a new
+   behavior, it goes into the service first.
+2. **Every action is identity-stamped.** No anonymous mutations. Each
+   mutating command requires an `actor_id` and an `actor_type`; review
+   actions from interactive interfaces are always `ActorType.HUMAN`.
+3. **No execution lane.** Nothing in these workstreams places, modifies, or
+   cancels broker orders. `mark-submitted` / `mark-filled` are audit
+   bookkeeping for manually executed tickets, not order routing.
+4. **Policy refusals are first-class UX.** `PolicyViolationError.violations`
+   is a list of every reason an approval was refused. Interfaces must show
+   the full list, never just the first reason or a generic failure.
+5. **JSON-first for agents.** All CLI commands support
+   `--format json` via the existing `CliResponse` envelope so Codex/Claude
+   and CI can drive the workflow programmatically. Text output follows the
+   `✓`/`✗` standards in CLAUDE.md.
+6. **Append-only mindset.** Interfaces never edit records in place. A change
+   request produces a `needs_changes` event; the revised record is a new
+   version saved via `resubmit`.
+
+## Shared Decisions (Workstream 0 — prerequisite)
+
+Both interfaces need the following; implement once, first.
+
+### Storage root
+
+- Default root: `var/data/trade_ideas/` (consistent with the existing
+  `var/data/status.json` convention). The service derives
+  `records/`, `audit.jsonl`, and `risk_budget.jsonl` under it.
+- Override: environment variable `GPT_TRADER_IDEAS_ROOT`; CLI also accepts
+  `--ideas-root PATH` (highest precedence) for tests and sandboxing.
+
+### Service factory
+
+Add to `features/trade_ideas/service.py`:
+
+```python
+DEFAULT_IDEAS_ROOT = Path("var/data/trade_ideas")
+
+def create_trade_idea_service(root: Path | None = None) -> TradeIdeaService:
+    """Resolve root (arg > GPT_TRADER_IDEAS_ROOT > default) and build the service."""
+```
+
+Optionally expose a cached `trade_idea_service` property on
+`ApplicationContainer` (see `docs/DI_POLICY.md`); the CLI may construct the
+service directly via the factory since idea review has no broker or config
+dependency, but the container property is the long-term home once the
+proposer loop runs inside the bot.
+
+### Actor identity resolution
+
+Precedence for `actor_id`: `--actor` flag → `GPT_TRADER_ACTOR` env var →
+`getpass.getuser()`. The resolved value is recorded verbatim in the audit
+log. `actor_type` rules:
+
+| Action | actor_type |
+|--------|-----------|
+| `propose`, `resubmit` | `ai` by default; `--actor-type human` allowed |
+| `approve`, `reject`, `request-changes`, `cancel` | always `human` (the policy enforces this for approve; interfaces hard-code it for the rest) |
+| `expire` (sweep) | `system` |
+| `mark-submitted` | `system` (default per service) or `human` |
+| `mark-filled` | `venue` (default per service) |
+| budget `set` | `human` (policy refuses non-human in current mode) |
+
+### Error mapping
+
+Add two members to `CliErrorCode` in `cli/response.py`:
+`POLICY_VIOLATION = "POLICY_VIOLATION"` and
+`IDEA_NOT_FOUND = "IDEA_NOT_FOUND"`.
+
+| Exception | CliErrorCode | Exit | Notes |
+|-----------|--------------|------|-------|
+| `PolicyViolationError` | `POLICY_VIOLATION` | 1 | Put `violations` list in `data["violations"]`; text mode prints each on its own line |
+| `UnknownTradeIdeaError` | `IDEA_NOT_FOUND` | 1 | |
+| `InvalidTransitionError` | `VALIDATION_ERROR` | 1 | |
+| `AuditIntegrityError` / `BudgetIntegrityError` | `OPERATION_FAILED` | 1 | Integrity failures are loud, never swallowed |
+| Malformed input JSON / missing fields | `INVALID_ARGUMENT` | 1 | Report the offending field |
+
+## Workstreams
+
+| # | Spec | Depends on | Size |
+|---|------|-----------|------|
+| 0 | Shared wiring (this doc, "Shared Decisions") | — | S |
+| 1 | [`TRADE_IDEA_CLI_SPEC.md`](TRADE_IDEA_CLI_SPEC.md) — `gpt-trader ideas` command group | 0 | M |
+| 2 | [`TRADE_IDEA_TUI_REVIEW_SPEC.md`](TRADE_IDEA_TUI_REVIEW_SPEC.md) — Ideas review screen | 0 (not 1) | M |
+
+Workstreams 1 and 2 are independently mergeable. Ship 0+1 first: the CLI is
+the agent-facing surface and unblocks the AI-propose → human-approve loop
+end to end; the TUI improves the human half afterward.
+
+## Non-Goals (all workstreams)
+
+- No order submission, modification, or cancellation through any broker API.
+- No broker-ticket payload generation (derived artifacts come later, after
+  approval-lane experience).
+- No bounded-autonomy behavior; `ApprovalPolicy` defaults stand.
+- No INTX surfaces (frozen).
+- No MCP server (a future workstream; the CLI JSON mode is the agent surface
+  for now).
+- No editing of historical records or audit events, ever.
+
+## Conventions Codex Must Follow
+
+- Naming: banned abbreviations `cfg`, `svc`, `mgr`, `util`, `utils`, `amt`,
+  `calc`, `upd` (see `docs/naming.md`). Run `uv run agent-naming`.
+- Tests: prefer `monkeypatch`; assert on `CliResponse` per CLAUDE.md
+  (`result.errors[0].code == CliErrorCode.X.value`). Unit tests live under
+  `tests/unit/gpt_trader/...` mirroring source paths.
+- Quality gate before PR: `uv run agent-check` (or `/quality`), plus
+  `uv run ruff check . --fix`, `uv run black .`, `uv run mypy src/gpt_trader`.
+- TUI CSS: edit modules under `src/gpt_trader/tui/styles/`, then run
+  `python scripts/build_tui_css.py`; never edit `styles/main.tcss` directly.
+  `DEFAULT_CSS` blocks use hardcoded hex with `/* $variable */` comments.
+- Import boundaries: `scripts/ci/check_import_boundaries.py` runs in CI —
+  keep interface code free of cross-slice imports it would flag.

--- a/docs/specs/TRADE_IDEA_TUI_REVIEW_SPEC.md
+++ b/docs/specs/TRADE_IDEA_TUI_REVIEW_SPEC.md
@@ -1,0 +1,167 @@
+---
+status: draft
+last-updated: 2026-06-12
+workstream: 2 (see TRADE_IDEA_INTERFACES_DESIGN_NOTES.md)
+depends-on: Workstream 0 (service factory, actor resolution); independent of the CLI workstream
+---
+
+# Implementation Spec: TUI Trade-Idea Review Screen
+
+## Goal
+
+A Textual screen where the human reviewer — the approval gate of
+`human_approved_execution` mode — can triage proposed trade ideas: read the
+full thesis/risk record, see exactly which policy checks pass or fail, and
+approve, reject, or request changes with a recorded reason. This is the
+operator decision point the framework requires.
+
+## Scope
+
+Review and audit only. The screen never proposes ideas (that is the AI/CLI
+lane), never edits records, and never touches a broker. It works in every TUI
+mode including demo, because it reads the filesystem-backed idea store, not
+the bot runtime.
+
+## Files
+
+| File | Action |
+|------|--------|
+| `src/gpt_trader/tui/screens/ideas_review_screen.py` | New — `IdeasReviewScreen(Screen)` + reason-input modal |
+| `src/gpt_trader/tui/screens/__init__.py` | Export the screen (match existing pattern) |
+| `src/gpt_trader/tui/app.py` (or `main_screen.py` — wherever global BINDINGS live) | Add binding + action to push the screen. Verify no key conflict before choosing; prefer `I` ("Ideas") |
+| `src/gpt_trader/tui/styles/screens/ideas_review.tcss` | New CSS module; then run `python scripts/build_tui_css.py` |
+| `tests/unit/gpt_trader/tui/test_ideas_review_screen.py` | New — behavior tests |
+| `tests/unit/gpt_trader/tui/test_snapshots_ideas_review.py` | New — snapshot tests |
+
+## Architecture decisions
+
+- **Service access:** construct via `create_trade_idea_service()` on mount
+  (root from `GPT_TRADER_IDEAS_ROOT` or default), injectable through the
+  screen constructor for tests:
+  `IdeasReviewScreen(service: TradeIdeaService | None = None)`.
+- **Not wired into `StateRegistry`/`TuiState`:** idea review is reviewer
+  workflow state, not bot telemetry. This is deliberate; document it in the
+  module docstring. Refresh is manual (`r` key) plus an optional
+  `set_interval` poll (30s) of `list_views()`.
+- **Reviewer identity:** resolve once at screen mount (same precedence as
+  CLI: `GPT_TRADER_ACTOR` env → OS user); display it in the header so the
+  reviewer knows what the audit log will record. All actions from this screen
+  use `ActorType.HUMAN`.
+- **Service calls are synchronous filesystem I/O** — small store, acceptable
+  on the UI thread for v1; wrap in `run_worker` only if list rendering
+  measurably stutters.
+
+## Layout
+
+```
+┌─ Ideas Review ── reviewer: rj ───────────────────────────────────────┐
+│ ┌─ Queue (DataTable) ──────────────┐ ┌─ Detail (VerticalScroll) ───┐ │
+│ │ ID  STATE  INSTR  DIR  LOSS% EXP │ │ thesis, instrument, entry,  │ │
+│ │ ...                              │ │ invalidation, target, loss, │ │
+│ │                                  │ │ sizing, horizon, confidence,│ │
+│ │                                  │ │ failure_mode, do_not_trade  │ │
+│ │                                  │ │ ─────────────────────────── │ │
+│ │                                  │ │ Policy check: ✓/✗ list      │ │
+│ │                                  │ │ History: audit events       │ │
+│ └──────────────────────────────────┘ └─────────────────────────────┘ │
+│ [a]pprove [x]reject [c]hanges [e]xpire [f]ilter [r]efresh [esc]back  │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+- **Queue table:** columns `decision_id`, `state`, `instrument`,
+  `direction`, `max_loss %`, `expires_at`. Default filter: `proposed` first,
+  then `needs_changes`, then everything else; `f` cycles
+  all → proposed → needs_changes → approved. Highlight rows whose
+  `expires_at` is within `RiskBudget.max_review_latency_hours` (stale-soon)
+  and rows already past expiry.
+- **Detail pane:** every field of the selected `TradeIdea` (the reviewer must
+  be able to check eligibility from recorded data alone, per Decision 2 of
+  the framework). Render `data_used` and `do_not_trade_if` as lists.
+- **Policy check section:** call
+  `ApprovalPolicy().approval_violations(idea, actor_type=ActorType.HUMAN,
+  budget=service.current_budget(),
+  open_approved_count=service.open_approved_count(), now=...)` read-only on
+  selection. Empty → `✓ would pass approval policy`. Otherwise one `✗` line
+  per violation. This preview must use the same policy object the service
+  uses — no reimplementation.
+- **History section:** the view's audit events,
+  `timestamp  actor  action  before→after  reason`.
+
+## Actions
+
+| Key | Action | Allowed when state is | Service call |
+|-----|--------|----------------------|--------------|
+| `a` | Approve | `proposed` | `approve(id, actor_id, reason)` |
+| `x` | Reject | `proposed`, `needs_changes` | `reject(...)` |
+| `c` | Request changes | `proposed` | `request_changes(...)` |
+| `e` | Expire | any non-terminal | `expire(id, actor_id=reviewer, actor_type=HUMAN, reason=...)` |
+| `r` | Refresh | — | `list_views()` |
+
+- Every mutating action opens a **reason modal** (`ModalScreen[str | None]`,
+  pattern: `api_setup_wizard.py`): a `TextArea`/`Input` for the reason
+  (required, non-empty — disable confirm until text present), confirm +
+  cancel buttons. The modal title states the action and decision_id, and for
+  approve it re-lists current policy violations so the reviewer confirms
+  with full context. (Approval with outstanding violations will be refused
+  by the service anyway — the modal is informational, not a bypass.)
+- On `PolicyViolationError`: show a notification (`notify` /
+  `notification_helpers.py` conventions, severity=error) containing **all**
+  violations, keep the idea selected, refresh the policy section.
+- On success: notification (severity=information), refresh queue + detail.
+- Keys for unavailable transitions are no-ops with a short "not allowed from
+  state X" notification (the state machine in `workflow.py` is the truth;
+  do not duplicate transition logic — attempt the call or check
+  `ALLOWED_TRANSITIONS` directly).
+
+## Styling
+
+- New CSS module `tui/styles/screens/ideas_review.tcss`; run
+  `python scripts/build_tui_css.py` after editing. Never edit
+  `styles/main.tcss`.
+- Any `DEFAULT_CSS` uses hardcoded hex + `/* $variable */` comments per
+  CLAUDE.md.
+- State colors should reuse the theme palette conventions in
+  `docs/TUI_STYLE_GUIDE.md` (e.g., success-green for `approved`,
+  warning-yellow for `needs_changes`/stale-soon, error-red for
+  `rejected`/expired).
+
+## Test plan
+
+Behavior tests (`tests/unit/gpt_trader/tui/test_ideas_review_screen.py`)
+using Textual's `App.run_test()` pilot and a `tmp_path` service injected via
+the constructor:
+
+1. Empty store → queue renders empty-state message, no crash.
+2. Seeded proposed idea appears in queue; selecting it renders all record
+   fields and a passing policy section for a compliant idea.
+3. Non-compliant idea (e.g., `max_loss` over budget) shows each violation
+   line in the policy section.
+4. Approve flow: `a` → modal → empty reason cannot confirm → with reason,
+   service state becomes `approved`, audit event has
+   `actor_type=human` and the typed reason.
+5. Approve refused: `PolicyViolationError` surfaces as an error notification
+   listing every violation; state unchanged.
+6. Reject and request-changes flows append the correct events.
+7. Action key on an idea in a terminal state → "not allowed" notification,
+   no service mutation.
+8. Filter cycling changes the visible row set.
+
+Snapshot tests (`test_snapshots_ideas_review.py`): empty state, populated
+queue with detail pane (compliant + violating idea). Update via
+`uv run pytest tests/unit/gpt_trader/tui/test_snapshots_*.py --snapshot-update`
+and review diffs.
+
+## Acceptance criteria
+
+- [ ] Reviewer can fully triage with keyboard only: open screen → select →
+      read record + policy verdict + history → approve/reject/request
+      changes with a reason → see the result reflected.
+- [ ] Every mutation lands in the audit log with `actor_type=human`, the
+      reviewer's id, and the typed reason; nothing mutates without a reason.
+- [ ] No policy/workflow logic re-implemented in TUI code (imports from
+      `features/trade_ideas` only: service, models, workflow, policy, audit
+      types). No imports from brokerage or live_trade slices.
+- [ ] Screen opens and functions in demo mode.
+- [ ] CSS built via `scripts/build_tui_css.py`; snapshot tests committed.
+- [ ] `uv run agent-check`, `agent-naming`, `mypy`, `ruff`, `black` clean;
+      TUI test suites green.

--- a/scripts/maintenance/docs_link_audit.py
+++ b/scripts/maintenance/docs_link_audit.py
@@ -106,6 +106,7 @@ def should_check_repo_paths(source: Path, *, root: Path) -> bool:
 
     excluded_dirs = {
         docs_root / "adr",
+        docs_root / "specs",
     }
     for excluded_dir in excluded_dirs:
         try:

--- a/src/gpt_trader/features/trade_ideas/__init__.py
+++ b/src/gpt_trader/features/trade_ideas/__init__.py
@@ -43,6 +43,17 @@ from gpt_trader.features.trade_ideas.models import (
 )
 from gpt_trader.features.trade_ideas.policy import ApprovalPolicy, PolicyViolationError
 from gpt_trader.features.trade_ideas.proposer import Proposer
+from gpt_trader.features.trade_ideas.replay import (
+    ReplayOutcome,
+    ReplayReport,
+    ReplayResult,
+    ReplayRunnerConfig,
+    ReplayScoringError,
+    ScoringLevels,
+    TradeIdeaReplayRunner,
+    extract_numeric_scoring_levels,
+    score_trade_idea,
+)
 from gpt_trader.features.trade_ideas.service import (
     TradeIdeaService,
     TradeIdeaView,
@@ -86,8 +97,14 @@ __all__ = [
     "PolicyViolationError",
     "ProductType",
     "Proposer",
+    "ReplayOutcome",
+    "ReplayReport",
+    "ReplayResult",
+    "ReplayRunnerConfig",
+    "ReplayScoringError",
     "RiskBudget",
     "RiskBudgetLog",
+    "ScoringLevels",
     "SizingRecommendation",
     "SnapshotIntegrityError",
     "SymbolSeries",
@@ -97,13 +114,16 @@ __all__ = [
     "TradeDirection",
     "TradeIdea",
     "TradeIdeaAuditLog",
+    "TradeIdeaReplayRunner",
     "TradeIdeaService",
     "TradeIdeaState",
     "TradeIdeaStore",
     "TradeIdeaView",
     "UnknownTradeIdeaError",
     "evaluate_eligibility",
+    "extract_numeric_scoring_levels",
     "is_eligible",
     "new_event_id",
+    "score_trade_idea",
     "validate_transition",
 ]

--- a/src/gpt_trader/features/trade_ideas/replay.py
+++ b/src/gpt_trader/features/trade_ideas/replay.py
@@ -182,6 +182,15 @@ class ReplayReport:
 LevelExtractor = Callable[[TradeIdea], ScoringLevels]
 
 _NUMBER_RE = re.compile(r"(?<![\w.])-?\d[\d,]*(?:\.\d+)?")
+_NON_PRICE_QUANTITY_SUFFIX_RE = re.compile(
+    rf"\s*(?:[-/]\s*{_NUMBER_RE.pattern}\s*)?(?:"
+    r"%|"
+    r"[Rr]\b|"
+    r"-(?:bar|bars|candle|candles|day|days|hour|hours|minute|minutes|week|weeks|month|months)\b|"
+    r"(?:bar|bars|candle|candles|trading\s+day|trading\s+days|day|days|hour|hours|minute|minutes|week|weeks|month|months)\b"
+    r")",
+    re.IGNORECASE,
+)
 _DIRECT_STOP_RE = re.compile(
     rf"\b(?:close|price|stop|invalid(?:ation|ated)?|break|move|trade)\w*\s+"
     rf"(?:below|under|beneath|above|over)\s+({_NUMBER_RE.pattern})",
@@ -404,7 +413,7 @@ def _extract_stop_level(
     direction: TradeDirection,
     entry_midpoint: Decimal,
 ) -> Decimal:
-    candidates = _numbers(text)
+    candidates = _price_level_numbers(text)
     if not candidates:
         raise ReplayScoringError(
             f"Trade idea '{decision_id}' invalidation has no numeric level",
@@ -428,7 +437,7 @@ def _extract_target_level(
     direction: TradeDirection,
     entry_midpoint: Decimal,
 ) -> Decimal:
-    candidates = _numbers_without_reward_multiples(text)
+    candidates = _price_level_numbers(text)
     if not candidates:
         raise ReplayScoringError(
             f"Trade idea '{decision_id}' target_exit has no numeric level",
@@ -469,32 +478,24 @@ def _nearest_directional_level(
     return min(directional_candidates, key=lambda value: abs(value - entry_midpoint))
 
 
-def _numbers(text: str) -> tuple[Decimal, ...]:
-    return tuple(Decimal(match.group().replace(",", "")) for match in _NUMBER_RE.finditer(text))
-
-
-def _first_number_after_stop_trigger(text: str) -> Decimal | None:
-    match = _DIRECT_STOP_RE.search(text)
-    if match is None:
-        return None
-    return Decimal(match.group(1).replace(",", ""))
-
-
-def _numbers_without_reward_multiples(text: str) -> tuple[Decimal, ...]:
+def _price_level_numbers(text: str) -> tuple[Decimal, ...]:
     values: list[Decimal] = []
     for match in _NUMBER_RE.finditer(text):
-        if _is_reward_multiple(text, match.end()) or _is_percentage_quantity(text, match.end()):
+        if _is_non_price_quantity(text, match.end()):
             continue
         values.append(Decimal(match.group().replace(",", "")))
     return tuple(values)
 
 
-def _is_reward_multiple(text: str, number_end: int) -> bool:
-    return re.match(r"\s*[Rr]\b", text[number_end:]) is not None
+def _first_number_after_stop_trigger(text: str) -> Decimal | None:
+    match = _DIRECT_STOP_RE.search(text)
+    if match is None or _is_non_price_quantity(text, match.end(1)):
+        return None
+    return Decimal(match.group(1).replace(",", ""))
 
 
-def _is_percentage_quantity(text: str, number_end: int) -> bool:
-    return re.match(r"\s*%", text[number_end:]) is not None
+def _is_non_price_quantity(text: str, number_end: int) -> bool:
+    return _NON_PRICE_QUANTITY_SUFFIX_RE.match(text[number_end:]) is not None
 
 
 def _validate_level_order(idea: TradeIdea, levels: ScoringLevels) -> None:

--- a/src/gpt_trader/features/trade_ideas/replay.py
+++ b/src/gpt_trader/features/trade_ideas/replay.py
@@ -186,14 +186,14 @@ _NON_PRICE_QUANTITY_SUFFIX_RE = re.compile(
     rf"\s*(?:[-/]\s*{_NUMBER_RE.pattern}\s*)?(?:"
     r"%|"
     r"[Rr]\b|"
-    r"-(?:bar|bars|candle|candles|day|days|hour|hours|minute|minutes|week|weeks|month|months)\b|"
-    r"(?:bar|bars|candle|candles|trading\s+day|trading\s+days|day|days|hour|hours|minute|minutes|week|weeks|month|months)\b"
+    r"-(?:bar|bars|candle|candles|day|days|hour|hours|minute|minutes|week|weeks|month|months|period|periods)\b|"
+    r"(?:bar|bars|candle|candles|trading\s+day|trading\s+days|day|days|hour|hours|minute|minutes|week|weeks|month|months|period|periods)\b"
     r")",
     re.IGNORECASE,
 )
 _DIRECT_STOP_RE = re.compile(
     rf"\b(?:close|price|stop|invalid(?:ation|ated)?|break|move|trade)\w*\s+"
-    rf"(?:below|under|beneath|above|over)\s+({_NUMBER_RE.pattern})",
+    rf"(?:below|under|beneath|above|over)\s+\$?\s*({_NUMBER_RE.pattern})",
     re.IGNORECASE,
 )
 

--- a/src/gpt_trader/features/trade_ideas/replay.py
+++ b/src/gpt_trader/features/trade_ideas/replay.py
@@ -182,6 +182,11 @@ class ReplayReport:
 LevelExtractor = Callable[[TradeIdea], ScoringLevels]
 
 _NUMBER_RE = re.compile(r"(?<![\w.])-?\d[\d,]*(?:\.\d+)?")
+_DIRECT_STOP_RE = re.compile(
+    rf"\b(?:close|price|stop|invalid(?:ation|ated)?|break|move|trade)\w*\s+"
+    rf"(?:below|under|beneath|above|over)\s+({_NUMBER_RE.pattern})",
+    re.IGNORECASE,
+)
 
 
 def extract_numeric_scoring_levels(idea: TradeIdea) -> ScoringLevels:
@@ -199,8 +204,19 @@ def extract_numeric_scoring_levels(idea: TradeIdea) -> ScoringLevels:
             field="entry_zone",
         )
 
-    stop = _extract_stop_level(idea.invalidation, idea.decision_id)
-    target = _extract_target_level(idea.target_exit, idea.decision_id)
+    entry_midpoint = (idea.entry_zone.lower + idea.entry_zone.upper) / Decimal("2")
+    stop = _extract_stop_level(
+        idea.invalidation,
+        idea.decision_id,
+        direction=idea.direction,
+        entry_midpoint=entry_midpoint,
+    )
+    target = _extract_target_level(
+        idea.target_exit,
+        idea.decision_id,
+        direction=idea.direction,
+        entry_midpoint=entry_midpoint,
+    )
     levels = ScoringLevels(
         entry_lower=idea.entry_zone.lower,
         entry_upper=idea.entry_zone.upper,
@@ -369,38 +385,100 @@ class TradeIdeaReplayRunner:
         )
 
 
-def _extract_stop_level(text: str, decision_id: str) -> Decimal:
-    parenthetical_numbers = _numbers_in_parentheses(text)
-    if parenthetical_numbers:
-        return parenthetical_numbers[-1]
-    numbers = _numbers(text)
-    if not numbers:
+def _extract_stop_level(
+    text: str,
+    decision_id: str,
+    *,
+    direction: TradeDirection,
+    entry_midpoint: Decimal,
+) -> Decimal:
+    candidates = _numbers(text)
+    if not candidates:
         raise ReplayScoringError(
             f"Trade idea '{decision_id}' invalidation has no numeric level",
             field="invalidation",
         )
-    return numbers[-1]
+    direct_stop = _first_number_after_stop_trigger(text)
+    if direct_stop is not None:
+        return direct_stop
+    return _nearest_directional_level(
+        candidates,
+        direction=direction,
+        entry_midpoint=entry_midpoint,
+        level_role="stop",
+    )
 
 
-def _extract_target_level(text: str, decision_id: str) -> Decimal:
-    numbers = _numbers(text)
-    if not numbers:
+def _extract_target_level(
+    text: str,
+    decision_id: str,
+    *,
+    direction: TradeDirection,
+    entry_midpoint: Decimal,
+) -> Decimal:
+    candidates = _numbers_without_reward_multiples(text)
+    if not candidates:
         raise ReplayScoringError(
             f"Trade idea '{decision_id}' target_exit has no numeric level",
             field="target_exit",
         )
-    return numbers[0]
+    return _nearest_directional_level(
+        candidates,
+        direction=direction,
+        entry_midpoint=entry_midpoint,
+        level_role="target",
+    )
+
+
+def _nearest_directional_level(
+    candidates: Sequence[Decimal],
+    *,
+    direction: TradeDirection,
+    entry_midpoint: Decimal,
+    level_role: str,
+) -> Decimal:
+    if direction is TradeDirection.LONG:
+        directional_candidates = tuple(
+            value
+            for value in candidates
+            if (value < entry_midpoint if level_role == "stop" else value > entry_midpoint)
+        )
+    elif direction is TradeDirection.SHORT:
+        directional_candidates = tuple(
+            value
+            for value in candidates
+            if (value > entry_midpoint if level_role == "stop" else value < entry_midpoint)
+        )
+    else:
+        directional_candidates = tuple(candidates)
+
+    if not directional_candidates:
+        return candidates[0] if level_role == "target" else candidates[-1]
+    return min(directional_candidates, key=lambda value: abs(value - entry_midpoint))
 
 
 def _numbers(text: str) -> tuple[Decimal, ...]:
     return tuple(Decimal(match.group().replace(",", "")) for match in _NUMBER_RE.finditer(text))
 
 
-def _numbers_in_parentheses(text: str) -> tuple[Decimal, ...]:
+def _first_number_after_stop_trigger(text: str) -> Decimal | None:
+    match = _DIRECT_STOP_RE.search(text)
+    if match is None:
+        return None
+    return Decimal(match.group(1).replace(",", ""))
+
+
+def _numbers_without_reward_multiples(text: str) -> tuple[Decimal, ...]:
     values: list[Decimal] = []
-    for match in re.finditer(r"\(([^)]*)\)", text):
-        values.extend(_numbers(match.group(1)))
+    for match in _NUMBER_RE.finditer(text):
+        if _is_reward_multiple(text, match.end()):
+            continue
+        values.append(Decimal(match.group().replace(",", "")))
     return tuple(values)
+
+
+def _is_reward_multiple(text: str, number_end: int) -> bool:
+    return re.match(r"\s*[Rr]\b", text[number_end:]) is not None
 
 
 def _validate_level_order(idea: TradeIdea, levels: ScoringLevels) -> None:

--- a/src/gpt_trader/features/trade_ideas/replay.py
+++ b/src/gpt_trader/features/trade_ideas/replay.py
@@ -1,0 +1,512 @@
+"""Replay scoring for proposer-generated trade ideas.
+
+This module keeps calibration separate from execution. It feeds historical,
+point-in-time snapshots to a proposer, then scores the emitted records against
+subsequent candles using only the plan already written on the trade idea.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from enum import Enum
+from typing import Any
+
+from gpt_trader.core import Candle
+from gpt_trader.errors import ValidationError
+from gpt_trader.features.trade_ideas.models import TradeDirection, TradeIdea
+from gpt_trader.features.trade_ideas.proposer import Proposer
+from gpt_trader.features.trade_ideas.snapshot import MarketSnapshot, SymbolSeries
+
+
+class ReplayScoringError(ValidationError):
+    """Raised when a trade idea cannot be scored from its record."""
+
+
+class ReplayOutcome(str, Enum):
+    """Terminal outcome for a replay-scored idea."""
+
+    TARGET_HIT = "target_hit"
+    STOP_HIT = "stop_hit"
+    TIMED_OUT = "timed_out"
+    NOT_FILLED = "not_filled"
+    NO_FUTURE_DATA = "no_future_data"
+
+
+@dataclass(frozen=True, slots=True)
+class ScoringLevels:
+    """Numeric plan levels used to score a trade idea against future candles."""
+
+    entry_lower: Decimal
+    entry_upper: Decimal
+    stop: Decimal
+    target: Decimal
+
+    @property
+    def entry_midpoint(self) -> Decimal:
+        return (self.entry_lower + self.entry_upper) / Decimal("2")
+
+
+@dataclass(frozen=True, slots=True)
+class ReplayResult:
+    """Replay outcome for one proposed trade idea."""
+
+    decision_id: str
+    record_hash: str
+    instrument: str
+    direction: TradeDirection
+    as_of: datetime
+    expires_at: datetime
+    outcome: ReplayOutcome
+    levels: ScoringLevels
+    entry_time: datetime | None = None
+    entry_price: Decimal | None = None
+    exit_time: datetime | None = None
+    exit_price: Decimal | None = None
+    return_r: Decimal | None = None
+    return_pct: Decimal | None = None
+    bars_evaluated: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "decision_id": self.decision_id,
+            "record_hash": self.record_hash,
+            "instrument": self.instrument,
+            "direction": self.direction.value,
+            "as_of": self.as_of.isoformat(),
+            "expires_at": self.expires_at.isoformat(),
+            "outcome": self.outcome.value,
+            "levels": {
+                "entry_lower": str(self.levels.entry_lower),
+                "entry_upper": str(self.levels.entry_upper),
+                "stop": str(self.levels.stop),
+                "target": str(self.levels.target),
+            },
+            "entry_time": self.entry_time.isoformat() if self.entry_time else None,
+            "entry_price": str(self.entry_price) if self.entry_price is not None else None,
+            "exit_time": self.exit_time.isoformat() if self.exit_time else None,
+            "exit_price": str(self.exit_price) if self.exit_price is not None else None,
+            "return_r": str(self.return_r) if self.return_r is not None else None,
+            "return_pct": str(self.return_pct) if self.return_pct is not None else None,
+            "bars_evaluated": self.bars_evaluated,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ReplayReport:
+    """Aggregate calibration report for a proposer replay run."""
+
+    proposer_id: str
+    symbol: str
+    granularity: str
+    source: str
+    snapshots_evaluated: int
+    ideas: tuple[ReplayResult, ...]
+
+    @property
+    def ideas_proposed(self) -> int:
+        return len(self.ideas)
+
+    @property
+    def target_hits(self) -> int:
+        return self._count(ReplayOutcome.TARGET_HIT)
+
+    @property
+    def stop_hits(self) -> int:
+        return self._count(ReplayOutcome.STOP_HIT)
+
+    @property
+    def timed_out(self) -> int:
+        return self._count(ReplayOutcome.TIMED_OUT)
+
+    @property
+    def not_filled(self) -> int:
+        return self._count(ReplayOutcome.NOT_FILLED)
+
+    @property
+    def no_future_data(self) -> int:
+        return self._count(ReplayOutcome.NO_FUTURE_DATA)
+
+    @property
+    def resolved_ideas(self) -> int:
+        return self.target_hits + self.stop_hits + self.timed_out
+
+    @property
+    def target_hit_rate(self) -> Decimal:
+        if self.resolved_ideas == 0:
+            return Decimal("0")
+        return Decimal(self.target_hits) / Decimal(self.resolved_ideas)
+
+    @property
+    def stop_hit_rate(self) -> Decimal:
+        if self.resolved_ideas == 0:
+            return Decimal("0")
+        return Decimal(self.stop_hits) / Decimal(self.resolved_ideas)
+
+    @property
+    def average_return_r(self) -> Decimal | None:
+        returns = [idea.return_r for idea in self.ideas if idea.return_r is not None]
+        if not returns:
+            return None
+        return sum(returns, Decimal("0")) / Decimal(len(returns))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "proposer_id": self.proposer_id,
+            "symbol": self.symbol,
+            "granularity": self.granularity,
+            "source": self.source,
+            "snapshots_evaluated": self.snapshots_evaluated,
+            "ideas_proposed": self.ideas_proposed,
+            "target_hits": self.target_hits,
+            "stop_hits": self.stop_hits,
+            "timed_out": self.timed_out,
+            "not_filled": self.not_filled,
+            "no_future_data": self.no_future_data,
+            "resolved_ideas": self.resolved_ideas,
+            "target_hit_rate": str(self.target_hit_rate),
+            "stop_hit_rate": str(self.stop_hit_rate),
+            "average_return_r": (
+                str(self.average_return_r) if self.average_return_r is not None else None
+            ),
+            "ideas": [idea.to_dict() for idea in self.ideas],
+        }
+
+    def _count(self, outcome: ReplayOutcome) -> int:
+        return sum(1 for idea in self.ideas if idea.outcome is outcome)
+
+
+LevelExtractor = Callable[[TradeIdea], ScoringLevels]
+
+_NUMBER_RE = re.compile(r"(?<![\w.])-?\d[\d,]*(?:\.\d+)?")
+
+
+def extract_numeric_scoring_levels(idea: TradeIdea) -> ScoringLevels:
+    """Extract numeric scoring levels from a broker-neutral trade idea.
+
+    The trade-idea model currently stores invalidation and target as explicit
+    prose fields. This extractor is intentionally narrow: it uses the structured
+    entry zone and reads the numeric stop/target from those explicit text fields.
+    Future proposers can pass a stricter ``LevelExtractor`` to avoid text
+    extraction once numeric exit levels are part of the proposer contract.
+    """
+    if idea.entry_zone.lower is None or idea.entry_zone.upper is None:
+        raise ReplayScoringError(
+            f"Trade idea '{idea.decision_id}' needs numeric entry_zone lower and upper",
+            field="entry_zone",
+        )
+
+    stop = _extract_stop_level(idea.invalidation, idea.decision_id)
+    target = _extract_target_level(idea.target_exit, idea.decision_id)
+    levels = ScoringLevels(
+        entry_lower=idea.entry_zone.lower,
+        entry_upper=idea.entry_zone.upper,
+        stop=stop,
+        target=target,
+    )
+    _validate_level_order(idea, levels)
+    return levels
+
+
+def score_trade_idea(
+    idea: TradeIdea,
+    *,
+    as_of: datetime,
+    future_candles: Sequence[Candle],
+    level_extractor: LevelExtractor = extract_numeric_scoring_levels,
+) -> ReplayResult:
+    """Score one trade idea against candles available after ``as_of``."""
+    if idea.time_horizon.expires_at is None:
+        raise ReplayScoringError(
+            f"Trade idea '{idea.decision_id}' has no expiry to score against",
+            field="time_horizon",
+        )
+    if idea.direction not in {TradeDirection.LONG, TradeDirection.SHORT}:
+        raise ReplayScoringError(
+            f"Trade idea '{idea.decision_id}' direction '{idea.direction.value}' is not scoreable",
+            field="direction",
+        )
+
+    levels = level_extractor(idea)
+    candles = tuple(
+        sorted(
+            (
+                candle
+                for candle in future_candles
+                if as_of <= candle.ts < idea.time_horizon.expires_at
+            ),
+            key=lambda candle: candle.ts,
+        )
+    )
+    if not candles:
+        return _result(
+            idea,
+            as_of=as_of,
+            levels=levels,
+            outcome=ReplayOutcome.NO_FUTURE_DATA,
+        )
+
+    entry_candle = _first_entry_candle(candles, levels)
+    if entry_candle is None:
+        return _result(
+            idea,
+            as_of=as_of,
+            levels=levels,
+            outcome=ReplayOutcome.NOT_FILLED,
+            bars_evaluated=len(candles),
+        )
+
+    entry_price = levels.entry_midpoint
+    entry_index = candles.index(entry_candle)
+    post_entry_candles = candles[entry_index:]
+    for bars_after_entry, candle in enumerate(post_entry_candles, start=1):
+        outcome_price = _bar_outcome_price(idea.direction, candle, levels)
+        if outcome_price is None:
+            continue
+        outcome, exit_price = outcome_price
+        return _result(
+            idea,
+            as_of=as_of,
+            levels=levels,
+            outcome=outcome,
+            entry_time=entry_candle.ts,
+            entry_price=entry_price,
+            exit_time=candle.ts,
+            exit_price=exit_price,
+            bars_evaluated=entry_index + bars_after_entry,
+        )
+
+    timeout_candle = post_entry_candles[-1]
+    return _result(
+        idea,
+        as_of=as_of,
+        levels=levels,
+        outcome=ReplayOutcome.TIMED_OUT,
+        entry_time=entry_candle.ts,
+        entry_price=entry_price,
+        exit_time=timeout_candle.ts,
+        exit_price=timeout_candle.close,
+        bars_evaluated=len(candles),
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class ReplayRunnerConfig:
+    """Configuration for replaying one historical candle series."""
+
+    source: str = "historical:candles"
+    min_history: int = 1
+
+    def __post_init__(self) -> None:
+        if self.min_history < 1:
+            raise ReplayScoringError(
+                "Replay runner min_history must be at least 1",
+                field="min_history",
+            )
+
+
+class TradeIdeaReplayRunner:
+    """Build point-in-time snapshots from history and score proposer output."""
+
+    def __init__(
+        self,
+        proposer: Proposer,
+        *,
+        config: ReplayRunnerConfig | None = None,
+        level_extractor: LevelExtractor = extract_numeric_scoring_levels,
+    ) -> None:
+        self._proposer = proposer
+        self._config = config or ReplayRunnerConfig()
+        self._level_extractor = level_extractor
+
+    def run_series(
+        self,
+        *,
+        symbol: str,
+        granularity: str,
+        candles: Sequence[Candle],
+    ) -> ReplayReport:
+        ordered_candles = tuple(sorted(candles, key=lambda candle: candle.ts))
+        results: list[ReplayResult] = []
+        snapshots_evaluated = 0
+
+        for index in range(self._config.min_history, len(ordered_candles)):
+            as_of = ordered_candles[index].ts
+            history = ordered_candles[:index]
+            future = ordered_candles[index:]
+            snapshot = MarketSnapshot(
+                as_of=as_of,
+                source=self._config.source,
+                series=(
+                    SymbolSeries(
+                        symbol=symbol,
+                        granularity=granularity,
+                        candles=history,
+                    ),
+                ),
+            )
+            snapshots_evaluated += 1
+            for idea in self._proposer.propose(snapshot):
+                results.append(
+                    score_trade_idea(
+                        idea,
+                        as_of=as_of,
+                        future_candles=future,
+                        level_extractor=self._level_extractor,
+                    )
+                )
+
+        return ReplayReport(
+            proposer_id=self._proposer.proposer_id,
+            symbol=symbol,
+            granularity=granularity,
+            source=self._config.source,
+            snapshots_evaluated=snapshots_evaluated,
+            ideas=tuple(results),
+        )
+
+
+def _extract_stop_level(text: str, decision_id: str) -> Decimal:
+    parenthetical_numbers = _numbers_in_parentheses(text)
+    if parenthetical_numbers:
+        return parenthetical_numbers[-1]
+    numbers = _numbers(text)
+    if not numbers:
+        raise ReplayScoringError(
+            f"Trade idea '{decision_id}' invalidation has no numeric level",
+            field="invalidation",
+        )
+    return numbers[-1]
+
+
+def _extract_target_level(text: str, decision_id: str) -> Decimal:
+    numbers = _numbers(text)
+    if not numbers:
+        raise ReplayScoringError(
+            f"Trade idea '{decision_id}' target_exit has no numeric level",
+            field="target_exit",
+        )
+    return numbers[0]
+
+
+def _numbers(text: str) -> tuple[Decimal, ...]:
+    return tuple(Decimal(match.group().replace(",", "")) for match in _NUMBER_RE.finditer(text))
+
+
+def _numbers_in_parentheses(text: str) -> tuple[Decimal, ...]:
+    values: list[Decimal] = []
+    for match in re.finditer(r"\(([^)]*)\)", text):
+        values.extend(_numbers(match.group(1)))
+    return tuple(values)
+
+
+def _validate_level_order(idea: TradeIdea, levels: ScoringLevels) -> None:
+    entry = levels.entry_midpoint
+    if idea.direction is TradeDirection.LONG:
+        valid = levels.stop < entry < levels.target
+    elif idea.direction is TradeDirection.SHORT:
+        valid = levels.target < entry < levels.stop
+    else:
+        valid = True
+
+    if not valid:
+        raise ReplayScoringError(
+            f"Trade idea '{idea.decision_id}' has inconsistent scoring levels",
+            field="target_exit",
+        )
+
+
+def _first_entry_candle(
+    candles: Sequence[Candle],
+    levels: ScoringLevels,
+) -> Candle | None:
+    entry_price = levels.entry_midpoint
+    for candle in candles:
+        if candle.low <= entry_price <= candle.high:
+            return candle
+    return None
+
+
+def _bar_outcome_price(
+    direction: TradeDirection,
+    candle: Candle,
+    levels: ScoringLevels,
+) -> tuple[ReplayOutcome, Decimal] | None:
+    # A single OHLC bar cannot reveal intrabar ordering. Score stops before
+    # targets when both are touched in the same bar so calibration stays
+    # conservative and never overstates replay quality.
+    if direction is TradeDirection.LONG:
+        if candle.low <= levels.stop:
+            return ReplayOutcome.STOP_HIT, levels.stop
+        if candle.high >= levels.target:
+            return ReplayOutcome.TARGET_HIT, levels.target
+        return None
+
+    if candle.high >= levels.stop:
+        return ReplayOutcome.STOP_HIT, levels.stop
+    if candle.low <= levels.target:
+        return ReplayOutcome.TARGET_HIT, levels.target
+    return None
+
+
+def _result(
+    idea: TradeIdea,
+    *,
+    as_of: datetime,
+    levels: ScoringLevels,
+    outcome: ReplayOutcome,
+    entry_time: datetime | None = None,
+    entry_price: Decimal | None = None,
+    exit_time: datetime | None = None,
+    exit_price: Decimal | None = None,
+    bars_evaluated: int = 0,
+) -> ReplayResult:
+    return_r = None
+    return_pct = None
+    if entry_price is not None and exit_price is not None:
+        risk = (
+            entry_price - levels.stop
+            if idea.direction is TradeDirection.LONG
+            else levels.stop - entry_price
+        )
+        if risk != 0:
+            profit = (
+                exit_price - entry_price
+                if idea.direction is TradeDirection.LONG
+                else entry_price - exit_price
+            )
+            return_r = profit / risk
+        if entry_price != 0:
+            signed_return = (
+                exit_price - entry_price
+                if idea.direction is TradeDirection.LONG
+                else entry_price - exit_price
+            )
+            return_pct = signed_return / entry_price * Decimal("100")
+
+    if idea.time_horizon.expires_at is None:
+        raise ReplayScoringError(
+            f"Trade idea '{idea.decision_id}' has no expiry to score against",
+            field="time_horizon",
+        )
+
+    return ReplayResult(
+        decision_id=idea.decision_id,
+        record_hash=idea.record_hash(),
+        instrument=idea.instrument,
+        direction=idea.direction,
+        as_of=as_of,
+        expires_at=idea.time_horizon.expires_at,
+        outcome=outcome,
+        levels=levels,
+        entry_time=entry_time,
+        entry_price=entry_price,
+        exit_time=exit_time,
+        exit_price=exit_price,
+        return_r=return_r,
+        return_pct=return_pct,
+        bars_evaluated=bars_evaluated,
+    )

--- a/src/gpt_trader/features/trade_ideas/replay.py
+++ b/src/gpt_trader/features/trade_ideas/replay.py
@@ -483,7 +483,7 @@ def _first_number_after_stop_trigger(text: str) -> Decimal | None:
 def _numbers_without_reward_multiples(text: str) -> tuple[Decimal, ...]:
     values: list[Decimal] = []
     for match in _NUMBER_RE.finditer(text):
-        if _is_reward_multiple(text, match.end()):
+        if _is_reward_multiple(text, match.end()) or _is_percentage_quantity(text, match.end()):
             continue
         values.append(Decimal(match.group().replace(",", "")))
     return tuple(values)
@@ -491,6 +491,10 @@ def _numbers_without_reward_multiples(text: str) -> tuple[Decimal, ...]:
 
 def _is_reward_multiple(text: str, number_end: int) -> bool:
     return re.match(r"\s*[Rr]\b", text[number_end:]) is not None
+
+
+def _is_percentage_quantity(text: str, number_end: int) -> bool:
+    return re.match(r"\s*%", text[number_end:]) is not None
 
 
 def _validate_level_order(idea: TradeIdea, levels: ScoringLevels) -> None:
@@ -556,16 +560,40 @@ def _bar_outcome_price(
 
 
 def _granularity_duration(granularity: str) -> timedelta | None:
+    normalized = granularity.strip().upper().replace("-", "_")
     return {
+        "1M": timedelta(minutes=1),
+        "1MIN": timedelta(minutes=1),
+        "1MINUTE": timedelta(minutes=1),
         "ONE_MINUTE": timedelta(minutes=1),
+        "5M": timedelta(minutes=5),
+        "5MIN": timedelta(minutes=5),
+        "5MINUTE": timedelta(minutes=5),
         "FIVE_MINUTE": timedelta(minutes=5),
+        "15M": timedelta(minutes=15),
+        "15MIN": timedelta(minutes=15),
+        "15MINUTE": timedelta(minutes=15),
         "FIFTEEN_MINUTE": timedelta(minutes=15),
+        "30M": timedelta(minutes=30),
+        "30MIN": timedelta(minutes=30),
+        "30MINUTE": timedelta(minutes=30),
         "THIRTY_MINUTE": timedelta(minutes=30),
+        "1H": timedelta(hours=1),
+        "1HR": timedelta(hours=1),
+        "1HOUR": timedelta(hours=1),
         "ONE_HOUR": timedelta(hours=1),
+        "2H": timedelta(hours=2),
+        "2HR": timedelta(hours=2),
+        "2HOUR": timedelta(hours=2),
         "TWO_HOUR": timedelta(hours=2),
+        "6H": timedelta(hours=6),
+        "6HR": timedelta(hours=6),
+        "6HOUR": timedelta(hours=6),
         "SIX_HOUR": timedelta(hours=6),
+        "1D": timedelta(days=1),
+        "1DAY": timedelta(days=1),
         "ONE_DAY": timedelta(days=1),
-    }.get(granularity)
+    }.get(normalized)
 
 
 def _result(

--- a/src/gpt_trader/features/trade_ideas/replay.py
+++ b/src/gpt_trader/features/trade_ideas/replay.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import re
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 from decimal import Decimal
 from enum import Enum
 from typing import Any
@@ -233,6 +233,7 @@ def score_trade_idea(
     as_of: datetime,
     future_candles: Sequence[Candle],
     level_extractor: LevelExtractor = extract_numeric_scoring_levels,
+    candle_duration: timedelta | None = None,
 ) -> ReplayResult:
     """Score one trade idea against candles available after ``as_of``."""
     if idea.time_horizon.expires_at is None:
@@ -252,7 +253,12 @@ def score_trade_idea(
             (
                 candle
                 for candle in future_candles
-                if as_of <= candle.ts < idea.time_horizon.expires_at
+                if as_of <= candle.ts
+                and _candle_ends_by_expiry(
+                    candle,
+                    expires_at=idea.time_horizon.expires_at,
+                    candle_duration=candle_duration,
+                )
             ),
             key=lambda candle: candle.ts,
         )
@@ -279,7 +285,12 @@ def score_trade_idea(
     entry_index = candles.index(entry_candle)
     post_entry_candles = candles[entry_index:]
     for bars_after_entry, candle in enumerate(post_entry_candles, start=1):
-        outcome_price = _bar_outcome_price(idea.direction, candle, levels)
+        outcome_price = _bar_outcome_price(
+            idea.direction,
+            candle,
+            levels,
+            allow_favorable_exit=candle is not entry_candle,
+        )
         if outcome_price is None:
             continue
         outcome, exit_price = outcome_price
@@ -372,6 +383,7 @@ class TradeIdeaReplayRunner:
                         as_of=as_of,
                         future_candles=future,
                         level_extractor=self._level_extractor,
+                        candle_duration=_granularity_duration(granularity),
                     )
                 )
 
@@ -508,10 +520,23 @@ def _first_entry_candle(
     return None
 
 
+def _candle_ends_by_expiry(
+    candle: Candle,
+    *,
+    expires_at: datetime,
+    candle_duration: timedelta | None,
+) -> bool:
+    if candle_duration is None:
+        return candle.ts < expires_at
+    return candle.ts + candle_duration <= expires_at
+
+
 def _bar_outcome_price(
     direction: TradeDirection,
     candle: Candle,
     levels: ScoringLevels,
+    *,
+    allow_favorable_exit: bool = True,
 ) -> tuple[ReplayOutcome, Decimal] | None:
     # A single OHLC bar cannot reveal intrabar ordering. Score stops before
     # targets when both are touched in the same bar so calibration stays
@@ -519,15 +544,28 @@ def _bar_outcome_price(
     if direction is TradeDirection.LONG:
         if candle.low <= levels.stop:
             return ReplayOutcome.STOP_HIT, levels.stop
-        if candle.high >= levels.target:
+        if allow_favorable_exit and candle.high >= levels.target:
             return ReplayOutcome.TARGET_HIT, levels.target
         return None
 
     if candle.high >= levels.stop:
         return ReplayOutcome.STOP_HIT, levels.stop
-    if candle.low <= levels.target:
+    if allow_favorable_exit and candle.low <= levels.target:
         return ReplayOutcome.TARGET_HIT, levels.target
     return None
+
+
+def _granularity_duration(granularity: str) -> timedelta | None:
+    return {
+        "ONE_MINUTE": timedelta(minutes=1),
+        "FIVE_MINUTE": timedelta(minutes=5),
+        "FIFTEEN_MINUTE": timedelta(minutes=15),
+        "THIRTY_MINUTE": timedelta(minutes=30),
+        "ONE_HOUR": timedelta(hours=1),
+        "TWO_HOUR": timedelta(hours=2),
+        "SIX_HOUR": timedelta(hours=6),
+        "ONE_DAY": timedelta(days=1),
+    }.get(granularity)
 
 
 def _result(

--- a/tests/unit/gpt_trader/features/trade_ideas/test_replay.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_replay.py
@@ -7,19 +7,11 @@ from tests.unit.gpt_trader.features.trade_ideas.conftest import build_trade_idea
 
 from gpt_trader.core import Candle
 from gpt_trader.features.trade_ideas import (
-    BaselineProposer,
-    BaselineProposerConfig,
     EntryZone,
-    MarketSnapshot,
     ReplayOutcome,
-    ReplayRunnerConfig,
-    ReplayScoringError,
-    ScoringLevels,
     TimeHorizon,
     TradeDirection,
     TradeIdea,
-    TradeIdeaReplayRunner,
-    extract_numeric_scoring_levels,
     score_trade_idea,
 )
 
@@ -56,68 +48,6 @@ def scoreable_idea(**overrides: object) -> TradeIdea:
     }
     fields.update(overrides)
     return build_trade_idea(**fields)
-
-
-def test_extract_numeric_scoring_levels_prefers_parenthesized_baseline_stop() -> None:
-    idea = scoreable_idea(
-        invalidation="Close below the 50-bar average (97.50)",
-        target_exit="Take profit near 113.00 (2R) or exit at expiry",
-    )
-
-    assert extract_numeric_scoring_levels(idea) == ScoringLevels(
-        entry_lower=Decimal("100"),
-        entry_upper=Decimal("102"),
-        stop=Decimal("97.50"),
-        target=Decimal("113.00"),
-    )
-
-
-def test_extract_numeric_scoring_levels_ignores_indicator_period_before_stop() -> None:
-    idea = scoreable_idea(
-        invalidation="Close below 95 if RSI (14) rolls over",
-        target_exit="Take profit near 113.00 (2R) or exit at expiry",
-    )
-
-    assert extract_numeric_scoring_levels(idea).stop == Decimal("95")
-
-
-def test_extract_numeric_scoring_levels_uses_direct_stop_when_indicator_is_closer() -> None:
-    idea = scoreable_idea(
-        entry_zone=EntryZone(lower=Decimal("15"), upper=Decimal("17")),
-        invalidation="Close below 10 if RSI (14) rolls over",
-        target_exit="Take profit near 25.00 (2R) or exit at expiry",
-    )
-
-    assert extract_numeric_scoring_levels(idea).stop == Decimal("10")
-
-
-def test_extract_numeric_scoring_levels_ignores_indicator_threshold_before_stop() -> None:
-    idea = scoreable_idea(
-        invalidation="Invalid if RSI below 30 or close below 95",
-        target_exit="Take profit near 113.00 (2R) or exit at expiry",
-    )
-
-    assert extract_numeric_scoring_levels(idea).stop == Decimal("95")
-
-
-def test_extract_numeric_scoring_levels_ignores_reward_multiple_before_short_target() -> None:
-    idea = scoreable_idea(
-        direction=TradeDirection.SHORT,
-        invalidation="Close above 106",
-        target_exit="2R target at 95 or exit at expiry",
-    )
-
-    assert extract_numeric_scoring_levels(idea).target == Decimal("95")
-
-
-def test_extract_numeric_scoring_levels_keeps_target_before_resistance_word() -> None:
-    idea = scoreable_idea(
-        direction=TradeDirection.SHORT,
-        invalidation="Close above 106",
-        target_exit="Take profit near 95 resistance or exit at expiry",
-    )
-
-    assert extract_numeric_scoring_levels(idea).target == Decimal("95")
 
 
 def test_score_trade_idea_records_target_hit() -> None:
@@ -306,83 +236,3 @@ def test_score_trade_idea_excludes_candles_that_extend_past_expiry() -> None:
 
     assert result.outcome is ReplayOutcome.NO_FUTURE_DATA
     assert result.bars_evaluated == 0
-
-
-def test_replay_runner_feeds_point_in_time_snapshots_and_reports_aggregates() -> None:
-    class ScriptedProposer:
-        proposer_id = "scripted"
-
-        def propose(self, snapshot: MarketSnapshot) -> list[TradeIdea]:
-            series = snapshot.series_for("BTC-USD")
-            assert series is not None
-            assert all(item.ts < snapshot.as_of for item in series.candles)
-            if len(series.candles) != 2:
-                return []
-            return [
-                scoreable_idea(
-                    decision_id=f"trade-{snapshot.as_of:%Y%m%d%H}",
-                    time_horizon=TimeHorizon(
-                        expected_hold="1-4 hours",
-                        expires_at=snapshot.as_of + timedelta(hours=4),
-                    ),
-                )
-            ]
-
-    candles = (
-        candle(-2, close="99", high="100", low="98"),
-        candle(-1, close="101", high="102", low="100"),
-        candle(0, close="102", high="103", low="100"),
-        candle(1, close="113", high="114", low="101"),
-    )
-
-    report = TradeIdeaReplayRunner(
-        ScriptedProposer(),
-        config=ReplayRunnerConfig(min_history=2),
-    ).run_series(symbol="BTC-USD", granularity="ONE_HOUR", candles=candles)
-
-    assert report.snapshots_evaluated == 2
-    assert report.ideas_proposed == 1
-    assert report.target_hits == 1
-    assert report.stop_hits == 0
-    assert report.target_hit_rate == Decimal("1")
-    assert report.average_return_r == Decimal("2")
-    assert report.to_dict()["ideas"][0]["outcome"] == "target_hit"
-
-
-def test_replay_runner_scores_baseline_proposer_on_historical_candles() -> None:
-    candles = (
-        candle(-5, close="100", high="100", low="100"),
-        candle(-4, close="100", high="100", low="100"),
-        candle(-3, close="100", high="100", low="100"),
-        candle(-2, close="100", high="100", low="100"),
-        candle(-1, close="110", high="110", low="110"),
-        candle(0, open_="110", close="111", high="112", low="109"),
-        candle(1, open_="111", close="126", high="126", low="111"),
-    )
-
-    report = TradeIdeaReplayRunner(
-        BaselineProposer(
-            BaselineProposerConfig(
-                short_window=2,
-                long_window=4,
-                crossover_lookback=1,
-                expiry_hours=3,
-            )
-        ),
-        config=ReplayRunnerConfig(source="fixture:candles", min_history=5),
-    ).run_series(symbol="BTC-USD", granularity="ONE_HOUR", candles=candles)
-
-    assert report.ideas_proposed == 1
-    assert report.target_hits == 1
-    assert report.ideas[0].outcome is ReplayOutcome.TARGET_HIT
-    assert report.ideas[0].levels.stop == Decimal("102.50")
-    assert report.ideas[0].levels.target == Decimal("125.00")
-
-
-def test_replay_runner_config_rejects_non_positive_min_history() -> None:
-    try:
-        ReplayRunnerConfig(min_history=0)
-    except ReplayScoringError as exc:
-        assert exc.context["field"] == "min_history"
-    else:  # pragma: no cover - defensive assertion
-        raise AssertionError("ReplayRunnerConfig should reject min_history=0")

--- a/tests/unit/gpt_trader/features/trade_ideas/test_replay.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_replay.py
@@ -1,0 +1,306 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+from tests.unit.gpt_trader.features.trade_ideas.conftest import build_trade_idea
+
+from gpt_trader.core import Candle
+from gpt_trader.features.trade_ideas import (
+    BaselineProposer,
+    BaselineProposerConfig,
+    EntryZone,
+    MarketSnapshot,
+    ReplayOutcome,
+    ReplayRunnerConfig,
+    ReplayScoringError,
+    ScoringLevels,
+    TimeHorizon,
+    TradeDirection,
+    TradeIdea,
+    TradeIdeaReplayRunner,
+    extract_numeric_scoring_levels,
+    score_trade_idea,
+)
+
+AS_OF = datetime(2026, 6, 12, 12, 0, tzinfo=UTC)
+
+
+def candle(
+    offset_hours: int,
+    *,
+    open_: str = "101",
+    high: str = "102",
+    low: str = "100",
+    close: str = "101",
+) -> Candle:
+    return Candle(
+        ts=AS_OF + timedelta(hours=offset_hours),
+        open=Decimal(open_),
+        high=Decimal(high),
+        low=Decimal(low),
+        close=Decimal(close),
+        volume=Decimal("1000"),
+    )
+
+
+def scoreable_idea(**overrides: object) -> TradeIdea:
+    fields = {
+        "entry_zone": EntryZone(lower=Decimal("100"), upper=Decimal("102")),
+        "invalidation": "Close below 95",
+        "target_exit": "Take profit at 113 or exit at expiry",
+        "time_horizon": TimeHorizon(
+            expected_hold="1-4 hours",
+            expires_at=AS_OF + timedelta(hours=4),
+        ),
+    }
+    fields.update(overrides)
+    return build_trade_idea(**fields)
+
+
+def test_extract_numeric_scoring_levels_prefers_parenthesized_baseline_stop() -> None:
+    idea = scoreable_idea(
+        invalidation="Close below the 50-bar average (97.50)",
+        target_exit="Take profit near 113.00 (2R) or exit at expiry",
+    )
+
+    assert extract_numeric_scoring_levels(idea) == ScoringLevels(
+        entry_lower=Decimal("100"),
+        entry_upper=Decimal("102"),
+        stop=Decimal("97.50"),
+        target=Decimal("113.00"),
+    )
+
+
+def test_score_trade_idea_records_target_hit() -> None:
+    result = score_trade_idea(
+        scoreable_idea(),
+        as_of=AS_OF,
+        future_candles=(
+            candle(0, high="103", low="100", close="102"),
+            candle(1, high="114", low="101", close="113"),
+        ),
+    )
+
+    assert result.outcome is ReplayOutcome.TARGET_HIT
+    assert result.entry_price == Decimal("101")
+    assert result.exit_price == Decimal("113")
+    assert result.return_r == Decimal("2")
+    assert result.bars_evaluated == 2
+
+
+def test_score_trade_idea_requires_midpoint_entry_fill() -> None:
+    result = score_trade_idea(
+        scoreable_idea(),
+        as_of=AS_OF,
+        future_candles=(
+            candle(0, high="100.10", low="99.50", close="100"),
+            candle(1, high="114", low="101", close="113"),
+        ),
+    )
+
+    assert result.outcome is ReplayOutcome.TARGET_HIT
+    assert result.entry_time == AS_OF + timedelta(hours=1)
+    assert result.entry_price == Decimal("101")
+    assert result.bars_evaluated == 2
+
+
+def test_score_trade_idea_reports_not_filled_when_only_entry_zone_edge_trades() -> None:
+    result = score_trade_idea(
+        scoreable_idea(),
+        as_of=AS_OF,
+        future_candles=(
+            candle(0, high="100.10", low="99.50", close="100"),
+            candle(1, high="100.50", low="99.75", close="100.25"),
+        ),
+    )
+
+    assert result.outcome is ReplayOutcome.NOT_FILLED
+    assert result.entry_time is None
+    assert result.entry_price is None
+
+
+def test_score_trade_idea_uses_conservative_stop_first_when_bar_hits_both() -> None:
+    result = score_trade_idea(
+        scoreable_idea(),
+        as_of=AS_OF,
+        future_candles=(candle(0, high="114", low="94", close="101"),),
+    )
+
+    assert result.outcome is ReplayOutcome.STOP_HIT
+    assert result.exit_price == Decimal("95")
+    assert result.return_r == Decimal("-1")
+
+
+def test_score_trade_idea_records_short_target_hit() -> None:
+    result = score_trade_idea(
+        scoreable_idea(
+            direction=TradeDirection.SHORT,
+            invalidation="Close above 106",
+            target_exit="Take profit at 95 or exit at expiry",
+        ),
+        as_of=AS_OF,
+        future_candles=(
+            candle(0, high="102", low="100", close="101"),
+            candle(1, high="101", low="94", close="95"),
+        ),
+    )
+
+    assert result.outcome is ReplayOutcome.TARGET_HIT
+    assert result.entry_price == Decimal("101")
+    assert result.exit_price == Decimal("95")
+    assert result.return_r == Decimal("1.2")
+
+
+def test_score_trade_idea_uses_conservative_short_stop_first_when_bar_hits_both() -> None:
+    result = score_trade_idea(
+        scoreable_idea(
+            direction=TradeDirection.SHORT,
+            invalidation="Close above 106",
+            target_exit="Take profit at 95 or exit at expiry",
+        ),
+        as_of=AS_OF,
+        future_candles=(candle(0, high="107", low="94", close="101"),),
+    )
+
+    assert result.outcome is ReplayOutcome.STOP_HIT
+    assert result.exit_price == Decimal("106")
+    assert result.return_r == Decimal("-1")
+
+
+def test_score_trade_idea_times_out_at_last_close_before_expiry() -> None:
+    result = score_trade_idea(
+        scoreable_idea(),
+        as_of=AS_OF,
+        future_candles=(
+            candle(0, high="103", low="100", close="102"),
+            candle(3, high="106", low="99", close="104"),
+            candle(4, high="120", low="104", close="119"),
+        ),
+    )
+
+    assert result.outcome is ReplayOutcome.TIMED_OUT
+    assert result.exit_time == AS_OF + timedelta(hours=3)
+    assert result.exit_price == Decimal("104")
+    assert result.return_r == Decimal("0.5")
+
+
+def test_score_trade_idea_counts_waiting_bars_before_delayed_entry() -> None:
+    result = score_trade_idea(
+        scoreable_idea(),
+        as_of=AS_OF,
+        future_candles=(
+            candle(0, high="99", low="96", close="98"),
+            candle(1, high="99.5", low="97", close="99"),
+            candle(2, high="103", low="100", close="101"),
+            candle(3, high="114", low="101", close="113"),
+        ),
+    )
+
+    assert result.outcome is ReplayOutcome.TARGET_HIT
+    assert result.entry_time == AS_OF + timedelta(hours=2)
+    assert result.exit_time == AS_OF + timedelta(hours=3)
+    assert result.bars_evaluated == 4
+
+
+def test_score_trade_idea_reports_not_filled_when_entry_zone_never_trades() -> None:
+    result = score_trade_idea(
+        scoreable_idea(),
+        as_of=AS_OF,
+        future_candles=(
+            candle(0, high="99", low="94", close="98"),
+            candle(1, high="99.5", low="96", close="99"),
+        ),
+    )
+
+    assert result.outcome is ReplayOutcome.NOT_FILLED
+    assert result.entry_time is None
+    assert result.return_r is None
+    assert result.bars_evaluated == 2
+
+
+def test_score_trade_idea_reports_no_future_data() -> None:
+    result = score_trade_idea(scoreable_idea(), as_of=AS_OF, future_candles=())
+
+    assert result.outcome is ReplayOutcome.NO_FUTURE_DATA
+    assert result.bars_evaluated == 0
+
+
+def test_replay_runner_feeds_point_in_time_snapshots_and_reports_aggregates() -> None:
+    class ScriptedProposer:
+        proposer_id = "scripted"
+
+        def propose(self, snapshot: MarketSnapshot) -> list[TradeIdea]:
+            series = snapshot.series_for("BTC-USD")
+            assert series is not None
+            assert all(item.ts < snapshot.as_of for item in series.candles)
+            if len(series.candles) != 2:
+                return []
+            return [
+                scoreable_idea(
+                    decision_id=f"trade-{snapshot.as_of:%Y%m%d%H}",
+                    time_horizon=TimeHorizon(
+                        expected_hold="1-4 hours",
+                        expires_at=snapshot.as_of + timedelta(hours=4),
+                    ),
+                )
+            ]
+
+    candles = (
+        candle(-2, close="99", high="100", low="98"),
+        candle(-1, close="101", high="102", low="100"),
+        candle(0, close="102", high="103", low="100"),
+        candle(1, close="113", high="114", low="101"),
+    )
+
+    report = TradeIdeaReplayRunner(
+        ScriptedProposer(),
+        config=ReplayRunnerConfig(min_history=2),
+    ).run_series(symbol="BTC-USD", granularity="ONE_HOUR", candles=candles)
+
+    assert report.snapshots_evaluated == 2
+    assert report.ideas_proposed == 1
+    assert report.target_hits == 1
+    assert report.stop_hits == 0
+    assert report.target_hit_rate == Decimal("1")
+    assert report.average_return_r == Decimal("2")
+    assert report.to_dict()["ideas"][0]["outcome"] == "target_hit"
+
+
+def test_replay_runner_scores_baseline_proposer_on_historical_candles() -> None:
+    candles = (
+        candle(-5, close="100", high="100", low="100"),
+        candle(-4, close="100", high="100", low="100"),
+        candle(-3, close="100", high="100", low="100"),
+        candle(-2, close="100", high="100", low="100"),
+        candle(-1, close="110", high="110", low="110"),
+        candle(0, open_="110", close="111", high="112", low="109"),
+        candle(1, open_="111", close="126", high="126", low="111"),
+    )
+
+    report = TradeIdeaReplayRunner(
+        BaselineProposer(
+            BaselineProposerConfig(
+                short_window=2,
+                long_window=4,
+                crossover_lookback=1,
+                expiry_hours=3,
+            )
+        ),
+        config=ReplayRunnerConfig(source="fixture:candles", min_history=5),
+    ).run_series(symbol="BTC-USD", granularity="ONE_HOUR", candles=candles)
+
+    assert report.ideas_proposed == 1
+    assert report.target_hits == 1
+    assert report.ideas[0].outcome is ReplayOutcome.TARGET_HIT
+    assert report.ideas[0].levels.stop == Decimal("102.50")
+    assert report.ideas[0].levels.target == Decimal("125.00")
+
+
+def test_replay_runner_config_rejects_non_positive_min_history() -> None:
+    try:
+        ReplayRunnerConfig(min_history=0)
+    except ReplayScoringError as exc:
+        assert exc.context["field"] == "min_history"
+    else:  # pragma: no cover - defensive assertion
+        raise AssertionError("ReplayRunnerConfig should reject min_history=0")

--- a/tests/unit/gpt_trader/features/trade_ideas/test_replay.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_replay.py
@@ -72,6 +72,54 @@ def test_extract_numeric_scoring_levels_prefers_parenthesized_baseline_stop() ->
     )
 
 
+def test_extract_numeric_scoring_levels_ignores_indicator_period_before_stop() -> None:
+    idea = scoreable_idea(
+        invalidation="Close below 95 if RSI (14) rolls over",
+        target_exit="Take profit near 113.00 (2R) or exit at expiry",
+    )
+
+    assert extract_numeric_scoring_levels(idea).stop == Decimal("95")
+
+
+def test_extract_numeric_scoring_levels_uses_direct_stop_when_indicator_is_closer() -> None:
+    idea = scoreable_idea(
+        entry_zone=EntryZone(lower=Decimal("15"), upper=Decimal("17")),
+        invalidation="Close below 10 if RSI (14) rolls over",
+        target_exit="Take profit near 25.00 (2R) or exit at expiry",
+    )
+
+    assert extract_numeric_scoring_levels(idea).stop == Decimal("10")
+
+
+def test_extract_numeric_scoring_levels_ignores_indicator_threshold_before_stop() -> None:
+    idea = scoreable_idea(
+        invalidation="Invalid if RSI below 30 or close below 95",
+        target_exit="Take profit near 113.00 (2R) or exit at expiry",
+    )
+
+    assert extract_numeric_scoring_levels(idea).stop == Decimal("95")
+
+
+def test_extract_numeric_scoring_levels_ignores_reward_multiple_before_short_target() -> None:
+    idea = scoreable_idea(
+        direction=TradeDirection.SHORT,
+        invalidation="Close above 106",
+        target_exit="2R target at 95 or exit at expiry",
+    )
+
+    assert extract_numeric_scoring_levels(idea).target == Decimal("95")
+
+
+def test_extract_numeric_scoring_levels_keeps_target_before_resistance_word() -> None:
+    idea = scoreable_idea(
+        direction=TradeDirection.SHORT,
+        invalidation="Close above 106",
+        target_exit="Take profit near 95 resistance or exit at expiry",
+    )
+
+    assert extract_numeric_scoring_levels(idea).target == Decimal("95")
+
+
 def test_score_trade_idea_records_target_hit() -> None:
     result = score_trade_idea(
         scoreable_idea(),

--- a/tests/unit/gpt_trader/features/trade_ideas/test_replay.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_replay.py
@@ -143,14 +143,15 @@ def test_score_trade_idea_requires_midpoint_entry_fill() -> None:
         as_of=AS_OF,
         future_candles=(
             candle(0, high="100.10", low="99.50", close="100"),
-            candle(1, high="114", low="101", close="113"),
+            candle(1, high="106", low="101", close="104"),
+            candle(2, high="114", low="102", close="113"),
         ),
     )
 
     assert result.outcome is ReplayOutcome.TARGET_HIT
     assert result.entry_time == AS_OF + timedelta(hours=1)
     assert result.entry_price == Decimal("101")
-    assert result.bars_evaluated == 2
+    assert result.bars_evaluated == 3
 
 
 def test_score_trade_idea_reports_not_filled_when_only_entry_zone_edge_trades() -> None:
@@ -178,6 +179,22 @@ def test_score_trade_idea_uses_conservative_stop_first_when_bar_hits_both() -> N
     assert result.outcome is ReplayOutcome.STOP_HIT
     assert result.exit_price == Decimal("95")
     assert result.return_r == Decimal("-1")
+
+
+def test_score_trade_idea_defers_target_hit_on_entry_candle() -> None:
+    result = score_trade_idea(
+        scoreable_idea(),
+        as_of=AS_OF,
+        future_candles=(
+            candle(0, open_="114", high="114", low="101", close="102"),
+            candle(1, high="106", low="101", close="104"),
+        ),
+    )
+
+    assert result.outcome is ReplayOutcome.TIMED_OUT
+    assert result.entry_time == AS_OF
+    assert result.exit_time == AS_OF + timedelta(hours=1)
+    assert result.exit_price == Decimal("104")
 
 
 def test_score_trade_idea_records_short_target_hit() -> None:
@@ -269,6 +286,23 @@ def test_score_trade_idea_reports_not_filled_when_entry_zone_never_trades() -> N
 
 def test_score_trade_idea_reports_no_future_data() -> None:
     result = score_trade_idea(scoreable_idea(), as_of=AS_OF, future_candles=())
+
+    assert result.outcome is ReplayOutcome.NO_FUTURE_DATA
+    assert result.bars_evaluated == 0
+
+
+def test_score_trade_idea_excludes_candles_that_extend_past_expiry() -> None:
+    result = score_trade_idea(
+        scoreable_idea(
+            time_horizon=TimeHorizon(
+                expected_hold="30 minutes",
+                expires_at=AS_OF + timedelta(minutes=30),
+            ),
+        ),
+        as_of=AS_OF,
+        future_candles=(candle(0, high="114", low="101", close="113"),),
+        candle_duration=timedelta(hours=1),
+    )
 
     assert result.outcome is ReplayOutcome.NO_FUTURE_DATA
     assert result.bars_evaluated == 0

--- a/tests/unit/gpt_trader/features/trade_ideas/test_replay_level_extraction.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_replay_level_extraction.py
@@ -130,3 +130,43 @@ def test_extract_numeric_scoring_levels_ignores_percentage_quantity_targets() ->
     )
 
     assert extract_numeric_scoring_levels(idea).target == Decimal("20")
+
+
+def test_extract_numeric_scoring_levels_ignores_indicator_lookback_before_stop() -> None:
+    idea = scoreable_idea(
+        entry_zone=EntryZone(lower=Decimal("59"), upper=Decimal("61")),
+        invalidation="Close below the 50-bar average (40)",
+        target_exit="Take profit at 75 or exit at expiry",
+    )
+
+    assert extract_numeric_scoring_levels(idea).stop == Decimal("40")
+
+
+def test_extract_numeric_scoring_levels_ignores_duration_before_target() -> None:
+    idea = scoreable_idea(
+        entry_zone=EntryZone(lower=Decimal("8"), upper=Decimal("10")),
+        invalidation="Close below 7",
+        target_exit="Take profit at 12 or exit after 10 trading days",
+    )
+
+    assert extract_numeric_scoring_levels(idea).target == Decimal("12")
+
+
+def test_extract_numeric_scoring_levels_ignores_duration_range_before_target() -> None:
+    idea = scoreable_idea(
+        entry_zone=EntryZone(lower=Decimal("8"), upper=Decimal("10")),
+        invalidation="Close below 7",
+        target_exit="Take profit at 12 or exit after 10-20 trading days",
+    )
+
+    assert extract_numeric_scoring_levels(idea).target == Decimal("12")
+
+
+def test_extract_numeric_scoring_levels_ignores_indicator_pair_before_stop() -> None:
+    idea = scoreable_idea(
+        entry_zone=EntryZone(lower=Decimal("59"), upper=Decimal("61")),
+        invalidation="Close below the 50/200-day average (40)",
+        target_exit="Take profit at 75 or exit at expiry",
+    )
+
+    assert extract_numeric_scoring_levels(idea).stop == Decimal("40")

--- a/tests/unit/gpt_trader/features/trade_ideas/test_replay_level_extraction.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_replay_level_extraction.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+from tests.unit.gpt_trader.features.trade_ideas.conftest import build_trade_idea
+
+from gpt_trader.core import Candle
+from gpt_trader.features.trade_ideas import (
+    EntryZone,
+    ScoringLevels,
+    TimeHorizon,
+    TradeDirection,
+    TradeIdea,
+    extract_numeric_scoring_levels,
+)
+
+AS_OF = datetime(2026, 6, 12, 12, 0, tzinfo=UTC)
+
+
+def candle(
+    offset_hours: int,
+    *,
+    open_: str = "101",
+    high: str = "102",
+    low: str = "100",
+    close: str = "101",
+) -> Candle:
+    return Candle(
+        ts=AS_OF + timedelta(hours=offset_hours),
+        open=Decimal(open_),
+        high=Decimal(high),
+        low=Decimal(low),
+        close=Decimal(close),
+        volume=Decimal("1000"),
+    )
+
+
+def scoreable_idea(**overrides: object) -> TradeIdea:
+    fields = {
+        "entry_zone": EntryZone(lower=Decimal("100"), upper=Decimal("102")),
+        "invalidation": "Close below 95",
+        "target_exit": "Take profit at 113 or exit at expiry",
+        "time_horizon": TimeHorizon(
+            expected_hold="1-4 hours",
+            expires_at=AS_OF + timedelta(hours=4),
+        ),
+    }
+    fields.update(overrides)
+    return build_trade_idea(**fields)
+
+
+def test_extract_numeric_scoring_levels_prefers_parenthesized_baseline_stop() -> None:
+    idea = scoreable_idea(
+        invalidation="Close below the 50-bar average (97.50)",
+        target_exit="Take profit near 113.00 (2R) or exit at expiry",
+    )
+
+    assert extract_numeric_scoring_levels(idea) == ScoringLevels(
+        entry_lower=Decimal("100"),
+        entry_upper=Decimal("102"),
+        stop=Decimal("97.50"),
+        target=Decimal("113.00"),
+    )
+
+
+def test_extract_numeric_scoring_levels_ignores_indicator_period_before_stop() -> None:
+    idea = scoreable_idea(
+        invalidation="Close below 95 if RSI (14) rolls over",
+        target_exit="Take profit near 113.00 (2R) or exit at expiry",
+    )
+
+    assert extract_numeric_scoring_levels(idea).stop == Decimal("95")
+
+
+def test_extract_numeric_scoring_levels_uses_direct_stop_when_indicator_is_closer() -> None:
+    idea = scoreable_idea(
+        entry_zone=EntryZone(lower=Decimal("15"), upper=Decimal("17")),
+        invalidation="Close below 10 if RSI (14) rolls over",
+        target_exit="Take profit near 25.00 (2R) or exit at expiry",
+    )
+
+    assert extract_numeric_scoring_levels(idea).stop == Decimal("10")
+
+
+def test_extract_numeric_scoring_levels_ignores_indicator_threshold_before_stop() -> None:
+    idea = scoreable_idea(
+        invalidation="Invalid if RSI below 30 or close below 95",
+        target_exit="Take profit near 113.00 (2R) or exit at expiry",
+    )
+
+    assert extract_numeric_scoring_levels(idea).stop == Decimal("95")
+
+
+def test_extract_numeric_scoring_levels_ignores_reward_multiple_before_short_target() -> None:
+    idea = scoreable_idea(
+        direction=TradeDirection.SHORT,
+        invalidation="Close above 106",
+        target_exit="2R target at 95 or exit at expiry",
+    )
+
+    assert extract_numeric_scoring_levels(idea).target == Decimal("95")
+
+
+def test_extract_numeric_scoring_levels_ignores_percentage_before_long_target() -> None:
+    idea = scoreable_idea(
+        entry_zone=EntryZone(lower=Decimal("19"), upper=Decimal("21")),
+        invalidation="Close below 18",
+        target_exit="Take 25% at 30 or exit at expiry",
+    )
+
+    assert extract_numeric_scoring_levels(idea).target == Decimal("30")
+
+
+def test_extract_numeric_scoring_levels_keeps_target_before_resistance_word() -> None:
+    idea = scoreable_idea(
+        direction=TradeDirection.SHORT,
+        invalidation="Close above 106",
+        target_exit="Take profit near 95 resistance or exit at expiry",
+    )
+
+    assert extract_numeric_scoring_levels(idea).target == Decimal("95")
+
+
+def test_extract_numeric_scoring_levels_ignores_percentage_quantity_targets() -> None:
+    idea = scoreable_idea(
+        entry_zone=EntryZone(lower=Decimal("15"), upper=Decimal("17")),
+        invalidation="Close below 12",
+        target_exit="Take 25% at 20, then exit the rest at expiry",
+    )
+
+    assert extract_numeric_scoring_levels(idea).target == Decimal("20")

--- a/tests/unit/gpt_trader/features/trade_ideas/test_replay_level_extraction.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_replay_level_extraction.py
@@ -170,3 +170,33 @@ def test_extract_numeric_scoring_levels_ignores_indicator_pair_before_stop() -> 
     )
 
     assert extract_numeric_scoring_levels(idea).stop == Decimal("40")
+
+
+def test_extract_numeric_scoring_levels_ignores_period_lookback_before_stop() -> None:
+    idea = scoreable_idea(
+        entry_zone=EntryZone(lower=Decimal("59"), upper=Decimal("61")),
+        invalidation="Close below the 50-period average (40)",
+        target_exit="Take profit at 75 or exit at expiry",
+    )
+
+    assert extract_numeric_scoring_levels(idea).stop == Decimal("40")
+
+
+def test_extract_numeric_scoring_levels_accepts_currency_prefixed_stop() -> None:
+    idea = scoreable_idea(
+        entry_zone=EntryZone(lower=Decimal("15"), upper=Decimal("17")),
+        invalidation="Close below $10 if RSI (14) rolls over",
+        target_exit="Take profit near 25.00 (2R) or exit at expiry",
+    )
+
+    assert extract_numeric_scoring_levels(idea).stop == Decimal("10")
+
+
+def test_extract_numeric_scoring_levels_accepts_spaced_currency_prefixed_stop() -> None:
+    idea = scoreable_idea(
+        entry_zone=EntryZone(lower=Decimal("15"), upper=Decimal("17")),
+        invalidation="Close below $ 10 if RSI (14) rolls over",
+        target_exit="Take profit near 25.00 (2R) or exit at expiry",
+    )
+
+    assert extract_numeric_scoring_levels(idea).stop == Decimal("10")

--- a/tests/unit/gpt_trader/features/trade_ideas/test_replay_runner.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_replay_runner.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+from tests.unit.gpt_trader.features.trade_ideas.conftest import build_trade_idea
+
+from gpt_trader.core import Candle
+from gpt_trader.features.trade_ideas import (
+    BaselineProposer,
+    BaselineProposerConfig,
+    EntryZone,
+    MarketSnapshot,
+    ReplayOutcome,
+    ReplayRunnerConfig,
+    ReplayScoringError,
+    TimeHorizon,
+    TradeIdea,
+    TradeIdeaReplayRunner,
+)
+
+AS_OF = datetime(2026, 6, 12, 12, 0, tzinfo=UTC)
+
+
+def candle(
+    offset_hours: int,
+    *,
+    open_: str = "101",
+    high: str = "102",
+    low: str = "100",
+    close: str = "101",
+) -> Candle:
+    return Candle(
+        ts=AS_OF + timedelta(hours=offset_hours),
+        open=Decimal(open_),
+        high=Decimal(high),
+        low=Decimal(low),
+        close=Decimal(close),
+        volume=Decimal("1000"),
+    )
+
+
+def scoreable_idea(**overrides: object) -> TradeIdea:
+    fields = {
+        "entry_zone": EntryZone(lower=Decimal("100"), upper=Decimal("102")),
+        "invalidation": "Close below 95",
+        "target_exit": "Take profit at 113 or exit at expiry",
+        "time_horizon": TimeHorizon(
+            expected_hold="1-4 hours",
+            expires_at=AS_OF + timedelta(hours=4),
+        ),
+    }
+    fields.update(overrides)
+    return build_trade_idea(**fields)
+
+
+def test_score_trade_idea_normalizes_common_granularity_aliases_for_expiry() -> None:
+    class ScriptedProposer:
+        proposer_id = "scripted"
+
+        def propose(self, snapshot: MarketSnapshot) -> list[TradeIdea]:
+            return [
+                scoreable_idea(
+                    time_horizon=TimeHorizon(
+                        expected_hold="30 minutes",
+                        expires_at=snapshot.as_of + timedelta(minutes=30),
+                    ),
+                )
+            ]
+
+    report = TradeIdeaReplayRunner(
+        ScriptedProposer(),
+        config=ReplayRunnerConfig(min_history=1),
+    ).run_series(
+        symbol="BTC-USD",
+        granularity="1H",
+        candles=(
+            candle(-1, high="102", low="100", close="101"),
+            candle(0, high="114", low="101", close="113"),
+        ),
+    )
+
+    assert report.ideas[0].outcome is ReplayOutcome.NO_FUTURE_DATA
+
+
+def test_replay_runner_normalizes_daily_granularity_before_expiry_filter() -> None:
+    class DailyProposer:
+        proposer_id = "daily"
+
+        def propose(self, snapshot: MarketSnapshot) -> list[TradeIdea]:
+            return [
+                scoreable_idea(
+                    time_horizon=TimeHorizon(
+                        expected_hold="12 hours",
+                        expires_at=snapshot.as_of + timedelta(hours=12),
+                    ),
+                )
+            ]
+
+    report = TradeIdeaReplayRunner(
+        DailyProposer(),
+        config=ReplayRunnerConfig(min_history=1),
+    ).run_series(
+        symbol="BTC-USD",
+        granularity="1d",
+        candles=(
+            candle(-24, close="100", high="101", low="99"),
+            candle(0, high="114", low="101", close="113"),
+        ),
+    )
+
+    assert report.ideas_proposed == 1
+    assert report.no_future_data == 1
+
+
+def test_replay_runner_feeds_point_in_time_snapshots_and_reports_aggregates() -> None:
+    class ScriptedProposer:
+        proposer_id = "scripted"
+
+        def propose(self, snapshot: MarketSnapshot) -> list[TradeIdea]:
+            series = snapshot.series_for("BTC-USD")
+            assert series is not None
+            assert all(item.ts < snapshot.as_of for item in series.candles)
+            if len(series.candles) != 2:
+                return []
+            return [
+                scoreable_idea(
+                    decision_id=f"trade-{snapshot.as_of:%Y%m%d%H}",
+                    time_horizon=TimeHorizon(
+                        expected_hold="1-4 hours",
+                        expires_at=snapshot.as_of + timedelta(hours=4),
+                    ),
+                )
+            ]
+
+    candles = (
+        candle(-2, close="99", high="100", low="98"),
+        candle(-1, close="101", high="102", low="100"),
+        candle(0, close="102", high="103", low="100"),
+        candle(1, close="113", high="114", low="101"),
+    )
+
+    report = TradeIdeaReplayRunner(
+        ScriptedProposer(),
+        config=ReplayRunnerConfig(min_history=2),
+    ).run_series(symbol="BTC-USD", granularity="ONE_HOUR", candles=candles)
+
+    assert report.snapshots_evaluated == 2
+    assert report.ideas_proposed == 1
+    assert report.target_hits == 1
+    assert report.stop_hits == 0
+    assert report.target_hit_rate == Decimal("1")
+    assert report.average_return_r == Decimal("2")
+    assert report.to_dict()["ideas"][0]["outcome"] == "target_hit"
+
+
+def test_replay_runner_scores_baseline_proposer_on_historical_candles() -> None:
+    candles = (
+        candle(-5, close="100", high="100", low="100"),
+        candle(-4, close="100", high="100", low="100"),
+        candle(-3, close="100", high="100", low="100"),
+        candle(-2, close="100", high="100", low="100"),
+        candle(-1, close="110", high="110", low="110"),
+        candle(0, open_="110", close="111", high="112", low="109"),
+        candle(1, open_="111", close="126", high="126", low="111"),
+    )
+
+    report = TradeIdeaReplayRunner(
+        BaselineProposer(
+            BaselineProposerConfig(
+                short_window=2,
+                long_window=4,
+                crossover_lookback=1,
+                expiry_hours=3,
+            )
+        ),
+        config=ReplayRunnerConfig(source="fixture:candles", min_history=5),
+    ).run_series(symbol="BTC-USD", granularity="ONE_HOUR", candles=candles)
+
+    assert report.ideas_proposed == 1
+    assert report.target_hits == 1
+    assert report.ideas[0].outcome is ReplayOutcome.TARGET_HIT
+    assert report.ideas[0].levels.stop == Decimal("102.50")
+    assert report.ideas[0].levels.target == Decimal("125.00")
+
+
+def test_replay_runner_config_rejects_non_positive_min_history() -> None:
+    try:
+        ReplayRunnerConfig(min_history=0)
+    except ReplayScoringError as exc:
+        assert exc.context["field"] == "min_history"
+    else:  # pragma: no cover - defensive assertion
+        raise AssertionError("ReplayRunnerConfig should reject min_history=0")

--- a/tests/unit/scripts/test_docs_maintenance.py
+++ b/tests/unit/scripts/test_docs_maintenance.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-
 from scripts.maintenance import docs_link_audit, docs_reachability_check
 
 
@@ -42,6 +41,25 @@ def test_iter_repo_path_references_filters_invalid_patterns() -> None:
         "scripts/maintenance/docs_link_audit.py",
         "config/environments/.env.template",
     ]
+
+
+def test_docs_link_audit_skips_repo_path_checks_for_proposed_specs() -> None:
+    root = Path("/repo")
+
+    assert (
+        docs_link_audit.should_check_repo_paths(
+            root / "docs" / "specs" / "future_interface.md",
+            root=root,
+        )
+        is False
+    )
+    assert (
+        docs_link_audit.should_check_repo_paths(
+            root / "docs" / "architecture" / "current_system.md",
+            root=root,
+        )
+        is True
+    )
 
 
 @pytest.mark.parametrize(

--- a/var/agents/configuration/environment_variables.json
+++ b/var/agents/configuration/environment_variables.json
@@ -2407,7 +2407,7 @@
       ],
       "code_references": [
         {
-          "line": 54,
+          "line": 56,
           "path": "src/gpt_trader/features/brokerages/coinbase/specs.py",
           "reader": "os.environ.get"
         }

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,8 +7,8 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6560,
-    "total_files": 772,
+    "total_tests": 6575,
+    "total_files": 773,
     "markers_used": 16
   },
   "quick_commands": {

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6580,
+    "total_tests": 6582,
     "total_files": 773,
     "markers_used": 16
   },

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,8 +7,8 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6582,
-    "total_files": 773,
+    "total_tests": 6586,
+    "total_files": 775,
     "markers_used": 16
   },
   "quick_commands": {

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6592,
+    "total_tests": 6595,
     "total_files": 775,
     "markers_used": 16
   },

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6575,
+    "total_tests": 6580,
     "total_files": 773,
     "markers_used": 16
   },

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6590,
+    "total_tests": 6592,
     "total_files": 775,
     "markers_used": 16
   },

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6586,
+    "total_tests": 6590,
     "total_files": 775,
     "markers_used": 16
   },

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,8 +95,8 @@
     ]
   },
   "counts": {
-    "unit": 6425,
-    "asyncio": 372,
+    "unit": 6427,
+    "asyncio": 373,
     "parametrize": 174,
     "endpoints": 83,
     "property": 82,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6415,
+    "unit": 6417,
     "asyncio": 372,
     "parametrize": 174,
     "endpoints": 83,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6410,
+    "unit": 6415,
     "asyncio": 372,
     "parametrize": 174,
     "endpoints": 83,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6395,
+    "unit": 6410,
     "asyncio": 372,
     "parametrize": 174,
     "endpoints": 83,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6421,
+    "unit": 6425,
     "asyncio": 372,
     "parametrize": 174,
     "endpoints": 83,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6417,
+    "unit": 6421,
     "asyncio": 372,
     "parametrize": 174,
     "endpoints": 83,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6427,
+    "unit": 6430,
     "asyncio": 373,
     "parametrize": 174,
     "endpoints": 83,

--- a/var/agents/testing/source_test_map.json
+++ b/var/agents/testing/source_test_map.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "summary": {
     "tests_scanned": 695,
-    "source_modules": 367,
+    "source_modules": 368,
     "unresolved_modules": 3
   },
   "source_to_tests": {
@@ -1425,6 +1425,9 @@
       "tests/unit/gpt_trader/monitoring/test_health_checks.py",
       "tests/unit/gpt_trader/monitoring/test_metrics_collector.py",
       "tests/unit/gpt_trader/monitoring/test_metrics_exporter.py"
+    ],
+    "gpt_trader.monitoring.notifications": [
+      "tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_core.py"
     ],
     "gpt_trader.monitoring.notifications.backends": [
       "tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_core.py",
@@ -3916,6 +3919,7 @@
     ],
     "tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_core.py": [
       "gpt_trader.monitoring.alert_types",
+      "gpt_trader.monitoring.notifications",
       "gpt_trader.monitoring.notifications.backends"
     ],
     "tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_edges.py": [
@@ -5067,6 +5071,7 @@
     "gpt_trader.monitoring.interfaces": "src/gpt_trader/monitoring/interfaces.py",
     "gpt_trader.monitoring.metrics_collector": "src/gpt_trader/monitoring/metrics_collector.py",
     "gpt_trader.monitoring.metrics_exporter": "src/gpt_trader/monitoring/metrics_exporter.py",
+    "gpt_trader.monitoring.notifications": "src/gpt_trader/monitoring/notifications/__init__.py",
     "gpt_trader.monitoring.notifications.backends": "src/gpt_trader/monitoring/notifications/backends.py",
     "gpt_trader.monitoring.notifications.service": "src/gpt_trader/monitoring/notifications/service.py",
     "gpt_trader.monitoring.profiling": "src/gpt_trader/monitoring/profiling.py",

--- a/var/agents/testing/source_test_map.json
+++ b/var/agents/testing/source_test_map.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "summary": {
-    "tests_scanned": 693,
+    "tests_scanned": 695,
     "source_modules": 367,
     "unresolved_modules": 3
   },
@@ -436,6 +436,8 @@
       "tests/unit/gpt_trader/features/live_trade/test_risk_time_windows.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_baseline_proposer.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_replay.py",
+      "tests/unit/gpt_trader/features/trade_ideas/test_replay_level_extraction.py",
+      "tests/unit/gpt_trader/features/trade_ideas/test_replay_runner.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_snapshot.py",
       "tests/unit/gpt_trader/tui/test_app_bootstrap_snapshot.py"
     ],
@@ -1244,6 +1246,8 @@
       "tests/unit/gpt_trader/features/trade_ideas/test_models.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_policy.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_replay.py",
+      "tests/unit/gpt_trader/features/trade_ideas/test_replay_level_extraction.py",
+      "tests/unit/gpt_trader/features/trade_ideas/test_replay_runner.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_service.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_snapshot.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_store.py",
@@ -3779,6 +3783,14 @@
       "gpt_trader.features.trade_ideas"
     ],
     "tests/unit/gpt_trader/features/trade_ideas/test_replay.py": [
+      "gpt_trader.core",
+      "gpt_trader.features.trade_ideas"
+    ],
+    "tests/unit/gpt_trader/features/trade_ideas/test_replay_level_extraction.py": [
+      "gpt_trader.core",
+      "gpt_trader.features.trade_ideas"
+    ],
+    "tests/unit/gpt_trader/features/trade_ideas/test_replay_runner.py": [
       "gpt_trader.core",
       "gpt_trader.features.trade_ideas"
     ],

--- a/var/agents/testing/source_test_map.json
+++ b/var/agents/testing/source_test_map.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "summary": {
-    "tests_scanned": 692,
+    "tests_scanned": 693,
     "source_modules": 367,
     "unresolved_modules": 3
   },
@@ -435,6 +435,7 @@
       "tests/unit/gpt_trader/features/live_trade/test_risk.py",
       "tests/unit/gpt_trader/features/live_trade/test_risk_time_windows.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_baseline_proposer.py",
+      "tests/unit/gpt_trader/features/trade_ideas/test_replay.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_snapshot.py",
       "tests/unit/gpt_trader/tui/test_app_bootstrap_snapshot.py"
     ],
@@ -1242,6 +1243,7 @@
       "tests/unit/gpt_trader/features/trade_ideas/test_eligibility.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_models.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_policy.py",
+      "tests/unit/gpt_trader/features/trade_ideas/test_replay.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_service.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_snapshot.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_store.py",
@@ -3774,6 +3776,10 @@
       "gpt_trader.features.trade_ideas"
     ],
     "tests/unit/gpt_trader/features/trade_ideas/test_policy.py": [
+      "gpt_trader.features.trade_ideas"
+    ],
+    "tests/unit/gpt_trader/features/trade_ideas/test_replay.py": [
+      "gpt_trader.core",
       "gpt_trader.features.trade_ideas"
     ],
     "tests/unit/gpt_trader/features/trade_ideas/test_service.py": [

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6590,
+    "total_tests": 6592,
     "total_files": 775,
     "markers_used": 16
   },
@@ -102,8 +102,8 @@
     ]
   },
   "marker_counts": {
-    "unit": 6425,
-    "asyncio": 372,
+    "unit": 6427,
+    "asyncio": 373,
     "parametrize": 174,
     "endpoints": 83,
     "property": 82,
@@ -16228,8 +16228,16 @@
     ],
     "tests/unit/gpt_trader/features/brokerages/coinbase/test_specs_order.py": [
       {
-        "name": "TestSpecsServiceCalculateSafePositionSize::test_calculate_safe_position_size_normal_case",
+        "name": "test_price_validated_order_types_are_constant_membership_set",
         "line": 13,
+        "markers": [
+          "unit"
+        ],
+        "docstring": "Price validation order types use a reusable constant set."
+      },
+      {
+        "name": "TestSpecsServiceCalculateSafePositionSize::test_calculate_safe_position_size_normal_case",
+        "line": 22,
         "markers": [
           "unit"
         ],
@@ -16238,7 +16246,7 @@
       },
       {
         "name": "TestSpecsServiceCalculateSafePositionSize::test_calculate_safe_position_size_below_min_size",
-        "line": 31,
+        "line": 40,
         "markers": [
           "unit"
         ],
@@ -16247,7 +16255,7 @@
       },
       {
         "name": "TestSpecsServiceCalculateSafePositionSize::test_calculate_safe_position_size_below_min_notional",
-        "line": 49,
+        "line": 58,
         "markers": [
           "unit"
         ],
@@ -16256,7 +16264,7 @@
       },
       {
         "name": "TestSpecsServiceCalculateSafePositionSize::test_calculate_safe_position_size_above_max_size",
-        "line": 68,
+        "line": 77,
         "markers": [
           "unit"
         ],
@@ -16265,7 +16273,7 @@
       },
       {
         "name": "TestSpecsServiceCalculateSafePositionSize::test_calculate_safe_position_size_cannot_meet_min_notional",
-        "line": 86,
+        "line": 95,
         "markers": [
           "unit"
         ],
@@ -16274,7 +16282,7 @@
       },
       {
         "name": "TestSpecsServiceValidateOrder::test_validate_order_market_order",
-        "line": 108,
+        "line": 117,
         "markers": [
           "unit"
         ],
@@ -16283,7 +16291,7 @@
       },
       {
         "name": "TestSpecsServiceValidateOrder::test_validate_order_limit_order_valid",
-        "line": 125,
+        "line": 134,
         "markers": [
           "unit"
         ],
@@ -16292,7 +16300,7 @@
       },
       {
         "name": "TestSpecsServiceValidateOrder::test_validate_order_size_too_small",
-        "line": 143,
+        "line": 152,
         "markers": [
           "unit"
         ],
@@ -16301,7 +16309,7 @@
       },
       {
         "name": "TestSpecsServiceValidateOrder::test_validate_order_size_too_large",
-        "line": 159,
+        "line": 168,
         "markers": [
           "unit"
         ],
@@ -16310,7 +16318,7 @@
       },
       {
         "name": "TestSpecsServiceValidateOrder::test_validate_order_notional_too_small",
-        "line": 175,
+        "line": 184,
         "markers": [
           "unit"
         ],
@@ -16319,7 +16327,7 @@
       },
       {
         "name": "TestSpecsServiceValidateOrder::test_validate_order_price_quantization",
-        "line": 193,
+        "line": 202,
         "markers": [
           "unit"
         ],
@@ -34370,7 +34378,7 @@
     "tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_core.py": [
       {
         "name": "TestConsoleNotificationBackend::test_name_property",
-        "line": 20,
+        "line": 22,
         "markers": [
           "unit"
         ],
@@ -34379,7 +34387,7 @@
       },
       {
         "name": "TestConsoleNotificationBackend::test_is_enabled_property",
-        "line": 24,
+        "line": 26,
         "markers": [
           "unit"
         ],
@@ -34388,7 +34396,7 @@
       },
       {
         "name": "TestConsoleNotificationBackend::test_send_prints_to_console",
-        "line": 32,
+        "line": 34,
         "markers": [
           "asyncio",
           "unit"
@@ -34398,7 +34406,7 @@
       },
       {
         "name": "TestConsoleNotificationBackend::test_send_filters_by_severity",
-        "line": 49,
+        "line": 51,
         "markers": [
           "asyncio",
           "unit"
@@ -34408,7 +34416,7 @@
       },
       {
         "name": "TestConsoleNotificationBackend::test_test_connection_always_true",
-        "line": 64,
+        "line": 66,
         "markers": [
           "asyncio",
           "unit"
@@ -34418,7 +34426,7 @@
       },
       {
         "name": "TestFileNotificationBackend::test_name_property",
-        "line": 73,
+        "line": 75,
         "markers": [
           "unit"
         ],
@@ -34427,7 +34435,7 @@
       },
       {
         "name": "TestFileNotificationBackend::test_send_writes_to_file",
-        "line": 78,
+        "line": 80,
         "markers": [
           "asyncio",
           "unit"
@@ -34437,7 +34445,17 @@
       },
       {
         "name": "TestFileNotificationBackend::test_test_connection_checks_writability",
-        "line": 100,
+        "line": 102,
+        "markers": [
+          "asyncio",
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestFileNotificationBackend"
+      },
+      {
+        "name": "TestFileNotificationBackend::test_test_connection_offloads_file_check_to_thread",
+        "line": 114,
         "markers": [
           "asyncio",
           "unit"
@@ -34447,7 +34465,7 @@
       },
       {
         "name": "TestFileNotificationBackend::test_test_connection_fails_for_invalid_path",
-        "line": 112,
+        "line": 138,
         "markers": [
           "asyncio",
           "unit"

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,8 +2,8 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6582,
-    "total_files": 773,
+    "total_tests": 6586,
+    "total_files": 775,
     "markers_used": 16
   },
   "marker_definitions": {
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6417,
+    "unit": 6421,
     "asyncio": 372,
     "parametrize": 174,
     "endpoints": 83,
@@ -526,6 +526,8 @@
       "tests/unit/gpt_trader/features/trade_ideas/test_models.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_policy.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_replay.py",
+      "tests/unit/gpt_trader/features/trade_ideas/test_replay_level_extraction.py",
+      "tests/unit/gpt_trader/features/trade_ideas/test_replay_runner.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_service.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_snapshot.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_store.py",
@@ -31840,56 +31842,8 @@
     ],
     "tests/unit/gpt_trader/features/trade_ideas/test_replay.py": [
       {
-        "name": "test_extract_numeric_scoring_levels_prefers_parenthesized_baseline_stop",
-        "line": 61,
-        "markers": [
-          "unit"
-        ],
-        "docstring": ""
-      },
-      {
-        "name": "test_extract_numeric_scoring_levels_ignores_indicator_period_before_stop",
-        "line": 75,
-        "markers": [
-          "unit"
-        ],
-        "docstring": ""
-      },
-      {
-        "name": "test_extract_numeric_scoring_levels_uses_direct_stop_when_indicator_is_closer",
-        "line": 84,
-        "markers": [
-          "unit"
-        ],
-        "docstring": ""
-      },
-      {
-        "name": "test_extract_numeric_scoring_levels_ignores_indicator_threshold_before_stop",
-        "line": 94,
-        "markers": [
-          "unit"
-        ],
-        "docstring": ""
-      },
-      {
-        "name": "test_extract_numeric_scoring_levels_ignores_reward_multiple_before_short_target",
-        "line": 103,
-        "markers": [
-          "unit"
-        ],
-        "docstring": ""
-      },
-      {
-        "name": "test_extract_numeric_scoring_levels_keeps_target_before_resistance_word",
-        "line": 113,
-        "markers": [
-          "unit"
-        ],
-        "docstring": ""
-      },
-      {
         "name": "test_score_trade_idea_records_target_hit",
-        "line": 123,
+        "line": 53,
         "markers": [
           "unit"
         ],
@@ -31897,7 +31851,7 @@
       },
       {
         "name": "test_score_trade_idea_requires_midpoint_entry_fill",
-        "line": 140,
+        "line": 70,
         "markers": [
           "unit"
         ],
@@ -31905,7 +31859,7 @@
       },
       {
         "name": "test_score_trade_idea_reports_not_filled_when_only_entry_zone_edge_trades",
-        "line": 157,
+        "line": 87,
         "markers": [
           "unit"
         ],
@@ -31913,7 +31867,7 @@
       },
       {
         "name": "test_score_trade_idea_uses_conservative_stop_first_when_bar_hits_both",
-        "line": 172,
+        "line": 102,
         "markers": [
           "unit"
         ],
@@ -31921,7 +31875,7 @@
       },
       {
         "name": "test_score_trade_idea_defers_target_hit_on_entry_candle",
-        "line": 184,
+        "line": 114,
         "markers": [
           "unit"
         ],
@@ -31929,7 +31883,7 @@
       },
       {
         "name": "test_score_trade_idea_records_short_target_hit",
-        "line": 200,
+        "line": 130,
         "markers": [
           "unit"
         ],
@@ -31937,7 +31891,7 @@
       },
       {
         "name": "test_score_trade_idea_uses_conservative_short_stop_first_when_bar_hits_both",
-        "line": 220,
+        "line": 150,
         "markers": [
           "unit"
         ],
@@ -31945,7 +31899,7 @@
       },
       {
         "name": "test_score_trade_idea_times_out_at_last_close_before_expiry",
-        "line": 236,
+        "line": 166,
         "markers": [
           "unit"
         ],
@@ -31953,7 +31907,7 @@
       },
       {
         "name": "test_score_trade_idea_counts_waiting_bars_before_delayed_entry",
-        "line": 253,
+        "line": 183,
         "markers": [
           "unit"
         ],
@@ -31961,7 +31915,7 @@
       },
       {
         "name": "test_score_trade_idea_reports_not_filled_when_entry_zone_never_trades",
-        "line": 271,
+        "line": 201,
         "markers": [
           "unit"
         ],
@@ -31969,7 +31923,7 @@
       },
       {
         "name": "test_score_trade_idea_reports_no_future_data",
-        "line": 287,
+        "line": 217,
         "markers": [
           "unit"
         ],
@@ -31977,7 +31931,91 @@
       },
       {
         "name": "test_score_trade_idea_excludes_candles_that_extend_past_expiry",
-        "line": 294,
+        "line": 224,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      }
+    ],
+    "tests/unit/gpt_trader/features/trade_ideas/test_replay_level_extraction.py": [
+      {
+        "name": "test_extract_numeric_scoring_levels_prefers_parenthesized_baseline_stop",
+        "line": 53,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_extract_numeric_scoring_levels_ignores_indicator_period_before_stop",
+        "line": 67,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_extract_numeric_scoring_levels_uses_direct_stop_when_indicator_is_closer",
+        "line": 76,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_extract_numeric_scoring_levels_ignores_indicator_threshold_before_stop",
+        "line": 86,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_extract_numeric_scoring_levels_ignores_reward_multiple_before_short_target",
+        "line": 95,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_extract_numeric_scoring_levels_ignores_percentage_before_long_target",
+        "line": 105,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_extract_numeric_scoring_levels_keeps_target_before_resistance_word",
+        "line": 115,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_extract_numeric_scoring_levels_ignores_percentage_quantity_targets",
+        "line": 125,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      }
+    ],
+    "tests/unit/gpt_trader/features/trade_ideas/test_replay_runner.py": [
+      {
+        "name": "test_score_trade_idea_normalizes_common_granularity_aliases_for_expiry",
+        "line": 57,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_replay_runner_normalizes_daily_granularity_before_expiry_filter",
+        "line": 86,
         "markers": [
           "unit"
         ],
@@ -31985,7 +32023,7 @@
       },
       {
         "name": "test_replay_runner_feeds_point_in_time_snapshots_and_reports_aggregates",
-        "line": 311,
+        "line": 116,
         "markers": [
           "unit"
         ],
@@ -31993,7 +32031,7 @@
       },
       {
         "name": "test_replay_runner_scores_baseline_proposer_on_historical_candles",
-        "line": 352,
+        "line": 157,
         "markers": [
           "unit"
         ],
@@ -32001,7 +32039,7 @@
       },
       {
         "name": "test_replay_runner_config_rejects_non_positive_min_history",
-        "line": 382,
+        "line": 187,
         "markers": [
           "unit"
         ],

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6586,
+    "total_tests": 6590,
     "total_files": 775,
     "markers_used": 16
   },
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6421,
+    "unit": 6425,
     "asyncio": 372,
     "parametrize": 174,
     "endpoints": 83,
@@ -31998,6 +31998,38 @@
       {
         "name": "test_extract_numeric_scoring_levels_ignores_percentage_quantity_targets",
         "line": 125,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_extract_numeric_scoring_levels_ignores_indicator_lookback_before_stop",
+        "line": 135,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_extract_numeric_scoring_levels_ignores_duration_before_target",
+        "line": 145,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_extract_numeric_scoring_levels_ignores_duration_range_before_target",
+        "line": 155,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_extract_numeric_scoring_levels_ignores_indicator_pair_before_stop",
+        "line": 165,
         "markers": [
           "unit"
         ],

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6575,
+    "total_tests": 6580,
     "total_files": 773,
     "markers_used": 16
   },
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6410,
+    "unit": 6415,
     "asyncio": 372,
     "parametrize": 174,
     "endpoints": 83,
@@ -31848,7 +31848,7 @@
         "docstring": ""
       },
       {
-        "name": "test_score_trade_idea_records_target_hit",
+        "name": "test_extract_numeric_scoring_levels_ignores_indicator_period_before_stop",
         "line": 75,
         "markers": [
           "unit"
@@ -31856,23 +31856,39 @@
         "docstring": ""
       },
       {
-        "name": "test_score_trade_idea_requires_midpoint_entry_fill",
-        "line": 92,
+        "name": "test_extract_numeric_scoring_levels_uses_direct_stop_when_indicator_is_closer",
+        "line": 84,
         "markers": [
           "unit"
         ],
         "docstring": ""
       },
       {
-        "name": "test_score_trade_idea_reports_not_filled_when_only_entry_zone_edge_trades",
-        "line": 108,
+        "name": "test_extract_numeric_scoring_levels_ignores_indicator_threshold_before_stop",
+        "line": 94,
         "markers": [
           "unit"
         ],
         "docstring": ""
       },
       {
-        "name": "test_score_trade_idea_uses_conservative_stop_first_when_bar_hits_both",
+        "name": "test_extract_numeric_scoring_levels_ignores_reward_multiple_before_short_target",
+        "line": 103,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_extract_numeric_scoring_levels_keeps_target_before_resistance_word",
+        "line": 113,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_score_trade_idea_records_target_hit",
         "line": 123,
         "markers": [
           "unit"
@@ -31880,23 +31896,23 @@
         "docstring": ""
       },
       {
-        "name": "test_score_trade_idea_records_short_target_hit",
-        "line": 135,
+        "name": "test_score_trade_idea_requires_midpoint_entry_fill",
+        "line": 140,
         "markers": [
           "unit"
         ],
         "docstring": ""
       },
       {
-        "name": "test_score_trade_idea_uses_conservative_short_stop_first_when_bar_hits_both",
-        "line": 155,
+        "name": "test_score_trade_idea_reports_not_filled_when_only_entry_zone_edge_trades",
+        "line": 156,
         "markers": [
           "unit"
         ],
         "docstring": ""
       },
       {
-        "name": "test_score_trade_idea_times_out_at_last_close_before_expiry",
+        "name": "test_score_trade_idea_uses_conservative_stop_first_when_bar_hits_both",
         "line": 171,
         "markers": [
           "unit"
@@ -31904,8 +31920,32 @@
         "docstring": ""
       },
       {
+        "name": "test_score_trade_idea_records_short_target_hit",
+        "line": 183,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_score_trade_idea_uses_conservative_short_stop_first_when_bar_hits_both",
+        "line": 203,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_score_trade_idea_times_out_at_last_close_before_expiry",
+        "line": 219,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
         "name": "test_score_trade_idea_counts_waiting_bars_before_delayed_entry",
-        "line": 188,
+        "line": 236,
         "markers": [
           "unit"
         ],
@@ -31913,7 +31953,7 @@
       },
       {
         "name": "test_score_trade_idea_reports_not_filled_when_entry_zone_never_trades",
-        "line": 206,
+        "line": 254,
         "markers": [
           "unit"
         ],
@@ -31921,22 +31961,6 @@
       },
       {
         "name": "test_score_trade_idea_reports_no_future_data",
-        "line": 222,
-        "markers": [
-          "unit"
-        ],
-        "docstring": ""
-      },
-      {
-        "name": "test_replay_runner_feeds_point_in_time_snapshots_and_reports_aggregates",
-        "line": 229,
-        "markers": [
-          "unit"
-        ],
-        "docstring": ""
-      },
-      {
-        "name": "test_replay_runner_scores_baseline_proposer_on_historical_candles",
         "line": 270,
         "markers": [
           "unit"
@@ -31944,8 +31968,24 @@
         "docstring": ""
       },
       {
+        "name": "test_replay_runner_feeds_point_in_time_snapshots_and_reports_aggregates",
+        "line": 277,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_replay_runner_scores_baseline_proposer_on_historical_candles",
+        "line": 318,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
         "name": "test_replay_runner_config_rejects_non_positive_min_history",
-        "line": 300,
+        "line": 348,
         "markers": [
           "unit"
         ],

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6580,
+    "total_tests": 6582,
     "total_files": 773,
     "markers_used": 16
   },
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6415,
+    "unit": 6417,
     "asyncio": 372,
     "parametrize": 174,
     "endpoints": 83,
@@ -31905,7 +31905,7 @@
       },
       {
         "name": "test_score_trade_idea_reports_not_filled_when_only_entry_zone_edge_trades",
-        "line": 156,
+        "line": 157,
         "markers": [
           "unit"
         ],
@@ -31913,7 +31913,15 @@
       },
       {
         "name": "test_score_trade_idea_uses_conservative_stop_first_when_bar_hits_both",
-        "line": 171,
+        "line": 172,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_score_trade_idea_defers_target_hit_on_entry_candle",
+        "line": 184,
         "markers": [
           "unit"
         ],
@@ -31921,7 +31929,7 @@
       },
       {
         "name": "test_score_trade_idea_records_short_target_hit",
-        "line": 183,
+        "line": 200,
         "markers": [
           "unit"
         ],
@@ -31929,7 +31937,7 @@
       },
       {
         "name": "test_score_trade_idea_uses_conservative_short_stop_first_when_bar_hits_both",
-        "line": 203,
+        "line": 220,
         "markers": [
           "unit"
         ],
@@ -31937,14 +31945,6 @@
       },
       {
         "name": "test_score_trade_idea_times_out_at_last_close_before_expiry",
-        "line": 219,
-        "markers": [
-          "unit"
-        ],
-        "docstring": ""
-      },
-      {
-        "name": "test_score_trade_idea_counts_waiting_bars_before_delayed_entry",
         "line": 236,
         "markers": [
           "unit"
@@ -31952,8 +31952,16 @@
         "docstring": ""
       },
       {
+        "name": "test_score_trade_idea_counts_waiting_bars_before_delayed_entry",
+        "line": 253,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
         "name": "test_score_trade_idea_reports_not_filled_when_entry_zone_never_trades",
-        "line": 254,
+        "line": 271,
         "markers": [
           "unit"
         ],
@@ -31961,7 +31969,15 @@
       },
       {
         "name": "test_score_trade_idea_reports_no_future_data",
-        "line": 270,
+        "line": 287,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_score_trade_idea_excludes_candles_that_extend_past_expiry",
+        "line": 294,
         "markers": [
           "unit"
         ],
@@ -31969,7 +31985,7 @@
       },
       {
         "name": "test_replay_runner_feeds_point_in_time_snapshots_and_reports_aggregates",
-        "line": 277,
+        "line": 311,
         "markers": [
           "unit"
         ],
@@ -31977,7 +31993,7 @@
       },
       {
         "name": "test_replay_runner_scores_baseline_proposer_on_historical_candles",
-        "line": 318,
+        "line": 352,
         "markers": [
           "unit"
         ],
@@ -31985,7 +32001,7 @@
       },
       {
         "name": "test_replay_runner_config_rejects_non_positive_min_history",
-        "line": 348,
+        "line": 382,
         "markers": [
           "unit"
         ],

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,8 +2,8 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6560,
-    "total_files": 772,
+    "total_tests": 6575,
+    "total_files": 773,
     "markers_used": 16
   },
   "marker_definitions": {
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6395,
+    "unit": 6410,
     "asyncio": 372,
     "parametrize": 174,
     "endpoints": 83,
@@ -525,6 +525,7 @@
       "tests/unit/gpt_trader/features/trade_ideas/test_eligibility.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_models.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_policy.py",
+      "tests/unit/gpt_trader/features/trade_ideas/test_replay.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_service.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_snapshot.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_store.py",
@@ -31837,6 +31838,120 @@
         "docstring": ""
       }
     ],
+    "tests/unit/gpt_trader/features/trade_ideas/test_replay.py": [
+      {
+        "name": "test_extract_numeric_scoring_levels_prefers_parenthesized_baseline_stop",
+        "line": 61,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_score_trade_idea_records_target_hit",
+        "line": 75,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_score_trade_idea_requires_midpoint_entry_fill",
+        "line": 92,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_score_trade_idea_reports_not_filled_when_only_entry_zone_edge_trades",
+        "line": 108,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_score_trade_idea_uses_conservative_stop_first_when_bar_hits_both",
+        "line": 123,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_score_trade_idea_records_short_target_hit",
+        "line": 135,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_score_trade_idea_uses_conservative_short_stop_first_when_bar_hits_both",
+        "line": 155,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_score_trade_idea_times_out_at_last_close_before_expiry",
+        "line": 171,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_score_trade_idea_counts_waiting_bars_before_delayed_entry",
+        "line": 188,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_score_trade_idea_reports_not_filled_when_entry_zone_never_trades",
+        "line": 206,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_score_trade_idea_reports_no_future_data",
+        "line": 222,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_replay_runner_feeds_point_in_time_snapshots_and_reports_aggregates",
+        "line": 229,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_replay_runner_scores_baseline_proposer_on_historical_candles",
+        "line": 270,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_replay_runner_config_rejects_non_positive_min_history",
+        "line": 300,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      }
+    ],
     "tests/unit/gpt_trader/features/trade_ideas/test_service.py": [
       {
         "name": "test_propose_creates_proposed_view",
@@ -60045,7 +60160,7 @@
     "tests/unit/scripts/test_docs_maintenance.py": [
       {
         "name": "test_iter_links_skips_external_strips_anchors_and_decodes",
-        "line": 14,
+        "line": 13,
         "markers": [
           "parametrize",
           "unit"
@@ -60054,7 +60169,15 @@
       },
       {
         "name": "test_iter_repo_path_references_filters_invalid_patterns",
-        "line": 32,
+        "line": 31,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_docs_link_audit_skips_repo_path_checks_for_proposed_specs",
+        "line": 46,
         "markers": [
           "unit"
         ],
@@ -60062,7 +60185,7 @@
       },
       {
         "name": "test_suggest_sections_for_representative_paths",
-        "line": 56,
+        "line": 74,
         "markers": [
           "parametrize",
           "unit"

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6592,
+    "total_tests": 6595,
     "total_files": 775,
     "markers_used": 16
   },
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6427,
+    "unit": 6430,
     "asyncio": 373,
     "parametrize": 174,
     "endpoints": 83,
@@ -32038,6 +32038,30 @@
       {
         "name": "test_extract_numeric_scoring_levels_ignores_indicator_pair_before_stop",
         "line": 165,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_extract_numeric_scoring_levels_ignores_period_lookback_before_stop",
+        "line": 175,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_extract_numeric_scoring_levels_accepts_currency_prefixed_stop",
+        "line": 185,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_extract_numeric_scoring_levels_accepts_spaced_currency_prefixed_stop",
+        "line": 195,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary
- add broker-neutral trade-idea replay scoring primitives and runner
- export replay primitives from `gpt_trader.features.trade_ideas`
- add draft interface specs for CLI/TUI review workstreams and keep docs reachable
- update docs-maintenance coverage and regenerated agent testing artifacts

## Verification
- `uv run pytest tests/unit/gpt_trader/features/trade_ideas/test_replay.py tests/unit/scripts/test_docs_maintenance.py -q` → 22 passed in 0.45s
- `uv run agent-regenerate --verify` → all context files up-to-date
- `uv run ruff check src/gpt_trader/features/trade_ideas/replay.py src/gpt_trader/features/trade_ideas/__init__.py tests/unit/gpt_trader/features/trade_ideas/test_replay.py scripts/maintenance/docs_link_audit.py tests/unit/scripts/test_docs_maintenance.py` → All checks passed
- `uv run black --check src/gpt_trader/features/trade_ideas/replay.py src/gpt_trader/features/trade_ideas/__init__.py tests/unit/gpt_trader/features/trade_ideas/test_replay.py scripts/maintenance/docs_link_audit.py tests/unit/scripts/test_docs_maintenance.py` → 5 files would be left unchanged
- `uv run mypy src/gpt_trader` → Success: no issues found in 435 source files
- `python scripts/maintenance/docs_reachability_check.py` → passed, 39 files reachable
- `uv run local-ci --profile quick` → Local CI passed; 6793 passed, 8 skipped

## Review notes
- Independent reviewer initially caught midpoint-fill scoring risk; this PR now requires midpoint trade before recording midpoint entry and adds regression coverage.
- Same-bar stop/target ambiguity is intentionally conservative: stops score before targets when both are touched in the same OHLC bar.

## Gates preserved
- Draft PR only.
- No merge, release/package publish, repo settings/secrets/branch protection change, deployment, credentials, or trading/broker/financial action.