### PR TITLE
Refactor product_catalog property setter for encapsulation

### DIFF
--- a/src/gpt_trader/features/brokerages/coinbase/rest/product_service.py
+++ b/src/gpt_trader/features/brokerages/coinbase/rest/product_service.py
@@ -39,6 +39,14 @@ class ProductService:
         self._product_catalog = product_catalog
         self._market_data = market_data
 
+    @property
+    def product_catalog(self) -> ProductCatalog:
+        return self._product_catalog
+
+    @product_catalog.setter
+    def product_catalog(self, value: ProductCatalog) -> None:
+        self._product_catalog = value
+
     def list_products(self) -> list[Product]:
         """List all available products."""
         try:

--- a/src/gpt_trader/features/brokerages/coinbase/rest_service.py
+++ b/src/gpt_trader/features/brokerages/coinbase/rest_service.py
@@ -128,7 +128,7 @@ class CoinbaseRestService:
         """Set product catalog and update composed services."""
         self._product_catalog = value
         # Update composed services that depend on product_catalog
-        self._product_service._product_catalog = value
+        self._product_service.product_catalog = value
         self._core.product_catalog = value
 
     # =========================================================================

--- a/tests/unit/gpt_trader/features/brokerages/coinbase/helpers.py
+++ b/tests/unit/gpt_trader/features/brokerages/coinbase/helpers.py
@@ -70,10 +70,6 @@ class CoinbaseBrokerage:
     @product_catalog.setter
     def product_catalog(self, value):
         self._product_catalog = value
-        # Sync with rest_service if possible, but rest_service has its own reference.
-        # Since we can't easily update rest_service's internal reference if it's not a property,
-        # we might need to recreate rest_service or hack it.
-        # CoinbaseRestService stores it in self.product_catalog.
         self.rest_service.product_catalog = value
 
     def connect(self):


### PR DESCRIPTION
Fixes direct modification of the protected `_product_catalog` attribute of `ProductService` from `CoinbaseRestService`, conforming to the repository conventions for composed services updating shared state. Obsolete workarounds in test helpers were also removed.

---
*PR created automatically by Jules for task [15317819400064650638](https://jules.google.com/task/15317819400064650638) started by @Solders-Girdles*