### PR TITLE
Fix agent-map qualified module queries

### DIFF
--- a/scripts/agents/dependency_graph.py
+++ b/scripts/agents/dependency_graph.py
@@ -377,7 +377,7 @@ def main() -> int:
     args = parser.parse_args()
 
     print("Building dependency graph...", file=sys.stderr)
-    graph = build_dependency_graph(SRC_DIR / "gpt_trader")
+    graph = build_dependency_graph(SRC_DIR)
 
     # Handle specific queries
     if args.dependencies_of:

--- a/scripts/agents/dependency_graph.py
+++ b/scripts/agents/dependency_graph.py
@@ -78,6 +78,23 @@ def file_to_module(file_path: Path, base: Path) -> str:
     return ".".join(parts)
 
 
+def resolve_import_module(module: str, file_path: Path, imported_module: str, level: int) -> str:
+    """Resolve an import module path relative to the current file's package."""
+    if level <= 0:
+        return imported_module
+
+    parts = module.split(".")
+    package_parts = parts if file_path.name == "__init__.py" else parts[:-1]
+    trim = level - 1
+    if trim > len(package_parts):
+        return imported_module
+
+    base_parts = package_parts[: len(package_parts) - trim] if trim else package_parts
+    if imported_module:
+        return ".".join(base_parts + [imported_module])
+    return ".".join(base_parts)
+
+
 def build_dependency_graph(source_dir: Path) -> dict[str, Any]:
     """Build a complete dependency graph of the codebase."""
     graph: dict[str, set[str]] = defaultdict(set)
@@ -103,19 +120,12 @@ def build_dependency_graph(source_dir: Path) -> dict[str, Any]:
         imports = extract_imports(py_file)
 
         for imp in imports:
-            imported_module = imp["module"]
-
-            # Handle relative imports
-            if imp.get("level", 0) > 0:
-                # Convert relative to absolute
-                parts = module.split(".")
-                level = imp["level"]
-                if level <= len(parts):
-                    base_parts = parts[:-level] if level > 0 else parts
-                    if imported_module:
-                        imported_module = ".".join(base_parts + [imported_module])
-                    else:
-                        imported_module = ".".join(base_parts)
+            imported_module = resolve_import_module(
+                module=module,
+                file_path=py_file,
+                imported_module=imp["module"],
+                level=imp.get("level", 0),
+            )
 
             # Check if it's an internal module
             is_internal = False

--- a/tests/unit/scripts/test_dependency_graph.py
+++ b/tests/unit/scripts/test_dependency_graph.py
@@ -23,6 +23,14 @@ def _sample_source_tree(tmp_path: Path) -> Path:
         src / "gpt_trader" / "features" / "alpha" / "service.py",
         "from gpt_trader.app.container import ApplicationContainer\n",
     )
+    _write_python(
+        src / "gpt_trader" / "utilities" / "__init__.py",
+        "from .datetime_helpers import utc_now\n",
+    )
+    _write_python(
+        src / "gpt_trader" / "utilities" / "datetime_helpers.py",
+        "def utc_now(): ...\n",
+    )
     return src
 
 
@@ -68,3 +76,25 @@ def test_main_queries_fully_qualified_dependents(tmp_path, monkeypatch, capsys) 
     output = json.loads(capsys.readouterr().out)
     assert output["module"] == "gpt_trader.app.container"
     assert output["direct_dependents"] == ["gpt_trader.features.alpha.service"]
+
+
+def test_main_resolves_package_init_relative_imports(tmp_path, monkeypatch, capsys) -> None:
+    src = _sample_source_tree(tmp_path)
+    monkeypatch.setattr(dependency_graph, "SRC_DIR", src)
+    monkeypatch.setattr(dependency_graph, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "dependency_graph.py",
+            "--depends-on",
+            "gpt_trader.utilities.datetime_helpers",
+        ],
+    )
+
+    result = dependency_graph.main()
+
+    assert result == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["module"] == "gpt_trader.utilities.datetime_helpers"
+    assert output["direct_dependents"] == ["gpt_trader.utilities"]

--- a/tests/unit/scripts/test_dependency_graph.py
+++ b/tests/unit/scripts/test_dependency_graph.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from scripts.agents import dependency_graph
+
+
+def _write_python(path: Path, content: str = "") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _sample_source_tree(tmp_path: Path) -> Path:
+    src = tmp_path / "src"
+    _write_python(src / "gpt_trader" / "__init__.py")
+    _write_python(src / "gpt_trader" / "app" / "__init__.py")
+    _write_python(src / "gpt_trader" / "app" / "container.py", "class ApplicationContainer: ...\n")
+    _write_python(src / "gpt_trader" / "features" / "__init__.py")
+    _write_python(src / "gpt_trader" / "features" / "alpha" / "__init__.py")
+    _write_python(
+        src / "gpt_trader" / "features" / "alpha" / "service.py",
+        "from gpt_trader.app.container import ApplicationContainer\n",
+    )
+    return src
+
+
+def test_main_queries_fully_qualified_dependencies(tmp_path, monkeypatch, capsys) -> None:
+    src = _sample_source_tree(tmp_path)
+    monkeypatch.setattr(dependency_graph, "SRC_DIR", src)
+    monkeypatch.setattr(dependency_graph, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "dependency_graph.py",
+            "--dependencies-of",
+            "gpt_trader.features.alpha.service",
+        ],
+    )
+
+    result = dependency_graph.main()
+
+    assert result == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["module"] == "gpt_trader.features.alpha.service"
+    assert output["direct_dependencies"] == ["gpt_trader.app.container"]
+
+
+def test_main_queries_fully_qualified_dependents(tmp_path, monkeypatch, capsys) -> None:
+    src = _sample_source_tree(tmp_path)
+    monkeypatch.setattr(dependency_graph, "SRC_DIR", src)
+    monkeypatch.setattr(dependency_graph, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "dependency_graph.py",
+            "--depends-on",
+            "gpt_trader.app.container",
+        ],
+    )
+
+    result = dependency_graph.main()
+
+    assert result == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["module"] == "gpt_trader.app.container"
+    assert output["direct_dependents"] == ["gpt_trader.features.alpha.service"]

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,8 +7,8 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6705,
-    "total_files": 792,
+    "total_tests": 6707,
+    "total_files": 793,
     "markers_used": 16
   },
   "quick_commands": {

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6707,
+    "total_tests": 6708,
     "total_files": 793,
     "markers_used": 16
   },

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6540,
+    "unit": 6542,
     "asyncio": 373,
     "parametrize": 189,
     "endpoints": 83,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6542,
+    "unit": 6543,
     "asyncio": 373,
     "parametrize": 189,
     "endpoints": 83,

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6707,
+    "total_tests": 6708,
     "total_files": 793,
     "markers_used": 16
   },
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6542,
+    "unit": 6543,
     "asyncio": 373,
     "parametrize": 189,
     "endpoints": 83,
@@ -61196,7 +61196,7 @@
     "tests/unit/scripts/test_dependency_graph.py": [
       {
         "name": "test_main_queries_fully_qualified_dependencies",
-        "line": 29,
+        "line": 37,
         "markers": [
           "unit"
         ],
@@ -61204,7 +61204,15 @@
       },
       {
         "name": "test_main_queries_fully_qualified_dependents",
-        "line": 51,
+        "line": 59,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_main_resolves_package_init_relative_imports",
+        "line": 81,
         "markers": [
           "unit"
         ],

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,8 +2,8 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6705,
-    "total_files": 792,
+    "total_tests": 6707,
+    "total_files": 793,
     "markers_used": 16
   },
   "marker_definitions": {
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6540,
+    "unit": 6542,
     "asyncio": 373,
     "parametrize": 189,
     "endpoints": 83,
@@ -769,6 +769,9 @@
     ],
     "test_decision_trace_probe.py": [
       "tests/unit/scripts/test_decision_trace_probe.py"
+    ],
+    "test_dependency_graph.py": [
+      "tests/unit/scripts/test_dependency_graph.py"
     ],
     "test_docs_maintenance.py": [
       "tests/unit/scripts/test_docs_maintenance.py"
@@ -61184,6 +61187,24 @@
       {
         "name": "test_json_error_output_redacts_sensitive_message",
         "line": 214,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      }
+    ],
+    "tests/unit/scripts/test_dependency_graph.py": [
+      {
+        "name": "test_main_queries_fully_qualified_dependencies",
+        "line": 29,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_main_queries_fully_qualified_dependents",
+        "line": 51,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary
Related issue / finding / RJ-routed package: RJ-routed goal-pipeline cycle 50 architecture-contract finding.

Fixes `agent-map` query mode so documented fully qualified module names like `gpt_trader.features.live_trade.engines.strategy` return real dependency and dependent data instead of silent empty results.

Planning artifacts:
- SPEC: `/Users/rj/Documents/Codex/2026-06-22/shou/work/goal-pipeline-gpt-trader/cycle-50-agent-map-qualified-modules/SPEC.md`
- GOAL: `/Users/rj/Documents/Codex/2026-06-22/shou/work/goal-pipeline-gpt-trader/cycle-50-agent-map-qualified-modules/GOAL.md`

## Type of change
- [ ] Refactor
- [ ] Feature
- [x] Bug fix
- [x] Tests only
- [x] CI/Docs/Tooling

## Scope & Impact
- Affected areas / components: `scripts/agents/dependency_graph.py`, dependency graph unit coverage, generated test inventory.
- Behavior change: `uv run agent-map --dependencies-of gpt_trader.*` and `--depends-on gpt_trader.*` now use graph keys with the `gpt_trader.` prefix, matching the documented CLI examples.

## Test Plan
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Contract tests (if applicable)
- [x] Ran locally: `uv run pytest tests/unit/scripts/test_dependency_graph.py tests/unit/gpt_trader/agents/test_cli_edges.py -q` -> 13 passed
- [x] Markers used appropriately (`unit`/`integration`/`slow`)

Additional verification:
- `uv run agent-map --dependencies-of gpt_trader.features.live_trade.engines.strategy` -> reports 39 direct dependencies
- `uv run agent-map --depends-on gpt_trader.features.live_trade.engines.strategy` -> reports `gpt_trader.features.live_trade.bot` as a direct dependent
- `uv run agent-regenerate --verify` -> all context files up to date
- `uv run local-ci --profile quick` -> 6972 passed, 8 skipped

## Complexity & Quality Gates
- [x] Mypy/type-check passed via quick local CI
- [ ] Xenon/radon complexity gate passed (CC ≤ 15 on live_trade execution)
- [x] No `sys.path` hacks in tests
- [x] No `MagicMock` on `async def` (use `AsyncMock`)
- [x] Import-lint rules respected (no “import up the stack”)

## Observability & Errors
- [ ] Structured JSON logs for new/changed paths
- [ ] Errors include diagnostic context (symbol, order_id, correlation_id)
- [ ] Added/updated sampling examples in tests (if applicable)

Not applicable: tooling-only dependency graph query fix.

## Configuration
- [ ] If config changed: `python -m gpt_trader.cli.config validate --profile <name>` passes
- [ ] Env docs re-generated (if applicable) and committed
- [x] No `ConfigLoader` usages introduced (ConfigManager-only)

## Breaking Changes
- [x] None
- [ ] Documented in PR body and release notes if any

## Screenshots / Logs (optional)
N/A

## Checklist
- [x] Acceptance criteria in linked issue(s), finding packet, or routed package met
- [x] Affected paths listed in PR description
- [ ] Changelog entry (repo does not appear to require one for this tooling fix)
