### PR TITLE
[codex] Align project review decision routing

### DIFF
--- a/docs/agents/project_review_pipeline.md
+++ b/docs/agents/project_review_pipeline.md
@@ -54,7 +54,8 @@ uv run local-ci --profile quick
 The scout may run narrower commands when there are no relevant changes since a
 recent run. It must not run real broker/API checks, canary operations, live
 trading commands, production preflight, or anything that assumes account
-capability unless a current owner-approved runbook explicitly opens that lane.
+capability unless a current `decision_needed` packet or explicitly approved
+runbook scopes that lane.
 
 After the cheap truth pass is green, choose exactly one discovery lane for the
 run. Rotate lanes across runs instead of scanning everything every hour.

--- a/docs/agents/project_review_pipeline.md
+++ b/docs/agents/project_review_pipeline.md
@@ -54,8 +54,9 @@ uv run local-ci --profile quick
 The scout may run narrower commands when there are no relevant changes since a
 recent run. It must not run real broker/API checks, canary operations, live
 trading commands, production preflight, or anything that assumes account
-capability unless a current `decision_needed` packet or explicitly approved
-runbook scopes that lane.
+capability unless a current decision packet or approved runbook explicitly
+scopes that lane. A `decision_needed` finding is not authorization by itself; it
+must first be resolved into a decision packet that scopes the command lane.
 
 After the cheap truth pass is green, choose exactly one discovery lane for the
 run. Rotate lanes across runs instead of scanning everything every hour.


### PR DESCRIPTION
Closes #901

## Summary
- replace the project-review scout boundary's owner-runbook wording with a current `decision_needed` packet or approved runbook lane
- preserve the prohibition on real broker/API checks, canary operations, live trading commands, production preflight, and account-capability assumptions outside a scoped lane

## Verification
- `uv run agent-regenerate --verify` -> pass
- `uv run local-ci --profile quick` -> pass (6978 passed, 8 skipped)

## Scope
- docs-only change to `docs/agents/project_review_pipeline.md`
- no trading behavior, broker adapter, execution policy, generated artifact, or order-flow changes