### PR TITLE
[codex] Validate project-review blocked_by entries

### DIFF
--- a/scripts/maintenance/project_review_issue_promoter.py
+++ b/scripts/maintenance/project_review_issue_promoter.py
@@ -244,8 +244,12 @@ def validate_packet(packet: dict[str, Any]) -> list[str]:
         errors.append("scope.touches_trading_execution=true requires routing.decision_needed=true")
 
     blocked_by = routing.get("blocked_by", [])
-    if blocked_by is not None and not isinstance(blocked_by, list):
+    if "blocked_by" in routing and not isinstance(blocked_by, list):
         errors.append("routing.blocked_by must be a list when present")
+    elif isinstance(blocked_by, list) and not all(
+        isinstance(blocker, str) and blocker.strip() for blocker in blocked_by
+    ):
+        errors.append("routing.blocked_by must contain only non-empty strings")
 
     return errors
 

--- a/tests/unit/scripts/test_project_review_issue_promoter.py
+++ b/tests/unit/scripts/test_project_review_issue_promoter.py
@@ -33,6 +33,42 @@ def test_dry_run_renders_issue_body(tmp_path: Path, capsys) -> None:
     assert "agent-ready" in captured.out
 
 
+def test_invalid_blocked_by_entry_is_reported_before_rendering(tmp_path: Path, capsys) -> None:
+    packet = promoter.example_packet()
+    packet["routing"]["blocked_by"] = [123]
+    packet_path = tmp_path / "finding.json"
+    packet_path.write_text(json.dumps(packet), encoding="utf-8")
+
+    exit_code = promoter.main(["--packet", str(packet_path)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "routing.blocked_by must contain only non-empty strings" in captured.err
+    assert captured.out == ""
+
+
+def test_blank_blocked_by_entry_is_reported() -> None:
+    packet = promoter.example_packet()
+    packet["routing"]["blocked_by"] = ["  "]
+
+    errors = promoter.validate_packet(packet)
+
+    assert "routing.blocked_by must contain only non-empty strings" in errors
+
+
+def test_dry_run_renders_valid_blocked_by_entries(tmp_path: Path, capsys) -> None:
+    packet = promoter.example_packet()
+    packet["routing"]["blocked_by"] = ["upstream decision packet", "review receipt"]
+    packet_path = tmp_path / "finding.json"
+    packet_path.write_text(json.dumps(packet), encoding="utf-8")
+
+    exit_code = promoter.main(["--packet", str(packet_path)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "- Blocked by: upstream decision packet, review receipt" in captured.out
+
+
 def test_invalid_candidate_type_is_reported() -> None:
     packet = promoter.example_packet()
     packet["routing"]["candidate_for"] = [{"not": "a string"}]

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6729,
+    "total_tests": 6732,
     "total_files": 795,
     "markers_used": 16
   },

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6564,
+    "unit": 6567,
     "asyncio": 379,
     "parametrize": 191,
     "endpoints": 83,

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6729,
+    "total_tests": 6732,
     "total_files": 795,
     "markers_used": 16
   },
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6564,
+    "unit": 6567,
     "asyncio": 379,
     "parametrize": 191,
     "endpoints": 83,
@@ -61730,7 +61730,7 @@
         "docstring": ""
       },
       {
-        "name": "test_invalid_candidate_type_is_reported",
+        "name": "test_invalid_blocked_by_entry_is_reported_before_rendering",
         "line": 36,
         "markers": [
           "unit"
@@ -61738,8 +61738,32 @@
         "docstring": ""
       },
       {
+        "name": "test_blank_blocked_by_entry_is_reported",
+        "line": 50,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_dry_run_renders_valid_blocked_by_entries",
+        "line": 59,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_invalid_candidate_type_is_reported",
+        "line": 72,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
         "name": "test_evidence_requires_command_path_or_url_anchor",
-        "line": 45,
+        "line": 81,
         "markers": [
           "unit"
         ],
@@ -61747,7 +61771,7 @@
       },
       {
         "name": "test_decision_needed_packet_is_not_agent_ready",
-        "line": 54,
+        "line": 90,
         "markers": [
           "unit"
         ],
@@ -61755,7 +61779,7 @@
       },
       {
         "name": "test_decision_candidate_requires_decision_needed",
-        "line": 66,
+        "line": 102,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
Closes #923

## Summary
- Validate `routing.blocked_by` as a list of non-empty strings before issue body rendering.
- Add focused promoter tests for non-string blocker validation, blank blocker validation, and valid dry-run blocker rendering.
- Regenerate `var/agents/testing` metadata for the added unit tests.

## Affected paths
- `scripts/maintenance/project_review_issue_promoter.py`
- `tests/unit/scripts/test_project_review_issue_promoter.py`
- `var/agents/testing/index.json`
- `var/agents/testing/markers.json`
- `var/agents/testing/test_inventory.json`

## Verification
- `uv run pytest tests/unit/scripts/test_project_review_issue_promoter.py -q` — passed, 10 tests.
- `uv run python scripts/maintenance/project_review_issue_promoter.py --packet -` with an equivalent Issue #923 packet — passed, rendered valid blockers in the issue body.
- `uv run agent-regenerate --verify` — passed after regenerating expected test inventory metadata.
- `uv run local-ci --profile quick` — passed, including 6999 core unit tests and 8 skips.

## Routing and boundaries
- Issue #923 is `agent-ready`/`codex`; no `decision-needed` gate is present.
- No live trading behavior, broker adapters, account capability assumptions, or execution policy changed.
- No real broker/API checks, live trading commands, production preflight, canary operations, or order submission were run.
- No breaking constructor/API behavior.

## Pipeline receipt
- Pipeline id: `goal-pipeline-20260624-gpt-trader-promoter-blocked-by-validation`
- Finding id: `project-review-promoter-blocked-by-validation-20260624`
- Delegation source thread: `019ef680-4a89-71b2-bc50-9d681dd37b2f`
- Commit: `589e2add33f5d99445964c68a47a01311c6ff8c0`
