### PR TITLE
[codex] Align naming enforcement docs

### DIFF
--- a/docs/agents/glossary.md
+++ b/docs/agents/glossary.md
@@ -2,7 +2,7 @@
 
 ---
 status: current
-last-updated: 2026-01-23
+last-updated: 2026-06-24
 ---
 
 This glossary lists abbreviations approved for use in the GPT-Trader codebase.
@@ -74,8 +74,8 @@ response_qty = api_response["qty"]  # naming: allow
 ## Enforcement
 
 Naming standards are enforced via:
-- **Pre-commit hook**: Blocks commits with violations (use `SKIP=naming-check git commit` to bypass)
-- **CI check**: Generates reports uploaded as artifacts
+- **Pre-commit hook**: Blocks commits with violations through the `naming-check` hook (use `SKIP=naming-check git commit` to bypass)
+- **Agent command**: Run `uv run agent-naming --strict --quiet` for explicit strict-scan proof, or `make agent-naming` for the default local scan
 - **Code review**: Reviewers flag deviations
 
 See `docs/naming.md` for complete naming conventions.

--- a/docs/naming.md
+++ b/docs/naming.md
@@ -2,7 +2,7 @@
 
 ---
 status: current
-last-updated: 2026-01-23
+last-updated: 2026-06-24
 ---
 
 This document establishes the naming conventions for the GPT-Trader codebase. Adherence to these standards ensures clarity, consistency, and maintainability across the repository.
@@ -57,6 +57,12 @@ The automated naming scan loads its banned pattern list from
 - Any new abbreviation requires maintainer approval; add to glossary when accepted.
 
 ## 4. Review & Enforcement
-- Incorporate naming checks into a dedicated agent preflight script (planned; not yet implemented).
+- Run the implemented naming scan with `uv run agent-naming`; the entrypoint
+  dispatches to `scripts/agents/naming_inventory.py` and loads its defaults from
+  `config/agents/naming_patterns.yaml`.
+- Use `uv run agent-naming --strict --quiet` for proof that the strict scan is
+  clean. The same strict command is wired as the local pre-commit
+  `naming-check` hook in `.pre-commit-config.yaml`; `make agent-naming` provides
+  the non-strict Makefile shortcut.
 - Require code review to flag deviations; reference this document in feedback.
 - Add a Definition of Done item: "Naming complies with standards or documented exception is provided."

--- a/docs/naming_suppressions.md
+++ b/docs/naming_suppressions.md
@@ -2,7 +2,7 @@
 
 ---
 status: current
-last-updated: 2026-01-31
+last-updated: 2026-06-24
 ---
 
 This document explains **how the naming-standards check works**, what it enforces, and
@@ -12,9 +12,19 @@ The goal is to keep naming consistent **without** turning every PR into a rename
 
 ## What enforces naming
 
-CI runs a strict naming scan via:
+The strict naming gate today is the local pre-commit `naming-check` hook in
+`.pre-commit-config.yaml`, which runs:
 
 - `uv run python scripts/agents/naming_inventory.py --strict --quiet`
+
+The equivalent first-class agent command is:
+
+- `uv run agent-naming --strict --quiet`
+
+`make agent-naming` runs the default non-strict scan for local review. The
+current GitHub CI workflow does not include a direct naming scan step; use the
+pre-commit hook or the strict `agent-naming` command when a PR needs explicit
+naming-compliance evidence.
 
 The banned/flagged patterns are defined in:
 

--- a/scripts/agents/README.md
+++ b/scripts/agents/README.md
@@ -49,6 +49,7 @@ uv run agent-tests --source gpt_trader.cli
 uv run agent-tests --source gpt_trader.cli --source-files
 uv run agent-risk --with-docs
 uv run agent-naming
+uv run agent-naming --strict --quiet
 uv run agent-health
 uv run agent-regenerate
 uv run agent-regenerate --only testing
@@ -57,7 +58,10 @@ uv run agent-artifacts package
 uv run agent-artifacts verify-package
 ```
 
-Naming defaults are loaded from `config/agents/naming_patterns.yaml`.
+`agent-naming` dispatches to `scripts/agents/naming_inventory.py`; defaults are
+loaded from `config/agents/naming_patterns.yaml`. Strict naming enforcement is
+wired through the local pre-commit `naming-check` hook, and the current GitHub CI
+workflow does not run a direct naming scan step.
 
 ## Artifact Publication
 


### PR DESCRIPTION
Closes #933

## Summary
- Updated `docs/naming.md` to point at the implemented `agent-naming` entrypoint and `scripts/agents/naming_inventory.py` path instead of describing a planned preflight.
- Corrected naming enforcement docs to state that strict naming is wired through the local pre-commit `naming-check` hook, with `uv run agent-naming --strict --quiet` as the explicit proof command.
- Aligned nearby agent docs so they no longer claim GitHub CI runs a direct naming scan.

## Affected paths
- `docs/naming.md`
- `docs/naming_suppressions.md`
- `docs/agents/glossary.md`
- `scripts/agents/README.md`

## Verification
- `uv run agent-naming --strict --quiet` PASS
- `python scripts/maintenance/docs_link_audit.py` PASS
- `python scripts/maintenance/docs_reachability_check.py` PASS
- `uv run local-ci --profile quick` PASS, including 7001 passed and 8 skipped core unit tests

## Decision and behavior notes
- Documentation-only change.
- No broad source renames, trading-control changes, broker/API behavior changes, canary operations, money movement, or order-submission paths touched.
- No breaking constructor/API behavior.