### PR TITLE
[codex] Update trade-idea CLI docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 ---
 status: current
-last-updated: 2026-05-06
+last-updated: 2026-06-24
 ---
 
 All docs under `docs/` must be reachable from this index (directly or via other linked docs).
@@ -28,7 +28,7 @@ When adding a new doc, link it below in the best-fit section.
 | [Live Operations Guide](production.md) | Readiness-gated live operations, rollback, and emergency procedures |
 | [Readiness Checklist](READINESS.md) | Gates to move from paper to live trading |
 | [Pre-Migration Decision Framework](PRE_MIGRATION_DECISION_FRAMEWORK.md) | AI-assisted trading autonomy, product, venue, approval, and audit gates |
-| [Trade-Idea Interface Design Notes](specs/TRADE_IDEA_INTERFACES_DESIGN_NOTES.md) | Proposed CLI/TUI workstreams for human-approved trade ideas |
+| [Trade-Idea Interface Design Notes](specs/TRADE_IDEA_INTERFACES_DESIGN_NOTES.md) | Implemented CLI and future TUI workstreams for human-approved trade ideas |
 | [Operating Rubric](OPERATING_RUBRIC.md) | Staged capabilities and graduation evidence for the autonomous entity |
 | [Reliability Guide](RELIABILITY.md) | Guard stack, degradation responses, chaos testing |
 | [TUI Guide](TUI_GUIDE.md) | Launching and operating the terminal UI |

--- a/docs/specs/TRADE_IDEA_CLI_SPEC.md
+++ b/docs/specs/TRADE_IDEA_CLI_SPEC.md
@@ -138,10 +138,15 @@ Thin wrappers over `service.reject` / `service.request_changes` /
 - `ideas expire DECISION_ID` — expire one idea (service defaults for
   reason/actor unless overridden).
 - `ideas expire --sweep` — list all non-terminal views and expire each idea
-  whose `time_horizon.expires_at` is set and `<= now`, or whose review time
-  exceeds `RiskBudget.max_review_latency_hours`. Report `data["expired"]` =
-  list of decision_ids; success even when zero matched (`was_noop=True`).
-  DECISION_ID and `--sweep` are mutually exclusive; one is required.
+  that can legally transition to expired when either:
+  - `time_horizon.expires_at` is set and `<= now`; or
+  - the review deadline has elapsed under the current
+    `RiskBudget.max_review_latency_hours` policy.
+  The review-latency path can expire a far-future idea whose `expires_at` is
+  still later than `now` when the review queue exceeds the configured budget.
+  Report `data["expired"]` = list of decision_ids; success even when zero
+  matched (`was_noop=True`). DECISION_ID and `--sweep` are mutually exclusive;
+  one is required.
 
 ### `ideas mark-submitted` / `ideas mark-filled`
 
@@ -204,8 +209,10 @@ Required cases:
 6. `approve` over-budget idea → exit 1, `POLICY_VIOLATION`, all violations in
    `data["violations"]` (assert ≥2 violations both present).
 7. `request-changes` → `resubmit` (revised record) → `approve` full loop.
-8. `reject`, `cancel`, `expire` single, `expire --sweep` (one stale + one
-   fresh idea: only stale expires; `was_noop` when none).
+8. `reject`, `cancel`, `expire` single, `expire --sweep` with explicit expiry
+   coverage (one stale + one fresh idea: only stale expires; `was_noop` when
+   none) plus review-latency sweep coverage for a far-future idea whose review
+   deadline exceeds `max_review_latency_hours`.
 9. `mark-submitted` then `mark-filled` with venue/external id recorded in
    audit events.
 10. `budget show` seeds defaults; `budget set --max-loss-per-idea-pct 2

--- a/docs/specs/TRADE_IDEA_CLI_SPEC.md
+++ b/docs/specs/TRADE_IDEA_CLI_SPEC.md
@@ -1,32 +1,36 @@
 ---
-status: draft
-last-updated: 2026-06-12
+status: current
+last-updated: 2026-06-24
 workstream: 1 (see TRADE_IDEA_INTERFACES_DESIGN_NOTES.md)
-depends-on: Workstream 0 (service factory, error codes, actor resolution)
+depends-on: Workstream 0 (implemented service factory, error codes, actor resolution)
 ---
 
-# Implementation Spec: `gpt-trader ideas` CLI Command Group
+# Implemented Spec: `gpt-trader ideas` CLI Command Group
 
 ## Goal
 
 A complete, scriptable CLI surface over `TradeIdeaService` so that AI agents
 can propose trade-idea records and humans can review them, with JSON output
 for programmatic use. This is the first working door into the staged-autonomy
-workflow.
+workflow and is implemented in `src/gpt_trader/cli/commands/ideas.py`.
+
+This document is now a maintainer reference for the implemented CLI contract,
+not a request to build a new command group. Future work should update the
+current command and tests rather than duplicating the trade-ideas interface.
 
 ## Files
 
 | File | Action |
 |------|--------|
-| `src/gpt_trader/cli/commands/ideas.py` | New — command group |
-| `src/gpt_trader/cli/__init__.py` | Add `ideas.register(subparsers)` alongside existing registrations |
-| `src/gpt_trader/cli/response.py` | Add `POLICY_VIOLATION`, `IDEA_NOT_FOUND` to `CliErrorCode` |
-| `src/gpt_trader/features/trade_ideas/service.py` | Add `DEFAULT_IDEAS_ROOT`, `create_trade_idea_service()` factory |
-| `tests/unit/gpt_trader/cli/commands/test_ideas_*.py` | New tests (split by lifecycle/query/budget) |
+| `src/gpt_trader/cli/commands/ideas.py` | Implemented command group |
+| `src/gpt_trader/cli/__init__.py` | Registers `ideas.register(subparsers)` alongside existing commands |
+| `src/gpt_trader/cli/response.py` | Defines `POLICY_VIOLATION`, `IDEA_NOT_FOUND` in `CliErrorCode` |
+| `src/gpt_trader/features/trade_ideas/service.py` | Defines `DEFAULT_IDEAS_ROOT`, `create_trade_idea_service()` factory |
+| `tests/unit/gpt_trader/cli/commands/test_ideas_*.py` | Implemented CLI tests split by lifecycle/query/budget and focused integrity cases |
 
-Follow the structure of `cli/commands/controls.py`: a `register(subparsers)`
-function, one `_handle_*` per subcommand returning `CliResponse`, with
-`options.add_output_options(parser)` on every subcommand.
+The implementation follows the structure of `cli/commands/controls.py`: a
+`register(subparsers)` function, one `_handle_*` per subcommand returning
+`CliResponse`, with `options.add_output_options(parser)` on every subcommand.
 
 ## Common options
 
@@ -39,6 +43,12 @@ Every subcommand accepts:
 Every mutating subcommand accepts:
 
 - `--actor ID` — actor identity (default: `GPT_TRADER_ACTOR` env, then OS user)
+
+Current behavior is discoverable with:
+
+```bash
+uv run gpt-trader ideas --help
+```
 
 ## Command tree
 
@@ -137,7 +147,7 @@ Thin wrappers over `service.reject` / `service.request_changes` /
 
 - Wrap `service.record_submission` / `service.record_fill`.
 - **These record manually executed tickets; they never touch a broker API.**
-  Help text must say so.
+  Help text says so, and this boundary must remain explicit in future changes.
 - `--venue` choices: `coinbase`, `manual` (no INTX-specific venue surface).
 
 ### `ideas budget show` / `ideas budget set`
@@ -177,7 +187,7 @@ mode returns the `CliResponse` envelope with `command="ideas <subcommand>"`.
 - Timestamps render ISO-8601 UTC.
 - Never print secrets; the audit contract forbids credentials in any record.
 
-## Test plan (tests/unit/gpt_trader/cli/commands/)
+## Implemented test plan (tests/unit/gpt_trader/cli/commands/)
 
 Use a `tmp_path`-rooted service via `--ideas-root` (no monkeypatching of
 globals needed; this is why the flag exists). Fixture helper builds a valid
@@ -208,12 +218,14 @@ Required cases:
 
 ## Acceptance criteria
 
-- [ ] `gpt-trader ideas --help` lists all subcommands with accurate help text.
-- [ ] Full loop works on a clean checkout with no env vars:
+- [x] `gpt-trader ideas --help` lists all subcommands with accurate help text.
+- [x] Full loop works on a clean checkout with no env vars:
       propose → list → show → approve → mark-submitted → mark-filled,
       and the audit log verifies afterward.
-- [ ] No import from `features/brokerages/` or `features/live_trade/` in
+- [x] No import from `features/brokerages/` or `features/live_trade/` in
       `ideas.py` (enforce by review; this surface must stay execution-free).
-- [ ] All policy violations reach the user; no first-error-only truncation.
-- [ ] `uv run agent-check`, `agent-naming`, `mypy`, `ruff`, `black` clean.
-- [ ] Test plan above implemented; `uv run pytest tests/unit -q` green.
+- [x] All policy violations reach the user; no first-error-only truncation.
+- [x] The focused `tests/unit/gpt_trader/cli/commands/test_ideas_*.py` suite
+      covers the implemented command group.
+- [ ] Re-run the repo-required quality bundle before merging any future change
+      that modifies this CLI or its tests.

--- a/docs/specs/TRADE_IDEA_CLI_SPEC.md
+++ b/docs/specs/TRADE_IDEA_CLI_SPEC.md
@@ -137,11 +137,11 @@ Thin wrappers over `service.reject` / `service.request_changes` /
 
 - `ideas expire DECISION_ID` — expire one idea (service defaults for
   reason/actor unless overridden).
-- `ideas expire --sweep` — list all non-terminal views, expire each whose
-  `time_horizon.expires_at` is set and `<= now`. Report
-  `data["expired"]` = list of decision_ids; success even when zero matched
-  (`was_noop=True`). DECISION_ID and `--sweep` are mutually exclusive;
-  one is required.
+- `ideas expire --sweep` — list all non-terminal views and expire each idea
+  whose `time_horizon.expires_at` is set and `<= now`, or whose review time
+  exceeds `RiskBudget.max_review_latency_hours`. Report `data["expired"]` =
+  list of decision_ids; success even when zero matched (`was_noop=True`).
+  DECISION_ID and `--sweep` are mutually exclusive; one is required.
 
 ### `ideas mark-submitted` / `ideas mark-filled`
 

--- a/docs/specs/TRADE_IDEA_INTERFACES_DESIGN_NOTES.md
+++ b/docs/specs/TRADE_IDEA_INTERFACES_DESIGN_NOTES.md
@@ -1,6 +1,6 @@
 ---
-status: draft
-last-updated: 2026-06-12
+status: current
+last-updated: 2026-06-24
 scope: Operator and agent interfaces over the trade_ideas slice
 audience: Implementation agents (Codex) and reviewers
 ---
@@ -25,14 +25,17 @@ already exists and is complete at the domain level:
 | `features/trade_ideas/store.py` | `TradeIdeaStore` — versioned records under record hash |
 | `features/trade_ideas/baseline.py`, `replay.py` | Baseline proposer and replay scoring |
 
-**The gap:** no human or agent can reach this service today. There is no CLI
-command, no TUI screen, and `TradeIdeaService` is constructed nowhere in
-production code (only tests). The approval workflow exists but has no door.
-The service docstring states the intent explicitly: *"interfaces such as CLI,
-TUI, or MCP servers must stay thin adapters over these methods."*
+**Current interface state:** the CLI door now exists. `gpt-trader ideas`
+constructs `TradeIdeaService` through the trade-ideas factory and exposes the
+agent-facing approval workflow: propose, list, show, approve, reject,
+request-changes, expire, resubmit, mark-submitted, mark-filled, budget, and
+audit. The remaining human-interface gap is the TUI review surface; MCP or other
+remote surfaces remain future work. The service docstring still states the
+adapter boundary explicitly: *"interfaces such as CLI, TUI, or MCP servers must
+stay thin adapters over these methods."*
 
-These notes define the two interface workstreams that close the gap, plus the
-shared wiring they both need.
+These notes preserve the interface decisions that shaped the implemented CLI
+and define the still-open TUI workstream.
 
 ## Design Principles
 
@@ -57,9 +60,10 @@ shared wiring they both need.
    request produces a `needs_changes` event; the revised record is a new
    version saved via `resubmit`.
 
-## Shared Decisions (Workstream 0 — prerequisite)
+## Shared Decisions (Workstream 0 — implemented)
 
-Both interfaces need the following; implement once, first.
+The CLI implements these decisions today. The TUI should reuse them instead of
+creating a parallel service or storage contract.
 
 ### Storage root
 
@@ -71,7 +75,7 @@ Both interfaces need the following; implement once, first.
 
 ### Service factory
 
-Add to `features/trade_ideas/service.py`:
+Implemented in `features/trade_ideas/service.py`:
 
 ```python
 DEFAULT_IDEAS_ROOT = Path("var/data/trade_ideas")
@@ -80,11 +84,10 @@ def create_trade_idea_service(root: Path | None = None) -> TradeIdeaService:
     """Resolve root (arg > GPT_TRADER_IDEAS_ROOT > default) and build the service."""
 ```
 
-Optionally expose a cached `trade_idea_service` property on
-`ApplicationContainer` (see `docs/DI_POLICY.md`); the CLI may construct the
-service directly via the factory since idea review has no broker or config
-dependency, but the container property is the long-term home once the
-proposer loop runs inside the bot.
+The CLI constructs the service directly through this factory because idea
+review has no broker or config dependency. A cached `trade_idea_service`
+property on `ApplicationContainer` remains a future option once a proposer loop
+runs inside the bot.
 
 ### Actor identity resolution
 
@@ -103,7 +106,7 @@ log. `actor_type` rules:
 
 ### Error mapping
 
-Add two members to `CliErrorCode` in `cli/response.py`:
+Implemented in `CliErrorCode` in `cli/response.py`:
 `POLICY_VIOLATION = "POLICY_VIOLATION"` and
 `IDEA_NOT_FOUND = "IDEA_NOT_FOUND"`.
 
@@ -119,13 +122,14 @@ Add two members to `CliErrorCode` in `cli/response.py`:
 
 | # | Spec | Depends on | Size |
 |---|------|-----------|------|
-| 0 | Shared wiring (this doc, "Shared Decisions") | — | S |
-| 1 | [`TRADE_IDEA_CLI_SPEC.md`](TRADE_IDEA_CLI_SPEC.md) — `gpt-trader ideas` command group | 0 | M |
-| 2 | [`TRADE_IDEA_TUI_REVIEW_SPEC.md`](TRADE_IDEA_TUI_REVIEW_SPEC.md) — Ideas review screen | 0 (not 1) | M |
+| 0 | Shared wiring (this doc, "Shared Decisions") | — | Implemented |
+| 1 | [`TRADE_IDEA_CLI_SPEC.md`](TRADE_IDEA_CLI_SPEC.md) — `gpt-trader ideas` command group | 0 | Implemented |
+| 2 | [`TRADE_IDEA_TUI_REVIEW_SPEC.md`](TRADE_IDEA_TUI_REVIEW_SPEC.md) — Ideas review screen | 0 (not 1) | Future |
 
-Workstreams 1 and 2 are independently mergeable. Ship 0+1 first: the CLI is
-the agent-facing surface and unblocks the AI-propose → human-approve loop
-end to end; the TUI improves the human half afterward.
+Workstreams 1 and 2 are independently mergeable. Workstreams 0+1 have shipped:
+the CLI is the agent-facing surface and unblocks the AI-propose -> human-approve
+loop end to end. The TUI improves the human review surface afterward and should
+not reimplement CLI or service behavior.
 
 ## Non-Goals (all workstreams)
 


### PR DESCRIPTION
## Summary
Closes #905.

Related issue / finding / RJ-routed package: #905 / `trade-idea-interface-docs-drift`

Updated the trade-idea interface docs so agents no longer read the `gpt-trader ideas` CLI as future or unimplemented. The docs now distinguish the implemented CLI door from the remaining future TUI review surface and keep `mark-submitted` / `mark-filled` explicitly audit-only with no broker/API/live-order behavior.

## Type of change
- [ ] Refactor
- [ ] Feature
- [ ] Bug fix
- [ ] Tests only
- [x] CI/Docs/Tooling

## Scope & Impact
- Affected areas / components: `docs/specs/TRADE_IDEA_INTERFACES_DESIGN_NOTES.md`, `docs/specs/TRADE_IDEA_CLI_SPEC.md`, `docs/README.md`
- Any behavior changes? No. Docs-only; no source, tests, config, broker/API, TUI, or live-order paths changed.

## Test Plan
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Contract tests (if applicable)
- [x] Ran locally: `uv run pytest tests/unit/gpt_trader/cli/commands/test_ideas_*.py -q`
- [x] Markers used appropriately (`unit`/`integration`/`slow`/`perf`)

Verification receipts:
- PASS `uv run gpt-trader ideas --help`
- REQUESTED COMMAND UNAVAILABLE `uv run python scripts/ci/check_docs_links.py` (`scripts/ci/check_docs_links.py` is not present in this checkout)
- PASS equivalent live docs check: `uv run python scripts/maintenance/docs_link_audit.py`
- PASS `uv run python scripts/maintenance/docs_reachability_check.py`
- PASS `uv run pytest tests/unit/gpt_trader/cli/commands/test_ideas_*.py -q` (79 passed)
- PASS `uv run agent-regenerate --verify` (all context files up-to-date)
- PASS `uv run local-ci --profile quick` (6978 passed, 8 skipped; quick profile skipped readiness gate, agent artifacts freshness, snapshots, property, and contract tests by design)

## Complexity & Quality Gates
- [x] Mypy/type-check passed (`uv run local-ci --profile quick`)
- [x] Xenon/radon complexity gate passed (not applicable to docs-only; no live_trade execution changes)
- [x] No `sys.path` hacks in tests
- [x] No `MagicMock` on `async def` (use `AsyncMock`)
- [x] Import-lint rules respected (no “import up the stack”; `uv run local-ci --profile quick`)

## Observability & Errors
- [x] Structured JSON logs for new/changed paths (not applicable; docs-only)
- [x] Errors include diagnostic context (not applicable; docs-only)
- [x] Added/updated sampling examples in tests (not applicable; docs-only)

## Configuration
- [x] If config changed: not applicable
- [x] Env docs re-generated (if applicable) and committed (not applicable)
- [x] No `ConfigLoader` usages introduced (docs-only)

## Breaking Changes
- [x] None
- [ ] Documented in PR body and release notes if any

## Screenshots / Logs (optional)
No UI change.

## Checklist
- [x] Acceptance criteria in linked issue(s), finding packet, or routed package met
- [x] Affected paths listed in PR description
- [x] Changelog entry (if repo uses one; not applicable)

Pipeline route packet:
- Pipeline id: `goal-pipeline-20260624-issue-905-trade-idea-docs-drift`
- Stage completed: `$gpt-trader-issue-to-pr` direct execution / `$goal-execute-pr` equivalent
- Current head SHA: `639d1498ab33d9f9506f122ed599b9e26dea0b18`
- Branch: `codex/issue-905-trade-idea-docs-drift`
- Next expected skill: `$goal-wait-pr` for checks/review-bot signals, then `$goal-curate-pr`
- Hard gates: no live broker/API checks, production preflight, canary operations, live trading commands, money movement, or order submission were run.
