### PR TITLE
Clarify direct package PR workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ## Summary
 <!-- What and why. Keep it crisp. Link related issues. -->
-Closes #<issue-id(s)>
+Related issue / finding / RJ-routed package:
 
 ## Type of change
 - [ ] Refactor
@@ -45,6 +45,6 @@ Closes #<issue-id(s)>
 <!-- Paste sample structured logs or screenshots to aid review -->
 
 ## Checklist
-- [ ] Acceptance criteria in linked issue(s) met
+- [ ] Acceptance criteria in linked issue(s), finding packet, or routed package met
 - [ ] Affected paths listed in PR description
 - [ ] Changelog entry (if repo uses one)

--- a/docs/agents/project_review_pipeline.md
+++ b/docs/agents/project_review_pipeline.md
@@ -2,7 +2,7 @@
 
 ---
 status: draft
-last-updated: 2026-06-20
+last-updated: 2026-06-22
 ---
 
 This document defines the recurring project-review pipeline for GPT-Trader. The
@@ -197,8 +197,28 @@ Claw and Hermes should treat each promoted issue as the implementation contract:
 - run the smallest meaningful verification plus repo-required checks
 - leave any broader discovery as a new finding instead of scope creep
 
-The PR body should follow `.github/pull_request_template.md` and include
-`Closes #<issue>`.
+The PR body should follow `.github/pull_request_template.md`. For
+issue-backed work, include `Closes #<issue>`.
+
+### Direct Package Cycles
+
+When RJ or the active agent workspace explicitly routes a build/package cycle,
+a promoted GitHub issue is useful but not required. In that path, the direct
+request, the observed repo evidence, and the PR body form the implementation
+contract.
+
+Use this path only when the work is already bounded and safe to verify locally:
+
+- name the package source in the PR body, such as `RJ-routed package`,
+  `agent-review finding`, or a specific doc/receipt
+- preserve the same trading boundaries as issue-backed work
+- run the smallest meaningful verification plus repo-required checks
+- push the branch and open the PR once the package is clean
+- do not stop at "ready for PR decision" unless a concrete blocker or explicit
+  park instruction exists
+
+Merge remains a separate later pipeline decision. Opening a review PR is part
+of packaging; merging is not.
 
 ## Stage 6: Review Feedback
 


### PR DESCRIPTION
## Summary
- Update the PR template so directly routed package work can name its source without pretending there is always a linked issue.
- Update the agent review pipeline to document direct package cycles: clean verified package -> open PR for review; merge remains a later gate.
- Preserve issue-backed flow for promoted findings while allowing RJ-routed packages to proceed without an artificial issue.

## Verification
- `python scripts/maintenance/docs_link_audit.py` -> passed
- `uv run pytest tests/unit/scripts/test_docs_maintenance.py tests/unit/scripts/test_project_review_issue_promoter.py -q` -> 14 passed
- `git diff --check` -> clean
- pre-commit hooks passed during commit

## Boundary
- Docs/tooling only.
- No broker/client calls.
- No credential reads.
- No account linking.
- No live trading.

## Review posture
RJ-routed package. Ready for review; merge remains a later pipeline decision.