### PR TITLE
[codex] Add trade idea TUI review screen

### DIFF
--- a/scripts/build_tui_css.py
+++ b/scripts/build_tui_css.py
@@ -61,6 +61,7 @@ CSS_MODULE_ORDER = [
     "screens/help.tcss",
     "screens/credential_validation.tcss",
     "screens/api_setup_wizard.tcss",
+    "screens/ideas_review.tcss",
     # NOTE: main_screen.tcss removed - it defined a conflicting 3-column grid
     # that overwrote the 4x4 Bento grid from workspace.tcss. The tile spans
     # in workspace.tcss are designed for the 4x4 grid.

--- a/src/gpt_trader/tui/app.py
+++ b/src/gpt_trader/tui/app.py
@@ -102,7 +102,8 @@ class TraderApp(
         ("l", "focus_logs", "Focus Logs"),
         ("m", "show_market", "Market"),  # Changed from mode_info
         ("d", "show_details", "Details"),  # New: Details overlay
-        ("i", "show_mode_info", "Mode Info"),  # Moved from 'm' to 'i'
+        ("i", "show_mode_info", "Mode Info"),
+        Binding("I", "show_ideas", "Ideas", show=True),
         ("r", "reconnect_data", "Reconnect"),
         ("p", "panic", "PANIC"),
         ("t", "toggle_theme", "Toggle Theme"),

--- a/src/gpt_trader/tui/app_actions.py
+++ b/src/gpt_trader/tui/app_actions.py
@@ -10,7 +10,12 @@ from typing import TYPE_CHECKING, Any
 
 from gpt_trader.features.live_trade.telemetry import get_execution_telemetry
 from gpt_trader.tui.notification_helpers import notify_action
-from gpt_trader.tui.screens import DetailsScreen, MarketScreen, StrategyDetailScreen
+from gpt_trader.tui.screens import (
+    DetailsScreen,
+    IdeasReviewScreen,
+    MarketScreen,
+    StrategyDetailScreen,
+)
 from gpt_trader.tui.widgets import SlimStatusWidget
 from gpt_trader.tui.widgets.execution_issues_modal import ExecutionIssuesModal
 from gpt_trader.tui.widgets.status import BotStatusWidget
@@ -118,6 +123,10 @@ class TraderAppActionsMixin:
     async def action_show_strategy(self: TraderApp) -> None:
         """Show strategy detail screen."""
         self.push_screen(StrategyDetailScreen())
+
+    async def action_show_ideas(self: TraderApp) -> None:
+        """Show trade-idea review screen."""
+        self.push_screen(IdeasReviewScreen())
 
     async def action_show_help(self: TraderApp) -> None:
         """Show help screen."""

--- a/src/gpt_trader/tui/screens/__init__.py
+++ b/src/gpt_trader/tui/screens/__init__.py
@@ -9,6 +9,7 @@ from .api_setup_wizard import APISetupWizardScreen
 from .credential_validation_screen import CredentialValidationScreen
 from .details_screen import DetailsScreen
 from .full_logs_screen import FullLogsScreen
+from .ideas_review_screen import IdeasReviewScreen
 from .main_screen import MainScreen
 from .market_screen import MarketScreen
 from .mode_selection import ModeSelectionScreen
@@ -21,6 +22,7 @@ __all__ = [
     "CredentialValidationScreen",
     "DetailsScreen",
     "FullLogsScreen",
+    "IdeasReviewScreen",
     "MainScreen",
     "MarketScreen",
     "ModeSelectionScreen",

--- a/src/gpt_trader/tui/screens/ideas_review_screen.py
+++ b/src/gpt_trader/tui/screens/ideas_review_screen.py
@@ -295,12 +295,12 @@ class IdeasReviewScreen(Screen[None]):
             f"Filter: {self._filter_label(self.FILTERS[self._filter_index])} "
             f"({len(visible)} of {len(self._views)})"
         )
-        if visible and self._selected_decision_id not in {
-            view.idea.decision_id for view in visible
-        }:
-            self._selected_decision_id = visible[0].idea.decision_id
-            table.move_cursor(row=0)
-        elif not visible:
+        if visible:
+            visible_decision_ids = [view.idea.decision_id for view in visible]
+            if self._selected_decision_id not in visible_decision_ids:
+                self._selected_decision_id = visible_decision_ids[0]
+            table.move_cursor(row=visible_decision_ids.index(self._selected_decision_id))
+        else:
             self._selected_decision_id = None
         self._render_detail()
 

--- a/src/gpt_trader/tui/screens/ideas_review_screen.py
+++ b/src/gpt_trader/tui/screens/ideas_review_screen.py
@@ -1,0 +1,422 @@
+"""Trade-idea review screen.
+
+This screen is deliberately not wired into ``StateRegistry``/``TuiState``:
+trade-idea review is reviewer workflow state backed by the trade-ideas store,
+not bot telemetry. The TUI stays a thin adapter over ``TradeIdeaService`` and
+does not place, modify, or cancel broker orders.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Literal
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Container, Horizontal, Vertical, VerticalScroll
+from textual.screen import ModalScreen, Screen
+from textual.widgets import Button, DataTable, Input, Label, Static
+
+from gpt_trader.errors import ValidationError
+from gpt_trader.features.trade_ideas import (
+    ALLOWED_TRANSITIONS,
+    ActorType,
+    AuditEvent,
+    PolicyViolationError,
+    TradeIdea,
+    TradeIdeaService,
+    TradeIdeaState,
+    TradeIdeaView,
+    create_trade_idea_service,
+    resolve_trade_idea_actor_id,
+)
+
+ReviewAction = Literal["approve", "reject", "request_changes", "expire"]
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewActionSpec:
+    action: ReviewAction
+    title: str
+    target_state: TradeIdeaState
+
+
+ACTION_SPECS: dict[ReviewAction, ReviewActionSpec] = {
+    "approve": ReviewActionSpec("approve", "Approve", TradeIdeaState.APPROVED),
+    "reject": ReviewActionSpec("reject", "Reject", TradeIdeaState.REJECTED),
+    "request_changes": ReviewActionSpec(
+        "request_changes", "Request Changes", TradeIdeaState.NEEDS_CHANGES
+    ),
+    "expire": ReviewActionSpec("expire", "Expire", TradeIdeaState.EXPIRED),
+}
+
+
+class ReasonModal(ModalScreen[str | None]):
+    """Collect a required reason before a review mutation."""
+
+    BINDINGS = [
+        Binding("escape", "cancel", "Cancel", show=True),
+        Binding("ctrl+s", "submit", "Submit", show=True),
+    ]
+
+    def __init__(
+        self,
+        *,
+        title: str,
+        decision_id: str,
+        policy_violations: list[str] | None = None,
+    ) -> None:
+        super().__init__()
+        self._title = title
+        self._decision_id = decision_id
+        self._policy_violations = policy_violations or []
+
+    def compose(self) -> ComposeResult:
+        with Container(id="ideas-reason-modal"):
+            yield Label(f"{self._title}: {self._decision_id}", classes="modal-title")
+            if self._policy_violations:
+                yield Static("Current approval policy refusals:", classes="modal-warning")
+                for violation in self._policy_violations:
+                    yield Static(f"- {violation}", classes="modal-warning")
+            yield Input(placeholder="Required reason", id="ideas-reason-input")
+            with Horizontal(classes="button-row"):
+                yield Button("Confirm", id="ideas-reason-confirm", variant="primary", disabled=True)
+                yield Button("Cancel", id="ideas-reason-cancel", variant="default")
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        if event.input.id != "ideas-reason-input":
+            return
+        self.query_one("#ideas-reason-confirm", Button).disabled = not bool(event.value.strip())
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "ideas-reason-cancel":
+            self.dismiss(None)
+            return
+        if event.button.id == "ideas-reason-confirm":
+            self.action_submit()
+
+    def action_submit(self) -> None:
+        reason = self.query_one("#ideas-reason-input", Input).value.strip()
+        if not reason:
+            return
+        self.dismiss(reason)
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
+
+class IdeasReviewScreen(Screen[None]):
+    """Keyboard-first trade-idea review surface."""
+
+    BINDINGS = [
+        Binding("a", "review_action('approve')", "Approve", show=True),
+        Binding("x", "review_action('reject')", "Reject", show=True),
+        Binding("c", "review_action('request_changes')", "Changes", show=True),
+        Binding("e", "review_action('expire')", "Expire", show=True),
+        Binding("f", "cycle_filter", "Filter", show=True),
+        Binding("r", "refresh", "Refresh", show=True),
+        Binding("escape", "back", "Back", show=True),
+    ]
+
+    FILTERS: tuple[TradeIdeaState | None, ...] = (
+        None,
+        TradeIdeaState.PROPOSED,
+        TradeIdeaState.NEEDS_CHANGES,
+        TradeIdeaState.APPROVED,
+    )
+
+    def __init__(
+        self,
+        service: TradeIdeaService | None = None,
+        *,
+        reviewer_id: str | None = None,
+    ) -> None:
+        super().__init__()
+        self._service = service
+        self._reviewer_id = reviewer_id
+        self._views: list[TradeIdeaView] = []
+        self._selected_decision_id: str | None = None
+        self._filter_index = 0
+
+    @property
+    def reviewer_id(self) -> str:
+        if self._reviewer_id is None:
+            self._reviewer_id = resolve_trade_idea_actor_id()
+        return self._reviewer_id
+
+    @property
+    def service(self) -> TradeIdeaService:
+        if self._service is None:
+            self._service = create_trade_idea_service()
+        return self._service
+
+    def compose(self) -> ComposeResult:
+        with Container(id="ideas-review"):
+            yield Label("", id="ideas-review-title")
+            yield Label("", id="ideas-review-filter")
+            with Horizontal(id="ideas-review-body"):
+                with Vertical(id="ideas-review-queue-pane"):
+                    yield Label("Queue", classes="pane-title")
+                    queue = DataTable(id="ideas-review-table", zebra_stripes=True)
+                    queue.cursor_type = "row"
+                    yield queue
+                with VerticalScroll(id="ideas-review-detail-pane"):
+                    yield Static("Select a trade idea", id="ideas-review-detail")
+            yield Label(
+                "[a]pprove [x]reject [c]hanges [e]xpire [f]ilter [r]efresh [esc]back",
+                id="ideas-review-actions",
+            )
+
+    def on_mount(self) -> None:
+        table = self.query_one("#ideas-review-table", DataTable)
+        table.add_columns("ID", "STATE", "INSTR", "DIR", "LOSS%", "EXPIRES")
+        self.query_one("#ideas-review-title", Label).update(
+            f"Ideas Review - reviewer: {self.reviewer_id}"
+        )
+        self.action_refresh()
+        self.set_interval(30, self.action_refresh)
+
+    def action_refresh(self) -> None:
+        self.refresh_views(notify=False)
+
+    def refresh_views(self, *, notify: bool = True) -> None:
+        try:
+            self._views = self._sorted_views(self.service.list_views())
+        except ValidationError as error:
+            self.notify(str(error), title="Ideas Review", severity="error", timeout=6)
+            return
+        self._render_queue()
+        if notify:
+            self.notify("Trade ideas refreshed", title="Ideas Review", timeout=2)
+
+    def action_cycle_filter(self) -> None:
+        self._filter_index = (self._filter_index + 1) % len(self.FILTERS)
+        self._render_queue()
+        self.notify(
+            f"Filter: {self._filter_label(self.FILTERS[self._filter_index])}",
+            title="Ideas Review",
+            timeout=2,
+        )
+
+    def action_back(self) -> None:
+        self.app.pop_screen()
+
+    def action_review_action(self, action: ReviewAction) -> None:
+        view = self._selected_view()
+        if view is None:
+            self.notify("Select a trade idea first", title="Ideas Review", severity="warning")
+            return
+        spec = ACTION_SPECS[action]
+        if spec.target_state not in ALLOWED_TRANSITIONS[view.state]:
+            self.notify(
+                f"{spec.title} not allowed from state {view.state.value}",
+                title="Ideas Review",
+                severity="warning",
+                timeout=3,
+            )
+            return
+        violations = self.service.approval_violations(view.idea) if action == "approve" else []
+        self.app.push_screen(
+            ReasonModal(
+                title=spec.title,
+                decision_id=view.idea.decision_id,
+                policy_violations=violations,
+            ),
+            callback=lambda reason: self._handle_reason(action, view.idea.decision_id, reason),
+        )
+
+    def _handle_reason(
+        self,
+        action: ReviewAction,
+        decision_id: str,
+        reason: str | None,
+    ) -> None:
+        if reason is None:
+            return
+        self._mutate(action, decision_id, reason)
+
+    def _mutate(self, action: ReviewAction, decision_id: str, reason: str) -> None:
+        try:
+            if action == "approve":
+                self.service.approve(decision_id, actor_id=self.reviewer_id, reason=reason)
+            elif action == "reject":
+                self.service.reject(decision_id, actor_id=self.reviewer_id, reason=reason)
+            elif action == "request_changes":
+                self.service.request_changes(decision_id, actor_id=self.reviewer_id, reason=reason)
+            elif action == "expire":
+                self.service.expire(
+                    decision_id,
+                    actor_id=self.reviewer_id,
+                    actor_type=ActorType.HUMAN,
+                    reason=reason,
+                )
+        except PolicyViolationError as error:
+            details = "\n".join(error.violations) if error.violations else str(error)
+            self.notify(details, title="Approval refused", severity="error", timeout=8)
+        except ValidationError as error:
+            self.notify(str(error), title="Ideas Review", severity="error", timeout=6)
+        else:
+            self.notify(f"{ACTION_SPECS[action].title} recorded", title="Ideas Review")
+        self.refresh_views(notify=False)
+
+    def on_data_table_row_highlighted(self, event: DataTable.RowHighlighted) -> None:
+        if event.data_table.id != "ideas-review-table":
+            return
+        self._select_row_key(event.row_key)
+
+    def on_data_table_row_selected(self, event: DataTable.RowSelected) -> None:
+        if event.data_table.id != "ideas-review-table":
+            return
+        self._select_row_key(event.row_key)
+
+    def _select_row_key(self, row_key: object) -> None:
+        value = getattr(row_key, "value", row_key)
+        self._selected_decision_id = str(value) if value is not None else None
+        self._render_detail()
+
+    def _render_queue(self) -> None:
+        table = self.query_one("#ideas-review-table", DataTable)
+        table.clear()
+        visible = self._visible_views()
+        for view in visible:
+            idea = view.idea
+            table.add_row(
+                idea.decision_id,
+                view.state.value,
+                idea.instrument,
+                idea.direction.value,
+                self._decimal_text(idea.max_loss.percent_of_account),
+                self._datetime_text(idea.time_horizon.expires_at),
+                key=idea.decision_id,
+            )
+        self.query_one("#ideas-review-filter", Label).update(
+            f"Filter: {self._filter_label(self.FILTERS[self._filter_index])} "
+            f"({len(visible)} of {len(self._views)})"
+        )
+        if visible and self._selected_decision_id not in {
+            view.idea.decision_id for view in visible
+        }:
+            self._selected_decision_id = visible[0].idea.decision_id
+            table.move_cursor(row=0)
+        elif not visible:
+            self._selected_decision_id = None
+        self._render_detail()
+
+    def _render_detail(self) -> None:
+        detail = self.query_one("#ideas-review-detail", Static)
+        view = self._selected_view()
+        if view is None:
+            detail.update("No trade ideas match the current filter.")
+            return
+        detail.update(self._detail_text(view))
+
+    def _selected_view(self) -> TradeIdeaView | None:
+        if self._selected_decision_id is None:
+            return None
+        for view in self._views:
+            if view.idea.decision_id == self._selected_decision_id:
+                return view
+        return None
+
+    def _visible_views(self) -> list[TradeIdeaView]:
+        active_filter = self.FILTERS[self._filter_index]
+        if active_filter is None:
+            return self._views
+        return [view for view in self._views if view.state is active_filter]
+
+    def _sorted_views(self, views: list[TradeIdeaView]) -> list[TradeIdeaView]:
+        state_rank = {
+            TradeIdeaState.PROPOSED: 0,
+            TradeIdeaState.NEEDS_CHANGES: 1,
+            TradeIdeaState.APPROVED: 2,
+        }
+        return sorted(
+            views,
+            key=lambda view: (
+                state_rank.get(view.state, 9),
+                view.idea.time_horizon.expires_at or datetime.max.replace(tzinfo=UTC),
+                view.idea.decision_id,
+            ),
+        )
+
+    def _detail_text(self, view: TradeIdeaView) -> str:
+        idea = view.idea
+        sections = [
+            f"{idea.decision_id}  [{view.state.value}]",
+            "",
+            self._idea_fields(idea),
+            "",
+            "Policy check:",
+            *self._policy_lines(idea),
+            "",
+            "History:",
+            *self._history_lines(view.events),
+        ]
+        return "\n".join(sections)
+
+    def _idea_fields(self, idea: TradeIdea) -> str:
+        return "\n".join(
+            [
+                f"Thesis: {idea.thesis}",
+                f"Instrument: {idea.instrument}",
+                f"Product: {idea.product_type.value}",
+                f"Direction: {idea.direction.value}",
+                "Entry zone: "
+                f"{self._decimal_text(idea.entry_zone.lower)} - "
+                f"{self._decimal_text(idea.entry_zone.upper)}"
+                + (f" ({idea.entry_zone.trigger})" if idea.entry_zone.trigger else ""),
+                f"Invalidation: {idea.invalidation}",
+                f"Target/exit: {idea.target_exit}",
+                "Max loss: "
+                f"{self._decimal_text(idea.max_loss.amount)} / "
+                f"{self._decimal_text(idea.max_loss.percent_of_account)}%",
+                f"Loss assumptions: {self._list_text(idea.max_loss.assumptions)}",
+                "Sizing: "
+                f"qty {self._decimal_text(idea.sizing_recommendation.quantity)}, "
+                f"notional {self._decimal_text(idea.sizing_recommendation.notional)}",
+                f"Sizing rationale: {idea.sizing_recommendation.rationale}",
+                f"Expected hold: {idea.time_horizon.expected_hold}",
+                f"Expires: {self._datetime_text(idea.time_horizon.expires_at)}",
+                f"Data used: {self._list_text(idea.data_used)}",
+                f"Confidence: {idea.confidence.label.value} - {idea.confidence.rationale}",
+                f"Failure mode: {idea.failure_mode}",
+                f"Do not trade if: {self._list_text(idea.do_not_trade_if)}",
+                "Broker ticket: "
+                f"{idea.broker_ticket.venue.value}/{idea.broker_ticket.status.value}",
+            ]
+        )
+
+    def _policy_lines(self, idea: TradeIdea) -> list[str]:
+        violations = self.service.approval_violations(idea)
+        if not violations:
+            return ["PASS would pass approval policy"]
+        return [f"FAIL {violation}" for violation in violations]
+
+    def _history_lines(self, events: tuple[AuditEvent, ...]) -> list[str]:
+        return [
+            " ".join(
+                [
+                    self._datetime_text(event.timestamp),
+                    f"{event.actor_type.value}:{event.actor_id}",
+                    event.action.value,
+                    f"{event.before_state.value if event.before_state else 'none'}->"
+                    f"{event.after_state.value}",
+                    f"reason={event.reason}",
+                ]
+            )
+            for event in events
+        ]
+
+    def _filter_label(self, state: TradeIdeaState | None) -> str:
+        return "all" if state is None else state.value
+
+    def _list_text(self, values: tuple[str, ...]) -> str:
+        return ", ".join(values) if values else "none"
+
+    def _datetime_text(self, value: datetime | None) -> str:
+        return value.isoformat(timespec="minutes") if value is not None else "-"
+
+    def _decimal_text(self, value: Decimal | None) -> str:
+        return str(value) if value is not None else "-"

--- a/src/gpt_trader/tui/styles/main.tcss
+++ b/src/gpt_trader/tui/styles/main.tcss
@@ -5796,3 +5796,111 @@ APISetupWizardScreen #cancel-btn {
 APISetupWizardScreen #cancel-btn:hover {
     background: $error;
 }
+
+
+/* ---------------------------------------------------------------------------- */
+/* SCREENS: Ideas Review                                                      */
+/* Source: styles/screens/ideas_review.tcss                                    */
+/* ---------------------------------------------------------------------------- */
+
+/* ========================================================================== */
+/* TRADE IDEA REVIEW SCREEN                                                   */
+/* ========================================================================== */
+
+IdeasReviewScreen {
+    background: $bg-primary;
+    color: $text-primary;
+}
+
+#ideas-review {
+    height: 100%;
+    layout: vertical;
+    background: $bg-primary;
+}
+
+#ideas-review-title {
+    dock: top;
+    height: 1;
+    padding: 0 2;
+    text-style: bold;
+    background: $bg-elevated;
+    color: $text-primary;
+}
+
+#ideas-review-filter {
+    height: 1;
+    padding: 0 2;
+    background: $bg-secondary;
+    color: $text-muted;
+}
+
+#ideas-review-body {
+    height: 1fr;
+}
+
+#ideas-review-queue-pane {
+    width: 44%;
+    height: 1fr;
+    border-right: solid $border-subtle;
+}
+
+#ideas-review-detail-pane {
+    width: 1fr;
+    height: 1fr;
+    padding: 1 2;
+}
+
+#ideas-review-detail {
+    color: $text-primary;
+}
+
+#ideas-review-table {
+    height: 1fr;
+}
+
+#ideas-review-actions {
+    dock: bottom;
+    height: 1;
+    padding: 0 2;
+    background: $bg-elevated;
+    color: $text-secondary;
+}
+
+IdeasReviewScreen .pane-title {
+    height: 1;
+    padding: 0 1;
+    text-style: bold;
+    background: $bg-secondary;
+    color: $text-secondary;
+}
+
+ReasonModal {
+    align: center middle;
+}
+
+#ideas-reason-modal {
+    width: 72;
+    height: auto;
+    padding: 1 2;
+    border: solid $accent;
+    background: $bg-secondary;
+}
+
+#ideas-reason-modal .modal-title {
+    text-style: bold;
+    color: $text-primary;
+    margin-bottom: 1;
+}
+
+#ideas-reason-modal .modal-warning {
+    color: $warning;
+}
+
+#ideas-reason-input {
+    margin-top: 1;
+}
+
+#ideas-reason-modal .button-row {
+    height: 3;
+    align: right middle;
+}

--- a/src/gpt_trader/tui/styles/main_high_contrast.tcss
+++ b/src/gpt_trader/tui/styles/main_high_contrast.tcss
@@ -5799,3 +5799,111 @@ APISetupWizardScreen #cancel-btn {
 APISetupWizardScreen #cancel-btn:hover {
     background: $error;
 }
+
+
+/* ---------------------------------------------------------------------------- */
+/* SCREENS: Ideas Review                                                      */
+/* Source: styles/screens/ideas_review.tcss                                    */
+/* ---------------------------------------------------------------------------- */
+
+/* ========================================================================== */
+/* TRADE IDEA REVIEW SCREEN                                                   */
+/* ========================================================================== */
+
+IdeasReviewScreen {
+    background: $bg-primary;
+    color: $text-primary;
+}
+
+#ideas-review {
+    height: 100%;
+    layout: vertical;
+    background: $bg-primary;
+}
+
+#ideas-review-title {
+    dock: top;
+    height: 1;
+    padding: 0 2;
+    text-style: bold;
+    background: $bg-elevated;
+    color: $text-primary;
+}
+
+#ideas-review-filter {
+    height: 1;
+    padding: 0 2;
+    background: $bg-secondary;
+    color: $text-muted;
+}
+
+#ideas-review-body {
+    height: 1fr;
+}
+
+#ideas-review-queue-pane {
+    width: 44%;
+    height: 1fr;
+    border-right: solid $border-subtle;
+}
+
+#ideas-review-detail-pane {
+    width: 1fr;
+    height: 1fr;
+    padding: 1 2;
+}
+
+#ideas-review-detail {
+    color: $text-primary;
+}
+
+#ideas-review-table {
+    height: 1fr;
+}
+
+#ideas-review-actions {
+    dock: bottom;
+    height: 1;
+    padding: 0 2;
+    background: $bg-elevated;
+    color: $text-secondary;
+}
+
+IdeasReviewScreen .pane-title {
+    height: 1;
+    padding: 0 1;
+    text-style: bold;
+    background: $bg-secondary;
+    color: $text-secondary;
+}
+
+ReasonModal {
+    align: center middle;
+}
+
+#ideas-reason-modal {
+    width: 72;
+    height: auto;
+    padding: 1 2;
+    border: solid $accent;
+    background: $bg-secondary;
+}
+
+#ideas-reason-modal .modal-title {
+    text-style: bold;
+    color: $text-primary;
+    margin-bottom: 1;
+}
+
+#ideas-reason-modal .modal-warning {
+    color: $warning;
+}
+
+#ideas-reason-input {
+    margin-top: 1;
+}
+
+#ideas-reason-modal .button-row {
+    height: 3;
+    align: right middle;
+}

--- a/src/gpt_trader/tui/styles/main_light.tcss
+++ b/src/gpt_trader/tui/styles/main_light.tcss
@@ -5796,3 +5796,111 @@ APISetupWizardScreen #cancel-btn {
 APISetupWizardScreen #cancel-btn:hover {
     background: $error;
 }
+
+
+/* ---------------------------------------------------------------------------- */
+/* SCREENS: Ideas Review                                                      */
+/* Source: styles/screens/ideas_review.tcss                                    */
+/* ---------------------------------------------------------------------------- */
+
+/* ========================================================================== */
+/* TRADE IDEA REVIEW SCREEN                                                   */
+/* ========================================================================== */
+
+IdeasReviewScreen {
+    background: $bg-primary;
+    color: $text-primary;
+}
+
+#ideas-review {
+    height: 100%;
+    layout: vertical;
+    background: $bg-primary;
+}
+
+#ideas-review-title {
+    dock: top;
+    height: 1;
+    padding: 0 2;
+    text-style: bold;
+    background: $bg-elevated;
+    color: $text-primary;
+}
+
+#ideas-review-filter {
+    height: 1;
+    padding: 0 2;
+    background: $bg-secondary;
+    color: $text-muted;
+}
+
+#ideas-review-body {
+    height: 1fr;
+}
+
+#ideas-review-queue-pane {
+    width: 44%;
+    height: 1fr;
+    border-right: solid $border-subtle;
+}
+
+#ideas-review-detail-pane {
+    width: 1fr;
+    height: 1fr;
+    padding: 1 2;
+}
+
+#ideas-review-detail {
+    color: $text-primary;
+}
+
+#ideas-review-table {
+    height: 1fr;
+}
+
+#ideas-review-actions {
+    dock: bottom;
+    height: 1;
+    padding: 0 2;
+    background: $bg-elevated;
+    color: $text-secondary;
+}
+
+IdeasReviewScreen .pane-title {
+    height: 1;
+    padding: 0 1;
+    text-style: bold;
+    background: $bg-secondary;
+    color: $text-secondary;
+}
+
+ReasonModal {
+    align: center middle;
+}
+
+#ideas-reason-modal {
+    width: 72;
+    height: auto;
+    padding: 1 2;
+    border: solid $accent;
+    background: $bg-secondary;
+}
+
+#ideas-reason-modal .modal-title {
+    text-style: bold;
+    color: $text-primary;
+    margin-bottom: 1;
+}
+
+#ideas-reason-modal .modal-warning {
+    color: $warning;
+}
+
+#ideas-reason-input {
+    margin-top: 1;
+}
+
+#ideas-reason-modal .button-row {
+    height: 3;
+    align: right middle;
+}

--- a/src/gpt_trader/tui/styles/screens/ideas_review.tcss
+++ b/src/gpt_trader/tui/styles/screens/ideas_review.tcss
@@ -1,0 +1,101 @@
+/* ========================================================================== */
+/* TRADE IDEA REVIEW SCREEN                                                   */
+/* ========================================================================== */
+
+IdeasReviewScreen {
+    background: $bg-primary;
+    color: $text-primary;
+}
+
+#ideas-review {
+    height: 100%;
+    layout: vertical;
+    background: $bg-primary;
+}
+
+#ideas-review-title {
+    dock: top;
+    height: 1;
+    padding: 0 2;
+    text-style: bold;
+    background: $bg-elevated;
+    color: $text-primary;
+}
+
+#ideas-review-filter {
+    height: 1;
+    padding: 0 2;
+    background: $bg-secondary;
+    color: $text-muted;
+}
+
+#ideas-review-body {
+    height: 1fr;
+}
+
+#ideas-review-queue-pane {
+    width: 44%;
+    height: 1fr;
+    border-right: solid $border-subtle;
+}
+
+#ideas-review-detail-pane {
+    width: 1fr;
+    height: 1fr;
+    padding: 1 2;
+}
+
+#ideas-review-detail {
+    color: $text-primary;
+}
+
+#ideas-review-table {
+    height: 1fr;
+}
+
+#ideas-review-actions {
+    dock: bottom;
+    height: 1;
+    padding: 0 2;
+    background: $bg-elevated;
+    color: $text-secondary;
+}
+
+IdeasReviewScreen .pane-title {
+    height: 1;
+    padding: 0 1;
+    text-style: bold;
+    background: $bg-secondary;
+    color: $text-secondary;
+}
+
+ReasonModal {
+    align: center middle;
+}
+
+#ideas-reason-modal {
+    width: 72;
+    height: auto;
+    padding: 1 2;
+    border: solid $accent;
+    background: $bg-secondary;
+}
+
+#ideas-reason-modal .modal-title {
+    text-style: bold;
+    color: $text-primary;
+    margin-bottom: 1;
+}
+
+#ideas-reason-modal .modal-warning {
+    color: $warning;
+}
+
+#ideas-reason-input {
+    margin-top: 1;
+}
+
+#ideas-reason-modal .button-row {
+    height: 3;
+    align: right middle;
+}

--- a/tests/unit/gpt_trader/tui/__snapshots__/test_snapshots_ideas_review/TestIdeasReviewSnapshots.test_empty_ideas_review_screen.raw
+++ b/tests/unit/gpt_trader/tui/__snapshots__/test_snapshots_ideas_review/TestIdeasReviewSnapshots.test_empty_ideas_review_screen.raw
@@ -1,0 +1,196 @@
+<svg class="rich-terminal" viewBox="0 0 1482 928.4" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    </style>
+
+    <defs>
+    <clipPath id="terminal-clip-terminal">
+      <rect x="0" y="0" width="1463.0" height="877.4" />
+    </clipPath>
+    <clipPath id="terminal-line-0">
+    <rect x="0" y="1.5" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-1">
+    <rect x="0" y="25.9" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-2">
+    <rect x="0" y="50.3" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-3">
+    <rect x="0" y="74.7" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-4">
+    <rect x="0" y="99.1" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-5">
+    <rect x="0" y="123.5" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-6">
+    <rect x="0" y="147.9" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-7">
+    <rect x="0" y="172.3" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-8">
+    <rect x="0" y="196.7" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-9">
+    <rect x="0" y="221.1" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-10">
+    <rect x="0" y="245.5" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-11">
+    <rect x="0" y="269.9" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-12">
+    <rect x="0" y="294.3" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-13">
+    <rect x="0" y="318.7" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-14">
+    <rect x="0" y="343.1" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-15">
+    <rect x="0" y="367.5" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-16">
+    <rect x="0" y="391.9" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-17">
+    <rect x="0" y="416.3" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-18">
+    <rect x="0" y="440.7" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-19">
+    <rect x="0" y="465.1" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-20">
+    <rect x="0" y="489.5" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-21">
+    <rect x="0" y="513.9" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-22">
+    <rect x="0" y="538.3" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-23">
+    <rect x="0" y="562.7" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-24">
+    <rect x="0" y="587.1" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-25">
+    <rect x="0" y="611.5" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-26">
+    <rect x="0" y="635.9" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-27">
+    <rect x="0" y="660.3" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-28">
+    <rect x="0" y="684.7" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-29">
+    <rect x="0" y="709.1" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-30">
+    <rect x="0" y="733.5" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-31">
+    <rect x="0" y="757.9" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-32">
+    <rect x="0" y="782.3" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-33">
+    <rect x="0" y="806.7" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-34">
+    <rect x="0" y="831.1" width="1464" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1480" height="926.4" rx="8"/><text class="terminal-title" fill="#c5c8c6" text-anchor="middle" x="740" y="27">IdeasReviewSnapshotApp</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+
+    <g transform="translate(9, 41)" clip-path="url(#terminal-clip-terminal)">
+    <rect fill="#121212" x="0" y="1.5" width="329.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="329.4" y="1.5" width="1134.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="25.9" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="244" y="25.9" width="1220" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="50.3" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="61" y="50.3" width="671" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="50.3" width="488" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1220" y="50.3" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d3740" x="0" y="74.7" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d3740" x="48.8" y="74.7" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d3740" x="134.2" y="74.7" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d3740" x="219.6" y="74.7" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d3740" x="280.6" y="74.7" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d3740" x="366" y="74.7" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#2b3339" x="475.8" y="74.7" width="256.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="74.7" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="99.1" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="99.1" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="123.5" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="123.5" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="147.9" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="147.9" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="172.3" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="172.3" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="196.7" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="196.7" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="221.1" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="221.1" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="245.5" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="245.5" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="269.9" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="269.9" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="294.3" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="294.3" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="318.7" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="318.7" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="343.1" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="343.1" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="367.5" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="367.5" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="391.9" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="391.9" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="416.3" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="416.3" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="440.7" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="440.7" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="465.1" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="465.1" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="489.5" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="489.5" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="513.9" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="513.9" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="538.3" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="538.3" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="562.7" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="562.7" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="587.1" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="587.1" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="611.5" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="611.5" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="635.9" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="635.9" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="660.3" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="660.3" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="684.7" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="684.7" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="709.1" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="709.1" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="733.5" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="733.5" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="757.9" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="757.9" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="782.3" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="782.3" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="806.7" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="806.7" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="831.1" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="831.1" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="855.5" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="85.4" y="855.5" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="170.8" y="855.5" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="256.2" y="855.5" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="329.4" y="855.5" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#e0e0e0" x="402.6" y="855.5" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#e0e0e0" x="488" y="855.5" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="536.8" y="855.5" width="927.2" height="24.65" shape-rendering="crispEdges"/>
+    <g class="terminal-matrix">
+    <text class="terminal-r" x="0" y="20" textLength="329.4" clip-path="url(#terminal-line-0)">Ideas&#160;Review&#160;-&#160;reviewer:&#160;rj</text><text class="terminal-r" x="1464" y="20" textLength="12.2" clip-path="url(#terminal-line-0)">
+</text><text class="terminal-r" x="0" y="44.4" textLength="244" clip-path="url(#terminal-line-1)">Filter:&#160;all&#160;(0&#160;of&#160;0)</text><text class="terminal-r" x="1464" y="44.4" textLength="12.2" clip-path="url(#terminal-line-1)">
+</text><text class="terminal-r" x="0" y="68.8" textLength="61" clip-path="url(#terminal-line-2)">Queue</text><text class="terminal-r" x="732" y="68.8" textLength="488" clip-path="url(#terminal-line-2)">No&#160;trade&#160;ideas&#160;match&#160;the&#160;current&#160;filter.</text><text class="terminal-r" x="1464" y="68.8" textLength="12.2" clip-path="url(#terminal-line-2)">
+</text><text class="terminal-r" x="0" y="93.2" textLength="48.8" clip-path="url(#terminal-line-3)">&#160;ID&#160;</text><text class="terminal-r" x="48.8" y="93.2" textLength="85.4" clip-path="url(#terminal-line-3)">&#160;STATE&#160;</text><text class="terminal-r" x="134.2" y="93.2" textLength="85.4" clip-path="url(#terminal-line-3)">&#160;INSTR&#160;</text><text class="terminal-r" x="219.6" y="93.2" textLength="61" clip-path="url(#terminal-line-3)">&#160;DIR&#160;</text><text class="terminal-r" x="280.6" y="93.2" textLength="85.4" clip-path="url(#terminal-line-3)">&#160;LOSS%&#160;</text><text class="terminal-r" x="366" y="93.2" textLength="109.8" clip-path="url(#terminal-line-3)">&#160;EXPIRES&#160;</text><text class="terminal-r" x="1464" y="93.2" textLength="12.2" clip-path="url(#terminal-line-3)">
+</text><text class="terminal-r" x="1464" y="117.6" textLength="12.2" clip-path="url(#terminal-line-4)">
+</text><text class="terminal-r" x="1464" y="142" textLength="12.2" clip-path="url(#terminal-line-5)">
+</text><text class="terminal-r" x="1464" y="166.4" textLength="12.2" clip-path="url(#terminal-line-6)">
+</text><text class="terminal-r" x="1464" y="190.8" textLength="12.2" clip-path="url(#terminal-line-7)">
+</text><text class="terminal-r" x="1464" y="215.2" textLength="12.2" clip-path="url(#terminal-line-8)">
+</text><text class="terminal-r" x="1464" y="239.6" textLength="12.2" clip-path="url(#terminal-line-9)">
+</text><text class="terminal-r" x="1464" y="264" textLength="12.2" clip-path="url(#terminal-line-10)">
+</text><text class="terminal-r" x="1464" y="288.4" textLength="12.2" clip-path="url(#terminal-line-11)">
+</text><text class="terminal-r" x="1464" y="312.8" textLength="12.2" clip-path="url(#terminal-line-12)">
+</text><text class="terminal-r" x="1464" y="337.2" textLength="12.2" clip-path="url(#terminal-line-13)">
+</text><text class="terminal-r" x="1464" y="361.6" textLength="12.2" clip-path="url(#terminal-line-14)">
+</text><text class="terminal-r" x="1464" y="386" textLength="12.2" clip-path="url(#terminal-line-15)">
+</text><text class="terminal-r" x="1464" y="410.4" textLength="12.2" clip-path="url(#terminal-line-16)">
+</text><text class="terminal-r" x="1464" y="434.8" textLength="12.2" clip-path="url(#terminal-line-17)">
+</text><text class="terminal-r" x="1464" y="459.2" textLength="12.2" clip-path="url(#terminal-line-18)">
+</text><text class="terminal-r" x="1464" y="483.6" textLength="12.2" clip-path="url(#terminal-line-19)">
+</text><text class="terminal-r" x="1464" y="508" textLength="12.2" clip-path="url(#terminal-line-20)">
+</text><text class="terminal-r" x="1464" y="532.4" textLength="12.2" clip-path="url(#terminal-line-21)">
+</text><text class="terminal-r" x="1464" y="556.8" textLength="12.2" clip-path="url(#terminal-line-22)">
+</text><text class="terminal-r" x="1464" y="581.2" textLength="12.2" clip-path="url(#terminal-line-23)">
+</text><text class="terminal-r" x="1464" y="605.6" textLength="12.2" clip-path="url(#terminal-line-24)">
+</text><text class="terminal-r" x="1464" y="630" textLength="12.2" clip-path="url(#terminal-line-25)">
+</text><text class="terminal-r" x="1464" y="654.4" textLength="12.2" clip-path="url(#terminal-line-26)">
+</text><text class="terminal-r" x="1464" y="678.8" textLength="12.2" clip-path="url(#terminal-line-27)">
+</text><text class="terminal-r" x="1464" y="703.2" textLength="12.2" clip-path="url(#terminal-line-28)">
+</text><text class="terminal-r" x="1464" y="727.6" textLength="12.2" clip-path="url(#terminal-line-29)">
+</text><text class="terminal-r" x="1464" y="752" textLength="12.2" clip-path="url(#terminal-line-30)">
+</text><text class="terminal-r" x="1464" y="776.4" textLength="12.2" clip-path="url(#terminal-line-31)">
+</text><text class="terminal-r" x="1464" y="800.8" textLength="12.2" clip-path="url(#terminal-line-32)">
+</text><text class="terminal-r" x="1464" y="825.2" textLength="12.2" clip-path="url(#terminal-line-33)">
+</text><text class="terminal-r" x="1464" y="849.6" textLength="12.2" clip-path="url(#terminal-line-34)">
+</text><text class="terminal-r" x="0" y="874" textLength="85.4" clip-path="url(#terminal-line-35)">pprove&#160;</text><text class="terminal-r" x="85.4" y="874" textLength="85.4" clip-path="url(#terminal-line-35)">reject&#160;</text><text class="terminal-r" x="170.8" y="874" textLength="85.4" clip-path="url(#terminal-line-35)">hanges&#160;</text><text class="terminal-r" x="256.2" y="874" textLength="73.2" clip-path="url(#terminal-line-35)">xpire&#160;</text><text class="terminal-r" x="329.4" y="874" textLength="73.2" clip-path="url(#terminal-line-35)">ilter&#160;</text><text class="terminal-r" x="402.6" y="874" textLength="85.4" clip-path="url(#terminal-line-35)">efresh&#160;</text><text class="terminal-r" x="488" y="874" textLength="48.8" clip-path="url(#terminal-line-35)">back</text>
+    </g>
+    </g>
+</svg>

--- a/tests/unit/gpt_trader/tui/__snapshots__/test_snapshots_ideas_review/TestIdeasReviewSnapshots.test_populated_ideas_review_screen.raw
+++ b/tests/unit/gpt_trader/tui/__snapshots__/test_snapshots_ideas_review/TestIdeasReviewSnapshots.test_populated_ideas_review_screen.raw
@@ -1,0 +1,196 @@
+<svg class="rich-terminal" viewBox="0 0 1482 928.4" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    </style>
+
+    <defs>
+    <clipPath id="terminal-clip-terminal">
+      <rect x="0" y="0" width="1463.0" height="877.4" />
+    </clipPath>
+    <clipPath id="terminal-line-0">
+    <rect x="0" y="1.5" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-1">
+    <rect x="0" y="25.9" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-2">
+    <rect x="0" y="50.3" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-3">
+    <rect x="0" y="74.7" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-4">
+    <rect x="0" y="99.1" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-5">
+    <rect x="0" y="123.5" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-6">
+    <rect x="0" y="147.9" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-7">
+    <rect x="0" y="172.3" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-8">
+    <rect x="0" y="196.7" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-9">
+    <rect x="0" y="221.1" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-10">
+    <rect x="0" y="245.5" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-11">
+    <rect x="0" y="269.9" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-12">
+    <rect x="0" y="294.3" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-13">
+    <rect x="0" y="318.7" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-14">
+    <rect x="0" y="343.1" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-15">
+    <rect x="0" y="367.5" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-16">
+    <rect x="0" y="391.9" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-17">
+    <rect x="0" y="416.3" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-18">
+    <rect x="0" y="440.7" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-19">
+    <rect x="0" y="465.1" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-20">
+    <rect x="0" y="489.5" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-21">
+    <rect x="0" y="513.9" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-22">
+    <rect x="0" y="538.3" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-23">
+    <rect x="0" y="562.7" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-24">
+    <rect x="0" y="587.1" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-25">
+    <rect x="0" y="611.5" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-26">
+    <rect x="0" y="635.9" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-27">
+    <rect x="0" y="660.3" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-28">
+    <rect x="0" y="684.7" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-29">
+    <rect x="0" y="709.1" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-30">
+    <rect x="0" y="733.5" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-31">
+    <rect x="0" y="757.9" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-32">
+    <rect x="0" y="782.3" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-33">
+    <rect x="0" y="806.7" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-line-34">
+    <rect x="0" y="831.1" width="1464" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1480" height="926.4" rx="8"/><text class="terminal-title" fill="#c5c8c6" text-anchor="middle" x="740" y="27">IdeasReviewSnapshotApp</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+
+    <g transform="translate(9, 41)" clip-path="url(#terminal-clip-terminal)">
+    <rect fill="#121212" x="0" y="1.5" width="329.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="329.4" y="1.5" width="1134.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="25.9" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="244" y="25.9" width="1220" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="50.3" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="61" y="50.3" width="671" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="50.3" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="976" y="50.3" width="488" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d3740" x="0" y="74.7" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d3740" x="244" y="74.7" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d3740" x="427" y="74.7" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d3740" x="536.8" y="74.7" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d3740" x="610" y="74.7" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d3740" x="695.4" y="74.7" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="74.7" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="74.7" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="0" y="99.1" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="244" y="99.1" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="427" y="99.1" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="536.8" y="99.1" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="610" y="99.1" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="695.4" y="99.1" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="99.1" width="707.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1439.6" y="99.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="123.5" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="244" y="123.5" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="427" y="123.5" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="536.8" y="123.5" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="610" y="123.5" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="695.4" y="123.5" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="123.5" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="805.2" y="123.5" width="658.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="0" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="12.2" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="24.4" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="36.6" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="48.8" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="61" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="73.2" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="85.4" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="97.6" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="109.8" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="122" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="134.2" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="146.4" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="158.6" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="170.8" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="183" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="195.2" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="207.4" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="219.6" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="231.8" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="244" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="256.2" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="268.4" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="280.6" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="292.8" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="305" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="317.2" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="329.4" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="341.6" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="353.8" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="366" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="378.2" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="390.4" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="402.6" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="414.8" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="427" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="439.2" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="451.4" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="463.6" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="475.8" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="488" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="500.2" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="512.4" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#003054" x="524.6" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="536.8" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="549" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="561.2" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="573.4" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="585.6" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="597.8" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="610" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="622.2" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="634.4" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="646.6" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="658.8" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="671" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="683.2" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="695.4" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="707.6" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="719.8" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="147.9" width="231.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="963.8" y="147.9" width="500.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="172.3" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="172.3" width="158.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="890.6" y="172.3" width="573.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="196.7" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="196.7" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="915" y="196.7" width="549" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="221.1" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="221.1" width="305" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1037" y="221.1" width="427" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="245.5" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="245.5" width="451.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1183.4" y="245.5" width="280.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="269.9" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="269.9" width="707.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1439.6" y="269.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="294.3" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="294.3" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="780.8" y="294.3" width="683.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="318.7" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="318.7" width="244" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="976" y="318.7" width="488" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="343.1" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="343.1" width="719.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1451.8" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="367.5" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="367.5" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="805.2" y="367.5" width="658.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="391.9" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="391.9" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1098" y="391.9" width="366" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="416.3" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="416.3" width="573.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1305.4" y="416.3" width="158.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="440.7" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="440.7" width="292.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1024.8" y="440.7" width="439.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="465.1" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="465.1" width="378.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1110.2" y="465.1" width="353.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="489.5" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="489.5" width="597.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1329.8" y="489.5" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="513.9" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="513.9" width="671" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1403" y="513.9" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="538.3" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="538.3" width="280.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1012.6" y="538.3" width="451.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="562.7" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="562.7" width="683.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1415.2" y="562.7" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="587.1" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="587.1" width="610" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1342" y="587.1" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="611.5" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="611.5" width="378.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1110.2" y="611.5" width="353.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="635.9" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="635.9" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="635.9" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="660.3" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="660.3" width="158.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="890.6" y="660.3" width="573.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="684.7" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="684.7" width="378.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1110.2" y="684.7" width="353.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="709.1" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="709.1" width="0" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="709.1" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="733.5" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="733.5" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="733.5" width="634.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="757.9" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="757.9" width="634.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1366.4" y="757.9" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="782.3" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="782.3" width="549" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1281" y="782.3" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="806.7" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="806.7" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="831.1" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="732" y="831.1" width="732" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="855.5" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="85.4" y="855.5" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="170.8" y="855.5" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="256.2" y="855.5" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="329.4" y="855.5" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#e0e0e0" x="402.6" y="855.5" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#e0e0e0" x="488" y="855.5" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="536.8" y="855.5" width="927.2" height="24.65" shape-rendering="crispEdges"/>
+    <g class="terminal-matrix">
+    <text class="terminal-r" x="0" y="20" textLength="329.4" clip-path="url(#terminal-line-0)">Ideas&#160;Review&#160;-&#160;reviewer:&#160;rj</text><text class="terminal-r" x="1464" y="20" textLength="12.2" clip-path="url(#terminal-line-0)">
+</text><text class="terminal-r" x="0" y="44.4" textLength="244" clip-path="url(#terminal-line-1)">Filter:&#160;all&#160;(2&#160;of&#160;2)</text><text class="terminal-r" x="1464" y="44.4" textLength="12.2" clip-path="url(#terminal-line-1)">
+</text><text class="terminal-r" x="0" y="68.8" textLength="61" clip-path="url(#terminal-line-2)">Queue</text><text class="terminal-r" x="732" y="68.8" textLength="244" clip-path="url(#terminal-line-2)">trade-20260612-001&#160;&#160;</text><text class="terminal-r" x="1464" y="68.8" textLength="12.2" clip-path="url(#terminal-line-2)">
+</text><text class="terminal-r" x="0" y="93.2" textLength="244" clip-path="url(#terminal-line-3)">&#160;ID&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-r" x="244" y="93.2" textLength="183" clip-path="url(#terminal-line-3)">&#160;STATE&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-r" x="427" y="93.2" textLength="109.8" clip-path="url(#terminal-line-3)">&#160;INSTR&#160;&#160;&#160;</text><text class="terminal-r" x="536.8" y="93.2" textLength="73.2" clip-path="url(#terminal-line-3)">&#160;DIR&#160;&#160;</text><text class="terminal-r" x="610" y="93.2" textLength="85.4" clip-path="url(#terminal-line-3)">&#160;LOSS%&#160;</text><text class="terminal-r" x="695.4" y="93.2" textLength="36.6" clip-path="url(#terminal-line-3)">&#160;EX</text><text class="terminal-r" x="1464" y="93.2" textLength="12.2" clip-path="url(#terminal-line-3)">
+</text><text class="terminal-r" x="0" y="117.6" textLength="244" clip-path="url(#terminal-line-4)">&#160;trade-20260612-001&#160;</text><text class="terminal-r" x="244" y="117.6" textLength="183" clip-path="url(#terminal-line-4)">&#160;proposed&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-r" x="427" y="117.6" textLength="109.8" clip-path="url(#terminal-line-4)">&#160;BTC-USD&#160;</text><text class="terminal-r" x="536.8" y="117.6" textLength="73.2" clip-path="url(#terminal-line-4)">&#160;long&#160;</text><text class="terminal-r" x="610" y="117.6" textLength="85.4" clip-path="url(#terminal-line-4)">&#160;1.5&#160;&#160;&#160;</text><text class="terminal-r" x="695.4" y="117.6" textLength="36.6" clip-path="url(#terminal-line-4)">&#160;20</text><text class="terminal-r" x="732" y="117.6" textLength="707.6" clip-path="url(#terminal-line-4)">Thesis:&#160;BTC&#160;reclaiming&#160;the&#160;50-day&#160;average&#160;with&#160;rising&#160;spot</text><text class="terminal-r" x="1464" y="117.6" textLength="12.2" clip-path="url(#terminal-line-4)">
+</text><text class="terminal-r" x="0" y="142" textLength="244" clip-path="url(#terminal-line-5)">&#160;trade-20260612-002&#160;</text><text class="terminal-r" x="244" y="142" textLength="183" clip-path="url(#terminal-line-5)">&#160;needs_changes&#160;</text><text class="terminal-r" x="427" y="142" textLength="109.8" clip-path="url(#terminal-line-5)">&#160;BTC-USD&#160;</text><text class="terminal-r" x="536.8" y="142" textLength="73.2" clip-path="url(#terminal-line-5)">&#160;long&#160;</text><text class="terminal-r" x="610" y="142" textLength="85.4" clip-path="url(#terminal-line-5)">&#160;1.5&#160;&#160;&#160;</text><text class="terminal-r" x="695.4" y="142" textLength="36.6" clip-path="url(#terminal-line-5)">&#160;20</text><text class="terminal-r" x="732" y="142" textLength="73.2" clip-path="url(#terminal-line-5)">volume</text><text class="terminal-r" x="1464" y="142" textLength="12.2" clip-path="url(#terminal-line-5)">
+</text><text class="terminal-r" x="536.8" y="166.4" textLength="12.2" clip-path="url(#terminal-line-6)">▌</text><text class="terminal-r" x="732" y="166.4" textLength="231.8" clip-path="url(#terminal-line-6)">Instrument:&#160;BTC-USD</text><text class="terminal-r" x="1464" y="166.4" textLength="12.2" clip-path="url(#terminal-line-6)">
+</text><text class="terminal-r" x="732" y="190.8" textLength="158.6" clip-path="url(#terminal-line-7)">Product:&#160;spot</text><text class="terminal-r" x="1464" y="190.8" textLength="12.2" clip-path="url(#terminal-line-7)">
+</text><text class="terminal-r" x="732" y="215.2" textLength="183" clip-path="url(#terminal-line-8)">Direction:&#160;long</text><text class="terminal-r" x="1464" y="215.2" textLength="12.2" clip-path="url(#terminal-line-8)">
+</text><text class="terminal-r" x="732" y="239.6" textLength="305" clip-path="url(#terminal-line-9)">Entry&#160;zone:&#160;60000&#160;-&#160;61500</text><text class="terminal-r" x="1464" y="239.6" textLength="12.2" clip-path="url(#terminal-line-9)">
+</text><text class="terminal-r" x="732" y="264" textLength="451.4" clip-path="url(#terminal-line-10)">Invalidation:&#160;Daily&#160;close&#160;below&#160;58000</text><text class="terminal-r" x="1464" y="264" textLength="12.2" clip-path="url(#terminal-line-10)">
+</text><text class="terminal-r" x="732" y="288.4" textLength="707.6" clip-path="url(#terminal-line-11)">Target/exit:&#160;Take&#160;profit&#160;at&#160;67000&#160;or&#160;exit&#160;after&#160;10&#160;trading</text><text class="terminal-r" x="1464" y="288.4" textLength="12.2" clip-path="url(#terminal-line-11)">
+</text><text class="terminal-r" x="732" y="312.8" textLength="48.8" clip-path="url(#terminal-line-12)">days</text><text class="terminal-r" x="1464" y="312.8" textLength="12.2" clip-path="url(#terminal-line-12)">
+</text><text class="terminal-r" x="732" y="337.2" textLength="244" clip-path="url(#terminal-line-13)">Max&#160;loss:&#160;250&#160;/&#160;1.5%</text><text class="terminal-r" x="1464" y="337.2" textLength="12.2" clip-path="url(#terminal-line-13)">
+</text><text class="terminal-r" x="732" y="361.6" textLength="719.8" clip-path="url(#terminal-line-14)">Loss&#160;assumptions:&#160;Fill&#160;at&#160;zone&#160;midpoint,&#160;No&#160;slippage&#160;beyond</text><text class="terminal-r" x="1464" y="361.6" textLength="12.2" clip-path="url(#terminal-line-14)">
+</text><text class="terminal-r" x="732" y="386" textLength="73.2" clip-path="url(#terminal-line-15)">10&#160;bps</text><text class="terminal-r" x="1464" y="386" textLength="12.2" clip-path="url(#terminal-line-15)">
+</text><text class="terminal-r" x="732" y="410.4" textLength="366" clip-path="url(#terminal-line-16)">Sizing:&#160;qty&#160;0.1,&#160;notional&#160;6075</text><text class="terminal-r" x="1464" y="410.4" textLength="12.2" clip-path="url(#terminal-line-16)">
+</text><text class="terminal-r" x="732" y="434.8" textLength="573.4" clip-path="url(#terminal-line-17)">Sizing&#160;rationale:&#160;Half-Kelly&#160;on&#160;backtested&#160;edge</text><text class="terminal-r" x="1464" y="434.8" textLength="12.2" clip-path="url(#terminal-line-17)">
+</text><text class="terminal-r" x="732" y="459.2" textLength="292.8" clip-path="url(#terminal-line-18)">Expected&#160;hold:&#160;3-10&#160;days</text><text class="terminal-r" x="1464" y="459.2" textLength="12.2" clip-path="url(#terminal-line-18)">
+</text><text class="terminal-r" x="732" y="483.6" textLength="378.2" clip-path="url(#terminal-line-19)">Expires:&#160;2026-06-19T16:00+00:00</text><text class="terminal-r" x="1464" y="483.6" textLength="12.2" clip-path="url(#terminal-line-19)">
+</text><text class="terminal-r" x="732" y="508" textLength="597.8" clip-path="url(#terminal-line-20)">Data&#160;used:&#160;coinbase:candles:BTC-USD:1d:2026-06-11</text><text class="terminal-r" x="1464" y="508" textLength="12.2" clip-path="url(#terminal-line-20)">
+</text><text class="terminal-r" x="732" y="532.4" textLength="671" clip-path="url(#terminal-line-21)">Confidence:&#160;medium&#160;-&#160;Volume&#160;confirmation&#160;present,&#160;macro</text><text class="terminal-r" x="1464" y="532.4" textLength="12.2" clip-path="url(#terminal-line-21)">
+</text><text class="terminal-r" x="732" y="556.8" textLength="280.6" clip-path="url(#terminal-line-22)">calendar&#160;risk&#160;this&#160;week</text><text class="terminal-r" x="1464" y="556.8" textLength="12.2" clip-path="url(#terminal-line-22)">
+</text><text class="terminal-r" x="732" y="581.2" textLength="683.2" clip-path="url(#terminal-line-23)">Failure&#160;mode:&#160;False&#160;breakout&#160;into&#160;a&#160;macro-driven&#160;selloff</text><text class="terminal-r" x="1464" y="581.2" textLength="12.2" clip-path="url(#terminal-line-23)">
+</text><text class="terminal-r" x="732" y="605.6" textLength="610" clip-path="url(#terminal-line-24)">Do&#160;not&#160;trade&#160;if:&#160;FOMC&#160;announcement&#160;within&#160;24&#160;hours</text><text class="terminal-r" x="1464" y="605.6" textLength="12.2" clip-path="url(#terminal-line-24)">
+</text><text class="terminal-r" x="732" y="630" textLength="378.2" clip-path="url(#terminal-line-25)">Broker&#160;ticket:&#160;none/not_created</text><text class="terminal-r" x="1464" y="630" textLength="12.2" clip-path="url(#terminal-line-25)">
+</text><text class="terminal-r" x="1464" y="654.4" textLength="12.2" clip-path="url(#terminal-line-26)">
+</text><text class="terminal-r" x="732" y="678.8" textLength="158.6" clip-path="url(#terminal-line-27)">Policy&#160;check:</text><text class="terminal-r" x="1464" y="678.8" textLength="12.2" clip-path="url(#terminal-line-27)">
+</text><text class="terminal-r" x="732" y="703.2" textLength="378.2" clip-path="url(#terminal-line-28)">PASS&#160;would&#160;pass&#160;approval&#160;policy</text><text class="terminal-r" x="1464" y="703.2" textLength="12.2" clip-path="url(#terminal-line-28)">
+</text><text class="terminal-r" x="1464" y="727.6" textLength="12.2" clip-path="url(#terminal-line-29)">
+</text><text class="terminal-r" x="732" y="752" textLength="97.6" clip-path="url(#terminal-line-30)">History:</text><text class="terminal-r" x="1464" y="752" textLength="12.2" clip-path="url(#terminal-line-30)">
+</text><text class="terminal-r" x="732" y="776.4" textLength="634.4" clip-path="url(#terminal-line-31)">2026-06-12T10:00+00:00&#160;ai:idea-generator-v1&#160;proposed</text><text class="terminal-r" x="1464" y="776.4" textLength="12.2" clip-path="url(#terminal-line-31)">
+</text><text class="terminal-r" x="732" y="800.8" textLength="549" clip-path="url(#terminal-line-32)">none-&gt;proposed&#160;reason=New&#160;trade&#160;idea&#160;proposed</text><text class="terminal-r" x="1464" y="800.8" textLength="12.2" clip-path="url(#terminal-line-32)">
+</text><text class="terminal-r" x="1464" y="825.2" textLength="12.2" clip-path="url(#terminal-line-33)">
+</text><text class="terminal-r" x="1464" y="849.6" textLength="12.2" clip-path="url(#terminal-line-34)">
+</text><text class="terminal-r" x="0" y="874" textLength="85.4" clip-path="url(#terminal-line-35)">pprove&#160;</text><text class="terminal-r" x="85.4" y="874" textLength="85.4" clip-path="url(#terminal-line-35)">reject&#160;</text><text class="terminal-r" x="170.8" y="874" textLength="85.4" clip-path="url(#terminal-line-35)">hanges&#160;</text><text class="terminal-r" x="256.2" y="874" textLength="73.2" clip-path="url(#terminal-line-35)">xpire&#160;</text><text class="terminal-r" x="329.4" y="874" textLength="73.2" clip-path="url(#terminal-line-35)">ilter&#160;</text><text class="terminal-r" x="402.6" y="874" textLength="85.4" clip-path="url(#terminal-line-35)">efresh&#160;</text><text class="terminal-r" x="488" y="874" textLength="48.8" clip-path="url(#terminal-line-35)">back</text>
+    </g>
+    </g>
+</svg>

--- a/tests/unit/gpt_trader/tui/test_ideas_review_screen.py
+++ b/tests/unit/gpt_trader/tui/test_ideas_review_screen.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+from tests.unit.gpt_trader.features.trade_ideas.conftest import build_trade_idea
+from textual.app import App
+
+from gpt_trader.features.trade_ideas import (
+    ActorType,
+    AuditAction,
+    MaxLoss,
+    TradeIdeaService,
+    TradeIdeaState,
+)
+from gpt_trader.tui.screens.ideas_review_screen import IdeasReviewScreen
+
+
+class IdeasReviewTestApp(App):
+    def __init__(self, screen: IdeasReviewScreen) -> None:
+        super().__init__()
+        self.ideas_screen = screen
+
+
+@pytest.fixture
+def service(tmp_path: Path) -> TradeIdeaService:
+    return TradeIdeaService(
+        tmp_path / "trade_ideas",
+        now_factory=lambda: datetime(2026, 6, 12, 10, 0, tzinfo=UTC),
+    )
+
+
+def _app(service: TradeIdeaService) -> IdeasReviewTestApp:
+    return IdeasReviewTestApp(IdeasReviewScreen(service=service, reviewer_id="rj"))
+
+
+def _text(widget) -> str:
+    return str(widget.render())
+
+
+async def _push_ideas_screen(pilot) -> IdeasReviewScreen:
+    await pilot.app.push_screen(pilot.app.ideas_screen)
+    await pilot.pause()
+    return pilot.app.ideas_screen
+
+
+@pytest.mark.asyncio
+async def test_empty_store_renders_empty_state(service: TradeIdeaService) -> None:
+    async with _app(service).run_test(size=(100, 30)) as pilot:
+        screen = await _push_ideas_screen(pilot)
+        detail = _text(screen.query_one("#ideas-review-detail"))
+        table = screen.query_one("#ideas-review-table")
+
+    assert "No trade ideas match" in str(detail)
+    assert table.row_count == 0
+
+
+@pytest.mark.asyncio
+async def test_populated_queue_renders_detail_and_policy(service: TradeIdeaService) -> None:
+    idea = build_trade_idea()
+    service.propose(idea, actor_id="idea-generator-v1")
+
+    async with _app(service).run_test(size=(120, 36)) as pilot:
+        screen = await _push_ideas_screen(pilot)
+        detail = _text(screen.query_one("#ideas-review-detail"))
+        table = screen.query_one("#ideas-review-table")
+
+    assert table.row_count == 1
+    assert idea.decision_id in detail
+    assert "BTC reclaiming the 50-day average" in detail
+    assert "PASS would pass approval policy" in detail
+    assert "History:" in detail
+
+
+@pytest.mark.asyncio
+async def test_policy_violations_are_listed(service: TradeIdeaService) -> None:
+    idea = build_trade_idea(
+        max_loss=MaxLoss(amount=Decimal("1200"), percent_of_account=Decimal("12"))
+    )
+    service.propose(idea, actor_id="idea-generator-v1")
+
+    async with _app(service).run_test(size=(120, 36)) as pilot:
+        screen = await _push_ideas_screen(pilot)
+        detail = _text(screen.query_one("#ideas-review-detail"))
+
+    assert "FAIL max_loss 12% exceeds budget cap" in detail
+
+
+@pytest.mark.asyncio
+async def test_approve_flow_records_human_reason(service: TradeIdeaService) -> None:
+    idea = build_trade_idea()
+    service.propose(idea, actor_id="idea-generator-v1")
+
+    async with _app(service).run_test(size=(120, 36)) as pilot:
+        await _push_ideas_screen(pilot)
+        await pilot.press("a")
+        await pilot.pause()
+        await pilot.press("ctrl+s")
+        await pilot.pause()
+        assert service.get(idea.decision_id).state is TradeIdeaState.PROPOSED
+        await pilot.click("#ideas-reason-input")
+        await pilot.press(*"Risk verified")
+        await pilot.press("ctrl+s")
+        await pilot.pause()
+
+    view = service.get(idea.decision_id)
+    assert view.state is TradeIdeaState.APPROVED
+    event = view.events[-1]
+    assert event.action is AuditAction.APPROVED
+    assert event.actor_type is ActorType.HUMAN
+    assert event.actor_id == "rj"
+    assert event.reason == "Risk verified"
+
+
+@pytest.mark.asyncio
+async def test_approve_refusal_keeps_state_unchanged(service: TradeIdeaService) -> None:
+    idea = build_trade_idea(
+        max_loss=MaxLoss(amount=Decimal("1200"), percent_of_account=Decimal("12"))
+    )
+    service.propose(idea, actor_id="idea-generator-v1")
+
+    async with _app(service).run_test(size=(120, 36)) as pilot:
+        await _push_ideas_screen(pilot)
+        await pilot.press("a")
+        await pilot.pause()
+        await pilot.click("#ideas-reason-input")
+        await pilot.press(*"Risk accepted")
+        await pilot.press("ctrl+s")
+        await pilot.pause()
+
+    view = service.get(idea.decision_id)
+    assert view.state is TradeIdeaState.PROPOSED
+    assert [event.action for event in view.events] == [AuditAction.PROPOSED]
+
+
+@pytest.mark.asyncio
+async def test_reject_and_request_changes_record_events(service: TradeIdeaService) -> None:
+    rejected = build_trade_idea(decision_id="trade-20260612-reject")
+    needs_changes = build_trade_idea(decision_id="trade-20260612-changes")
+    service.propose(rejected, actor_id="idea-generator-v1")
+    service.propose(needs_changes, actor_id="idea-generator-v1")
+
+    async with _app(service).run_test(size=(120, 36)) as pilot:
+        screen = await _push_ideas_screen(pilot)
+        screen._mutate("reject", rejected.decision_id, "No longer attractive")
+        screen._mutate("request_changes", needs_changes.decision_id, "Add invalidation evidence")
+
+    rejected_view = service.get(rejected.decision_id)
+    changes_view = service.get(needs_changes.decision_id)
+    assert rejected_view.state is TradeIdeaState.REJECTED
+    assert rejected_view.events[-1].actor_type is ActorType.HUMAN
+    assert rejected_view.events[-1].reason == "No longer attractive"
+    assert changes_view.state is TradeIdeaState.NEEDS_CHANGES
+    assert changes_view.events[-1].actor_type is ActorType.HUMAN
+    assert changes_view.events[-1].reason == "Add invalidation evidence"
+
+
+@pytest.mark.asyncio
+async def test_terminal_state_action_is_noop(service: TradeIdeaService) -> None:
+    idea = build_trade_idea()
+    service.propose(idea, actor_id="idea-generator-v1")
+    service.reject(idea.decision_id, actor_id="rj", reason="Rejected already")
+
+    async with _app(service).run_test(size=(120, 36)) as pilot:
+        await _push_ideas_screen(pilot)
+        await pilot.press("a")
+        await pilot.pause()
+
+    view = service.get(idea.decision_id)
+    assert view.state is TradeIdeaState.REJECTED
+    assert [event.action for event in view.events] == [
+        AuditAction.PROPOSED,
+        AuditAction.REJECTED,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_filter_cycle_changes_visible_rows(service: TradeIdeaService) -> None:
+    proposed = build_trade_idea(decision_id="trade-20260612-proposed")
+    approved = build_trade_idea(decision_id="trade-20260612-approved")
+    service.propose(proposed, actor_id="idea-generator-v1")
+    service.propose(approved, actor_id="idea-generator-v1")
+    service.approve(approved.decision_id, actor_id="rj", reason="Risk verified")
+
+    async with _app(service).run_test(size=(120, 36)) as pilot:
+        screen = await _push_ideas_screen(pilot)
+        table = screen.query_one("#ideas-review-table")
+        assert table.row_count == 2
+        await pilot.press("f")
+        await pilot.pause()
+        assert table.row_count == 1
+        assert "proposed" in _text(screen.query_one("#ideas-review-filter"))
+        await pilot.press("f")
+        await pilot.pause()
+        assert table.row_count == 0
+        assert "needs_changes" in _text(screen.query_one("#ideas-review-filter"))

--- a/tests/unit/gpt_trader/tui/test_ideas_review_screen.py
+++ b/tests/unit/gpt_trader/tui/test_ideas_review_screen.py
@@ -196,3 +196,31 @@ async def test_filter_cycle_changes_visible_rows(service: TradeIdeaService) -> N
         await pilot.pause()
         assert table.row_count == 0
         assert "needs_changes" in _text(screen.query_one("#ideas-review-filter"))
+
+
+@pytest.mark.asyncio
+async def test_refresh_preserves_selected_visible_idea(service: TradeIdeaService) -> None:
+    first = build_trade_idea(decision_id="trade-20260612-001")
+    selected = build_trade_idea(decision_id="trade-20260612-002")
+    third = build_trade_idea(decision_id="trade-20260612-003")
+    service.propose(first, actor_id="idea-generator-v1")
+    service.propose(selected, actor_id="idea-generator-v1")
+    service.propose(third, actor_id="idea-generator-v1")
+
+    async with _app(service).run_test(size=(120, 36)) as pilot:
+        screen = await _push_ideas_screen(pilot)
+        table = screen.query_one("#ideas-review-table")
+        table.move_cursor(row=1)
+        screen._select_row_key(selected.decision_id)
+        await pilot.pause()
+
+        screen.refresh_views(notify=False)
+        await pilot.pause()
+
+        selected_row = table.get_row_at(table.cursor_row)
+        detail = _text(screen.query_one("#ideas-review-detail"))
+
+    assert screen._selected_decision_id == selected.decision_id
+    assert selected_row[0] == selected.decision_id
+    assert table.cursor_row == 1
+    assert selected.decision_id in detail

--- a/tests/unit/gpt_trader/tui/test_screen_flows_quick_navigation_and_state.py
+++ b/tests/unit/gpt_trader/tui/test_screen_flows_quick_navigation_and_state.py
@@ -212,3 +212,19 @@ class TestModeInfoFlow:
 
             assert len(app.screen_stack) > initial_stack_size
             assert isinstance(app.screen, ModeInfoModal)
+
+    @pytest.mark.asyncio
+    async def test_ideas_review_opens_on_shift_i(self, mock_bot_with_status):
+        """Test that pressing 'I' opens the trade-idea review screen."""
+        app = TraderApp(bot=mock_bot_with_status)
+
+        async with app.run_test() as pilot:
+            from gpt_trader.tui.screens import IdeasReviewScreen
+
+            initial_stack_size = len(app.screen_stack)
+
+            await pilot.press("I")
+            await pilot.pause()
+
+            assert len(app.screen_stack) > initial_stack_size
+            assert isinstance(app.screen, IdeasReviewScreen)

--- a/tests/unit/gpt_trader/tui/test_snapshots_ideas_review.py
+++ b/tests/unit/gpt_trader/tui/test_snapshots_ideas_review.py
@@ -1,0 +1,64 @@
+"""Visual snapshots for the trade-idea review screen."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from tests.unit.gpt_trader.features.trade_ideas.conftest import build_trade_idea
+from textual.app import App
+
+from gpt_trader.features.trade_ideas import TradeIdeaService
+from gpt_trader.tui.screens.ideas_review_screen import IdeasReviewScreen
+
+
+class IdeasReviewSnapshotApp(App):
+    def __init__(self, service: TradeIdeaService) -> None:
+        super().__init__()
+        self._service = service
+
+    async def action_open_ideas(self) -> None:
+        await self.push_screen(IdeasReviewScreen(service=self._service, reviewer_id="rj"))
+
+
+def _service(root: Path) -> TradeIdeaService:
+    return TradeIdeaService(
+        root / "trade_ideas",
+        now_factory=lambda: datetime(2026, 6, 12, 10, 0, tzinfo=UTC),
+    )
+
+
+class TestIdeasReviewSnapshots:
+    def test_empty_ideas_review_screen(self, snap_compare, tmp_path: Path) -> None:
+        async def open_ideas(pilot) -> None:
+            await pilot.app.action_open_ideas()
+            await pilot.pause()
+
+        assert snap_compare(
+            IdeasReviewSnapshotApp(_service(tmp_path)),
+            terminal_size=(120, 36),
+            run_before=open_ideas,
+        )
+
+    def test_populated_ideas_review_screen(self, snap_compare, tmp_path: Path) -> None:
+        service = _service(tmp_path)
+        service.propose(build_trade_idea(), actor_id="idea-generator-v1")
+        service.propose(
+            build_trade_idea(decision_id="trade-20260612-002", thesis="ETH failed breakout"),
+            actor_id="idea-generator-v1",
+        )
+        service.request_changes(
+            "trade-20260612-002",
+            actor_id="rj",
+            reason="Add stronger invalidation evidence",
+        )
+
+        async def open_ideas(pilot) -> None:
+            await pilot.app.action_open_ideas()
+            await pilot.pause()
+
+        assert snap_compare(
+            IdeasReviewSnapshotApp(service),
+            terminal_size=(120, 36),
+            run_before=open_ideas,
+        )

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,8 +7,8 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6740,
-    "total_files": 796,
+    "total_tests": 6751,
+    "total_files": 798,
     "markers_used": 16
   },
   "quick_commands": {

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6751,
+    "total_tests": 6752,
     "total_files": 798,
     "markers_used": 16
   },

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,8 +95,8 @@
     ]
   },
   "counts": {
-    "unit": 6575,
-    "asyncio": 380,
+    "unit": 6586,
+    "asyncio": 389,
     "parametrize": 191,
     "endpoints": 83,
     "property": 82,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,8 +95,8 @@
     ]
   },
   "counts": {
-    "unit": 6586,
-    "asyncio": 389,
+    "unit": 6587,
+    "asyncio": 390,
     "parametrize": 191,
     "endpoints": 83,
     "property": 82,

--- a/var/agents/testing/source_test_map.json
+++ b/var/agents/testing/source_test_map.json
@@ -1,8 +1,8 @@
 {
   "version": "1.0",
   "summary": {
-    "tests_scanned": 712,
-    "source_modules": 371,
+    "tests_scanned": 714,
+    "source_modules": 372,
     "unresolved_modules": 3
   },
   "source_to_tests": {
@@ -1292,7 +1292,9 @@
       "tests/unit/gpt_trader/features/trade_ideas/test_service_preapproval_broker_ticket.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_snapshot.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_store.py",
-      "tests/unit/gpt_trader/features/trade_ideas/test_workflow.py"
+      "tests/unit/gpt_trader/features/trade_ideas/test_workflow.py",
+      "tests/unit/gpt_trader/tui/test_ideas_review_screen.py",
+      "tests/unit/gpt_trader/tui/test_snapshots_ideas_review.py"
     ],
     "gpt_trader.logging.correlation": [
       "tests/unit/gpt_trader/features/live_trade/execution/test_order_submission_observability.py",
@@ -1749,6 +1751,7 @@
     ],
     "gpt_trader.tui.screens": [
       "tests/unit/gpt_trader/tui/test_screen_flows_help.py",
+      "tests/unit/gpt_trader/tui/test_screen_flows_quick_navigation_and_state.py",
       "tests/unit/gpt_trader/tui/test_screens.py"
     ],
     "gpt_trader.tui.screens.alert_history": [
@@ -1761,6 +1764,10 @@
     "gpt_trader.tui.screens.help": [
       "tests/unit/gpt_trader/tui/test_screen_flows_help.py",
       "tests/unit/gpt_trader/tui/test_screen_flows_quick_navigation_and_state.py"
+    ],
+    "gpt_trader.tui.screens.ideas_review_screen": [
+      "tests/unit/gpt_trader/tui/test_ideas_review_screen.py",
+      "tests/unit/gpt_trader/tui/test_snapshots_ideas_review.py"
     ],
     "gpt_trader.tui.screens.main_screen": [
       "tests/unit/gpt_trader/tui/services/test_state_registry.py",
@@ -4564,6 +4571,10 @@
     "tests/unit/gpt_trader/tui/test_helpers.py": [
       "gpt_trader.tui"
     ],
+    "tests/unit/gpt_trader/tui/test_ideas_review_screen.py": [
+      "gpt_trader.features.trade_ideas",
+      "gpt_trader.tui.screens.ideas_review_screen"
+    ],
     "tests/unit/gpt_trader/tui/test_indicator_contributions.py": [
       "gpt_trader.tui.types"
     ],
@@ -4602,12 +4613,17 @@
     ],
     "tests/unit/gpt_trader/tui/test_screen_flows_quick_navigation_and_state.py": [
       "gpt_trader.tui.app",
+      "gpt_trader.tui.screens",
       "gpt_trader.tui.screens.help",
       "gpt_trader.tui.widgets"
     ],
     "tests/unit/gpt_trader/tui/test_screens.py": [
       "gpt_trader.tui.screens",
       "gpt_trader.tui.state"
+    ],
+    "tests/unit/gpt_trader/tui/test_snapshots_ideas_review.py": [
+      "gpt_trader.features.trade_ideas",
+      "gpt_trader.tui.screens.ideas_review_screen"
     ],
     "tests/unit/gpt_trader/tui/test_snapshots_main_screen.py": [
       "gpt_trader.tui.app",
@@ -5255,6 +5271,7 @@
     "gpt_trader.tui.screens.alert_history": "src/gpt_trader/tui/screens/alert_history.py",
     "gpt_trader.tui.screens.api_setup_wizard": "src/gpt_trader/tui/screens/api_setup_wizard.py",
     "gpt_trader.tui.screens.help": "src/gpt_trader/tui/screens/help.py",
+    "gpt_trader.tui.screens.ideas_review_screen": "src/gpt_trader/tui/screens/ideas_review_screen.py",
     "gpt_trader.tui.screens.main_screen": "src/gpt_trader/tui/screens/main_screen.py",
     "gpt_trader.tui.screens.strategy_detail_screen": "src/gpt_trader/tui/screens/strategy_detail_screen.py",
     "gpt_trader.tui.screens.system_details_screen": "src/gpt_trader/tui/screens/system_details_screen.py",

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6751,
+    "total_tests": 6752,
     "total_files": 798,
     "markers_used": 16
   },
@@ -102,8 +102,8 @@
     ]
   },
   "marker_counts": {
-    "unit": 6586,
-    "asyncio": 389,
+    "unit": 6587,
+    "asyncio": 390,
     "parametrize": 191,
     "endpoints": 83,
     "property": 82,
@@ -50012,6 +50012,15 @@
       {
         "name": "test_filter_cycle_changes_visible_rows",
         "line": 180,
+        "markers": [
+          "asyncio",
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_refresh_preserves_selected_visible_idea",
+        "line": 202,
         "markers": [
           "asyncio",
           "unit"

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,8 +2,8 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6740,
-    "total_files": 796,
+    "total_tests": 6751,
+    "total_files": 798,
     "markers_used": 16
   },
   "marker_definitions": {
@@ -102,8 +102,8 @@
     ]
   },
   "marker_counts": {
-    "unit": 6575,
-    "asyncio": 380,
+    "unit": 6586,
+    "asyncio": 389,
     "parametrize": 191,
     "endpoints": 83,
     "property": 82,
@@ -876,6 +876,7 @@
       "tests/unit/gpt_trader/tui/test_events_widget_handlers.py",
       "tests/unit/gpt_trader/tui/test_formatting.py",
       "tests/unit/gpt_trader/tui/test_helpers.py",
+      "tests/unit/gpt_trader/tui/test_ideas_review_screen.py",
       "tests/unit/gpt_trader/tui/test_indicator_contributions.py",
       "tests/unit/gpt_trader/tui/test_log_manager.py",
       "tests/unit/gpt_trader/tui/test_log_manager_formatters.py",
@@ -886,6 +887,7 @@
       "tests/unit/gpt_trader/tui/test_screen_flows_help.py",
       "tests/unit/gpt_trader/tui/test_screen_flows_quick_navigation_and_state.py",
       "tests/unit/gpt_trader/tui/test_screens.py",
+      "tests/unit/gpt_trader/tui/test_snapshots_ideas_review.py",
       "tests/unit/gpt_trader/tui/test_snapshots_main_screen.py",
       "tests/unit/gpt_trader/tui/test_snapshots_modals.py",
       "tests/unit/gpt_trader/tui/test_snapshots_portfolio_overlays.py",
@@ -49943,6 +49945,80 @@
         "docstring": "Test @safe_update handles tracker failures gracefully."
       }
     ],
+    "tests/unit/gpt_trader/tui/test_ideas_review_screen.py": [
+      {
+        "name": "test_empty_store_renders_empty_state",
+        "line": 50,
+        "markers": [
+          "asyncio",
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_populated_queue_renders_detail_and_policy",
+        "line": 61,
+        "markers": [
+          "asyncio",
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_policy_violations_are_listed",
+        "line": 78,
+        "markers": [
+          "asyncio",
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_approve_flow_records_human_reason",
+        "line": 92,
+        "markers": [
+          "asyncio",
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_approve_refusal_keeps_state_unchanged",
+        "line": 118,
+        "markers": [
+          "asyncio",
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_reject_and_request_changes_record_events",
+        "line": 139,
+        "markers": [
+          "asyncio",
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_terminal_state_action_is_noop",
+        "line": 161,
+        "markers": [
+          "asyncio",
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_filter_cycle_changes_visible_rows",
+        "line": 180,
+        "markers": [
+          "asyncio",
+          "unit"
+        ],
+        "docstring": ""
+      }
+    ],
     "tests/unit/gpt_trader/tui/test_indicator_contributions.py": [
       {
         "name": "TestIndicatorContribution::test_is_bullish_positive_contribution",
@@ -50718,6 +50794,16 @@
         ],
         "docstring": "Test that pressing 'i' opens the mode info modal.",
         "class": "TestModeInfoFlow"
+      },
+      {
+        "name": "TestModeInfoFlow::test_ideas_review_opens_on_shift_i",
+        "line": 217,
+        "markers": [
+          "asyncio",
+          "unit"
+        ],
+        "docstring": "Test that pressing 'I' opens the trade-idea review screen.",
+        "class": "TestModeInfoFlow"
       }
     ],
     "tests/unit/gpt_trader/tui/test_screens.py": [
@@ -50729,6 +50815,26 @@
         ],
         "docstring": "Test that update_ui correctly sets screen state for StateRegistry broadcast.\n\nWith the StateRegistry pattern, update_ui() sets self.state which triggers\nwatch_state() -> StateRegistry.broadcast(). Widgets that implement StateObserver\nreceive updates via their on_state_updated() method rather than direct property\nassignment from MainScreen.",
         "class": "TestMainScreen"
+      }
+    ],
+    "tests/unit/gpt_trader/tui/test_snapshots_ideas_review.py": [
+      {
+        "name": "TestIdeasReviewSnapshots::test_empty_ideas_review_screen",
+        "line": 32,
+        "markers": [
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestIdeasReviewSnapshots"
+      },
+      {
+        "name": "TestIdeasReviewSnapshots::test_populated_ideas_review_screen",
+        "line": 43,
+        "markers": [
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestIdeasReviewSnapshots"
       }
     ],
     "tests/unit/gpt_trader/tui/test_snapshots_main_screen.py": [


### PR DESCRIPTION
## Summary
- Add an IdeasReviewScreen TUI surface over the existing trade-ideas service, including queue/detail panes, policy preview, audit history, filters, refresh, and required-reason review actions.
- Wire the screen to uppercase I from the main TUI while preserving lowercase i for Mode Info.
- Add modular TCSS, generated theme CSS, behavior tests, snapshot baselines, and regenerated agent testing artifacts.

Closes #939

## Affected paths
- src/gpt_trader/tui/screens/ideas_review_screen.py
- src/gpt_trader/tui/app.py
- src/gpt_trader/tui/app_actions.py
- src/gpt_trader/tui/styles/screens/ideas_review.tcss
- tests/unit/gpt_trader/tui/test_ideas_review_screen.py
- tests/unit/gpt_trader/tui/test_snapshots_ideas_review.py
- tests/unit/gpt_trader/tui/test_screen_flows_quick_navigation_and_state.py
- var/agents/testing/*

## Verification
- uv run pytest tests/unit/gpt_trader/tui/test_ideas_review_screen.py -q
- uv run pytest tests/unit/gpt_trader/tui/test_snapshots_ideas_review.py --snapshot-update -q
- uv run pytest tests/unit/gpt_trader/tui/test_snapshots_ideas_review.py -q
- uv run pytest tests/unit/gpt_trader/tui/test_screen_flows_quick_navigation_and_state.py::TestModeInfoFlow -q
- python scripts/ci/check_tui_css_up_to_date.py
- uv run agent-naming --strict --quiet
- uv run ruff check .
- uv run black --check .
- uv run mypy src/gpt_trader
- uv run agent-regenerate --verify
- uv run local-ci --profile quick

## Notes
- Review actions remain audit/workflow-only and call TradeIdeaService. This PR does not add broker execution, live-trade commands, account capability checks, canary operations, production preflight, money movement, or order submission.
- Snapshot coverage is included for empty and populated review screens.