### PR TITLE
[codex] Show top-level help for root CLI

### DIFF
--- a/src/gpt_trader/cli/__init__.py
+++ b/src/gpt_trader/cli/__init__.py
@@ -196,8 +196,6 @@ def _ensure_command(argv: Sequence[str]) -> list[str]:
         return ["run"]
 
     if any(token in {"-h", "--help"} for token in argv):
-        if argv[0] in {"-h", "--help"}:
-            return ["run", *argv]
         return list(argv)
 
     first = argv[0]

--- a/tests/unit/gpt_trader/cli/test_cli_unit.py
+++ b/tests/unit/gpt_trader/cli/test_cli_unit.py
@@ -6,6 +6,35 @@ import builtins
 import importlib
 from types import SimpleNamespace
 
+import pytest
+
+
+def test_cli_root_help_shows_command_list(capsys):
+    cli = importlib.import_module("gpt_trader.cli")
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(["--help"])
+
+    assert exc_info.value.code == 0
+    output = capsys.readouterr().out
+    assert "Coinbase Trading Bot" in output
+    for command_name in (
+        "tui",
+        "run",
+        "account",
+        "coinbase",
+        "controls",
+        "orders",
+        "treasury",
+        "report",
+        "strategy",
+        "optimize",
+        "preflight",
+        "broker-check",
+    ):
+        assert command_name in output
+    assert "Perpetuals Trading Bot" not in output
+
 
 def test_cli_run_defaults_to_run_subcommand(monkeypatch):
     argv = [

--- a/var/agents/configuration/environment_variables.json
+++ b/var/agents/configuration/environment_variables.json
@@ -576,7 +576,7 @@
       ],
       "code_references": [
         {
-          "line": 215,
+          "line": 213,
           "path": "src/gpt_trader/cli/__init__.py",
           "reader": "_env_flag"
         },
@@ -2267,7 +2267,7 @@
       ],
       "code_references": [
         {
-          "line": 215,
+          "line": 213,
           "path": "src/gpt_trader/cli/__init__.py",
           "reader": "_env_flag"
         },

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6626,
+    "total_tests": 6627,
     "total_files": 777,
     "markers_used": 16
   },

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6461,
+    "unit": 6462,
     "asyncio": 373,
     "parametrize": 174,
     "endpoints": 83,

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6626,
+    "total_tests": 6627,
     "total_files": 777,
     "markers_used": 16
   },
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6461,
+    "unit": 6462,
     "asyncio": 373,
     "parametrize": 174,
     "endpoints": 83,
@@ -9023,8 +9023,16 @@
     ],
     "tests/unit/gpt_trader/cli/test_cli_unit.py": [
       {
+        "name": "test_cli_root_help_shows_command_list",
+        "line": 12,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
         "name": "test_cli_run_defaults_to_run_subcommand",
-        "line": 10,
+        "line": 39,
         "markers": [
           "unit"
         ],
@@ -9032,7 +9040,7 @@
       },
       {
         "name": "test_orders_preview_invokes_broker_preview",
-        "line": 72,
+        "line": 101,
         "markers": [
           "unit"
         ],
@@ -9040,7 +9048,7 @@
       },
       {
         "name": "test_cli_preflight_delegates_to_preflight_cli",
-        "line": 154,
+        "line": 183,
         "markers": [
           "unit"
         ],
@@ -9048,7 +9056,7 @@
       },
       {
         "name": "test_orders_profile_argument_inherits_across_nested_subcommands",
-        "line": 172,
+        "line": 201,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary
- Fix root `gpt-trader --help` / `-h` so argparse shows the top-level command list instead of rewriting to `run --help`.
- Add a focused CLI unit test for the top-level help behavior.
- Finish the reviewable source/test portion of the dirty local CLI work behind this PR; generated QA spreadsheet / feature-audit artifacts are intentionally excluded because they are local generated artifacts and not needed for this root-help fix.

Closes #884

## Affected paths
- `src/gpt_trader/cli/__init__.py`
- `tests/unit/gpt_trader/cli/test_cli_unit.py`

## Routing / scope notes
- Issue #884 is labeled `needs-human-decision`; per the automation contract, this is carried as review context rather than a blocker because the repo-scoped CLI fix is reviewable.
- This PR does not touch broker adapters, live trading, order submission, production preflight, canary paths, secrets, or account/venue capability assumptions.
- This PR does not duplicate #882/#883; generated agent artifact freshness remains tracked there.
- No breaking constructor/API behavior.

## Verification
- `uv run pytest tests/unit/gpt_trader/cli/test_cli_unit.py -q` -> 5 passed
- `uv run local-ci --profile quick` -> passed; core unit suite reported 6821 passed, 8 skipped

Quick profile intentionally skipped readiness, agent artifacts freshness, TUI snapshots, property tests, and contract tests, which do not exercise this root-help parsing change.

## Claude review
Claude Opus was consulted after the first local verification pass. It found the change correctly scoped, no forbidden trading/broker surface, no overlap with #882/#883, and no blocker. It flagged a minor line-wrapping brittleness in the original command-list assertion; the test was tightened and the targeted test plus quick local CI were rerun successfully.
