### PR TITLE
[codex] Ignore local health reports during agent verify

### DIFF
--- a/scripts/agents/regenerate_all.py
+++ b/scripts/agents/regenerate_all.py
@@ -249,6 +249,21 @@ def _diff_directories(committed_dir: Path, generated_dir: Path) -> str | None:
             f"{generated_dir.as_posix()})."
         )
 
+    ignored_paths = _git_ignored_paths_under(committed_dir)
+    if ignored_paths:
+        with tempfile.TemporaryDirectory(prefix="agent-diff-") as temp_dir:
+            filtered_committed_dir = Path(temp_dir) / committed_dir.name
+            _copy_directory_without_paths(
+                committed_dir,
+                filtered_committed_dir,
+                ignored_paths,
+            )
+            return _run_directory_diff(filtered_committed_dir, generated_dir)
+
+    return _run_directory_diff(committed_dir, generated_dir)
+
+
+def _run_directory_diff(committed_dir: Path, generated_dir: Path) -> str | None:
     diff_result = subprocess.run(
         [
             "git",
@@ -272,6 +287,62 @@ def _diff_directories(committed_dir: Path, generated_dir: Path) -> str | None:
 
     message = (diff_result.stderr or diff_result.stdout).strip() or "Unknown git diff error"
     return f"git diff failed ({diff_result.returncode}): {message}"
+
+
+def _git_ignored_paths_under(directory: Path) -> set[Path]:
+    try:
+        repo_relative_dir = directory.resolve().relative_to(PROJECT_ROOT.resolve())
+    except ValueError:
+        return set()
+
+    result = subprocess.run(
+        [
+            "git",
+            "ls-files",
+            "--others",
+            "--ignored",
+            "--exclude-standard",
+            "-z",
+            "--",
+            repo_relative_dir.as_posix(),
+        ],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return set()
+
+    ignored_paths: set[Path] = set()
+    for raw_path in result.stdout.split("\0"):
+        if not raw_path:
+            continue
+        try:
+            ignored_paths.add(Path(raw_path).relative_to(repo_relative_dir))
+        except ValueError:
+            continue
+    return ignored_paths
+
+
+def _copy_directory_without_paths(
+    source_dir: Path,
+    target_dir: Path,
+    excluded_paths: set[Path],
+) -> None:
+    def ignore(directory: str, names: list[str]) -> set[str]:
+        try:
+            directory_relative = Path(directory).relative_to(source_dir)
+        except ValueError:
+            directory_relative = Path()
+
+        ignored_names: set[str] = set()
+        for name in names:
+            candidate = directory_relative / name
+            if candidate in excluded_paths:
+                ignored_names.add(name)
+        return ignored_names
+
+    shutil.copytree(source_dir, target_dir, ignore=ignore)
 
 
 def verify_freshness(generators: Sequence[tuple[str, str, str]] | None = None) -> int:

--- a/tests/unit/scripts/test_regenerate_all_verify.py
+++ b/tests/unit/scripts/test_regenerate_all_verify.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
+import subprocess
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Sequence
 
 import pytest
-
 from scripts.agents import regenerate_all
 
 SAMPLE_GENERATORS: list[tuple[str, str, str]] = [
@@ -47,6 +47,12 @@ def _patch_regenerate_all(monkeypatch: pytest.MonkeyPatch, success: bool = True)
         return results, success
 
     monkeypatch.setattr(regenerate_all, "regenerate_all", fake_regenerate_all)
+
+
+def _init_git_repo(path: Path) -> None:
+    if regenerate_all.shutil.which("git") is None:
+        pytest.skip("git is required for regenerate_all diff tests")
+    subprocess.run(["git", "init"], cwd=path, check=True, capture_output=True, text=True)
 
 
 @pytest.mark.parametrize("generators", [SAMPLE_GENERATORS])
@@ -131,3 +137,95 @@ def test_verify_freshness_bails_on_generator_failure(
     assert not diff_called
     captured = capsys.readouterr()
     assert "Some generators failed. Cannot verify freshness." in captured.err
+
+
+def test_diff_directories_ignores_git_ignored_health_reports(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    _init_git_repo(repo_root)
+    (repo_root / ".gitignore").write_text(
+        "var/agents/health/health_report.*\n",
+        encoding="utf-8",
+    )
+
+    committed_dir = repo_root / "var" / "agents" / "health"
+    generated_dir = tmp_path / "generated" / "health"
+    committed_dir.mkdir(parents=True)
+    generated_dir.mkdir(parents=True)
+
+    (committed_dir / "agent_health_schema.json").write_text(
+        '{"schema": "same"}\n',
+        encoding="utf-8",
+    )
+    subprocess.run(
+        ["git", "add", ".gitignore", "var/agents/health/agent_health_schema.json"],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    (generated_dir / "agent_health_schema.json").write_text(
+        '{"schema": "same"}\n',
+        encoding="utf-8",
+    )
+    (committed_dir / "health_report.json").write_text(
+        '{"status": "local"}\n',
+        encoding="utf-8",
+    )
+    (committed_dir / "health_report.txt").write_text(
+        "local report\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(regenerate_all, "PROJECT_ROOT", repo_root)
+
+    assert regenerate_all._diff_directories(committed_dir, generated_dir) is None
+
+
+def test_diff_directories_still_reports_tracked_stale_health_files(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    _init_git_repo(repo_root)
+    (repo_root / ".gitignore").write_text(
+        "var/agents/health/health_report.*\n",
+        encoding="utf-8",
+    )
+
+    committed_dir = repo_root / "var" / "agents" / "health"
+    generated_dir = tmp_path / "generated" / "health"
+    committed_dir.mkdir(parents=True)
+    generated_dir.mkdir(parents=True)
+
+    (committed_dir / "agent_health_schema.json").write_text(
+        '{"schema": "committed"}\n',
+        encoding="utf-8",
+    )
+    subprocess.run(
+        ["git", "add", ".gitignore", "var/agents/health/agent_health_schema.json"],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    (generated_dir / "agent_health_schema.json").write_text(
+        '{"schema": "generated"}\n',
+        encoding="utf-8",
+    )
+    (committed_dir / "health_report.json").write_text(
+        '{"status": "local"}\n',
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(regenerate_all, "PROJECT_ROOT", repo_root)
+
+    diff_text = regenerate_all._diff_directories(committed_dir, generated_dir)
+
+    assert diff_text is not None
+    assert "agent_health_schema.json" in diff_text
+    assert "health_report.json" not in diff_text

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6624,
+    "total_tests": 6626,
     "total_files": 777,
     "markers_used": 16
   },

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6459,
+    "unit": 6461,
     "asyncio": 373,
     "parametrize": 174,
     "endpoints": 83,

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6624,
+    "total_tests": 6626,
     "total_files": 777,
     "markers_used": 16
   },
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6459,
+    "unit": 6461,
     "asyncio": 373,
     "parametrize": 174,
     "endpoints": 83,
@@ -60931,7 +60931,7 @@
     "tests/unit/scripts/test_regenerate_all_verify.py": [
       {
         "name": "test_verify_freshness_reports_all_up_to_date",
-        "line": 53,
+        "line": 59,
         "markers": [
           "parametrize",
           "unit"
@@ -60940,7 +60940,7 @@
       },
       {
         "name": "test_verify_freshness_reports_stale_and_limits_diff_scope",
-        "line": 74,
+        "line": 80,
         "markers": [
           "unit"
         ],
@@ -60948,7 +60948,23 @@
       },
       {
         "name": "test_verify_freshness_bails_on_generator_failure",
-        "line": 106,
+        "line": 112,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_diff_directories_ignores_git_ignored_health_reports",
+        "line": 142,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_diff_directories_still_reports_tracked_stale_health_files",
+        "line": 188,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
Closes #882

## Summary
- filter git-ignored local files out of the committed-side agent artifact diff before running `git diff --no-index`
- add verifier coverage for ignored `var/agents/health/health_report.*` files and for real stale generated health files still failing
- refresh generated test inventory artifacts for the new unit coverage

## Affected paths
- `scripts/agents/regenerate_all.py`
- `tests/unit/scripts/test_regenerate_all_verify.py`
- `var/agents/testing/index.json`
- `var/agents/testing/markers.json`
- `var/agents/testing/test_inventory.json`

## Verification
- `uv run pytest tests/unit/scripts/test_regenerate_all_verify.py -q` - passed, 5 passed
- ignored health report reproduction: `git status --short --ignored var/agents/health` showed only ignored `health_report.json` and `health_report.txt`; `uv run agent-regenerate --verify` passed
- `uv run agent-regenerate --verify` - passed on the final tree
- `uv run local-ci --profile quick` - passed, 6820 passed and 8 skipped

## Routing notes
- Issue labels are `agent-ready`, `agent-review`, `ci`, `claw-candidate`, and `codex`; no human-decision gate is present.
- This is tooling/test-only. It does not touch broker/API checks, live trading commands, production preflight, order submission, secrets, or execution automation.