### PR TITLE
Make agent artifact validation ignore gitignored residue

### DIFF
--- a/scripts/agents/agent_artifacts.py
+++ b/scripts/agents/agent_artifacts.py
@@ -8,6 +8,7 @@ import gzip
 import hashlib
 import json
 import os
+import subprocess
 import sys
 import tarfile
 import tempfile
@@ -90,8 +91,64 @@ def _sha256_file(path: Path) -> str:
     return digest.hexdigest()
 
 
+def _git_root_for(path: Path) -> Path | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(path), "rev-parse", "--show-toplevel"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return None
+
+    root = result.stdout.strip()
+    return Path(root) if root else None
+
+
+def _gitignored_files(paths: list[Path], *, git_root: Path) -> set[Path]:
+    resolved_git_root = git_root.resolve()
+    relative_paths: list[str] = []
+    path_by_relative: dict[str, Path] = {}
+    for path in paths:
+        try:
+            relative = path.resolve().relative_to(resolved_git_root).as_posix()
+        except ValueError:
+            return set()
+        relative_paths.append(relative)
+        path_by_relative[relative] = path
+
+    if not relative_paths:
+        return set()
+
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(git_root), "check-ignore", "--stdin"],
+            input="\n".join(relative_paths) + "\n",
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        return set()
+
+    if result.returncode not in {0, 1}:
+        return set()
+
+    return {
+        path_by_relative[relative]
+        for relative in result.stdout.splitlines()
+        if relative in path_by_relative
+    }
+
+
 def _iter_source_files(source_dir: Path) -> list[Path]:
-    return sorted(path for path in source_dir.rglob("*") if path.is_file())
+    files = sorted(path for path in source_dir.rglob("*") if path.is_file())
+    git_root = _git_root_for(source_dir)
+    if git_root is None:
+        return files
+
+    ignored = _gitignored_files(files, git_root=git_root)
+    return [path for path in files if path not in ignored]
 
 
 def _relative_posix(path: Path, base: Path) -> str:

--- a/scripts/agents/agent_artifacts.py
+++ b/scripts/agents/agent_artifacts.py
@@ -141,14 +141,23 @@ def _gitignored_files(paths: list[Path], *, git_root: Path) -> set[Path]:
     }
 
 
-def _iter_source_files(source_dir: Path) -> list[Path]:
+def _iter_source_files(
+    source_dir: Path,
+    *,
+    indexed_files: set[str] | None = None,
+) -> list[Path]:
     files = sorted(path for path in source_dir.rglob("*") if path.is_file())
     git_root = _git_root_for(source_dir)
     if git_root is None:
         return files
 
     ignored = _gitignored_files(files, git_root=git_root)
-    return [path for path in files if path not in ignored]
+    return [
+        path
+        for path in files
+        if path not in ignored
+        or (indexed_files is not None and _relative_posix(path, source_dir) in indexed_files)
+    ]
 
 
 def _relative_posix(path: Path, base: Path) -> str:
@@ -181,6 +190,25 @@ def _resource_files(resources: dict[str, Any], report: ValidationReport) -> set[
                 report.error(f"Resource {resource_name!r} contains an invalid file entry")
                 continue
             indexed_files.add(PurePosixPath(resource_path, file_name).as_posix())
+    return indexed_files
+
+
+def _indexed_files_from_root_index(root_index: dict[str, Any]) -> set[str]:
+    indexed_files: set[str] = {"index.json"}
+    resources = root_index.get("resources")
+    if not isinstance(resources, dict):
+        return indexed_files
+
+    for resource_payload in resources.values():
+        if not isinstance(resource_payload, dict):
+            continue
+        resource_path = resource_payload.get("path")
+        files = resource_payload.get("files")
+        if not isinstance(resource_path, str) or not isinstance(files, list):
+            continue
+        for file_name in files:
+            if isinstance(file_name, str) and file_name.strip():
+                indexed_files.add(PurePosixPath(resource_path, file_name).as_posix())
     return indexed_files
 
 
@@ -236,7 +264,7 @@ def _validate_root_index(source_dir: Path, report: ValidationReport) -> dict[str
     indexed_files = _resource_files(resources, report)
     actual_files = {
         _relative_posix(path, source_dir)
-        for path in _iter_source_files(source_dir)
+        for path in _iter_source_files(source_dir, indexed_files=indexed_files)
         if path.name != ".gitkeep"
     }
     unindexed = sorted(
@@ -335,12 +363,15 @@ def validate_agent_artifacts(
         return report, {}
 
     root_index = _validate_root_index(source_dir, report)
+    indexed_files = _indexed_files_from_root_index(root_index)
     _validate_expected_content(source_dir, report)
+    files = _iter_source_files(source_dir, indexed_files=indexed_files)
 
     total_bytes = sum(path.stat().st_size for path in files)
     summary = {
         "source_dir": str(source_dir),
         "file_count": len(files),
+        "indexed_files": sorted(indexed_files),
         "total_bytes": total_bytes,
         "resources": (
             sorted(root_index.get("resources", {}).keys())
@@ -356,9 +387,13 @@ def validate_agent_artifacts(
     return report, summary
 
 
-def _manifest_files(source_dir: Path, package_prefix: str) -> list[dict[str, Any]]:
+def _manifest_files(
+    source_dir: Path,
+    package_prefix: str,
+    indexed_files: set[str],
+) -> list[dict[str, Any]]:
     entries: list[dict[str, Any]] = []
-    for path in _iter_source_files(source_dir):
+    for path in _iter_source_files(source_dir, indexed_files=indexed_files):
         relative = _relative_posix(path, source_dir)
         archive_path = PurePosixPath(package_prefix, relative).as_posix()
         entries.append(
@@ -371,12 +406,17 @@ def _manifest_files(source_dir: Path, package_prefix: str) -> list[dict[str, Any
     return entries
 
 
-def _write_tar_gz(source_dir: Path, package_path: Path, package_prefix: str) -> None:
+def _write_tar_gz(
+    source_dir: Path,
+    package_path: Path,
+    package_prefix: str,
+    indexed_files: set[str],
+) -> None:
     package_path.parent.mkdir(parents=True, exist_ok=True)
     with package_path.open("wb") as raw_handle:
         with gzip.GzipFile(fileobj=raw_handle, mode="wb", mtime=0) as gzip_handle:
             with tarfile.open(fileobj=gzip_handle, mode="w") as archive:
-                for path in _iter_source_files(source_dir):
+                for path in _iter_source_files(source_dir, indexed_files=indexed_files):
                     relative = _relative_posix(path, source_dir)
                     archive_name = PurePosixPath(package_prefix, relative).as_posix()
                     info = archive.gettarinfo(str(path), arcname=archive_name)
@@ -409,8 +449,9 @@ def package_agent_artifacts(
     package_path = output_dir / DEFAULT_PACKAGE_NAME
     manifest_path = output_dir / DEFAULT_MANIFEST_NAME
 
-    _write_tar_gz(source_dir, package_path, package_prefix)
-    manifest_files = _manifest_files(source_dir, package_prefix)
+    indexed_files = set(summary["indexed_files"])
+    _write_tar_gz(source_dir, package_path, package_prefix, indexed_files)
+    manifest_files = _manifest_files(source_dir, package_prefix, indexed_files)
     manifest = {
         "schema_version": "1.0",
         "created_at_unix": int(time.time()),

--- a/tests/unit/scripts/test_agent_artifacts.py
+++ b/tests/unit/scripts/test_agent_artifacts.py
@@ -183,6 +183,50 @@ def test_validate_agent_artifacts_ignores_gitignored_residue_but_reports_nonigno
     assert not any("naming_inventory.json" in error for error in report.errors)
 
 
+def test_package_preserves_indexed_gitignored_artifact_without_residue(
+    tmp_path: Path,
+) -> None:
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    (tmp_path / ".gitignore").write_text(
+        "*.csv\nnaming_inventory.json\n",
+        encoding="utf-8",
+    )
+    source = _create_valid_agent_artifacts(tmp_path)
+    root_index_path = source / "index.json"
+    root_index = json.loads(root_index_path.read_text(encoding="utf-8"))
+    root_index["resources"]["testing"]["files"].append("data.csv")
+    _write_json(root_index_path, root_index)
+    _write_text(source / "testing" / "data.csv", "symbol,price\nBTC,1\n")
+    _write_json(source / "naming_inventory.json", {"local_report": True})
+    output_dir = tmp_path / "dist"
+
+    report, summary = agent_artifacts.validate_agent_artifacts(source, quiet=True)
+    package_status = agent_artifacts.package_agent_artifacts(
+        source,
+        output_dir,
+        git_sha="abc123",
+    )
+    verify_status = agent_artifacts.verify_agent_artifact_package(
+        output_dir / agent_artifacts.DEFAULT_PACKAGE_NAME,
+        output_dir / agent_artifacts.DEFAULT_MANIFEST_NAME,
+    )
+
+    assert report.errors == []
+    assert "testing/data.csv" in summary["indexed_files"]
+    manifest = json.loads((output_dir / agent_artifacts.DEFAULT_MANIFEST_NAME).read_text())
+    manifest_paths = {entry["path"] for entry in manifest["files"]}
+    with tarfile.open(output_dir / agent_artifacts.DEFAULT_PACKAGE_NAME, "r:gz") as archive:
+        tar_paths = {member.name for member in archive.getmembers() if member.isfile()}
+    indexed_artifact = "var/agents/testing/data.csv"
+    ignored_residue = "var/agents/naming_inventory.json"
+    assert package_status == 0
+    assert verify_status == 0
+    assert indexed_artifact in manifest_paths
+    assert indexed_artifact in tar_paths
+    assert ignored_residue not in manifest_paths
+    assert ignored_residue not in tar_paths
+
+
 def test_validate_agent_artifacts_reports_empty_source(tmp_path: Path) -> None:
     source = tmp_path / "var" / "agents"
     source.mkdir(parents=True)

--- a/tests/unit/scripts/test_agent_artifacts.py
+++ b/tests/unit/scripts/test_agent_artifacts.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import tarfile
 from pathlib import Path
 
@@ -161,6 +162,25 @@ def test_validate_agent_artifacts_reports_missing_indexed_file(tmp_path: Path) -
     report, _ = agent_artifacts.validate_agent_artifacts(source, quiet=True)
 
     assert any("risk_config_schema.json" in error for error in report.errors)
+
+
+def test_validate_agent_artifacts_ignores_gitignored_residue_but_reports_nonignored(
+    tmp_path: Path,
+) -> None:
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    (tmp_path / ".gitignore").write_text("naming_inventory.json\n", encoding="utf-8")
+    source = _create_valid_agent_artifacts(tmp_path)
+    _write_json(source / "naming_inventory.json", {"local_report": True})
+
+    report, _ = agent_artifacts.validate_agent_artifacts(source, quiet=True)
+
+    assert report.errors == []
+
+    _write_json(source / "unindexed_artifact.json", {"contract_drift": True})
+    report, _ = agent_artifacts.validate_agent_artifacts(source, quiet=True)
+
+    assert any("unindexed_artifact.json" in error for error in report.errors)
+    assert not any("naming_inventory.json" in error for error in report.errors)
 
 
 def test_validate_agent_artifacts_reports_empty_source(tmp_path: Path) -> None:

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6739,
+    "total_tests": 6740,
     "total_files": 796,
     "markers_used": 16
   },

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6738,
+    "total_tests": 6739,
     "total_files": 796,
     "markers_used": 16
   },

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6574,
+    "unit": 6575,
     "asyncio": 380,
     "parametrize": 191,
     "endpoints": 83,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6573,
+    "unit": 6574,
     "asyncio": 380,
     "parametrize": 191,
     "endpoints": 83,

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6738,
+    "total_tests": 6739,
     "total_files": 796,
     "markers_used": 16
   },
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6573,
+    "unit": 6574,
     "asyncio": 380,
     "parametrize": 191,
     "endpoints": 83,
@@ -60233,7 +60233,7 @@
     "tests/unit/scripts/test_agent_artifacts.py": [
       {
         "name": "test_validate_agent_artifacts_accepts_complete_tree",
-        "line": 138,
+        "line": 139,
         "markers": [
           "unit"
         ],
@@ -60241,7 +60241,7 @@
       },
       {
         "name": "test_committed_agent_artifacts_index_matches_tree",
-        "line": 148,
+        "line": 149,
         "markers": [
           "unit"
         ],
@@ -60249,7 +60249,15 @@
       },
       {
         "name": "test_validate_agent_artifacts_reports_missing_indexed_file",
-        "line": 157,
+        "line": 158,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_validate_agent_artifacts_ignores_gitignored_residue_but_reports_nonignored",
+        "line": 167,
         "markers": [
           "unit"
         ],
@@ -60257,7 +60265,7 @@
       },
       {
         "name": "test_validate_agent_artifacts_reports_empty_source",
-        "line": 166,
+        "line": 186,
         "markers": [
           "unit"
         ],
@@ -60265,7 +60273,7 @@
       },
       {
         "name": "test_package_and_verify_agent_artifacts",
-        "line": 175,
+        "line": 195,
         "markers": [
           "unit"
         ],
@@ -60273,7 +60281,7 @@
       },
       {
         "name": "test_verify_agent_artifact_package_rejects_unsafe_path",
-        "line": 196,
+        "line": 216,
         "markers": [
           "unit"
         ],

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6739,
+    "total_tests": 6740,
     "total_files": 796,
     "markers_used": 16
   },
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6574,
+    "unit": 6575,
     "asyncio": 380,
     "parametrize": 191,
     "endpoints": 83,
@@ -60264,7 +60264,7 @@
         "docstring": ""
       },
       {
-        "name": "test_validate_agent_artifacts_reports_empty_source",
+        "name": "test_package_preserves_indexed_gitignored_artifact_without_residue",
         "line": 186,
         "markers": [
           "unit"
@@ -60272,8 +60272,16 @@
         "docstring": ""
       },
       {
+        "name": "test_validate_agent_artifacts_reports_empty_source",
+        "line": 230,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
         "name": "test_package_and_verify_agent_artifacts",
-        "line": 195,
+        "line": 239,
         "markers": [
           "unit"
         ],
@@ -60281,7 +60289,7 @@
       },
       {
         "name": "test_verify_agent_artifact_package_rejects_unsafe_path",
-        "line": 216,
+        "line": 260,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary
Related issue / finding / RJ-routed package: Closes #937

Make `agent-artifacts` enumerate source files through Git ignore rules when the source tree is inside a Git worktree. This excludes ignored local naming inventory residue from validation, packaging, and manifest generation without adding `naming_inventory.json` to the artifact contract.

## Type of change
- [x] CI/Docs/Tooling
- [x] Bug fix
- [x] Tests only

## Scope & Impact
- Affected areas / components: `scripts/agents/agent_artifacts.py`, `tests/unit/scripts/test_agent_artifacts.py`, regenerated `var/agents/testing/*` inventory.
- Behavior change: gitignored files under `var/agents` are excluded from artifact enumeration; nonignored unindexed files still fail validation.

## Test Plan
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Contract tests (if applicable)
- [x] Ran locally: `uv run pytest tests/unit/scripts/test_agent_artifacts.py -q`
- [x] Markers used appropriately (`unit`/`integration`/`slow`/`perf`)

Additional local verification:
- `uv run agent-naming --strict --quiet` -> passed
- `uv run agent-artifacts validate --source var/agents --github-annotations` -> passed
- `uv run pytest tests/unit/scripts/test_agent_artifacts.py -q` -> 7 passed
- `uv run agent-regenerate --verify` -> passed, all context files up-to-date
- `uv run local-ci --profile quick` -> passed, 7004 passed, 8 skipped

## Complexity & Quality Gates
- [x] Mypy/type-check passed
- [x] Xenon/radon complexity gate passed (CC ≤ 15 on live_trade execution)
- [x] No `sys.path` hacks in tests
- [x] No `MagicMock` on `async def` (use `AsyncMock`)
- [x] Import-lint rules respected (no “import up the stack”)

## Observability & Errors
- [ ] Structured JSON logs for new/changed paths
- [ ] Errors include diagnostic context (symbol, order_id, correlation_id)
- [ ] Added/updated sampling examples in tests (if applicable)

Not applicable: agent artifact validation path only; no runtime trading logs or order/error context changed.

## Configuration
- [ ] If config changed: `python -m gpt_trader.cli.config validate --profile <name>` passes
- [ ] Env docs re-generated (if applicable) and committed
- [x] No `ConfigLoader` usages introduced (ConfigManager-only)

## Breaking Changes
- [x] None
- [ ] Documented in PR body and release notes if any

## Checklist
- [x] Acceptance criteria in linked issue(s), finding packet, or routed package met
- [x] Affected paths listed in PR description
- [ ] Changelog entry (if repo uses one)