### PR TITLE
[codex] Create notification file parent dirs

### DIFF
--- a/src/gpt_trader/monitoring/notifications/backends.py
+++ b/src/gpt_trader/monitoring/notifications/backends.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 from gpt_trader.monitoring.alert_types import Alert, AlertSeverity
@@ -281,6 +282,7 @@ class FileNotificationBackend:
             return False
 
     def _append_to_file(self, line: str) -> None:
+        self._ensure_parent_directory()
         with open(self.file_path, "a") as f:
             f.write(line)
 
@@ -296,5 +298,9 @@ class FileNotificationBackend:
             return False
 
     def _check_file_writable(self) -> None:
+        self._ensure_parent_directory()
         with open(self.file_path, "a"):
             pass  # Just test if we can open for append
+
+    def _ensure_parent_directory(self) -> None:
+        Path(self.file_path).parent.mkdir(parents=True, exist_ok=True)

--- a/tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_core.py
+++ b/tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_core.py
@@ -135,7 +135,13 @@ class TestFileNotificationBackend:
             Path(file_path).unlink(missing_ok=True)
 
     @pytest.mark.asyncio
-    async def test_test_connection_fails_for_invalid_path(self) -> None:
-        backend = FileNotificationBackend(file_path="/nonexistent/path/alerts.jsonl")
+    async def test_test_connection_fails_for_invalid_path(self, tmp_path) -> None:
+        blocking_file = tmp_path / "not-a-directory"
+        blocking_file.write_text("seed\n")
+        invalid_path = blocking_file / "alerts.jsonl"
+        backend = FileNotificationBackend(file_path=str(invalid_path))
+
         result = await backend.test_connection()
+
         assert result is False
+        assert blocking_file.read_text() == "seed\n"

--- a/tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_edges.py
+++ b/tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_edges.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from unittest.mock import Mock
 
 import pytest
@@ -51,16 +52,34 @@ async def test_file_backend_handles_json_serialization_failure(tmp_path) -> None
 
 
 @pytest.mark.asyncio
-async def test_file_backend_nested_path_without_parents_fails_cleanly(tmp_path) -> None:
+async def test_file_backend_nested_path_creates_parents_and_writes_jsonl(tmp_path) -> None:
     nested_path = tmp_path / "nested" / "alerts" / "out.jsonl"
     backend = FileNotificationBackend(file_path=str(nested_path))
     alert = Alert(
         severity=AlertSeverity.ERROR,
         title="Nested Path",
-        message="should fail without parent directories",
+        message="should create parent directories",
     )
 
     result = await backend.send(alert)
 
-    assert result is False
-    assert not nested_path.exists()
+    assert result is True
+    assert nested_path.parent.is_dir()
+    assert nested_path.exists()
+    lines = nested_path.read_text().splitlines()
+    assert len(lines) == 1
+    payload = json.loads(lines[0])
+    assert payload["title"] == "Nested Path"
+    assert payload["message"] == "should create parent directories"
+
+
+@pytest.mark.asyncio
+async def test_file_backend_test_connection_creates_missing_parents(tmp_path) -> None:
+    nested_path = tmp_path / "connection" / "alerts" / "out.jsonl"
+    backend = FileNotificationBackend(file_path=str(nested_path))
+
+    result = await backend.test_connection()
+
+    assert result is True
+    assert nested_path.parent.is_dir()
+    assert nested_path.exists()

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6734,
+    "total_tests": 6735,
     "total_files": 796,
     "markers_used": 16
   },

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,8 +95,8 @@
     ]
   },
   "counts": {
-    "unit": 6569,
-    "asyncio": 379,
+    "unit": 6570,
+    "asyncio": 380,
     "parametrize": 191,
     "endpoints": 83,
     "property": 82,

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6734,
+    "total_tests": 6735,
     "total_files": 796,
     "markers_used": 16
   },
@@ -102,8 +102,8 @@
     ]
   },
   "marker_counts": {
-    "unit": 6569,
-    "asyncio": 379,
+    "unit": 6570,
+    "asyncio": 380,
     "parametrize": 191,
     "endpoints": 83,
     "property": 82,
@@ -35235,7 +35235,7 @@
     "tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_edges.py": [
       {
         "name": "test_console_backend_handles_empty_or_nonprintable_messages",
-        "line": 18,
+        "line": 19,
         "markers": [
           "asyncio",
           "parametrize",
@@ -35245,7 +35245,7 @@
       },
       {
         "name": "test_file_backend_handles_json_serialization_failure",
-        "line": 35,
+        "line": 36,
         "markers": [
           "asyncio",
           "unit"
@@ -35253,8 +35253,17 @@
         "docstring": ""
       },
       {
-        "name": "test_file_backend_nested_path_without_parents_fails_cleanly",
-        "line": 54,
+        "name": "test_file_backend_nested_path_creates_parents_and_writes_jsonl",
+        "line": 55,
+        "markers": [
+          "asyncio",
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_file_backend_test_connection_creates_missing_parents",
+        "line": 77,
         "markers": [
           "asyncio",
           "unit"


### PR DESCRIPTION
Closes #931

## Summary
- Create missing parent directories before `FileNotificationBackend` appends JSONL alerts.
- Use the same parent-directory preparation before `test_connection` checks file writability.
- Update the nested-path edge coverage to assert successful parent creation and JSONL output, then refresh generated testing inventories.

## Affected paths
- `src/gpt_trader/monitoring/notifications/backends.py`
- `tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_edges.py`
- `var/agents/testing/index.json`
- `var/agents/testing/markers.json`
- `var/agents/testing/test_inventory.json`

## Verification
- `uv run pytest tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_core.py tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_edges.py -q` - passed, 15 passed.
- `uv run agent-regenerate --verify` - initially detected stale test inventories after the test change; after `uv run agent-regenerate`, passed with all context files up to date.
- `uv run local-ci --profile quick` - passed, including 7001 unit tests passed and 8 skipped.
- `git diff --check` - passed.

## Decision / API notes
- Issue #931 is `agent-ready`; no decision-needed packet was required.
- No constructor or public API behavior breaks are intended. Existing unwritable paths still fail through the existing error-handling path.
