### PR TITLE
Harden canary watchdog state loading

### DIFF
--- a/scripts/ops/canary_watchdog.py
+++ b/scripts/ops/canary_watchdog.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import argparse
+import json
+import math
 import sqlite3
 import sys
 import time
@@ -15,6 +17,8 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from scripts.ops import canary_process, liveness_check  # noqa: E402
+
+STATE_FILE_NAME = "watchdog_state.json"
 
 
 @dataclass
@@ -87,6 +91,74 @@ def _parse_args() -> argparse.Namespace:
 
 def _now() -> float:
     return time.time()
+
+
+def _state_path(runtime_root: Path, profile: str) -> Path:
+    return runtime_root / "runtime_data" / profile / STATE_FILE_NAME
+
+
+def _finite_int_or_default(value: str | int | float | None, default: int = 0) -> int:
+    if value is None:
+        return default
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return default
+    if not math.isfinite(numeric):
+        return default
+    return int(numeric)
+
+
+def _finite_float_or_none(value: str | int | float | None) -> float | None:
+    if value is None:
+        return None
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(numeric):
+        return None
+    return numeric
+
+
+def _load_state(state_path: Path) -> WatchdogState:
+    try:
+        payload = state_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return WatchdogState()
+    except (OSError, UnicodeDecodeError):
+        return WatchdogState()
+
+    try:
+        raw_state = json.loads(payload)
+    except (json.JSONDecodeError, ValueError):
+        return WatchdogState()
+
+    if not isinstance(raw_state, dict):
+        return WatchdogState()
+
+    consecutive_reds = _finite_int_or_default(raw_state.get("consecutive_reds", 0))
+    if consecutive_reds < 0:
+        consecutive_reds = 0
+    last_restart_ts = _finite_float_or_none(raw_state.get("last_restart_ts"))
+
+    return WatchdogState(
+        consecutive_reds=consecutive_reds,
+        last_restart_ts=last_restart_ts,
+    )
+
+
+def _save_state(state_path: Path, state: WatchdogState) -> None:
+    payload = {
+        "consecutive_reds": state.consecutive_reds,
+        "last_restart_ts": state.last_restart_ts,
+        "updated_at": _now(),
+    }
+    try:
+        state_path.parent.mkdir(parents=True, exist_ok=True)
+        state_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    except OSError:
+        return
 
 
 def _format_event_ages(rows: Iterable[liveness_check.EventAge]) -> str:
@@ -194,7 +266,8 @@ def main() -> int:
     args = _parse_args()
     event_types = args.event_type or list(liveness_check.DEFAULT_EVENT_TYPES)
     runtime_root = args.runtime_root.resolve()
-    state = WatchdogState()
+    state_path = _state_path(runtime_root, args.profile)
+    state = _load_state(state_path)
 
     if args.once:
         is_green, failed = _poll_and_print(
@@ -207,6 +280,7 @@ def main() -> int:
             restart_cooldown_seconds=args.restart_cooldown_seconds,
             state=state,
         )
+        _save_state(state_path, state)
         if failed:
             return 2
         return 0 if is_green else 1
@@ -222,6 +296,7 @@ def main() -> int:
             restart_cooldown_seconds=args.restart_cooldown_seconds,
             state=state,
         )
+        _save_state(state_path, state)
         if failed:
             return 2
         time.sleep(args.poll_seconds)

--- a/tests/unit/scripts/test_canary_watchdog.py
+++ b/tests/unit/scripts/test_canary_watchdog.py
@@ -159,3 +159,49 @@ def test_once_exit_codes(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Non
 
     monkeypatch.setattr(canary_watchdog.liveness_check, "check_liveness", _red)
     assert canary_watchdog.main() == 1
+
+
+def test_load_state_handles_non_utf8(tmp_path: Path) -> None:
+    state_path = canary_watchdog._state_path(tmp_path, "canary")
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_bytes(b"\xff\xfe\xfa\xfb")
+
+    state = canary_watchdog._load_state(state_path)
+
+    assert state == canary_watchdog.WatchdogState()
+
+
+def test_load_state_rejects_non_finite_consecutive_reds(tmp_path: Path) -> None:
+    state_path = canary_watchdog._state_path(tmp_path, "canary")
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text('{"consecutive_reds": 1e309}', encoding="utf-8")
+
+    state = canary_watchdog._load_state(state_path)
+
+    assert state == canary_watchdog.WatchdogState()
+
+
+def test_load_state_rejects_oversized_numeric_literal(tmp_path: Path) -> None:
+    state_path = canary_watchdog._state_path(tmp_path, "canary")
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(
+        '{"consecutive_reds": ' + ("9" * 5000) + "}",
+        encoding="utf-8",
+    )
+
+    state = canary_watchdog._load_state(state_path)
+
+    assert state == canary_watchdog.WatchdogState()
+
+
+def test_load_state_rejects_non_finite_last_restart_ts(tmp_path: Path) -> None:
+    state_path = canary_watchdog._state_path(tmp_path, "canary")
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(
+        '{"consecutive_reds": 1, "last_restart_ts": Infinity}',
+        encoding="utf-8",
+    )
+
+    state = canary_watchdog._load_state(state_path)
+
+    assert state == canary_watchdog.WatchdogState(consecutive_reds=1)


### PR DESCRIPTION
Replacement for stale PRs #844/#853.\n\nFixes:\n- persist canary watchdog state under runtime_data/<profile>/watchdog_state.json\n- tolerate missing, non-UTF8, unreadable, malformed, and oversized-numeric state files\n- reject non-finite consecutive_reds and last_restart_ts values instead of crashing\n- keep watchdog self-healing behavior alive when state is corrupted\n\nLocal verification:\n- uv run pytest tests/unit/scripts/test_canary_watchdog.py -q -> 8 passed\n- uv run ruff check scripts/ops/canary_watchdog.py tests/unit/scripts/test_canary_watchdog.py -> passed\n- uv run black --check scripts/ops/canary_watchdog.py tests/unit/scripts/test_canary_watchdog.py -> passed\n- git diff --check -> passed\n- independent review -> passed; no security concerns or blocking logic errors\n\nBoundary: no deploy/release/settings/secrets/credentials/trading action.