### PR TITLE
Test decision trace probe JSON output sanitization

### DIFF
--- a/scripts/ops/decision_trace_probe.py
+++ b/scripts/ops/decision_trace_probe.py
@@ -5,6 +5,7 @@ import argparse
 import asyncio
 import json
 import logging
+import re
 import sqlite3
 import sys
 from datetime import datetime, timezone
@@ -27,6 +28,16 @@ EXIT_OK = 0
 EXIT_INVALID_INPUT = 2
 EXIT_PROBE_ERROR = 3
 EXIT_EVENT_STORE_ERROR = 4
+SENSITIVE_FIELD_RE = re.compile(
+    r"(?P<quote>['\"]?)"
+    r"\b(?P<label>api[_-]?key|api[_-]?secret|client[_-]?secret|private[_-]?key|"
+    r"access[_-]?token|refresh[_-]?token|auth[_-]?token|bearer[_-]?token|id[_-]?token|"
+    r"secret|token|password|passwd)"
+    r"(?P=quote)"
+    r"(?P<separator>\s*[=:]\s*|\s+)"
+    r"(?P<value>'[^']*'|\"[^\"]*\"|\S+)",
+    re.IGNORECASE,
+)
 
 
 def _parse_args() -> argparse.Namespace:
@@ -131,10 +142,21 @@ async def _run_probe(
         clear_application_container()
 
 
+def _redact_sensitive_text(text: str) -> str:
+    def _replace(match: re.Match[str]) -> str:
+        label = match.group("label")
+        separator = match.group("separator")
+        if separator.strip() in {"=", ":"}:
+            return f"{label}=[REDACTED]"
+        return f"{label} [REDACTED]"
+
+    return SENSITIVE_FIELD_RE.sub(_replace, text)
+
+
 def _summarize_reason(reason: str | None) -> str | None:
     if not reason:
         return None
-    return " ".join(reason.split())
+    return _redact_sensitive_text(" ".join(reason.split()))
 
 
 def _build_json_payload(
@@ -164,10 +186,11 @@ def _print_json_payload(payload: dict[str, object]) -> None:
 
 
 def _emit_error(message: str, *, json_output: bool, exit_code: int) -> int:
+    sanitized_message = _redact_sensitive_text(" ".join(message.split()))
     if json_output:
-        _print_json_payload({"status": "error", "error": message})
+        _print_json_payload({"status": "error", "error": sanitized_message})
     else:
-        print(f"error={message}")
+        print(f"error={sanitized_message}")
     return exit_code
 
 
@@ -225,7 +248,7 @@ def main() -> int:
     print(f"status={status}")
     print(f"decision_id={decision_id or '-'}")
     if reason:
-        print(f"blocked_reason={reason}")
+        print(f"blocked_reason={_summarize_reason(reason)}")
     if latest_id is not None:
         print(f"latest_trace_id={latest_id}")
     print(f"latest_trace_ts={_format_timestamp(latest_ts)}")

--- a/tests/unit/scripts/test_decision_trace_probe.py
+++ b/tests/unit/scripts/test_decision_trace_probe.py
@@ -4,7 +4,6 @@ import argparse
 import json
 
 import pytest
-
 from scripts.ops import decision_trace_probe
 
 
@@ -79,6 +78,33 @@ def test_main_outputs_text_by_default(
     ]
 
 
+def test_main_redacts_sensitive_text_output_reason(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path,
+) -> None:
+    async def fake_run_probe(*_: object, **__: object) -> tuple[str, str | None, str | None]:
+        return "blocked", "decision-1", "token=secret-token"
+
+    monkeypatch.setattr(decision_trace_probe, "_run_probe", fake_run_probe)
+    monkeypatch.setattr(decision_trace_probe, "_read_latest_trace", lambda _: (None, None))
+
+    args = argparse.Namespace(
+        profile="canary",
+        symbol="BTC-USD",
+        side="buy",
+        runtime_root=tmp_path,
+        json=False,
+    )
+    monkeypatch.setattr(decision_trace_probe, "_parse_args", lambda: args)
+
+    assert decision_trace_probe.main() == 0
+    output = capsys.readouterr().out
+
+    assert "blocked_reason=token=[REDACTED]" in output
+    assert "secret-token" not in output
+
+
 def test_invalid_profile_returns_actionable_error(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -96,3 +122,107 @@ def test_invalid_profile_returns_actionable_error(
     payload = json.loads(capsys.readouterr().out)
     assert payload["status"] == "error"
     assert payload["error"].startswith("invalid profile: nope")
+
+
+def test_json_payload_has_deterministic_allowlisted_shape() -> None:
+    payload = decision_trace_probe._build_json_payload(
+        status="blocked",
+        decision_id="decision-1",
+        reason="risk limit exceeded",
+        latest_id=7,
+        latest_ts="not-a-timestamp",
+    )
+
+    assert list(payload) == [
+        "status",
+        "decision_id",
+        "blocked_reason",
+        "latest_trace",
+    ]
+    latest_trace = payload["latest_trace"]
+    assert isinstance(latest_trace, dict)
+    assert list(latest_trace) == ["found", "id", "timestamp"]
+    assert payload == {
+        "status": "blocked",
+        "decision_id": "decision-1",
+        "blocked_reason": "risk limit exceeded",
+        "latest_trace": {
+            "found": True,
+            "id": 7,
+            "timestamp": "not-a-timestamp",
+        },
+    }
+
+
+def test_json_payload_handles_missing_trace_metadata() -> None:
+    payload = decision_trace_probe._build_json_payload(
+        status="blocked",
+        decision_id=None,
+        reason=None,
+        latest_id=None,
+        latest_ts=None,
+    )
+
+    assert payload == {
+        "status": "blocked",
+        "decision_id": None,
+        "blocked_reason": None,
+        "latest_trace": {
+            "found": False,
+            "id": None,
+            "timestamp": None,
+        },
+    }
+
+
+def test_json_payload_redacts_sensitive_reason_fields() -> None:
+    payload = decision_trace_probe._build_json_payload(
+        status="blocked",
+        decision_id="decision-1",
+        reason="api_key=sk-live secret='abc123' token: bearer-value password hunter2",
+        latest_id=None,
+        latest_ts=None,
+    )
+
+    assert payload["blocked_reason"] == (
+        "api_key=[REDACTED] secret=[REDACTED] token=[REDACTED] password [REDACTED]"
+    )
+    assert "sk-live" not in json.dumps(payload)
+    assert "abc123" not in json.dumps(payload)
+    assert "bearer-value" not in json.dumps(payload)
+    assert "hunter2" not in json.dumps(payload)
+
+
+def test_json_payload_redacts_quoted_sensitive_reason_fields() -> None:
+    payload = decision_trace_probe._build_json_payload(
+        status="blocked",
+        decision_id="decision-1",
+        reason='{ "api_key": "sk-live", "nested": {"password": "hunter2"} }',
+        latest_id=None,
+        latest_ts=None,
+    )
+
+    rendered = json.dumps(payload)
+    blocked_reason = payload["blocked_reason"]
+    assert isinstance(blocked_reason, str)
+    assert "sk-live" not in rendered
+    assert "hunter2" not in rendered
+    assert "api_key=[REDACTED]" in blocked_reason
+    assert "password=[REDACTED]" in blocked_reason
+
+
+def test_json_error_output_redacts_sensitive_message(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    exit_code = decision_trace_probe._emit_error(
+        "probe failed: password=secret-token",
+        json_output=True,
+        exit_code=decision_trace_probe.EXIT_PROBE_ERROR,
+    )
+
+    assert exit_code == decision_trace_probe.EXIT_PROBE_ERROR
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {
+        "status": "error",
+        "error": "probe failed: password=[REDACTED]",
+    }


### PR DESCRIPTION
Fixes #762\n\nAdds deterministic/offline coverage for decision trace probe output sanitization and tightens the sanitizer used by probe output paths.\n\nChanges:\n- assert JSON payload uses a deterministic allowlisted envelope\n- assert missing trace metadata still emits a stable JSON shape\n- assert malformed timestamps are stable and non-throwing\n- redact sensitive key/value fragments in JSON blocked_reason, text blocked_reason, JSON errors, and text errors\n- cover quoted JSON/dict-style sensitive keys as well as key=value, colon, and whitespace forms\n\nLocal verification:\n- uv run pytest tests/unit/scripts/test_decision_trace_probe.py tests/unit/scripts/test_tail_decision_traces.py -q -> 12 passed\n- uv run ruff check scripts/ops/decision_trace_probe.py tests/unit/scripts/test_decision_trace_probe.py tests/unit/scripts/test_tail_decision_traces.py -> passed\n- uv run black --check scripts/ops/decision_trace_probe.py tests/unit/scripts/test_decision_trace_probe.py tests/unit/scripts/test_tail_decision_traces.py -> passed\n- git diff --check -> passed\n- independent review -> passed; no security concerns or blocking logic errors\n\nBoundary: no live decision execution behavior change, no deploy/release/settings/secrets/credentials/trading action.