### PR TITLE
[codex] Reconcile pre-migration decision status

### DIFF
--- a/docs/GPT_TRADER_DECISION_LOG.md
+++ b/docs/GPT_TRADER_DECISION_LOG.md
@@ -2,11 +2,45 @@
 
 ---
 status: current
-last-updated: 2026-06-22
+last-updated: 2026-06-24
 ---
 
 Durable product and engineering direction for GPT-Trader. Use this log for
 decisions that should outlive chat, PR receipts, and local branch state.
+
+## 2026-06-11 — Accept Pre-Migration Direction And Trade-Idea Rails
+
+- **Status:** accepted direction; Stage 0 trade-idea rails implemented where
+  noted below
+- **Owner:** RJ
+- **Decision / direction:** Use the
+  [Pre-Migration Decision Framework](PRE_MIGRATION_DECISION_FRAMEWORK.md) as
+  the execution-migration gate. The accepted path is approval-gated execution
+  (`human_approved_execution`) as the validation phase, with
+  `bounded_autonomy` only as a later destination. Coinbase spot plus CFM futures
+  research are the current Coinbase-only scope; Robinhood, options execution,
+  INTX-only work, and other venues stay out of scope unless a later decision
+  packet explicitly reopens them.
+- **Implemented evidence:** The trade-idea slice implements broker-neutral
+  records (`src/gpt_trader/features/trade_ideas/models.py`), the approval
+  workflow (`src/gpt_trader/features/trade_ideas/workflow.py`), append-only
+  audit events (`src/gpt_trader/features/trade_ideas/audit.py`), seeded
+  versioned risk budgets (`src/gpt_trader/features/trade_ideas/budget.py`),
+  eligibility and approval policy (`src/gpt_trader/features/trade_ideas/eligibility.py`,
+  `src/gpt_trader/features/trade_ideas/policy.py`), and operator lifecycle
+  controls (`src/gpt_trader/features/trade_ideas/service.py`).
+- **Safety boundary:** This decision does not authorize real broker/API calls,
+  live trading commands, production preflight, canary operations, credential
+  reads, money movement, or order submission. Any non-manual execution lane
+  still needs a decision packet or approved runbook that names the lane,
+  constraints, verification boundary, and rollback/kill-switch expectations.
+- **Still pending:** Official venue/API/account capability review for any
+  non-manual execution, product-specific migration envelopes, bounded-autonomy
+  strategy envelopes, kill-switch drills, and any policy change that would
+  allow submission without explicit approval.
+- **Rejected alternatives:** Do not migrate unrestricted spot-only automation
+  into the new shape. Do not use existing broker adapters or live profiles as
+  proof that a product or venue should be automated.
 
 ## 2026-06-22 — Continue Trade-Ideas CLI As The Active Discovery Lane
 

--- a/docs/OPERATING_RUBRIC.md
+++ b/docs/OPERATING_RUBRIC.md
@@ -2,7 +2,7 @@
 
 ---
 status: current
-last-updated: 2026-06-11
+last-updated: 2026-06-24
 ---
 
 This rubric defines what the bot must be able to do to "run successfully" as an
@@ -42,14 +42,21 @@ A stage is complete when every capability in it has its evidence.
 
 ### Stage 0 — Rails (in progress)
 
+These rails are the implemented evidence for the accepted pre-migration record,
+approval, audit, budget, eligibility, and operator-control triggers in the
+[Pre-Migration Decision Framework](PRE_MIGRATION_DECISION_FRAMEWORK.md). They
+do not settle venue/API/account capability, product expansion, or autonomous
+submission policy.
+
 | Capability | Evidence |
 |------------|----------|
-| Broker-neutral trade-idea record with thesis, invalidation, max loss, sizing, expiry | Unit-tested round-trip + record hashing (`features/trade_ideas/models.py`) |
-| Workflow where execution is impossible without approval | State-machine tests prove `submitted` is reachable only from `approved` |
-| Append-only audit trail pinning every action to a record version | Audit log rejects out-of-order or conflicting appends |
-| Eligibility gate encoding automatic rejection conditions | Ineligible ideas cannot be approved |
-| Versioned risk budget that agents can later renegotiate | Budget changes append to their own audited log; current budget is always derivable |
-| Policy module that encodes the autonomy mode | Approval by a non-human actor is refused in `human_approved_execution` mode |
+| Broker-neutral trade-idea record with thesis, invalidation, max loss, sizing, expiry | Unit-tested round-trip + record hashing (`src/gpt_trader/features/trade_ideas/models.py`) |
+| Workflow where execution is impossible without approval | `src/gpt_trader/features/trade_ideas/workflow.py` and its state-machine tests prove `submitted` is reachable only from `approved` |
+| Append-only audit trail pinning every action to a record version | `src/gpt_trader/features/trade_ideas/audit.py` rejects out-of-order or conflicting appends and verifies per-decision sequencing |
+| Eligibility gate encoding automatic rejection conditions | `src/gpt_trader/features/trade_ideas/eligibility.py` and `src/gpt_trader/features/trade_ideas/policy.py` keep ineligible ideas from approval |
+| Versioned risk budget that agents can later renegotiate | `src/gpt_trader/features/trade_ideas/budget.py` appends budget changes to their own audited log; the current budget is always derivable |
+| Policy module that encodes the autonomy mode | `src/gpt_trader/features/trade_ideas/policy.py` refuses non-human approval in `human_approved_execution` mode |
+| Operator can reject, expire, and amend tickets before execution | `src/gpt_trader/features/trade_ideas/service.py` exposes audited request-changes/resubmit, reject, cancel, expire, and expire-due paths before submission |
 
 ### Stage 1 — Human-approved loop
 

--- a/docs/PRE_MIGRATION_DECISION_FRAMEWORK.md
+++ b/docs/PRE_MIGRATION_DECISION_FRAMEWORK.md
@@ -2,7 +2,7 @@
 
 ---
 status: current
-last-updated: 2026-06-11
+last-updated: 2026-06-24
 scope: AI-assisted trade research and execution migration
 ---
 
@@ -288,19 +288,24 @@ Until these are filled in, AI may produce research only or draft tickets marked
 
 ## Migration Trigger Checklist
 
-Do not migrate the existing bot into this shape until every item is complete:
+Do not migrate the existing bot into this shape until every row has no pending
+migration trigger. `Accepted` and `Implemented` rows are current evidence only;
+they do not authorize real broker/API calls, live trading commands, production
+preflight, money movement, or order submission.
 
-- [ ] Autonomy mode selected.
-- [ ] First asset and product universe selected.
-- [ ] Broker execution policy selected.
-- [ ] Numeric risk budget selected.
-- [ ] Required output schema accepted.
-- [ ] Approval workflow accepted.
-- [ ] Audit log format accepted.
-- [ ] Official venue/API capability review completed for any non-manual venue.
-- [ ] Strategy eligibility gate accepted.
-- [ ] Operator can reject, expire, and amend tickets before execution.
-- [ ] No unrestricted spot-only bot continuation remains in scope.
+| Trigger | Current Status | Evidence | Still Pending Before Migration |
+| --- | --- | --- | --- |
+| Autonomy mode selected | Accepted; current phase implemented | 2026-06-11 direction selected `human_approved_execution` as the validation phase and `bounded_autonomy` as the destination; `src/gpt_trader/features/trade_ideas/policy.py` enforces human approval in the current mode. | Any move to `bounded_autonomy` still needs a fresh decision packet plus strategy-envelope, kill-switch, and audit evidence. |
+| First asset and product universe selected | Accepted for current research scope | Coinbase spot plus CFM futures research are the accepted Coinbase-only lane. | Account, product, and API capability must be verified before any non-manual execution lane. |
+| Broker execution policy selected | Accepted for current phase; implemented in trade-idea rails | Broker-neutral records remain canonical; `src/gpt_trader/features/trade_ideas/workflow.py` and `src/gpt_trader/features/trade_ideas/service.py` only allow submission records after approval. | Any actual broker command lane still needs an explicit decision packet or approved runbook naming constraints and rollback/kill-switch expectations. |
+| Numeric risk budget selected | Accepted and implemented as the Stage 0 seed | `src/gpt_trader/features/trade_ideas/budget.py` seeds versioned risk budgets from the accepted rubric; `src/gpt_trader/features/trade_ideas/policy.py` checks approvals against the current budget. | Future strategy-envelope budgets and agent-renegotiated budget changes must stay audited and reviewable. |
+| Required output schema accepted | Implemented as typed broker-neutral record | `src/gpt_trader/features/trade_ideas/models.py` implements the trade-idea record fields, record hashing, and broker-neutral ticket envelope. | Schema publication or adapter-specific payload derivation remains separate migration work. |
+| Approval workflow accepted | Implemented in trade-idea rails | `src/gpt_trader/features/trade_ideas/workflow.py` defines the state machine; `src/gpt_trader/features/trade_ideas/service.py` applies policy before approval and submission records. | Execution adapters must continue to consume approved records without bypassing the workflow. |
+| Audit log format accepted | Implemented in trade-idea rails | `src/gpt_trader/features/trade_ideas/audit.py` implements append-only JSONL events pinned to record hashes and verifies per-decision sequencing. | Venue-specific external order identifiers can be recorded only after an approved submission lane exists. |
+| Official venue/API capability review completed for any non-manual venue | Pending | None in this framework authorizes account, venue, product, or API capability. | Complete a fresh venue/API/account capability review before non-manual Coinbase or other venue execution. |
+| Strategy eligibility gate accepted | Implemented in trade-idea rails | `src/gpt_trader/features/trade_ideas/eligibility.py` encodes automatic rejection conditions; `src/gpt_trader/features/trade_ideas/policy.py` blocks approval when eligibility or budget checks fail. | New product-specific eligibility rules need explicit evidence before expansion. |
+| Operator can reject, expire, and amend tickets before execution | Implemented in trade-idea rails | `src/gpt_trader/features/trade_ideas/service.py` supports request-changes/resubmit, reject, cancel, expire, and expire-due lifecycle paths before submission. | Any new operator surface must remain a thin adapter over the audited service path. |
+| No unrestricted spot-only bot continuation remains in scope | Accepted boundary | 2026-06-11 direction rejects unrestricted autonomous spot continuation. | Future spot work must stay research/approval-gated unless a new decision packet changes the scope. |
 
 ## Initial Decision Record
 
@@ -312,6 +317,12 @@ Do not migrate the existing bot into this shape until every item is complete:
 | Robinhood role | Out of scope | Accepted 2026-06-11 |
 | Internal architecture | Broker-neutral trade idea, risk, approval, and audit records | Accepted 2026-06-11 |
 | Existing spot bot | Do not migrate as unrestricted autonomous spot execution | Accepted 2026-06-11 |
+
+The durable project log mirrors these accepted decisions in
+[GPT-Trader Decision Log](GPT_TRADER_DECISION_LOG.md). The implemented Stage 0
+trade-idea rails are evidence for the accepted record, approval, audit,
+budget, eligibility, and operator-control triggers above; they are not evidence
+that venue/account/API capability has been verified.
 
 Once this table is accepted and the trigger checklist is filled, migration work
 can start with schemas and audit persistence before any execution adapter change.


### PR DESCRIPTION
## Summary
Related issue / finding / RJ-routed package: Closes #907

Reconciles the accepted 2026-06-11 pre-migration direction with the current documentation surface. The framework checklist now separates accepted/implemented trade-idea rails from still-pending migration triggers, and the durable decision log records the accepted pre-migration direction instead of leaving it only in the framework table.

## Type of change
- [ ] Refactor
- [ ] Feature
- [ ] Bug fix
- [ ] Tests only
- [x] CI/Docs/Tooling

## Scope & Impact
- Affected areas / components:
  - `docs/PRE_MIGRATION_DECISION_FRAMEWORK.md`
  - `docs/GPT_TRADER_DECISION_LOG.md`
  - `docs/OPERATING_RUBRIC.md`
- Any behavior changes? If yes, describe and link tests.
  - None. Documentation-only reconciliation; no runtime approval policy, broker adapters, risk limits, credentials, live trading controls, generated artifacts, or order submission behavior changed.

## Test Plan
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Contract tests (if applicable)
- [x] Ran locally: `uv run python scripts/maintenance/docs_link_audit.py` -> passed, Markdown link audit passed (64 files scanned)
- [x] Ran locally: `uv run local-ci --profile quick` -> passed, 6978 passed, 8 skipped
- [x] Markers used appropriately (`unit`/`integration`/`slow`/`perf`)

## Complexity & Quality Gates
- [x] Mypy/type-check passed via `uv run local-ci --profile quick`
- [x] Xenon/radon complexity gate passed (CC <= 15 on live_trade execution) (not applicable to docs-only change)
- [x] No `sys.path` hacks in tests
- [x] No `MagicMock` on `async def` (use `AsyncMock`)
- [x] Import-lint rules respected (no "import up the stack") via `uv run local-ci --profile quick`

## Observability & Errors
- [ ] Structured JSON logs for new/changed paths
- [ ] Errors include diagnostic context (symbol, order_id, correlation_id)
- [ ] Added/updated sampling examples in tests (if applicable)

Not applicable: docs-only change.

## Configuration
- [ ] If config changed: `python -m gpt_trader.cli.config validate --profile <name>` passes
- [ ] Env docs re-generated (if applicable) and committed
- [x] No `ConfigLoader` usages introduced (ConfigManager-only)

No configuration changed.

## Breaking Changes
- [x] None
- [ ] Documented in PR body and release notes if any

## Screenshots / Logs (optional)
Verification:
- `uv run python scripts/maintenance/docs_link_audit.py` -> passed, Markdown link audit passed (64 files scanned)
- `uv run local-ci --profile quick` -> passed, 6978 passed, 8 skipped

Quick profile expected skips were agent health, agent artifacts freshness, readiness gate, TUI snapshot tests, property tests, and contract tests.

## Checklist
- [x] Acceptance criteria in linked issue(s), finding packet, or routed package met
- [x] Affected paths listed in PR description
- [x] Changelog entry (if repo uses one) (not applicable; docs-only reconciliation)
