### PR TITLE
[codex] Refresh generated agent testing inventory

### DIFF
--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6715,
+    "total_tests": 6717,
     "total_files": 794,
     "markers_used": 16
   },

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6550,
+    "unit": 6552,
     "asyncio": 379,
     "parametrize": 189,
     "endpoints": 83,

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6715,
+    "total_tests": 6717,
     "total_files": 794,
     "markers_used": 16
   },
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6550,
+    "unit": 6552,
     "asyncio": 379,
     "parametrize": 189,
     "endpoints": 83,
@@ -61520,7 +61520,7 @@
         "docstring": ""
       },
       {
-        "name": "test_snapshot_step_expands_test_files_before_subprocess",
+        "name": "test_strict_profile_description_distinguishes_pr_and_readiness",
         "line": 55,
         "markers": [
           "unit"
@@ -61528,8 +61528,24 @@
         "docstring": ""
       },
       {
+        "name": "test_snapshot_step_expands_test_files_before_subprocess",
+        "line": 62,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
         "name": "test_print_profile_banner_reports_alias_and_status",
-        "line": 67,
+        "line": 74,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_strict_profile_banner_distinguishes_pull_request_ci",
+        "line": 85,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary
Closes #911.

Refreshes the generated testing inventory after the local CI test changes from PR #910 so the agent artifact freshness gate is clean again.

Related issue / finding / RJ-routed package:
- Issue #911
- Finding id: agent-testing-inventory-stale-after-local-ci-docs
- Pipeline id: goal-pipeline-20260624-gpt-trader-agent-testing-inventory-drift

## Type of change
- [ ] Refactor
- [ ] Feature
- [ ] Bug fix
- [ ] Tests only
- [x] CI/Docs/Tooling

## Scope & Impact
- Affected areas / components: generated agent testing inventory artifacts only.
- Any behavior changes? No source, test, docs, or trading behavior files changed.

Affected paths:
- `var/agents/testing/index.json`
- `var/agents/testing/markers.json`
- `var/agents/testing/test_inventory.json`

## Test Plan
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Contract tests (if applicable)
- [x] Ran locally: `MOCK_BROKER=1 DRY_RUN=1 uv run local-ci --profile quick`
- [x] Markers used appropriately (`unit`/`integration`/`slow`/`perf`)

Verification:
- `uv run agent-regenerate --verify` -> passed after regeneration; all context files up-to-date.
- Focused generated-artifact diff scope -> passed; only the three generated testing artifacts changed.
- `uv run pytest tests/unit/gpt_trader/utilities/test_quantization.py::TestQuantizeIdempotence::test_idempotence -q` -> passed after the first quick CI run hit an unrelated Hypothesis too_slow health check.
- `MOCK_BROKER=1 DRY_RUN=1 uv run local-ci --profile quick` -> passed on rerun with 6978 passed, 8 skipped; quick profile skipped readiness gate and agent-artifact freshness by design.

## Complexity & Quality Gates
- [x] Mypy/type-check passed
- [x] Xenon/radon complexity gate passed (CC ≤ 15 on live_trade execution)
- [x] No `sys.path` hacks in tests
- [x] No `MagicMock` on `async def` (use `AsyncMock`)
- [x] Import-lint rules respected (no “import up the stack”)

## Observability & Errors
- [x] Structured JSON logs for new/changed paths
- [x] Errors include diagnostic context (symbol, order_id, correlation_id)
- [x] Added/updated sampling examples in tests (if applicable)

## Configuration
- [x] If config changed: `python -m gpt_trader.cli.config validate --profile <name>` passes
- [x] Env docs re-generated (if applicable) and committed
- [x] No `ConfigLoader` usages introduced (ConfigManager-only)

## Breaking Changes
- [x] None
- [ ] Documented in PR body and release notes if any

## Checklist
- [x] Acceptance criteria in linked issue(s), finding packet, or routed package met
- [x] Affected paths listed in PR description
- [x] Changelog entry (if repo uses one)

## Known risks / follow-ups
- None. This PR is generated artifact freshness only.
