### PR TITLE
[codex] Clarify execution decision routing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ Do not treat existing live profiles or broker adapters as proof that a product s
 - **Spot Trading** - Implemented Coinbase spot paths; require explicit profile and readiness gates
 - **CFM Futures** - Implemented/gated US-regulated futures paths; require account, product, and risk verification
 - **INTX Perpetuals** - Implemented/gated international derivatives paths; require eligible-region/account verification
-- **AI-assisted execution** - Planning and approval-gated tickets only; live order submission requires an explicitly scoped approval decision before any order submission
+- **AI-assisted execution** - Planning and approval-gated tickets only; live order submission requires recorded human approval plus any explicitly scoped decision packet or runbook constraints before any order submission
 
 ## Environment Setup
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,13 +40,13 @@ Note: `PYTHONWARNINGS` value must be `default` (not `1`) if set.
 
 GPT-Trader is a Coinbase-oriented trading system using vertical slice architecture with modern Dependency Injection via `ApplicationContainer`. Trading strategies currently use technical analysis and rule-based decisioning, not LLM inference.
 
-Do not treat existing live profiles or broker adapters as proof that a product should be automated. Before migration or new execution work, use `docs/PRE_MIGRATION_DECISION_FRAMEWORK.md`: start with `human_approved_execution`, keep broker-neutral records canonical, and verify venue/API/account capability before adding or enabling execution paths.
+Do not treat existing live profiles or broker adapters as proof that a product should be automated. Before migration or new execution work, use `docs/PRE_MIGRATION_DECISION_FRAMEWORK.md`: start from the current approval-gated execution phase (`human_approved_execution` compatibility label), keep broker-neutral records canonical, route unresolved live-control choices through `decision-needed` packets, and verify venue/API/account capability before adding or enabling execution paths.
 
 **Trading Modes:**
 - **Spot Trading** - Implemented Coinbase spot paths; require explicit profile and readiness gates
 - **CFM Futures** - Implemented/gated US-regulated futures paths; require account, product, and risk verification
 - **INTX Perpetuals** - Implemented/gated international derivatives paths; require eligible-region/account verification
-- **AI-assisted execution** - Planning only; v1 target is human approval before any order submission
+- **AI-assisted execution** - Planning and approval-gated tickets only; live order submission requires an explicitly scoped approval decision before any order submission
 
 ## Environment Setup
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,7 +21,7 @@ last-updated: 2026-01-24
 
 GPT-Trader is a Coinbase Advanced Trade oriented trading system with implemented **spot**, **CFM futures**, and gated **INTX perpetuals** paths. Treat these as implementation capabilities, not as blanket approval for live automation.
 
-For broader migration, the canonical planning gate is [Pre-Migration Decision Framework](PRE_MIGRATION_DECISION_FRAMEWORK.md). New AI-assisted execution work should start from `human_approved_execution`, broker-neutral trade records, explicit risk budgets, and verified venue/API/account capability.
+For broader migration, the canonical planning gate is [Pre-Migration Decision Framework](PRE_MIGRATION_DECISION_FRAMEWORK.md). New AI-assisted execution work should start from the current approval-gated execution phase (`human_approved_execution` compatibility label), broker-neutral trade records, explicit risk budgets, `decision-needed` packets for unresolved live-control choices, and verified venue/API/account capability.
 
 > 📘 **Trust reminder:** Confirm key details against current source + generated inventories (`var/agents/**`) before acting on them.
 
@@ -525,7 +525,8 @@ the gates in [Live Operations](production.md) and the
 
 The snippets below are illustrative config snapshots, not approval. Live
 profiles (`canary`, `prod`) only run after the gates in
-[Live Operations](production.md) are satisfied with recorded human approval.
+[Live Operations](production.md) are satisfied with a recorded approval decision
+or explicitly scoped runbook.
 
 ### Development Profile
 ```yaml

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -525,8 +525,9 @@ the gates in [Live Operations](production.md) and the
 
 The snippets below are illustrative config snapshots, not approval. Live
 profiles (`canary`, `prod`) only run after the gates in
-[Live Operations](production.md) are satisfied with a recorded approval decision
-or explicitly scoped runbook.
+[Live Operations](production.md) are satisfied with a recorded human approval
+decision. An approved runbook may scope the command lane and checks, but it
+does not replace the approval event required by the current runtime policy.
 
 ### Development Profile
 ```yaml

--- a/docs/PRE_MIGRATION_DECISION_FRAMEWORK.md
+++ b/docs/PRE_MIGRATION_DECISION_FRAMEWORK.md
@@ -80,6 +80,9 @@ approval decision.
 broker/API, venue, account, or AI-assisted trading choices. It is not a
 terminal human-only stop. A decision packet may approve docs, code, tests,
 mock-only controls, or a scoped runbook when the evidence supports that route.
+In the current `human_approved_execution` phase, it may recommend or prepare a
+trade-ticket approval path, but it does not replace the human approval event
+required by runtime policy.
 
 That packet does not by itself authorize real broker/API calls, live trading
 commands, production preflight, canary operations, money movement, or order
@@ -218,13 +221,13 @@ typed model only after the decisions in this document are accepted.
 Minimum v1 workflow:
 
 1. AI creates a `proposed` trade idea record.
-2. A reviewer or decision agent checks strategy eligibility, data freshness, risk, and
+2. A human reviewer checks strategy eligibility, data freshness, risk, and
    do-not-trade conditions.
-3. The reviewer or decision packet either rejects the idea, requests changes,
-   or approves it.
+3. The human reviewer either rejects the idea, requests changes, or approves it.
 4. Approved ideas produce a broker-specific ticket.
-5. Execution is manual or explicitly triggered by an approval event scoped by a
-   decision packet or approved runbook.
+5. Execution is manual or explicitly triggered by the human approval event, and
+   any API command lane must also be scoped by a decision packet or approved
+   runbook.
 6. The result is appended to the audit log.
 
 Allowed states:
@@ -232,17 +235,16 @@ Allowed states:
 | State | Meaning |
 | --- | --- |
 | `proposed` | AI generated the record; no execution allowed |
-| `needs_changes` | Reviewer or decision packet requested edits or missing evidence |
-| `rejected` | Reviewer or decision packet rejected the idea; terminal |
-| `approved` | Approval decision accepted the ticket; execution may proceed by policy |
+| `needs_changes` | Human reviewer requested edits or missing evidence |
+| `rejected` | Human reviewer rejected the idea; terminal |
+| `approved` | Human approval decision accepted the ticket; execution may proceed by policy |
 | `submitted` | Order was manually entered or API-submitted after approval |
 | `filled` | Venue confirmed fill |
 | `cancelled` | Reviewer, operator, system, or venue cancelled before fill |
 | `expired` | Idea passed its review or execution deadline |
 
 Approval must be append-only. Do not overwrite the original thesis when a
-reviewer or decision packet changes the ticket; append a new event that explains
-the change.
+human reviewer changes the ticket; append a new event that explains the change.
 
 ## Audit Log Contract
 

--- a/docs/PRE_MIGRATION_DECISION_FRAMEWORK.md
+++ b/docs/PRE_MIGRATION_DECISION_FRAMEWORK.md
@@ -14,11 +14,13 @@ with the exploratory tables below, this section wins.
 - **Destination:** an autonomous trading entity — a bot that observes markets,
   does its own research, and manages funds inside machine-enforced limits
   (`bounded_autonomy`).
-- **Path:** `human_approved_execution` is the required validation phase, not the
-  end state. The AI side must first produce complete trade-idea records (thesis,
-  entry, invalidation, max loss, sizing) that a human approves. Autonomy is
-  granted per strategy envelope only after the approval-phase track record,
-  risk budgets, kill switches, and audit logs exist.
+- **Path:** the current approval-gated execution phase
+  (`human_approved_execution` compatibility label) is the required validation
+  phase, not the end state. The AI side must first produce complete trade-idea
+  records (thesis, entry, invalidation, max loss, sizing) that receive an
+  explicit approval decision. Autonomy is granted per strategy envelope only
+  after the approval-phase track record, risk budgets, kill switches, and audit
+  logs exist.
 - **Scope:** Coinbase only (spot + CFM futures). Options, Robinhood, and other
   venues are out of scope until the Coinbase lane works end to end.
 - **INTX perpetuals:** frozen — no new work or tests; remove INTX-only surfaces
@@ -58,28 +60,43 @@ otherwise.
 
 ## Recommendation
 
-The v1 migration target should be `human_approved_execution`.
+The v1 migration target should be approval-gated execution, currently named
+`human_approved_execution` in runtime and historical docs.
 
-AI may produce complete, broker-ready trade tickets, but a human approves,
-changes, rejects, or manually executes them. This preserves a clear operator
-decision point while creating the artifacts needed for future automation:
-thesis records, risk checks, approval history, and audit logs.
+AI may produce complete, broker-ready trade tickets, but an explicit approval
+decision changes, rejects, or releases them for manual or scoped API execution.
+This preserves a clear decision point while creating the artifacts needed for
+future automation: thesis records, risk checks, approval history, and audit
+logs.
 
 `bounded_autonomy` should be treated as a later milestone. It needs
 machine-enforced strategy envelopes, numeric risk budgets, kill-switch coverage,
-and proven auditability before any order can be submitted without human
-approval.
+and proven auditability before any order can be submitted without an explicit
+approval decision.
+
+## Decision Packet Alignment
+
+`decision-needed` is the pipeline route for unsettled policy, live-operation,
+broker/API, venue, account, or AI-assisted trading choices. It is not a
+terminal human-only stop. A decision packet may approve docs, code, tests,
+mock-only controls, or a scoped runbook when the evidence supports that route.
+
+That packet does not by itself authorize real broker/API calls, live trading
+commands, production preflight, canary operations, money movement, or order
+submission. Those command lanes require the packet or runbook to explicitly
+name the lane, constraints, verification boundary, and rollback/kill-switch
+expectations.
 
 ## Decision 1: Autonomy Boundary
 
 | Mode | AI May Produce | AI May Submit Orders | v1 Status |
 | --- | --- | --- | --- |
 | `research_only` | Research notes, theses, watchlists | No | Allowed, but too weak as the main target |
-| `human_approved_execution` | Broker-ready tickets and risk records | No, approval required first | Recommended default |
+| `human_approved_execution` | Broker-ready tickets and risk records | No, explicit approval required first | Recommended default compatibility label |
 | `bounded_autonomy` | Tickets inside pre-approved envelopes | Yes, only inside hard limits | Future milestone |
 
-Hard v1 rule: AI does not submit live orders. Any API execution lane must require
-an explicit human approval event first.
+Hard v1 rule: AI does not submit live orders. Any API execution lane must
+require an explicit approval event first.
 
 ## Decision 2: Strategy Eligibility
 
@@ -201,11 +218,13 @@ typed model only after the decisions in this document are accepted.
 Minimum v1 workflow:
 
 1. AI creates a `proposed` trade idea record.
-2. A reviewer checks strategy eligibility, data freshness, risk, and
+2. A reviewer or decision agent checks strategy eligibility, data freshness, risk, and
    do-not-trade conditions.
-3. The reviewer either rejects the idea, requests changes, or approves it.
+3. The reviewer or decision packet either rejects the idea, requests changes,
+   or approves it.
 4. Approved ideas produce a broker-specific ticket.
-5. Execution is manual or explicitly triggered by a human approval event.
+5. Execution is manual or explicitly triggered by an approval event scoped by a
+   decision packet or approved runbook.
 6. The result is appended to the audit log.
 
 Allowed states:
@@ -213,16 +232,17 @@ Allowed states:
 | State | Meaning |
 | --- | --- |
 | `proposed` | AI generated the record; no execution allowed |
-| `needs_changes` | Human requested edits or missing evidence |
-| `rejected` | Human rejected the idea; terminal |
-| `approved` | Human approved the ticket; execution may proceed by policy |
+| `needs_changes` | Reviewer or decision packet requested edits or missing evidence |
+| `rejected` | Reviewer or decision packet rejected the idea; terminal |
+| `approved` | Approval decision accepted the ticket; execution may proceed by policy |
 | `submitted` | Order was manually entered or API-submitted after approval |
 | `filled` | Venue confirmed fill |
-| `cancelled` | Human or venue cancelled before fill |
+| `cancelled` | Reviewer, operator, system, or venue cancelled before fill |
 | `expired` | Idea passed its review or execution deadline |
 
-Approval must be append-only. Do not overwrite the original thesis when a human
-changes the ticket; append a new event that explains the change.
+Approval must be append-only. Do not overwrite the original thesis when a
+reviewer or decision packet changes the ticket; append a new event that explains
+the change.
 
 ## Audit Log Contract
 
@@ -284,7 +304,7 @@ Do not migrate the existing bot into this shape until every item is complete:
 
 | Decision | Accepted Value | Status |
 | --- | --- | --- |
-| Autonomy mode | `human_approved_execution` now; `bounded_autonomy` is the accepted destination | Accepted 2026-06-11 |
+| Autonomy mode | Approval-gated execution (`human_approved_execution` compatibility label) now; `bounded_autonomy` is the accepted destination | Accepted 2026-06-11 |
 | Primary product universe | Coinbase spot + CFM futures research | Accepted 2026-06-11 |
 | API canary lane | Coinbase CFM only after account/product verification | Accepted 2026-06-11 |
 | Robinhood role | Out of scope | Accepted 2026-06-11 |


### PR DESCRIPTION
## Summary
Clarifies how GPT-Trader's current approval-gated execution phase relates to agent `decision-needed` routing.

Related issue / finding / RJ-routed package: Closes #903
Decision packet: https://github.com/Solders-Girdles/GPT-Trader/issues/903#issuecomment-4786607480

## Type of change
- [ ] Refactor
- [ ] Feature
- [ ] Bug fix
- [ ] Tests only
- [x] CI/Docs/Tooling

## Scope & Impact
- Affected areas / components: `AGENTS.md`, `docs/PRE_MIGRATION_DECISION_FRAMEWORK.md`, `docs/ARCHITECTURE.md`
- Behavior changes: none. This is docs-only and does not change runtime gates, broker adapters, live commands, or order submission.

## Test Plan
- [x] Unit tests added/updated: not applicable, docs-only
- [ ] Integration tests added/updated
- [ ] Contract tests (if applicable)
- [x] Ran locally: `uv run pytest tests/unit/scripts/test_canary_reduce_only_test.py tests/unit/gpt_trader/features/trade_ideas/test_policy.py -q` -> 18 passed
- [x] Markers used appropriately (`unit`/`integration`/`slow`/`perf`)

Additional verification:
- `uv run agent-regenerate --verify` -> passed, all context files up-to-date
- `python scripts/maintenance/docs_link_audit.py` -> passed, 64 files scanned
- `uv run local-ci --profile quick` -> passed, 6978 passed / 8 skipped

## Complexity & Quality Gates
- [x] Mypy/type-check passed via `uv run local-ci --profile quick`
- [x] Xenon/radon complexity gate passed (not applicable; no Python source changes)
- [x] No `sys.path` hacks in tests
- [x] No `MagicMock` on `async def` (use `AsyncMock`)
- [x] Import-lint rules respected (no source imports changed)

## Observability & Errors
- [x] Structured JSON logs for new/changed paths: not applicable, docs-only
- [x] Errors include diagnostic context: not applicable, docs-only
- [x] Added/updated sampling examples in tests: not applicable, docs-only

## Configuration
- [x] If config changed: not applicable, no config changes
- [x] Env docs re-generated: not applicable; verifier passed with no artifact changes
- [x] No `ConfigLoader` usages introduced (ConfigManager-only)

## Breaking Changes
- [x] None
- [ ] Documented in PR body and release notes if any

## Screenshots / Logs (optional)
No UI changes.

## Checklist
- [x] Acceptance criteria in linked issue(s), finding packet, or routed package met
- [x] Affected paths listed in PR description
- [x] Changelog entry: not applicable

## Notes
This PR preserves the current `human_approved_execution` compatibility label while clarifying that `decision-needed` is the agent route for unsettled policy/live-control choices. It does not authorize live broker/API calls, canary operations, production preflight, money movement, or order submission.