### PR TITLE
Use decision-needed routing for review findings

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent-review-finding.md
+++ b/.github/ISSUE_TEMPLATE/agent-review-finding.md
@@ -36,7 +36,7 @@ Touches trading execution: `false`
 ## Routing
 
 - Candidate for: claw
-- Needs human decision: `false`
+- Decision needed: `false`
 - Blocked by: none
 
 ## Dedupe

--- a/docs/agents/project_review_pipeline.md
+++ b/docs/agents/project_review_pipeline.md
@@ -2,7 +2,7 @@
 
 ---
 status: draft
-last-updated: 2026-06-22
+last-updated: 2026-06-24
 ---
 
 This document defines the recurring project-review pipeline for GPT-Trader. The
@@ -16,7 +16,7 @@ Hermes, and Codex review loops.
 - Promote only actionable, evidence-backed findings.
 - Use GitHub issues as the durable queue for Claw/Hermes implementation.
 - Preserve GPT-Trader safety boundaries around broker access, trading
-  execution, account capability, and human approval.
+  execution, account capability, and explicit decision records.
 - Feed PR review feedback back into implementation agents without broadening
   scope.
 
@@ -124,7 +124,7 @@ Required fields:
   ],
   "routing": {
     "candidate_for": ["claw"],
-    "needs_human_decision": false,
+    "decision_needed": false,
     "blocked_by": []
   }
 }
@@ -140,10 +140,11 @@ Allowed categories are `bug`, `ci`, `docs`, `architecture`, `tests`,
 `cleanup`, `security`, `trading-readiness`, and `tooling`.
 
 If `scope.touches_trading_execution` is true, the finding must either be
-docs/test-only and clearly execution-free, or `routing.needs_human_decision`
-must be true. Use `docs/PRE_MIGRATION_DECISION_FRAMEWORK.md` for anything that
-touches execution automation, broker adapters, venue support, account
-capability, or AI-assisted execution.
+docs/test-only and clearly execution-free, or `routing.decision_needed` must be
+true. Use `docs/PRE_MIGRATION_DECISION_FRAMEWORK.md` for anything that touches
+execution automation, broker adapters, venue support, account capability, or
+AI-assisted execution, and include enough context for a decision agent to
+recommend the next policy and implementation route.
 
 ## Stage 3: Promote
 
@@ -177,10 +178,10 @@ GitHub issues are the durable queue. These labels are routing signals:
 | Label | Meaning |
 | --- | --- |
 | `agent-review` | Finding came from the recurring GPT-Trader review lane |
-| `agent-ready` | Finding passed promotion gates, has no human/blocker gate, and is ready for implementation |
+| `agent-ready` | Finding passed promotion gates, has no decision/blocker gate, and is ready for implementation |
 | `claw-candidate` | Candidate for Claw implementation |
 | `hermes-candidate` | Candidate for Hermes implementation |
-| `needs-human-decision` | Blocked on RJ or an explicit human gate |
+| `decision-needed` | Requires an explicit decision packet and agent recommendation before implementation or execution |
 | `codex-review-feedback` | Follow-up from Codex review comments or checks |
 
 The promoter can create missing labels with `--create-labels`. If labels are
@@ -232,8 +233,9 @@ convert each actionable item into a bounded fix packet for the active executor:
 - verification command
 - stop condition
 
-If the feedback contradicts the issue acceptance criteria or crosses a human
-gate, label the issue or PR `needs-human-decision` and stop the automation loop.
+If the feedback contradicts the issue acceptance criteria or crosses an
+undecided policy boundary, label the issue or PR `decision-needed` and route a
+decision packet before implementation continues.
 
 ## Stage 7: Merge And Closeout
 

--- a/scripts/maintenance/project_review_issue_promoter.py
+++ b/scripts/maintenance/project_review_issue_promoter.py
@@ -26,7 +26,7 @@ CATEGORIES = {
     "tooling",
     "trading-readiness",
 }
-CANDIDATES = {"claw", "hermes", "codex-review", "human"}
+CANDIDATES = {"claw", "hermes", "codex-review", "decision"}
 EVIDENCE_ANCHOR_FIELDS = ("command", "path", "url")
 
 CUSTOM_LABELS = {
@@ -46,9 +46,9 @@ CUSTOM_LABELS = {
         "color": "006b75",
         "description": "Candidate for Hermes implementation",
     },
-    "needs-human-decision": {
+    "decision-needed": {
         "color": "d876e3",
-        "description": "Blocked on RJ or an explicit human gate",
+        "description": "Requires an explicit decision packet and agent recommendation",
     },
     "codex-review-feedback": {
         "color": "fbca04",
@@ -132,7 +132,7 @@ def example_packet() -> dict[str, Any]:
         "suggested_verification": ["uv run agent-regenerate --verify"],
         "routing": {
             "candidate_for": ["claw"],
-            "needs_human_decision": False,
+            "decision_needed": False,
             "blocked_by": [],
         },
     }
@@ -231,13 +231,11 @@ def validate_packet(packet: dict[str, Any]) -> list[str]:
             unknown_candidates = sorted(set(candidates) - CANDIDATES)
         if unknown_candidates:
             errors.append(f"routing.candidate_for contains unknown values: {unknown_candidates}")
-    if not isinstance(routing.get("needs_human_decision"), bool):
-        errors.append("routing.needs_human_decision must be true or false")
+    if not isinstance(routing.get("decision_needed"), bool):
+        errors.append("routing.decision_needed must be true or false")
 
-    if scope.get("touches_trading_execution") and not routing.get("needs_human_decision"):
-        errors.append(
-            "scope.touches_trading_execution=true requires routing.needs_human_decision=true"
-        )
+    if scope.get("touches_trading_execution") and not routing.get("decision_needed"):
+        errors.append("scope.touches_trading_execution=true requires routing.decision_needed=true")
 
     blocked_by = routing.get("blocked_by", [])
     if blocked_by is not None and not isinstance(blocked_by, list):
@@ -261,7 +259,7 @@ def packet_labels(packet: dict[str, Any]) -> list[str]:
     routing = packet.get("routing", {})
     if isinstance(routing, dict):
         blocked_by = routing.get("blocked_by", [])
-        if not routing.get("needs_human_decision") and not blocked_by:
+        if not routing.get("decision_needed") and not blocked_by:
             labels.add("agent-ready")
         candidates = routing.get("candidate_for", [])
         if isinstance(candidates, list):
@@ -271,8 +269,8 @@ def packet_labels(packet: dict[str, Any]) -> list[str]:
                 labels.add("hermes-candidate")
             if "codex-review" in candidates:
                 labels.add("codex-review-feedback")
-        if routing.get("needs_human_decision"):
-            labels.add("needs-human-decision")
+        if routing.get("decision_needed"):
+            labels.add("decision-needed")
 
     return sorted(labels)
 
@@ -397,7 +395,7 @@ def render_issue_body(packet: dict[str, Any], labels: list[str], missing_labels:
         "",
         "## Routing",
         f"- Candidate for: {', '.join(routing['candidate_for'])}",
-        f"- Needs human decision: `{str(routing['needs_human_decision']).lower()}`",
+        f"- Decision needed: `{str(routing['decision_needed']).lower()}`",
         f"- Blocked by: {', '.join(routing.get('blocked_by', [])) or 'none'}",
         "",
         "## Dedupe",

--- a/scripts/maintenance/project_review_issue_promoter.py
+++ b/scripts/maintenance/project_review_issue_promoter.py
@@ -218,6 +218,7 @@ def validate_packet(packet: dict[str, Any]) -> list[str]:
         errors.append("routing must be an object")
         routing = {}
     candidates = routing.get("candidate_for")
+    normalized_candidates: set[str] = set()
     if not isinstance(candidates, list) or not candidates:
         errors.append("routing.candidate_for must be a non-empty list")
     else:
@@ -228,11 +229,16 @@ def validate_packet(packet: dict[str, Any]) -> list[str]:
             errors.append("routing.candidate_for must contain only strings")
             unknown_candidates: list[str] = []
         else:
-            unknown_candidates = sorted(set(candidates) - CANDIDATES)
+            normalized_candidates = set(candidates)
+            unknown_candidates = sorted(normalized_candidates - CANDIDATES)
         if unknown_candidates:
             errors.append(f"routing.candidate_for contains unknown values: {unknown_candidates}")
     if not isinstance(routing.get("decision_needed"), bool):
         errors.append("routing.decision_needed must be true or false")
+    elif "decision" in normalized_candidates and not routing.get("decision_needed"):
+        errors.append(
+            "routing.candidate_for includes decision requires routing.decision_needed=true"
+        )
 
     if scope.get("touches_trading_execution") and not routing.get("decision_needed"):
         errors.append("scope.touches_trading_execution=true requires routing.decision_needed=true")
@@ -259,9 +265,10 @@ def packet_labels(packet: dict[str, Any]) -> list[str]:
     routing = packet.get("routing", {})
     if isinstance(routing, dict):
         blocked_by = routing.get("blocked_by", [])
-        if not routing.get("decision_needed") and not blocked_by:
-            labels.add("agent-ready")
         candidates = routing.get("candidate_for", [])
+        decision_candidate = isinstance(candidates, list) and "decision" in candidates
+        if not routing.get("decision_needed") and not blocked_by and not decision_candidate:
+            labels.add("agent-ready")
         if isinstance(candidates, list):
             if "claw" in candidates:
                 labels.add("claw-candidate")
@@ -269,7 +276,7 @@ def packet_labels(packet: dict[str, Any]) -> list[str]:
                 labels.add("hermes-candidate")
             if "codex-review" in candidates:
                 labels.add("codex-review-feedback")
-        if routing.get("decision_needed"):
+        if routing.get("decision_needed") or decision_candidate:
             labels.add("decision-needed")
 
     return sorted(labels)

--- a/tests/unit/scripts/test_project_review_issue_promoter.py
+++ b/tests/unit/scripts/test_project_review_issue_promoter.py
@@ -54,9 +54,20 @@ def test_evidence_requires_command_path_or_url_anchor() -> None:
 def test_decision_needed_packet_is_not_agent_ready() -> None:
     packet = promoter.example_packet()
     packet["routing"]["decision_needed"] = True
+    packet["routing"]["candidate_for"] = ["decision"]
     packet["routing"]["blocked_by"] = ["live-start control decision"]
 
     labels = promoter.packet_labels(packet)
 
     assert "agent-ready" not in labels
     assert "decision-needed" in labels
+
+
+def test_decision_candidate_requires_decision_needed() -> None:
+    packet = promoter.example_packet()
+    packet["routing"]["candidate_for"] = ["decision"]
+    packet["routing"]["decision_needed"] = False
+
+    errors = promoter.validate_packet(packet)
+
+    assert "routing.candidate_for includes decision requires routing.decision_needed=true" in errors

--- a/tests/unit/scripts/test_project_review_issue_promoter.py
+++ b/tests/unit/scripts/test_project_review_issue_promoter.py
@@ -10,16 +10,14 @@ def test_example_packet_is_valid() -> None:
     assert promoter.validate_packet(promoter.example_packet()) == []
 
 
-def test_trading_execution_findings_require_human_decision() -> None:
+def test_trading_execution_findings_require_decision_needed() -> None:
     packet = promoter.example_packet()
     packet["scope"]["touches_trading_execution"] = True
-    packet["routing"]["needs_human_decision"] = False
+    packet["routing"]["decision_needed"] = False
 
     errors = promoter.validate_packet(packet)
 
-    assert (
-        "scope.touches_trading_execution=true requires routing.needs_human_decision=true" in errors
-    )
+    assert "scope.touches_trading_execution=true requires routing.decision_needed=true" in errors
 
 
 def test_dry_run_renders_issue_body(tmp_path: Path, capsys) -> None:
@@ -53,12 +51,12 @@ def test_evidence_requires_command_path_or_url_anchor() -> None:
     assert "evidence[1] must include at least one anchor: command, path, url" in errors
 
 
-def test_human_gated_packet_is_not_agent_ready() -> None:
+def test_decision_needed_packet_is_not_agent_ready() -> None:
     packet = promoter.example_packet()
-    packet["routing"]["needs_human_decision"] = True
-    packet["routing"]["blocked_by"] = ["RJ venue decision"]
+    packet["routing"]["decision_needed"] = True
+    packet["routing"]["blocked_by"] = ["live-start control decision"]
 
     labels = promoter.packet_labels(packet)
 
     assert "agent-ready" not in labels
-    assert "needs-human-decision" in labels
+    assert "decision-needed" in labels

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6708,
+    "total_tests": 6709,
     "total_files": 793,
     "markers_used": 16
   },

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6543,
+    "unit": 6544,
     "asyncio": 373,
     "parametrize": 189,
     "endpoints": 83,

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6708,
+    "total_tests": 6709,
     "total_files": 793,
     "markers_used": 16
   },
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6543,
+    "unit": 6544,
     "asyncio": 373,
     "parametrize": 189,
     "endpoints": 83,
@@ -61567,6 +61567,14 @@
       {
         "name": "test_decision_needed_packet_is_not_agent_ready",
         "line": 54,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_decision_candidate_requires_decision_needed",
+        "line": 66,
         "markers": [
           "unit"
         ],

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -61533,7 +61533,7 @@
         "docstring": ""
       },
       {
-        "name": "test_trading_execution_findings_require_human_decision",
+        "name": "test_trading_execution_findings_require_decision_needed",
         "line": 13,
         "markers": [
           "unit"
@@ -61542,7 +61542,7 @@
       },
       {
         "name": "test_dry_run_renders_issue_body",
-        "line": 25,
+        "line": 23,
         "markers": [
           "unit"
         ],
@@ -61550,7 +61550,7 @@
       },
       {
         "name": "test_invalid_candidate_type_is_reported",
-        "line": 38,
+        "line": 36,
         "markers": [
           "unit"
         ],
@@ -61558,15 +61558,15 @@
       },
       {
         "name": "test_evidence_requires_command_path_or_url_anchor",
-        "line": 47,
+        "line": 45,
         "markers": [
           "unit"
         ],
         "docstring": ""
       },
       {
-        "name": "test_human_gated_packet_is_not_agent_ready",
-        "line": 56,
+        "name": "test_decision_needed_packet_is_not_agent_ready",
+        "line": 54,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary
- replace project-review finding routing from needs-human-decision to decision-needed
- update the issue promoter schema, label, issue template, and project-review docs
- refresh generated test inventory after renaming promoter tests

## Verification
- uv run pytest tests/unit/scripts/test_project_review_issue_promoter.py -q
- uv run ruff check scripts/maintenance/project_review_issue_promoter.py tests/unit/scripts/test_project_review_issue_promoter.py
- uv run black --check scripts/maintenance/project_review_issue_promoter.py tests/unit/scripts/test_project_review_issue_promoter.py
- uv run agent-regenerate --verify
- uv run local-ci --profile quick

## Notes
- Issue #898 was relabeled to decision-needed and its routing section now points to a decision packet rather than a human-only blocker.
