### PR TITLE
Address replay entry-candle prefill stops

### DIFF
--- a/src/gpt_trader/features/trade_ideas/replay.py
+++ b/src/gpt_trader/features/trade_ideas/replay.py
@@ -299,6 +299,10 @@ def score_trade_idea(
             candle,
             levels,
             allow_favorable_exit=candle is not entry_candle,
+            allow_adverse_exit=(
+                candle is not entry_candle
+                or not _entry_candle_proves_prefill_stop(idea.direction, candle, levels)
+            ),
         )
         if outcome_price is None:
             continue
@@ -536,24 +540,38 @@ def _candle_ends_by_expiry(
     return candle.ts + candle_duration <= expires_at
 
 
+def _entry_candle_proves_prefill_stop(
+    direction: TradeDirection,
+    candle: Candle,
+    levels: ScoringLevels,
+) -> bool:
+    entry_price = levels.entry_midpoint
+    if direction is TradeDirection.LONG:
+        return candle.open == candle.low and candle.open <= levels.stop < entry_price
+    if direction is TradeDirection.SHORT:
+        return candle.open == candle.high and candle.open >= levels.stop > entry_price
+    return False
+
+
 def _bar_outcome_price(
     direction: TradeDirection,
     candle: Candle,
     levels: ScoringLevels,
     *,
     allow_favorable_exit: bool = True,
+    allow_adverse_exit: bool = True,
 ) -> tuple[ReplayOutcome, Decimal] | None:
     # A single OHLC bar cannot reveal intrabar ordering. Score stops before
     # targets when both are touched in the same bar so calibration stays
     # conservative and never overstates replay quality.
     if direction is TradeDirection.LONG:
-        if candle.low <= levels.stop:
+        if allow_adverse_exit and candle.low <= levels.stop:
             return ReplayOutcome.STOP_HIT, levels.stop
         if allow_favorable_exit and candle.high >= levels.target:
             return ReplayOutcome.TARGET_HIT, levels.target
         return None
 
-    if candle.high >= levels.stop:
+    if allow_adverse_exit and candle.high >= levels.stop:
         return ReplayOutcome.STOP_HIT, levels.stop
     if allow_favorable_exit and candle.low <= levels.target:
         return ReplayOutcome.TARGET_HIT, levels.target

--- a/tests/unit/gpt_trader/features/trade_ideas/test_replay.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_replay.py
@@ -127,6 +127,68 @@ def test_score_trade_idea_defers_target_hit_on_entry_candle() -> None:
     assert result.exit_price == Decimal("104")
 
 
+def test_score_trade_idea_defers_prefill_long_stop_on_entry_candle() -> None:
+    result = score_trade_idea(
+        scoreable_idea(),
+        as_of=AS_OF,
+        future_candles=(
+            candle(0, open_="94", high="102", low="94", close="101"),
+            candle(1, high="106", low="101", close="104"),
+        ),
+    )
+
+    assert result.outcome is ReplayOutcome.TIMED_OUT
+    assert result.entry_time == AS_OF
+    assert result.exit_time == AS_OF + timedelta(hours=1)
+    assert result.exit_price == Decimal("104")
+
+
+def test_score_trade_idea_defers_prefill_short_stop_on_entry_candle() -> None:
+    result = score_trade_idea(
+        scoreable_idea(
+            direction=TradeDirection.SHORT,
+            invalidation="Close above 106",
+            target_exit="Take profit at 95 or exit at expiry",
+        ),
+        as_of=AS_OF,
+        future_candles=(
+            candle(0, open_="107", high="107", low="100", close="101"),
+            candle(1, high="101", low="97", close="98"),
+        ),
+    )
+
+    assert result.outcome is ReplayOutcome.TIMED_OUT
+    assert result.entry_time == AS_OF
+    assert result.exit_time == AS_OF + timedelta(hours=1)
+    assert result.exit_price == Decimal("98")
+
+
+def test_score_trade_idea_keeps_long_entry_candle_stop_when_not_pinned_to_open() -> None:
+    result = score_trade_idea(
+        scoreable_idea(),
+        as_of=AS_OF,
+        future_candles=(candle(0, open_="94", high="102", low="93", close="101"),),
+    )
+
+    assert result.outcome is ReplayOutcome.STOP_HIT
+    assert result.exit_price == Decimal("95")
+
+
+def test_score_trade_idea_keeps_short_entry_candle_stop_when_not_pinned_to_open() -> None:
+    result = score_trade_idea(
+        scoreable_idea(
+            direction=TradeDirection.SHORT,
+            invalidation="Close above 106",
+            target_exit="Take profit at 95 or exit at expiry",
+        ),
+        as_of=AS_OF,
+        future_candles=(candle(0, open_="107", high="108", low="100", close="101"),),
+    )
+
+    assert result.outcome is ReplayOutcome.STOP_HIT
+    assert result.exit_price == Decimal("106")
+
+
 def test_score_trade_idea_records_short_target_hit() -> None:
     result = score_trade_idea(
         scoreable_idea(


### PR DESCRIPTION
Follow-up to #869 after Codex review flagged impossible entry-candle pre-fill stop-outs.\n\nChanges:\n- suppress entry-candle stop scoring only when the adverse stop touch is pinned to the bar open/extreme before the entry midpoint can fill\n- keep conservative stop-first behavior when the adverse extreme is not pinned to the open\n- add long/short regressions for both behaviors\n\nLocal verification:\n- uv run pytest tests/unit/gpt_trader/features/trade_ideas/test_replay.py tests/unit/gpt_trader/features/trade_ideas/test_replay_level_extraction.py tests/unit/gpt_trader/features/trade_ideas/test_replay_runner.py -q -> 36 passed\n- uv run local-ci --profile quick on same patch before clean cherry-pick -> Local CI passed; 6817 passed, 8 skipped\n- independent review -> passed; no security concerns or blocking logic errors\n\nBoundary: no release/deploy/settings/secrets/credentials/trading action.