### PR TITLE
[codex] Clarify local CI readiness contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,18 +78,20 @@ For testing without real API access, set `MOCK_BROKER=1` in `.env`.
 
 ### Local CI
 
-Run `make ci-required` when you want the required PR validation surface that
-GitHub pull_request CI enforces locally. It runs lint/format, docs audits, type
-checks, agent artifact freshness, TUI CSS checks, test guardrails, and core unit
-tests. GitHub pull_request CI does not run the canary readiness gate.
+Run `make ci-required` when you want the local PR-readiness command set. It runs
+lint/format, docs audits, type checks, agent artifact freshness, TUI CSS checks,
+test guardrails, and core unit tests, stopping on the first local failure.
+GitHub pull_request CI runs a related agent-freshness job, but stale artifacts
+are reported as non-blocking on pull requests. GitHub pull_request CI also does
+not run the canary readiness gate.
 
 Run `uv run local-ci` (or `python -m gpt_trader.ci.local_ci`) with the default
 strict/full profile when you also want local/live readiness evidence. Strict/full
-runs the PR-required local validation set plus the canary readiness gate and
+runs the local PR-readiness validation set plus the canary readiness gate and
 agent artifacts freshness; the CLI prints the selected profile and the
 readiness/artifact statuses before executing commands.
 
-For faster loops without readiness reports or regenerating `var/agents`, use the quick/dev profile via `--profile quick` or `--profile dev`. That profile disables the readiness gate and agent artifacts freshness steps (the output notes which checks were skipped and why). Run `make ci-required` for the PR-required validation surface, and run strict `uv run local-ci` when you need the additional local/live readiness gate before operational readiness work.
+For faster loops without readiness reports or regenerating `var/agents`, use the quick/dev profile via `--profile quick` or `--profile dev`. That profile disables the readiness gate and agent artifacts freshness steps (the output notes which checks were skipped and why). Run `make ci-required` for the local PR-readiness command set, and run strict `uv run local-ci` when you need the additional local/live readiness gate before operational readiness work.
 
 ## GitHub Workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,9 +78,18 @@ For testing without real API access, set `MOCK_BROKER=1` in `.env`.
 
 ### Local CI
 
-Run `uv run local-ci` (or `python -m gpt_trader.ci.local_ci`) with the default strict/full profile when you want to mirror the required PR checks. Strict/full keeps the readiness gate and agent artifacts freshness steps enabled so the local run mirrors CI; the CLI prints the selected profile and the readiness/artifact statuses before executing commands.
+Run `make ci-required` when you want the required PR validation surface that
+GitHub pull_request CI enforces locally. It runs lint/format, docs audits, type
+checks, agent artifact freshness, TUI CSS checks, test guardrails, and core unit
+tests. GitHub pull_request CI does not run the canary readiness gate.
 
-For faster loops without readiness reports or regenerating `var/agents`, use the quick/dev profile via `--profile quick` or `--profile dev`. That profile disables the readiness gate and agent artifacts freshness steps (the output notes which checks were skipped and why), but run the strict profile before pushing or merging to ensure those gated checks execute locally.
+Run `uv run local-ci` (or `python -m gpt_trader.ci.local_ci`) with the default
+strict/full profile when you also want local/live readiness evidence. Strict/full
+runs the PR-required local validation set plus the canary readiness gate and
+agent artifacts freshness; the CLI prints the selected profile and the
+readiness/artifact statuses before executing commands.
+
+For faster loops without readiness reports or regenerating `var/agents`, use the quick/dev profile via `--profile quick` or `--profile dev`. That profile disables the readiness gate and agent artifacts freshness steps (the output notes which checks were skipped and why). Run `make ci-required` for the PR-required validation surface, and run strict `uv run local-ci` when you need the additional local/live readiness gate before operational readiness work.
 
 ## GitHub Workflow
 

--- a/docs/DEVELOPMENT_GUIDELINES.md
+++ b/docs/DEVELOPMENT_GUIDELINES.md
@@ -105,26 +105,47 @@ bypass guards:
 
 ### Local CI Command
 
-For a fail-fast entrypoint that mirrors the required PR checks, run:
+For a fail-fast entrypoint that matches the local command set expected for
+required PR validation, run:
 
 ```bash
 make ci-required
 ```
 
 It runs lint/format, docs audits, mypy, agent artifacts freshness, the TUI CSS
-check, test guardrails, and core unit tests, stopping on the first failure.
-Use it when you want the required CI gates without optional suites.
+check, test guardrails, and core unit tests, stopping on the first failure. Use
+it when you want the PR-required validation surface without optional suites or
+local readiness evidence.
 
-Run the local CI command to mirror the required PR checks:
+Run the local CI command when you want the same PR-required validation set plus
+the repository's optional local profile controls:
 
 ```bash
 uv run local-ci
 ```
 
-This runs the same commands as CI (lint + format, docs audits, mypy, agent artifacts
-freshness, TUI CSS check, test guardrails, and core unit tests).
+This covers the same core validation categories used around PRs: lint + format,
+docs audits, mypy, agent artifacts freshness, TUI CSS check, test guardrails,
+and core unit tests. Profile-specific local checks can still differ from GitHub
+pull_request enforcement, especially around readiness evidence.
 
-The command now accepts `--profile`/`-p` to select either the default strict/full profile or the quick/dev profile. Strict (the default and the `full` alias) keeps the readiness gate and agent artifacts freshness checks so the local run mirrors the required PR gates, and the CLI prints the active profile plus the status of the readiness gate and agent-artifacts checks before executing any steps. Quick (aliased as `dev`) intentionally disables those two checks so you can run local CI without needing readiness reports or regenerating `var/agents`; the output still documents which checks were skipped and why. Run the strict profile before pushing or merging to ensure those gated checks execute locally.
+The command accepts `--profile`/`-p` to select either the default strict/full
+profile or the quick/dev profile. Strict (the default and the `full` alias) runs
+the PR-required local validation set, keeps agent artifacts freshness enabled,
+and adds the canary readiness gate as local/live readiness evidence. GitHub
+pull_request CI and `make ci-required` do not enforce that canary readiness gate.
+The CLI prints the active profile plus the status of the readiness gate and
+agent-artifacts checks before executing any steps. Quick (aliased as `dev`)
+intentionally disables those two checks so you can run local CI without needing
+readiness reports or regenerating `var/agents`; the output still documents which
+checks were skipped and why.
+
+| Command | Intended use | Readiness gate |
+| --- | --- | --- |
+| `make ci-required` | Local PR-required validation surface | Not run |
+| GitHub pull_request CI | Required PR validation in GitHub Actions | Not run |
+| `uv run local-ci` / strict/full | PR-required local validation plus local/live readiness evidence | Runs `scripts/ci/check_readiness_gate.py --profile canary --strict` |
+| `uv run local-ci --profile quick` | Fast development loop | Skipped with an explicit banner reason |
 
 Optional suites:
 
@@ -153,7 +174,7 @@ Need help diagnosing `uv run local-ci` failures? See the [Local CI troubleshooti
 
 ### Local CI troubleshooting
 
-Local CI (`make ci-required` / `uv run local-ci`) can report failures before the unit tests run. Two recurring causes are stale agent artifacts and readiness gate inputs. When you hit one of these failures, follow the sequence below before re-running the command.
+Local CI (`make ci-required` / `uv run local-ci`) can report failures before the unit tests run. Two recurring causes are stale agent artifacts and readiness gate inputs. The readiness gate applies to strict/full `uv run local-ci` and direct readiness checks, not to `make ci-required` or GitHub pull_request CI. When you hit one of these failures, follow the sequence below before re-running the command.
 
 #### 1. Agent artifacts freshness
 

--- a/docs/DEVELOPMENT_GUIDELINES.md
+++ b/docs/DEVELOPMENT_GUIDELINES.md
@@ -105,8 +105,7 @@ bypass guards:
 
 ### Local CI Command
 
-For a fail-fast entrypoint that matches the local command set expected for
-required PR validation, run:
+For a fail-fast entrypoint that matches the local PR-readiness command set, run:
 
 ```bash
 make ci-required
@@ -114,10 +113,11 @@ make ci-required
 
 It runs lint/format, docs audits, mypy, agent artifacts freshness, the TUI CSS
 check, test guardrails, and core unit tests, stopping on the first failure. Use
-it when you want the PR-required validation surface without optional suites or
-local readiness evidence.
+it when you want the local PR-readiness surface without optional suites or local
+readiness evidence. This local command fails on stale agent artifacts; GitHub
+pull_request CI reports stale artifacts as non-blocking instead.
 
-Run the local CI command when you want the same PR-required validation set plus
+Run the local CI command when you want the same local PR-readiness set plus
 the repository's optional local profile controls:
 
 ```bash
@@ -131,7 +131,7 @@ pull_request enforcement, especially around readiness evidence.
 
 The command accepts `--profile`/`-p` to select either the default strict/full
 profile or the quick/dev profile. Strict (the default and the `full` alias) runs
-the PR-required local validation set, keeps agent artifacts freshness enabled,
+the local PR-readiness validation set, keeps agent artifacts freshness enabled,
 and adds the canary readiness gate as local/live readiness evidence. GitHub
 pull_request CI and `make ci-required` do not enforce that canary readiness gate.
 The CLI prints the active profile plus the status of the readiness gate and
@@ -140,12 +140,12 @@ intentionally disables those two checks so you can run local CI without needing
 readiness reports or regenerating `var/agents`; the output still documents which
 checks were skipped and why.
 
-| Command | Intended use | Readiness gate |
-| --- | --- | --- |
-| `make ci-required` | Local PR-required validation surface | Not run |
-| GitHub pull_request CI | Required PR validation in GitHub Actions | Not run |
-| `uv run local-ci` / strict/full | PR-required local validation plus local/live readiness evidence | Runs `scripts/ci/check_readiness_gate.py --profile canary --strict` |
-| `uv run local-ci --profile quick` | Fast development loop | Skipped with an explicit banner reason |
+| Command | Intended use | Agent artifacts freshness | Readiness gate |
+| --- | --- | --- | --- |
+| `make ci-required` | Local PR-readiness validation surface | Blocking local step | Not run |
+| GitHub pull_request CI | GitHub PR validation in Actions | Non-blocking if stale on pull requests | Not run |
+| `uv run local-ci` / strict/full | Local PR-readiness validation plus local/live readiness evidence | Blocking local step | Runs `scripts/ci/check_readiness_gate.py --profile canary --strict` |
+| `uv run local-ci --profile quick` | Fast development loop | Skipped with an explicit banner reason | Skipped with an explicit banner reason |
 
 Optional suites:
 

--- a/src/gpt_trader/ci/local_ci.py
+++ b/src/gpt_trader/ci/local_ci.py
@@ -69,8 +69,8 @@ LOCAL_CI_PROFILES: dict[str, LocalCIProfile] = {
     "strict": LocalCIProfile(
         canonical_name="strict",
         description=(
-            "Strict profile runs the PR-required local validation set plus local/live "
-            "readiness checks that GitHub pull_request CI does not enforce."
+            "Strict profile runs the local PR-readiness validation set plus local/live "
+            "readiness checks beyond GitHub pull_request CI."
         ),
         readiness_enabled=True,
         readiness_skip_reason=None,

--- a/src/gpt_trader/ci/local_ci.py
+++ b/src/gpt_trader/ci/local_ci.py
@@ -68,7 +68,10 @@ class LocalCIProfile:
 LOCAL_CI_PROFILES: dict[str, LocalCIProfile] = {
     "strict": LocalCIProfile(
         canonical_name="strict",
-        description="Strict profile mirrors the required CI checks, including the readiness gate and agent artifacts freshness steps.",
+        description=(
+            "Strict profile runs the PR-required local validation set plus local/live "
+            "readiness checks that GitHub pull_request CI does not enforce."
+        ),
         readiness_enabled=True,
         readiness_skip_reason=None,
         agent_artifacts_enabled=True,
@@ -110,7 +113,10 @@ def find_repo_root(start_path: Path) -> Path:
 
 def parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Run local CI checks that mirror required GitHub Actions jobs."
+        description=(
+            "Run GPT-Trader local validation. The strict profile includes local/live "
+            "readiness evidence beyond GitHub pull_request CI."
+        )
     )
     parser.add_argument(
         "--include-snapshots",

--- a/tests/unit/scripts/test_local_ci.py
+++ b/tests/unit/scripts/test_local_ci.py
@@ -52,6 +52,13 @@ def test_strict_profile_runs_readiness_and_agent_artifacts() -> None:
     assert artifacts_step.skip_reason is None
 
 
+def test_strict_profile_description_distinguishes_pr_and_readiness() -> None:
+    profile = local_ci.resolve_profile("strict")
+
+    assert "PR-required local validation set" in profile.description
+    assert "readiness checks that GitHub pull_request CI does not enforce" in profile.description
+
+
 def test_snapshot_step_expands_test_files_before_subprocess() -> None:
     args = _make_args("quick", include_snapshots=True)
     profile = local_ci.resolve_profile(args.profile)
@@ -73,3 +80,11 @@ def test_print_profile_banner_reports_alias_and_status(capsys) -> None:
     assert "Local CI profile: quick (alias 'dev')" in output
     assert "Readiness gate: disabled" in output
     assert "Agent artifacts freshness: disabled" in output
+
+
+def test_strict_profile_banner_distinguishes_pull_request_ci(capsys) -> None:
+    profile = local_ci.resolve_profile("strict")
+    local_ci.print_profile_banner("strict", profile)
+    output = capsys.readouterr().out
+    assert "PR-required local validation set" in output
+    assert "GitHub pull_request CI does not enforce" in output

--- a/tests/unit/scripts/test_local_ci.py
+++ b/tests/unit/scripts/test_local_ci.py
@@ -55,8 +55,8 @@ def test_strict_profile_runs_readiness_and_agent_artifacts() -> None:
 def test_strict_profile_description_distinguishes_pr_and_readiness() -> None:
     profile = local_ci.resolve_profile("strict")
 
-    assert "PR-required local validation set" in profile.description
-    assert "readiness checks that GitHub pull_request CI does not enforce" in profile.description
+    assert "local PR-readiness validation set" in profile.description
+    assert "readiness checks beyond GitHub pull_request CI" in profile.description
 
 
 def test_snapshot_step_expands_test_files_before_subprocess() -> None:
@@ -86,5 +86,5 @@ def test_strict_profile_banner_distinguishes_pull_request_ci(capsys) -> None:
     profile = local_ci.resolve_profile("strict")
     local_ci.print_profile_banner("strict", profile)
     output = capsys.readouterr().out
-    assert "PR-required local validation set" in output
-    assert "GitHub pull_request CI does not enforce" in output
+    assert "local PR-readiness validation set" in output
+    assert "readiness checks beyond GitHub pull_request CI" in output


### PR DESCRIPTION
Closes #909

## Summary
- Clarifies that `make ci-required` is the local PR-readiness command set and can be stricter than GitHub `pull_request` enforcement.
- Documents that GitHub `pull_request` CI reports stale agent artifacts as non-blocking, while local `make ci-required` and strict `uv run local-ci` keep agent artifact freshness as a blocking local step.
- Keeps the readiness-gate clarification intact: GitHub `pull_request` CI and `make ci-required` do not run the canary readiness gate, while strict/full `uv run local-ci` adds it as local/live readiness evidence.
- Adds focused unit assertions for the strict profile/banner contract so future wording does not drift back to exact PR-CI equivalence.

## Affected paths
- `AGENTS.md`
- `docs/DEVELOPMENT_GUIDELINES.md`
- `src/gpt_trader/ci/local_ci.py`
- `tests/unit/scripts/test_local_ci.py`

## Verification
- `uv run pytest tests/unit/scripts/test_local_ci.py -q` -> passed, 7 passed
- `python scripts/maintenance/docs_link_audit.py` -> passed, 65 files scanned
- `python scripts/maintenance/docs_reachability_check.py` -> passed, 41 files reachable
- `uv run local-ci --profile quick` -> passed, 6978 passed, 8 skipped

## Revision
- Addressed `discussion_r3466989351` by removing wording that implied GitHub `pull_request` CI hard-enforces agent artifact freshness.

## Routing / decision notes
- Issue #909 is labeled `agent-ready` and is not `decision-needed`.
- No live broker/API calls, live trading commands, production preflight/canary operations, order submission, or secrets were used.
- The readiness gate remains available for strict/local readiness evidence.
- `uv run agent-regenerate --verify` was not run because no `var/agents/**`, `scripts/agents/**`, or `config/environments/.env.template` inputs changed.

## Breaking changes
None. No constructor, API, or runtime readiness behavior changed.
