### PR TITLE
[codex] Tighten telemetry health exception logging

### DIFF
--- a/scripts/agents/generate_event_catalog.py
+++ b/scripts/agents/generate_event_catalog.py
@@ -71,11 +71,19 @@ def scan_logging_calls(source_dir: Path) -> dict[str, Any]:
             status_match = re.search(r'status\s*=\s*["\']([^"\']+)["\']', context)
             status = status_match.group(1) if status_match else None
 
-            # Determine log level from context
+            # Determine log level from context. StructuredLogger.exception
+            # emits at ERROR level even though the method name differs.
             level = "INFO"
-            for lvl in ["debug", "info", "warning", "error", "critical"]:
-                if f".{lvl}(" in context.lower():
-                    level = lvl.upper()
+            for method, event_level in [
+                ("debug", "DEBUG"),
+                ("info", "INFO"),
+                ("warning", "WARNING"),
+                ("error", "ERROR"),
+                ("exception", "ERROR"),
+                ("critical", "CRITICAL"),
+            ]:
+                if f".{method}(" in context.lower():
+                    level = event_level
                     break
 
             # Find other keyword arguments

--- a/src/gpt_trader/features/live_trade/engines/telemetry_health.py
+++ b/src/gpt_trader/features/live_trade/engines/telemetry_health.py
@@ -35,7 +35,7 @@ to maintain real-time market state and detect connectivity issues.
 from __future__ import annotations
 
 import time
-from decimal import Decimal
+from decimal import Decimal, DecimalException
 from typing import TYPE_CHECKING, Any
 
 from gpt_trader.utilities import utc_now
@@ -59,8 +59,8 @@ def extract_mark_from_message(msg: dict[str, Any]) -> Decimal | None:
         if raw_mark is not None:
             mark = Decimal(str(raw_mark))
             return mark if mark > 0 else None
-    except Exception as exc:
-        logger.error(
+    except DecimalException as exc:
+        logger.exception(
             "Failed to extract mark from message",
             error_type=type(exc).__name__,
             error_message=str(exc),
@@ -83,7 +83,7 @@ def update_mark_and_metrics(
     if strategy_coordinator and hasattr(strategy_coordinator, "update_mark_window"):
         try:
             strategy_coordinator.update_mark_window(symbol, mark)
-        except Exception as exc:  # pragma: no cover - defensive logging
+        except Exception as exc:  # noqa: BLE001 - best-effort telemetry adapter callback
             logger.debug(
                 "Failed to update mark window",
                 error=str(exc),
@@ -126,7 +126,7 @@ def update_mark_and_metrics(
     if monitor is not None:
         try:
             monitor.record_update(symbol)
-        except Exception:  # pragma: no cover - defensive logging
+        except Exception:  # noqa: BLE001 - best-effort telemetry adapter callback
             logger.debug(
                 "Failed to record market update",
                 symbol=symbol,
@@ -145,7 +145,7 @@ def update_mark_and_metrics(
                 result = record_fn(symbol, timestamp)
                 if result is not None:
                     stored = result
-            except Exception:  # pragma: no cover - defensive logging
+            except Exception:  # noqa: BLE001 - best-effort risk-manager adapter callback
                 logger.exception(
                     "WS mark update bookkeeping failed",
                     symbol=symbol,
@@ -160,7 +160,7 @@ def update_mark_and_metrics(
                 last_updates = {}
                 setattr(risk_manager, "last_mark_update", last_updates)
             last_updates[symbol] = stored
-        except Exception:  # pragma: no cover - defensive logging
+        except Exception:  # noqa: BLE001 - best-effort risk-manager state persistence
             logger.debug(
                 "Failed to persist last mark update",
                 symbol=symbol,
@@ -174,7 +174,7 @@ def update_mark_and_metrics(
         last_emit = {}
         try:
             setattr(coordinator, "_mark_metric_last_emit", last_emit)
-        except Exception:
+        except Exception:  # noqa: BLE001 - coordinator may reject dynamic telemetry state
             last_emit = {}
 
     raw_interval = getattr(config, "status_interval", 60)

--- a/tests/unit/gpt_trader/features/live_trade/engines/test_telemetry_health.py
+++ b/tests/unit/gpt_trader/features/live_trade/engines/test_telemetry_health.py
@@ -6,6 +6,9 @@ from decimal import Decimal
 from typing import Any
 from unittest.mock import Mock
 
+import pytest
+
+import gpt_trader.features.live_trade.engines.telemetry_health as telemetry_health_module
 from gpt_trader.features.live_trade.engines.telemetry_health import (
     extract_mark_from_message,
     health_check,
@@ -72,6 +75,16 @@ class TestExtractMarkFromMessage:
         result = extract_mark_from_message(msg)
 
         assert result is None
+
+    def test_invalid_decimal_logs_exception_context(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mock_logger = Mock()
+        monkeypatch.setattr(telemetry_health_module, "logger", mock_logger)
+
+        result = extract_mark_from_message({"last": "not_a_number"})
+
+        assert result is None
+        mock_logger.exception.assert_called_once()
+        assert mock_logger.exception.call_args.kwargs["operation"] == "extract_mark"
 
     def test_handles_bid_only(self) -> None:
         msg = {"bid": "100"}

--- a/tests/unit/scripts/test_generate_event_catalog.py
+++ b/tests/unit/scripts/test_generate_event_catalog.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from scripts.agents.generate_event_catalog import scan_logging_calls
+
+
+def test_exception_logging_counts_as_error_level(tmp_path):
+    source_dir = tmp_path / "src"
+    source_dir.mkdir()
+    (source_dir / "sample.py").write_text(
+        """
+def record_failure(logger):
+    logger.exception(
+        "Failed to extract mark from message",
+        operation="extract_mark",
+        error_type="InvalidOperation",
+    )
+""",
+        encoding="utf-8",
+    )
+
+    results = scan_logging_calls(source_dir)
+
+    event = results["operations"]["extract_mark"][0]
+    assert event["level"] == "ERROR"
+    assert results["levels"] == {"ERROR": 1}

--- a/var/agents/logging/event_catalog.json
+++ b/var/agents/logging/event_catalog.json
@@ -694,7 +694,7 @@
       ],
       "components": null,
       "levels": [
-        "INFO"
+        "ERROR"
       ],
       "occurrence_count": 1,
       "source_files": [
@@ -1957,7 +1957,7 @@
       "components": null,
       "levels": [
         "DEBUG",
-        "INFO",
+        "ERROR",
         "WARNING"
       ],
       "occurrence_count": 6,
@@ -2207,6 +2207,7 @@
       "components": null,
       "levels": [
         "DEBUG",
+        "ERROR",
         "INFO"
       ],
       "occurrence_count": 4,
@@ -2550,6 +2551,7 @@
       "components": null,
       "levels": [
         "DEBUG",
+        "ERROR",
         "INFO"
       ],
       "occurrence_count": 7,
@@ -2594,8 +2596,8 @@
   "level_distribution": {
     "CRITICAL": 1,
     "DEBUG": 51,
-    "ERROR": 88,
-    "INFO": 127,
+    "ERROR": 97,
+    "INFO": 118,
     "WARNING": 76
   },
   "total_event_types": 135,

--- a/var/agents/logging/event_catalog.json
+++ b/var/agents/logging/event_catalog.json
@@ -694,7 +694,7 @@
       ],
       "components": null,
       "levels": [
-        "ERROR"
+        "INFO"
       ],
       "occurrence_count": 1,
       "source_files": [
@@ -2594,8 +2594,8 @@
   "level_distribution": {
     "CRITICAL": 1,
     "DEBUG": 51,
-    "ERROR": 89,
-    "INFO": 126,
+    "ERROR": 88,
+    "INFO": 127,
     "WARNING": 76
   },
   "total_event_types": 135,

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,8 +7,8 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6733,
-    "total_files": 795,
+    "total_tests": 6734,
+    "total_files": 796,
     "markers_used": 16
   },
   "quick_commands": {

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6732,
+    "total_tests": 6733,
     "total_files": 795,
     "markers_used": 16
   },

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6568,
+    "unit": 6569,
     "asyncio": 379,
     "parametrize": 191,
     "endpoints": 83,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6567,
+    "unit": 6568,
     "asyncio": 379,
     "parametrize": 191,
     "endpoints": 83,

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6732,
+    "total_tests": 6733,
     "total_files": 795,
     "markers_used": 16
   },
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6567,
+    "unit": 6568,
     "asyncio": 379,
     "parametrize": 191,
     "endpoints": 83,
@@ -20651,7 +20651,7 @@
     "tests/unit/gpt_trader/features/live_trade/engines/test_telemetry_health.py": [
       {
         "name": "TestExtractMarkFromMessage::test_extracts_from_bid_ask",
-        "line": 16,
+        "line": 19,
         "markers": [
           "unit"
         ],
@@ -20660,7 +20660,7 @@
       },
       {
         "name": "TestExtractMarkFromMessage::test_extracts_from_bid_ask_strings",
-        "line": 22,
+        "line": 25,
         "markers": [
           "unit"
         ],
@@ -20669,7 +20669,7 @@
       },
       {
         "name": "TestExtractMarkFromMessage::test_prefers_best_bid_over_bid",
-        "line": 28,
+        "line": 31,
         "markers": [
           "unit"
         ],
@@ -20678,7 +20678,7 @@
       },
       {
         "name": "TestExtractMarkFromMessage::test_extracts_from_last_price",
-        "line": 34,
+        "line": 37,
         "markers": [
           "unit"
         ],
@@ -20687,7 +20687,7 @@
       },
       {
         "name": "TestExtractMarkFromMessage::test_extracts_from_price_key",
-        "line": 40,
+        "line": 43,
         "markers": [
           "unit"
         ],
@@ -20696,7 +20696,7 @@
       },
       {
         "name": "TestExtractMarkFromMessage::test_returns_none_for_empty_message",
-        "line": 46,
+        "line": 49,
         "markers": [
           "unit"
         ],
@@ -20705,7 +20705,7 @@
       },
       {
         "name": "TestExtractMarkFromMessage::test_returns_none_for_zero_mark",
-        "line": 52,
+        "line": 55,
         "markers": [
           "unit"
         ],
@@ -20714,7 +20714,7 @@
       },
       {
         "name": "TestExtractMarkFromMessage::test_returns_none_for_negative_mark",
-        "line": 58,
+        "line": 61,
         "markers": [
           "unit"
         ],
@@ -20723,7 +20723,7 @@
       },
       {
         "name": "TestExtractMarkFromMessage::test_returns_none_for_zero_bid_ask_average",
-        "line": 64,
+        "line": 67,
         "markers": [
           "unit"
         ],
@@ -20732,7 +20732,16 @@
       },
       {
         "name": "TestExtractMarkFromMessage::test_returns_none_for_invalid_decimal",
-        "line": 70,
+        "line": 73,
+        "markers": [
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestExtractMarkFromMessage"
+      },
+      {
+        "name": "TestExtractMarkFromMessage::test_invalid_decimal_logs_exception_context",
+        "line": 79,
         "markers": [
           "unit"
         ],
@@ -20741,7 +20750,7 @@
       },
       {
         "name": "TestExtractMarkFromMessage::test_handles_bid_only",
-        "line": 76,
+        "line": 89,
         "markers": [
           "unit"
         ],
@@ -20750,7 +20759,7 @@
       },
       {
         "name": "TestExtractMarkFromMessage::test_handles_ask_only",
-        "line": 82,
+        "line": 95,
         "markers": [
           "unit"
         ],
@@ -20759,7 +20768,7 @@
       },
       {
         "name": "TestHealthCheck::test_healthy_when_market_monitor_present",
-        "line": 99,
+        "line": 112,
         "markers": [
           "unit"
         ],
@@ -20768,7 +20777,7 @@
       },
       {
         "name": "TestHealthCheck::test_unhealthy_when_no_monitor_or_streaming",
-        "line": 109,
+        "line": 122,
         "markers": [
           "unit"
         ],
@@ -20777,7 +20786,7 @@
       },
       {
         "name": "TestHealthCheck::test_healthy_when_streaming_active",
-        "line": 118,
+        "line": 131,
         "markers": [
           "unit"
         ],
@@ -20786,7 +20795,7 @@
       },
       {
         "name": "TestHealthCheck::test_detects_market_monitor_from_coordinator",
-        "line": 129,
+        "line": 142,
         "markers": [
           "unit"
         ],
@@ -20795,7 +20804,7 @@
       },
       {
         "name": "TestHealthCheck::test_no_market_monitor",
-        "line": 137,
+        "line": 150,
         "markers": [
           "unit"
         ],
@@ -20804,7 +20813,7 @@
       },
       {
         "name": "TestHealthCheck::test_streaming_active_when_task_running",
-        "line": 144,
+        "line": 157,
         "markers": [
           "unit"
         ],
@@ -20813,7 +20822,7 @@
       },
       {
         "name": "TestHealthCheck::test_streaming_inactive_when_task_done",
-        "line": 154,
+        "line": 167,
         "markers": [
           "unit"
         ],
@@ -20822,7 +20831,7 @@
       },
       {
         "name": "TestHealthCheck::test_streaming_inactive_when_no_task",
-        "line": 164,
+        "line": 177,
         "markers": [
           "unit"
         ],
@@ -20831,7 +20840,7 @@
       },
       {
         "name": "TestHealthCheck::test_counts_background_tasks",
-        "line": 171,
+        "line": 184,
         "markers": [
           "unit"
         ],
@@ -20840,7 +20849,7 @@
       },
       {
         "name": "TestHealthCheck::test_health_with_both_monitor_and_streaming",
-        "line": 179,
+        "line": 192,
         "markers": [
           "unit"
         ],
@@ -20849,7 +20858,7 @@
       },
       {
         "name": "TestHealthCheck::test_health_details_always_present",
-        "line": 192,
+        "line": 205,
         "markers": [
           "unit"
         ],

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,8 +2,8 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6733,
-    "total_files": 795,
+    "total_tests": 6734,
+    "total_files": 796,
     "markers_used": 16
   },
   "marker_definitions": {
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6568,
+    "unit": 6569,
     "asyncio": 379,
     "parametrize": 191,
     "endpoints": 83,
@@ -782,6 +782,9 @@
     ],
     "test_feature_slice_scaffold.py": [
       "tests/unit/scripts/test_feature_slice_scaffold.py"
+    ],
+    "test_generate_event_catalog.py": [
+      "tests/unit/scripts/test_generate_event_catalog.py"
     ],
     "test_generate_test_inventory.py": [
       "tests/unit/scripts/test_generate_test_inventory.py"
@@ -61539,6 +61542,16 @@
       {
         "name": "test_refuses_overwrite",
         "line": 46,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      }
+    ],
+    "tests/unit/scripts/test_generate_event_catalog.py": [
+      {
+        "name": "test_exception_logging_counts_as_error_level",
+        "line": 6,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
Closes #925

Summary:
- Narrow invalid mark parsing to DecimalException and preserve stack context with logger.exception.
- Document defensive telemetry adapter broad catches with explicit Ruff justifications.
- Add regression coverage for invalid decimal mark logging and regenerate agent indexes.

Verification:
- uv run ruff check src/gpt_trader/features/live_trade/engines/telemetry_health.py --select BLE,TRY --output-format concise
- uv run pytest tests/unit/gpt_trader/features/live_trade/engines/test_telemetry_health.py tests/unit/gpt_trader/features/live_trade/engines/test_telemetry_health_mark_updates.py -q
- uv run agent-regenerate --verify
- uv run local-ci --profile quick (7000 passed, 8 skipped)

Risk / gates:
- No live broker/API calls, trading controls, canary changes, production profile, or order submission touched.
