### PR TITLE
[codex] Require explicit OrderValidator failure tracker

### DIFF
--- a/src/gpt_trader/features/live_trade/execution/validation.py
+++ b/src/gpt_trader/features/live_trade/execution/validation.py
@@ -196,7 +196,7 @@ class OrderValidator:
         enable_order_preview: bool,
         record_preview_callback: Any,
         record_rejection_callback: Any,
-        failure_tracker: ValidationFailureTracker | None = None,
+        failure_tracker: ValidationFailureTracker,
         broker_calls: Any | None = None,
     ) -> None:
         """
@@ -208,17 +208,14 @@ class OrderValidator:
             enable_order_preview: Whether to preview orders before submission
             record_preview_callback: Function to record preview results
             record_rejection_callback: Function to record rejections
-            failure_tracker: Optional tracker for consecutive failures.
-                If not provided, uses the global tracker.
+            failure_tracker: Tracker for consecutive validation failures.
         """
         self.broker = broker
         self.risk_manager = risk_manager
         self.enable_order_preview = enable_order_preview
         self._record_preview = record_preview_callback
         self._record_rejection = record_rejection_callback
-        self._failure_tracker = (
-            failure_tracker if failure_tracker is not None else get_failure_tracker()
-        )
+        self._failure_tracker = failure_tracker
         self._broker_calls = (
             broker_calls
             if broker_calls is not None

--- a/tests/unit/gpt_trader/features/live_trade/execution/test_validation.py
+++ b/tests/unit/gpt_trader/features/live_trade/execution/test_validation.py
@@ -37,6 +37,20 @@ class TestOrderValidatorInit:
         assert validator._record_preview is record_preview
         assert validator._record_rejection is record_rejection
 
+    def test_init_requires_explicit_failure_tracker(
+        self,
+        mock_broker: MagicMock,
+        mock_risk_manager: MagicMock,
+    ) -> None:
+        with pytest.raises(TypeError, match="failure_tracker"):
+            OrderValidator(
+                broker=mock_broker,
+                risk_manager=mock_risk_manager,
+                enable_order_preview=True,
+                record_preview_callback=MagicMock(),
+                record_rejection_callback=MagicMock(),
+            )
+
 
 class TestRunPreTradeValidation:
     def test_delegates_to_risk_manager(


### PR DESCRIPTION
## Summary
Require `OrderValidator` callers to pass a `ValidationFailureTracker` explicitly instead of falling back to `get_failure_tracker()` from the constructor.

Closes #876

## Type of change
- [x] Refactor
- [ ] Feature
- [ ] Bug fix
- [x] Tests only
- [ ] CI/Docs/Tooling

## Scope & Impact
- Affected areas / components: `src/gpt_trader/features/live_trade/execution/validation.py`, `tests/unit/gpt_trader/features/live_trade/execution/test_validation.py`
- Behavior changes: constructing `OrderValidator` without `failure_tracker` now fails at the Python signature boundary. Existing production and test call sites already pass the tracker explicitly.

## Test Plan
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Contract tests (if applicable)
- [x] Ran locally: `uv run pytest tests/unit/gpt_trader/features/live_trade/execution -q`
- [x] Ran locally: `uv run local-ci --profile quick`
- [x] Markers used appropriately (`unit`/`integration`/`slow`/`perf`)

## Complexity & Quality Gates
- [x] Mypy/type-check passed
- [x] Xenon/radon complexity gate passed (CC <= 15 on live_trade execution)
- [x] No `sys.path` hacks in tests
- [x] No `MagicMock` on `async def` (use `AsyncMock`)
- [x] Import-lint rules respected (no “import up the stack”)

## Observability & Errors
- [x] Structured JSON logs for new/changed paths
- [x] Errors include diagnostic context (symbol, order_id, correlation_id)
- [ ] Added/updated sampling examples in tests (if applicable)

## Configuration
- [ ] If config changed: `python -m gpt_trader.cli.config validate --profile <name>` passes
- [ ] Env docs re-generated (if applicable) and committed
- [x] No `ConfigLoader` usages introduced (ConfigManager-only)

## Breaking Changes
- [ ] None
- [x] Documented in PR body and release notes if any

This is a constructor compatibility break for callers that still omitted `failure_tracker`; the current source and unit/integration test call sites discovered locally already pass it explicitly.

## Screenshots / Logs (optional)
- `uv run pytest tests/unit/gpt_trader/features/live_trade/execution -q`: 361 passed
- `uv run local-ci --profile quick`: passed with 6819 passed, 8 skipped
- First quick local CI attempt hit a transient Hypothesis health-check failure in `tests/unit/gpt_trader/utilities/test_quantization.py::TestQuantizeIdempotence::test_idempotence`; the exact test passed on direct rerun before the second full quick local CI pass.

## Checklist
- [x] Acceptance criteria in linked issue(s) met
- [x] Affected paths listed in PR description
- [ ] Changelog entry (if repo uses one)
