### PR TITLE
[codex] Tighten Coinbase account snapshot exception logging

### DIFF
--- a/src/gpt_trader/features/brokerages/coinbase/account_manager.py
+++ b/src/gpt_trader/features/brokerages/coinbase/account_manager.py
@@ -101,14 +101,14 @@ class CoinbaseAccountManager:
                     )
                     snapshot_data["intx_collateral"] = collateral
                     freshness_data["intx_collateral"] = collateral_meta
-            except Exception as e:
-                logger.warning(f"Failed to get INTX data: {e}")
+            except Exception as error:  # noqa: BLE001 - snapshot must degrade on broker failures
+                logger.warning("Failed to get INTX data: %s", error, exc_info=error)
                 self._record_intx_fallback(
                     snapshot_data,
                     freshness_data,
-                    reason=str(e),
+                    reason=str(error),
                     status=self._FRESHNESS_ERROR,
-                    error_code=self._error_code_from_exception(e),
+                    error_code=self._error_code_from_exception(error),
                 )
 
         snapshot_data["freshness"] = freshness_data
@@ -125,19 +125,25 @@ class CoinbaseAccountManager:
     def _execute_snapshot_probe(self, key: str, probe_name: str) -> tuple[Any, dict[str, Any]]:
         try:
             probe = getattr(self.broker, probe_name)
-            if not callable(probe):
-                raise TypeError(f"{probe_name} is not callable")
-            result = probe()
-            return result, self._freshness_entry(self._FRESHNESS_FRESH)
-        except Exception as error:
-            logger.warning("Failed to collect %s: %s", key, error)
-            return (
-                self._snapshot_error_payload(error),
-                self._freshness_entry(
-                    self._FRESHNESS_ERROR,
-                    error_code=self._error_code_from_exception(error),
-                ),
-            )
+            if callable(probe):
+                result = probe()
+                return result, self._freshness_entry(self._FRESHNESS_FRESH)
+        except Exception as error:  # noqa: BLE001 - optional probes should not abort snapshot
+            return self._snapshot_probe_failure(key, error)
+
+        return self._snapshot_probe_failure(key, TypeError(f"{probe_name} is not callable"))
+
+    def _snapshot_probe_failure(
+        self, key: str, error: Exception
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        logger.warning("Failed to collect %s: %s", key, error, exc_info=error)
+        return (
+            self._snapshot_error_payload(error),
+            self._freshness_entry(
+                self._FRESHNESS_ERROR,
+                error_code=self._error_code_from_exception(error),
+            ),
+        )
 
     @staticmethod
     def _snapshot_error_payload(error: Exception) -> dict[str, Any]:
@@ -163,15 +169,20 @@ class CoinbaseAccountManager:
         try:
             balances = self.broker.get_intx_balances(portfolio_uuid)
             return balances, self._freshness_entry(self._FRESHNESS_FRESH), portfolio_uuid
-        except Exception as error:
-            logger.warning("Failed to collect intx_balances: %s", error)
+        except Exception as error:  # noqa: BLE001 - INTX balance probe is best-effort
+            logger.warning("Failed to collect intx_balances: %s", error, exc_info=error)
             refreshed_uuid = self.broker.resolve_intx_portfolio(refresh=True)
             if refreshed_uuid:
                 try:
                     balances = self.broker.get_intx_balances(refreshed_uuid)
                     return balances, self._freshness_entry(self._FRESHNESS_FRESH), refreshed_uuid
-                except Exception as retry_error:
-                    logger.warning("Retry failed for intx_balances: %s", retry_error)
+                except Exception as retry_error:  # noqa: BLE001
+                    # Retry is best-effort; failure returns deterministic metadata.
+                    logger.warning(
+                        "Retry failed for intx_balances: %s",
+                        retry_error,
+                        exc_info=retry_error,
+                    )
                     return (
                         [],
                         self._freshness_entry(
@@ -195,8 +206,8 @@ class CoinbaseAccountManager:
         try:
             value = fetcher()
             return value, self._freshness_entry(self._FRESHNESS_FRESH)
-        except Exception as error:
-            logger.warning("Failed to collect %s: %s", key, error)
+        except Exception as error:  # noqa: BLE001 - INTX sections should degrade independently
+            logger.warning("Failed to collect %s: %s", key, error, exc_info=error)
             return (
                 default,
                 self._freshness_entry(


### PR DESCRIPTION
## Summary
Related issue / finding / RJ-routed package: Fixes #929

Pipeline run id: `goal-pipeline-20260624-coinbase-account-manager-exception-logging`
Execution stage id: `goal-execute-pr-issue-929`

Tightens `CoinbaseAccountManager` snapshot exception logging without changing the best-effort snapshot contract. Broad catches remain only where optional account/CFM/INTX snapshot sections must degrade into deterministic payloads and freshness/error metadata, and those paths now log with exception context. The synthetic non-callable probe error no longer raises inside the probe try block, clearing the targeted TRY cleanup.

## Type of change
- [x] Refactor
- [ ] Feature
- [ ] Bug fix
- [ ] Tests only
- [x] CI/Docs/Tooling

## Scope & Impact
- Affected areas / components: `src/gpt_trader/features/brokerages/coinbase/account_manager.py`
- Any behavior changes? No Coinbase REST client contract, auth, signing, portfolio transfer, convert, money-moving account operation, trading policy, or live execution behavior changes. Snapshot degradation behavior is preserved for optional probes, CFM, and INTX failures, including freshness/error metadata and `account_manager_snapshot` telemetry.

## Test Plan
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Contract tests (if applicable)
- [ ] Ran locally: `pytest -m "unit and not slow"`
- [x] Markers used appropriately (`unit`/`integration`/`slow`/`perf`)

Verification run locally:
- [x] `uv run ruff check src/gpt_trader/features/brokerages/coinbase/account_manager.py --select BLE,TRY --output-format concise` -> passed
- [x] `uv run pytest tests/unit/gpt_trader/features/brokerages/coinbase/test_coinbase_account_manager_snapshot.py -q` -> 10 passed
- [x] `uv run agent-regenerate --verify` -> all context files are up-to-date
- [x] `uv run black src/gpt_trader/features/brokerages/coinbase/account_manager.py` -> formatted touched file
- [x] `git diff --check` -> passed

## Complexity & Quality Gates
- [ ] Mypy/type-check passed
- [ ] Xenon/radon complexity gate passed (CC <= 15 on live_trade execution)
- [x] No `sys.path` hacks in tests
- [x] No `MagicMock` on `async def` (use `AsyncMock`)
- [x] Import-lint rules respected (no import changes)

## Observability & Errors
- [ ] Structured JSON logs for new/changed paths
- [x] Errors include diagnostic context (snapshot fallback logs now pass exception context via `exc_info`)
- [ ] Added/updated sampling examples in tests (if applicable)

## Configuration
- [ ] If config changed: `python -m gpt_trader.cli.config validate --profile <name>` passes
- [ ] Env docs re-generated (if applicable) and committed
- [x] No `ConfigLoader` usages introduced (ConfigManager-only)

## Breaking Changes
- [x] None
- [ ] Documented in PR body and release notes if any

## Screenshots / Logs (optional)
Not applicable.

## Checklist
- [x] Acceptance criteria in linked issue(s), finding packet, or routed package met
- [x] Affected paths listed in PR description
- [ ] Changelog entry (if repo uses one)
