### PR TITLE
[codex] Add trade idea closeout attribution

### DIFF
--- a/src/gpt_trader/features/trade_ideas/__init__.py
+++ b/src/gpt_trader/features/trade_ideas/__init__.py
@@ -25,6 +25,14 @@ from gpt_trader.features.trade_ideas.budget import (
     RiskBudget,
     RiskBudgetLog,
 )
+from gpt_trader.features.trade_ideas.closeout import (
+    CloseoutAttribution,
+    CloseoutAttributionIntegrityError,
+    CloseoutAttributionLog,
+    CloseoutResolution,
+    DuplicateCloseoutAttributionError,
+    MaxLossSnapshot,
+)
 from gpt_trader.features.trade_ideas.eligibility import evaluate_eligibility, is_eligible
 from gpt_trader.features.trade_ideas.models import (
     AutonomyMode,
@@ -87,6 +95,7 @@ __all__ = [
     "ACTOR_ENV_VAR",
     "DEFAULT_RISK_BUDGET",
     "DEFAULT_IDEAS_ROOT",
+    "DuplicateCloseoutAttributionError",
     "DuplicateTradeIdeaError",
     "IDEAS_ROOT_ENV_VAR",
     "TERMINAL_STATES",
@@ -101,12 +110,17 @@ __all__ = [
     "BrokerTicket",
     "BudgetIntegrityError",
     "BudgetLogEntry",
+    "CloseoutAttribution",
+    "CloseoutAttributionIntegrityError",
+    "CloseoutAttributionLog",
+    "CloseoutResolution",
     "Confidence",
     "ConfidenceLabel",
     "EntryZone",
     "InvalidTransitionError",
     "MarketSnapshot",
     "MaxLoss",
+    "MaxLossSnapshot",
     "PreApprovalBrokerTicketError",
     "PolicyViolationError",
     "ProductType",

--- a/src/gpt_trader/features/trade_ideas/closeout.py
+++ b/src/gpt_trader/features/trade_ideas/closeout.py
@@ -69,6 +69,12 @@ def _string_value(value: Any, field: str) -> str:
     return value
 
 
+def _object_payload(value: Any, field: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{field} must be a JSON object")
+    return value
+
+
 def _require_timezone_aware(value: datetime, field: str) -> None:
     if value.tzinfo is None or value.utcoffset() is None:
         raise ValueError(f"{field} must include a timezone")
@@ -97,6 +103,7 @@ class MaxLossSnapshot:
 
     @classmethod
     def from_dict(cls, payload: Mapping[str, Any]) -> MaxLossSnapshot:
+        payload = _object_payload(payload, "max_loss")
         return cls(
             amount=_decimal_or_none(payload.get("amount"), "max_loss.amount"),
             percent_of_account=_decimal_or_none(
@@ -168,6 +175,7 @@ class CloseoutAttribution:
 
     @classmethod
     def from_dict(cls, payload: Mapping[str, Any]) -> CloseoutAttribution:
+        payload = _object_payload(payload, "closeout_attribution")
         return cls(
             decision_id=_string_value(payload["decision_id"], "decision_id"),
             timestamp=datetime.fromisoformat(_string_value(payload["timestamp"], "timestamp")),

--- a/src/gpt_trader/features/trade_ideas/closeout.py
+++ b/src/gpt_trader/features/trade_ideas/closeout.py
@@ -46,6 +46,11 @@ def _decimal_or_none(value: Any, field: str) -> Decimal | None:
     return parsed
 
 
+def _validate_non_negative_decimal(value: Decimal | None, field: str) -> None:
+    if value is not None and value < 0:
+        raise ValueError(f"{field} must be non-negative")
+
+
 def _decimal_to_str(value: Decimal | None) -> str | None:
     if value is None:
         return None
@@ -92,6 +97,11 @@ class MaxLossSnapshot:
             self,
             "percent_of_account",
             _decimal_or_none(self.percent_of_account, "max_loss.percent_of_account"),
+        )
+        _validate_non_negative_decimal(self.amount, "max_loss.amount")
+        _validate_non_negative_decimal(
+            self.percent_of_account,
+            "max_loss.percent_of_account",
         )
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/gpt_trader/features/trade_ideas/closeout.py
+++ b/src/gpt_trader/features/trade_ideas/closeout.py
@@ -1,0 +1,260 @@
+"""Broker-neutral closeout attribution for terminal trade ideas.
+
+Closeout attribution is intentionally separate from the lifecycle audit log:
+terminal workflow states stay terminal, while this append-only log records why
+the idea resolved and how realized profit/loss compares with the original
+max-loss snapshot.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+from gpt_trader.errors import ValidationError
+
+
+class CloseoutResolution(str, Enum):
+    THESIS_TARGET = "thesis_target"
+    INVALIDATION = "invalidation"
+    EXPIRY = "expiry"
+
+
+class DuplicateCloseoutAttributionError(ValidationError):
+    """Raised when a decision already has conflicting closeout attribution."""
+
+
+class CloseoutAttributionIntegrityError(ValidationError):
+    """Raised when a closeout attribution record is malformed."""
+
+
+def _decimal_or_none(value: Any, field: str) -> Decimal | None:
+    if value is None:
+        return None
+    try:
+        parsed = Decimal(str(value))
+    except Exception as error:
+        raise ValueError(f"{field} must be a finite decimal") from error
+    if not parsed.is_finite():
+        raise ValueError(f"{field} must be finite")
+    return parsed
+
+
+def _decimal_to_str(value: Decimal | None) -> str | None:
+    if value is None:
+        return None
+    return str(value)
+
+
+def _string_sequence(value: Any, field: str) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str) or not isinstance(value, (list, tuple)):
+        raise ValueError(f"{field} must be a JSON array of strings")
+    for index, item in enumerate(value):
+        if not isinstance(item, str):
+            raise ValueError(f"{field}[{index}] must be a string")
+    return tuple(value)
+
+
+def _string_value(value: Any, field: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{field} must be a string")
+    return value
+
+
+def _require_timezone_aware(value: datetime, field: str) -> None:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError(f"{field} must include a timezone")
+
+
+@dataclass(frozen=True, slots=True)
+class MaxLossSnapshot:
+    amount: Decimal | None = None
+    percent_of_account: Decimal | None = None
+    assumptions: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "amount", _decimal_or_none(self.amount, "max_loss.amount"))
+        object.__setattr__(
+            self,
+            "percent_of_account",
+            _decimal_or_none(self.percent_of_account, "max_loss.percent_of_account"),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "amount": _decimal_to_str(self.amount),
+            "percent_of_account": _decimal_to_str(self.percent_of_account),
+            "assumptions": list(self.assumptions),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> MaxLossSnapshot:
+        return cls(
+            amount=_decimal_or_none(payload.get("amount"), "max_loss.amount"),
+            percent_of_account=_decimal_or_none(
+                payload.get("percent_of_account"), "max_loss.percent_of_account"
+            ),
+            assumptions=_string_sequence(payload.get("assumptions", ()), "max_loss.assumptions"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class CloseoutAttribution:
+    decision_id: str
+    timestamp: datetime
+    actor_type: str
+    actor_id: str
+    terminal_event_id: str
+    record_hash: str
+    resolution: CloseoutResolution
+    max_loss: MaxLossSnapshot
+    realized_profit_loss_amount: Decimal | None = None
+    realized_profit_loss_percent: Decimal | None = None
+    realized_profit_loss_unavailable_reason: str = ""
+    evidence: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        _require_timezone_aware(self.timestamp, "timestamp")
+        object.__setattr__(
+            self,
+            "realized_profit_loss_amount",
+            _decimal_or_none(
+                self.realized_profit_loss_amount,
+                "realized_profit_loss_amount",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "realized_profit_loss_percent",
+            _decimal_or_none(
+                self.realized_profit_loss_percent,
+                "realized_profit_loss_percent",
+            ),
+        )
+        if (
+            self.realized_profit_loss_amount is None
+            and self.realized_profit_loss_percent is None
+            and not self.realized_profit_loss_unavailable_reason.strip()
+        ):
+            raise ValueError(
+                "realized profit/loss requires amount, percent, or an unavailable reason"
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "decision_id": self.decision_id,
+            "timestamp": self.timestamp.isoformat(),
+            "actor_type": self.actor_type,
+            "actor_id": self.actor_id,
+            "terminal_event_id": self.terminal_event_id,
+            "record_hash": self.record_hash,
+            "resolution": self.resolution.value,
+            "realized_profit_loss_amount": _decimal_to_str(self.realized_profit_loss_amount),
+            "realized_profit_loss_percent": _decimal_to_str(self.realized_profit_loss_percent),
+            "realized_profit_loss_unavailable_reason": (
+                self.realized_profit_loss_unavailable_reason
+            ),
+            "max_loss": self.max_loss.to_dict(),
+            "evidence": list(self.evidence),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> CloseoutAttribution:
+        return cls(
+            decision_id=_string_value(payload["decision_id"], "decision_id"),
+            timestamp=datetime.fromisoformat(_string_value(payload["timestamp"], "timestamp")),
+            actor_type=_string_value(payload["actor_type"], "actor_type"),
+            actor_id=_string_value(payload["actor_id"], "actor_id"),
+            terminal_event_id=_string_value(
+                payload["terminal_event_id"],
+                "terminal_event_id",
+            ),
+            record_hash=_string_value(payload["record_hash"], "record_hash"),
+            resolution=CloseoutResolution(payload["resolution"]),
+            realized_profit_loss_amount=_decimal_or_none(
+                payload.get("realized_profit_loss_amount"),
+                "realized_profit_loss_amount",
+            ),
+            realized_profit_loss_percent=_decimal_or_none(
+                payload.get("realized_profit_loss_percent"),
+                "realized_profit_loss_percent",
+            ),
+            realized_profit_loss_unavailable_reason=_string_value(
+                payload.get("realized_profit_loss_unavailable_reason", ""),
+                "realized_profit_loss_unavailable_reason",
+            ),
+            max_loss=MaxLossSnapshot.from_dict(payload["max_loss"]),
+            evidence=_string_sequence(payload.get("evidence", ()), "evidence"),
+        )
+
+
+class CloseoutAttributionLog:
+    """Append-only JSONL log keyed by decision id."""
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def append(self, record: CloseoutAttribution) -> CloseoutAttribution:
+        existing = self.get(record.decision_id)
+        if existing is not None:
+            if existing == record:
+                return existing
+            raise DuplicateCloseoutAttributionError(
+                f"Closeout attribution already exists for decision_id '{record.decision_id}'",
+                field="decision_id",
+                value=record.decision_id,
+            )
+
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(record.to_dict(), sort_keys=True, separators=(",", ":"))
+        with self._path.open("a", encoding="utf-8") as handle:
+            handle.write(line + "\n")
+        return record
+
+    def get(self, decision_id: str) -> CloseoutAttribution | None:
+        for record in self.read_records(decision_id):
+            return record
+        return None
+
+    def read_records(self, decision_id: str | None = None) -> list[CloseoutAttribution]:
+        if not self._path.exists():
+            return []
+        records: list[CloseoutAttribution] = []
+        seen: dict[str, CloseoutAttribution] = {}
+        with self._path.open("r", encoding="utf-8") as handle:
+            for line_number, raw_line in enumerate(handle, start=1):
+                line = raw_line.strip()
+                if not line:
+                    continue
+                try:
+                    record = CloseoutAttribution.from_dict(json.loads(line))
+                except (KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
+                    raise CloseoutAttributionIntegrityError(
+                        f"Closeout attribution log line {line_number} is malformed: {error}",
+                        field="line",
+                        value=line_number,
+                    ) from error
+                existing = seen.get(record.decision_id)
+                if existing is not None and existing != record:
+                    raise DuplicateCloseoutAttributionError(
+                        f"Closeout attribution log line {line_number} conflicts for "
+                        f"decision_id '{record.decision_id}'",
+                        field="decision_id",
+                        value=record.decision_id,
+                    )
+                seen[record.decision_id] = record
+                if decision_id is None or record.decision_id == decision_id:
+                    records.append(record)
+        return records

--- a/src/gpt_trader/features/trade_ideas/service.py
+++ b/src/gpt_trader/features/trade_ideas/service.py
@@ -13,8 +13,9 @@ import os
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from decimal import InvalidOperation
+from decimal import Decimal, InvalidOperation
 from pathlib import Path
+from typing import cast
 
 from gpt_trader.errors import ValidationError
 from gpt_trader.features.trade_ideas.audit import (
@@ -31,10 +32,17 @@ from gpt_trader.features.trade_ideas.budget import (
     RiskBudget,
     RiskBudgetLog,
 )
+from gpt_trader.features.trade_ideas.closeout import (
+    CloseoutAttribution,
+    CloseoutAttributionLog,
+    CloseoutResolution,
+    MaxLossSnapshot,
+)
 from gpt_trader.features.trade_ideas.models import TicketStatus, TicketVenue, TradeIdea
 from gpt_trader.features.trade_ideas.policy import ApprovalPolicy, PolicyViolationError
 from gpt_trader.features.trade_ideas.store import TradeIdeaStore
 from gpt_trader.features.trade_ideas.workflow import (
+    TERMINAL_STATES,
     InvalidTransitionError,
     TradeIdeaState,
     validate_transition,
@@ -71,6 +79,7 @@ class TradeIdeaView:
     idea: TradeIdea
     state: TradeIdeaState
     events: tuple[AuditEvent, ...]
+    closeout_attribution: CloseoutAttribution | None = None
 
 
 def _utc_now() -> datetime:
@@ -107,6 +116,7 @@ class TradeIdeaService:
     ) -> None:
         self._store = TradeIdeaStore(root / "records")
         self._audit = TradeIdeaAuditLog(root / "audit.jsonl")
+        self._closeouts = CloseoutAttributionLog(root / "closeout_attributions.jsonl")
         self._budget_log = RiskBudgetLog(root / "risk_budget.jsonl")
         self._policy = policy or ApprovalPolicy()
         self._now = now_factory
@@ -114,6 +124,10 @@ class TradeIdeaService:
     @property
     def audit_log(self) -> TradeIdeaAuditLog:
         return self._audit
+
+    @property
+    def closeout_log(self) -> CloseoutAttributionLog:
+        return self._closeouts
 
     # -- budget ----------------------------------------------------------
 
@@ -393,6 +407,59 @@ class TradeIdeaService:
         )
         return self.get(decision_id)
 
+    def record_closeout_attribution(
+        self,
+        decision_id: str,
+        *,
+        actor_id: str,
+        resolution: CloseoutResolution | str,
+        realized_profit_loss_amount: object = None,
+        realized_profit_loss_percent: object = None,
+        realized_profit_loss_unavailable_reason: str = "",
+        evidence: tuple[str, ...] = (),
+        actor_type: ActorType = ActorType.HUMAN,
+    ) -> CloseoutAttribution:
+        """Record why a terminal idea resolved and its realized profit/loss evidence."""
+        view = self.get(decision_id)
+        if view.state not in TERMINAL_STATES:
+            raise InvalidTransitionError(
+                f"Trade idea '{decision_id}' must be terminal before closeout attribution; "
+                f"got '{view.state.value}'",
+                field="after_state",
+                value=view.state.value,
+            )
+
+        terminal_event = view.events[-1]
+        record = CloseoutAttribution(
+            decision_id=decision_id,
+            timestamp=self._now(),
+            actor_type=actor_type.value,
+            actor_id=actor_id,
+            terminal_event_id=terminal_event.event_id,
+            record_hash=terminal_event.record_hash,
+            resolution=CloseoutResolution(resolution),
+            realized_profit_loss_amount=cast(
+                Decimal | None,
+                realized_profit_loss_amount,
+            ),
+            realized_profit_loss_percent=cast(
+                Decimal | None,
+                realized_profit_loss_percent,
+            ),
+            realized_profit_loss_unavailable_reason=realized_profit_loss_unavailable_reason,
+            max_loss=MaxLossSnapshot(
+                amount=view.idea.max_loss.amount,
+                percent_of_account=view.idea.max_loss.percent_of_account,
+                assumptions=view.idea.max_loss.assumptions,
+            ),
+            evidence=evidence,
+        )
+        return self._closeouts.append(record)
+
+    def get_closeout_attribution(self, decision_id: str) -> CloseoutAttribution | None:
+        self._require_idea(decision_id)
+        return self._closeouts.get(decision_id)
+
     # -- queries -----------------------------------------------------------
 
     def get(self, decision_id: str) -> TradeIdeaView:
@@ -405,7 +472,12 @@ class TradeIdeaService:
                 value=decision_id,
             )
         state = events[-1].after_state
-        return TradeIdeaView(idea=idea, state=state, events=events)
+        return TradeIdeaView(
+            idea=idea,
+            state=state,
+            events=events,
+            closeout_attribution=self._closeouts.get(decision_id),
+        )
 
     def list_views(self, state: TradeIdeaState | None = None) -> list[TradeIdeaView]:
         views = [self.get(decision_id) for decision_id in self._store.list_decision_ids()]

--- a/src/gpt_trader/features/trade_ideas/service.py
+++ b/src/gpt_trader/features/trade_ideas/service.py
@@ -87,6 +87,24 @@ def _utc_now() -> datetime:
     return datetime.now(UTC)
 
 
+def _max_loss_snapshot_for(idea: TradeIdea) -> MaxLossSnapshot:
+    return MaxLossSnapshot(
+        amount=idea.max_loss.amount,
+        percent_of_account=idea.max_loss.percent_of_account,
+        assumptions=idea.max_loss.assumptions,
+    )
+
+
+def _max_loss_snapshot_context(snapshot: MaxLossSnapshot) -> dict[str, object]:
+    return {
+        "amount": str(snapshot.amount) if snapshot.amount is not None else None,
+        "percent_of_account": (
+            str(snapshot.percent_of_account) if snapshot.percent_of_account is not None else None
+        ),
+        "assumptions": list(snapshot.assumptions),
+    }
+
+
 def resolve_ideas_root(root: Path | None = None) -> Path:
     """Resolve the trade-idea storage root from arg, environment, or default."""
     if root is not None:
@@ -476,7 +494,7 @@ class TradeIdeaService:
             idea=idea,
             state=state,
             events=events,
-            closeout_attribution=self._validated_closeout_attribution(decision_id, events),
+            closeout_attribution=self._validated_closeout_attribution(idea, events),
         )
 
     def list_views(self, state: TradeIdeaState | None = None) -> list[TradeIdeaView]:
@@ -504,20 +522,24 @@ class TradeIdeaService:
 
     def _validated_closeout_attribution(
         self,
-        decision_id: str,
+        idea: TradeIdea,
         events: tuple[AuditEvent, ...],
     ) -> CloseoutAttribution | None:
+        decision_id = idea.decision_id
         closeout = self._closeouts.get(decision_id)
         if closeout is None:
             return None
 
         current_event = events[-1]
+        current_max_loss = _max_loss_snapshot_for(idea)
         context = {
             "decision_id": decision_id,
             "stored_terminal_event_id": closeout.terminal_event_id,
             "current_terminal_event_id": current_event.event_id,
             "stored_record_hash": closeout.record_hash,
             "current_record_hash": current_event.record_hash,
+            "stored_max_loss": _max_loss_snapshot_context(closeout.max_loss),
+            "current_max_loss": _max_loss_snapshot_context(current_max_loss),
         }
         if current_event.after_state not in TERMINAL_STATES:
             raise CloseoutAttributionIntegrityError(
@@ -549,6 +571,38 @@ class TradeIdeaService:
                 f"Closeout attribution for decision_id '{decision_id}' does not match "
                 f"the current terminal audit event: {'; '.join(mismatch_details)}",
                 field=mismatch_field,
+                value=decision_id,
+                context=context,
+            )
+        max_loss_mismatch_details: list[str] = []
+        max_loss_mismatch_field = "max_loss"
+        if closeout.max_loss.amount != current_max_loss.amount:
+            max_loss_mismatch_field = "max_loss.amount"
+            max_loss_mismatch_details.append(
+                f"max_loss.amount expected '{current_max_loss.amount}' "
+                f"but found '{closeout.max_loss.amount}'"
+            )
+        if closeout.max_loss.percent_of_account != current_max_loss.percent_of_account:
+            if max_loss_mismatch_field == "max_loss":
+                max_loss_mismatch_field = "max_loss.percent_of_account"
+            max_loss_mismatch_details.append(
+                "max_loss.percent_of_account expected "
+                f"'{current_max_loss.percent_of_account}' "
+                f"but found '{closeout.max_loss.percent_of_account}'"
+            )
+        if closeout.max_loss.assumptions != current_max_loss.assumptions:
+            if max_loss_mismatch_field == "max_loss":
+                max_loss_mismatch_field = "max_loss.assumptions"
+            max_loss_mismatch_details.append(
+                f"max_loss.assumptions expected {list(current_max_loss.assumptions)!r} "
+                f"but found {list(closeout.max_loss.assumptions)!r}"
+            )
+        if max_loss_mismatch_details:
+            raise CloseoutAttributionIntegrityError(
+                f"Closeout attribution for decision_id '{decision_id}' does not match "
+                "the audited max-loss snapshot from the current terminal record: "
+                f"{'; '.join(max_loss_mismatch_details)}",
+                field=max_loss_mismatch_field,
                 value=decision_id,
                 context=context,
             )

--- a/src/gpt_trader/features/trade_ideas/service.py
+++ b/src/gpt_trader/features/trade_ideas/service.py
@@ -34,6 +34,7 @@ from gpt_trader.features.trade_ideas.budget import (
 )
 from gpt_trader.features.trade_ideas.closeout import (
     CloseoutAttribution,
+    CloseoutAttributionIntegrityError,
     CloseoutAttributionLog,
     CloseoutResolution,
     MaxLossSnapshot,
@@ -457,8 +458,7 @@ class TradeIdeaService:
         return self._closeouts.append(record)
 
     def get_closeout_attribution(self, decision_id: str) -> CloseoutAttribution | None:
-        self._require_idea(decision_id)
-        return self._closeouts.get(decision_id)
+        return self.get(decision_id).closeout_attribution
 
     # -- queries -----------------------------------------------------------
 
@@ -476,7 +476,7 @@ class TradeIdeaService:
             idea=idea,
             state=state,
             events=events,
-            closeout_attribution=self._closeouts.get(decision_id),
+            closeout_attribution=self._validated_closeout_attribution(decision_id, events),
         )
 
     def list_views(self, state: TradeIdeaState | None = None) -> list[TradeIdeaView]:
@@ -501,6 +501,58 @@ class TradeIdeaService:
         for event in self._audit.read_events():
             latest_events[event.decision_id] = event
         return latest_events
+
+    def _validated_closeout_attribution(
+        self,
+        decision_id: str,
+        events: tuple[AuditEvent, ...],
+    ) -> CloseoutAttribution | None:
+        closeout = self._closeouts.get(decision_id)
+        if closeout is None:
+            return None
+
+        current_event = events[-1]
+        context = {
+            "decision_id": decision_id,
+            "stored_terminal_event_id": closeout.terminal_event_id,
+            "current_terminal_event_id": current_event.event_id,
+            "stored_record_hash": closeout.record_hash,
+            "current_record_hash": current_event.record_hash,
+        }
+        if current_event.after_state not in TERMINAL_STATES:
+            raise CloseoutAttributionIntegrityError(
+                f"Closeout attribution for decision_id '{decision_id}' cannot be current "
+                f"because latest audit state is '{current_event.after_state.value}', "
+                "not terminal",
+                field="after_state",
+                value=current_event.after_state.value,
+                context=context,
+            )
+
+        mismatch_details: list[str] = []
+        mismatch_field = "closeout_attribution"
+        if closeout.terminal_event_id != current_event.event_id:
+            mismatch_field = "terminal_event_id"
+            mismatch_details.append(
+                f"terminal_event_id expected '{current_event.event_id}' "
+                f"but found '{closeout.terminal_event_id}'"
+            )
+        if closeout.record_hash != current_event.record_hash:
+            if mismatch_field == "closeout_attribution":
+                mismatch_field = "record_hash"
+            mismatch_details.append(
+                f"record_hash expected '{current_event.record_hash}' "
+                f"but found '{closeout.record_hash}'"
+            )
+        if mismatch_details:
+            raise CloseoutAttributionIntegrityError(
+                f"Closeout attribution for decision_id '{decision_id}' does not match "
+                f"the current terminal audit event: {'; '.join(mismatch_details)}",
+                field=mismatch_field,
+                value=decision_id,
+                context=context,
+            )
+        return closeout
 
     def _require_idea(self, decision_id: str) -> TradeIdea:
         try:

--- a/tests/unit/gpt_trader/features/trade_ideas/test_models.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_models.py
@@ -9,7 +9,10 @@ from tests.unit.gpt_trader.features.trade_ideas.conftest import build_trade_idea
 
 from gpt_trader.features.trade_ideas import (
     BrokerTicket,
+    CloseoutAttribution,
+    CloseoutResolution,
     MaxLoss,
+    MaxLossSnapshot,
     TicketStatus,
     TicketVenue,
     TimeHorizon,
@@ -179,3 +182,68 @@ def test_from_dict_rejects_malformed_scalar_strings(
 
     with pytest.raises(ValueError, match=re.escape(message)):
         TradeIdea.from_dict(payload)
+
+
+def test_closeout_attribution_round_trip_preserves_record() -> None:
+    record = CloseoutAttribution(
+        decision_id="trade-20260612-001",
+        timestamp=datetime.fromisoformat("2026-06-12T10:05:00+00:00"),
+        actor_type="human",
+        actor_id="rj",
+        terminal_event_id="evt-terminal",
+        record_hash="record-hash",
+        resolution=CloseoutResolution.THESIS_TARGET,
+        realized_profit_loss_amount=Decimal("125.50"),
+        realized_profit_loss_percent=Decimal("2.4"),
+        max_loss=MaxLossSnapshot(
+            amount=Decimal("250"),
+            percent_of_account=Decimal("1.5"),
+            assumptions=("Fill at zone midpoint",),
+        ),
+        evidence=("broker-statement:abc",),
+    )
+
+    payload = record.to_dict()
+    restored = CloseoutAttribution.from_dict(payload)
+
+    assert payload["realized_profit_loss_amount"] == "125.50"
+    assert payload["realized_profit_loss_percent"] == "2.4"
+    assert payload["max_loss"]["amount"] == "250"
+    assert restored == record
+
+
+def test_closeout_attribution_rejects_malformed_numeric_payload() -> None:
+    payload = {
+        "decision_id": "trade-20260612-001",
+        "timestamp": "2026-06-12T10:05:00+00:00",
+        "actor_type": "human",
+        "actor_id": "rj",
+        "terminal_event_id": "evt-terminal",
+        "record_hash": "record-hash",
+        "resolution": CloseoutResolution.INVALIDATION.value,
+        "realized_profit_loss_amount": "not-a-decimal",
+        "realized_profit_loss_percent": None,
+        "realized_profit_loss_unavailable_reason": "",
+        "max_loss": {"amount": "250", "percent_of_account": "1.5", "assumptions": []},
+        "evidence": [],
+    }
+
+    with pytest.raises(ValueError, match="realized_profit_loss_amount must be a finite decimal"):
+        CloseoutAttribution.from_dict(payload)
+
+
+def test_closeout_attribution_requires_profit_loss_or_unavailable_reason() -> None:
+    with pytest.raises(
+        ValueError,
+        match=re.escape("realized profit/loss requires amount, percent, or an unavailable reason"),
+    ):
+        CloseoutAttribution(
+            decision_id="trade-20260612-001",
+            timestamp=datetime.fromisoformat("2026-06-12T10:05:00+00:00"),
+            actor_type="human",
+            actor_id="rj",
+            terminal_event_id="evt-terminal",
+            record_hash="record-hash",
+            resolution=CloseoutResolution.EXPIRY,
+            max_loss=MaxLossSnapshot(amount=Decimal("250")),
+        )

--- a/tests/unit/gpt_trader/features/trade_ideas/test_replay.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_replay.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
+from pathlib import Path
 
 from tests.unit.gpt_trader.features.trade_ideas.conftest import build_trade_idea
 
@@ -12,6 +13,7 @@ from gpt_trader.features.trade_ideas import (
     TimeHorizon,
     TradeDirection,
     TradeIdea,
+    TradeIdeaService,
     score_trade_idea,
 )
 
@@ -298,3 +300,25 @@ def test_score_trade_idea_excludes_candles_that_extend_past_expiry() -> None:
 
     assert result.outcome is ReplayOutcome.NO_FUTURE_DATA
     assert result.bars_evaluated == 0
+
+
+def test_replay_scoring_does_not_mutate_live_closeout_records(tmp_path: Path) -> None:
+    idea = scoreable_idea()
+    service = TradeIdeaService(
+        tmp_path / "trade_ideas",
+        now_factory=lambda: AS_OF,
+    )
+    service.propose(idea, actor_id="idea-generator-v1")
+
+    result = score_trade_idea(
+        idea,
+        as_of=AS_OF,
+        future_candles=(
+            candle(0, high="103", low="100", close="102"),
+            candle(1, high="114", low="101", close="113"),
+        ),
+    )
+
+    assert result.outcome is ReplayOutcome.TARGET_HIT
+    assert service.get_closeout_attribution(idea.decision_id) is None
+    assert not service.closeout_log.path.exists()

--- a/tests/unit/gpt_trader/features/trade_ideas/test_service_closeout.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_service_closeout.py
@@ -17,6 +17,7 @@ from gpt_trader.features.trade_ideas import (
     InvalidTransitionError,
     TradeIdeaService,
     TradeIdeaState,
+    TradeIdeaView,
     UnknownTradeIdeaError,
 )
 
@@ -27,6 +28,39 @@ def service(tmp_path: Path) -> TradeIdeaService:
         tmp_path / "trade_ideas",
         now_factory=lambda: datetime(2026, 6, 12, 10, 0, tzinfo=UTC),
     )
+
+
+def _write_closeout_payload(
+    service: TradeIdeaService,
+    view: TradeIdeaView,
+    **overrides: object,
+) -> None:
+    max_loss = view.idea.max_loss
+    payload: dict[str, object] = {
+        "decision_id": view.idea.decision_id,
+        "timestamp": "2026-06-12T10:05:00+00:00",
+        "actor_type": "human",
+        "actor_id": "rj",
+        "terminal_event_id": view.events[-1].event_id,
+        "record_hash": view.events[-1].record_hash,
+        "resolution": CloseoutResolution.EXPIRY.value,
+        "realized_profit_loss_amount": None,
+        "realized_profit_loss_percent": None,
+        "realized_profit_loss_unavailable_reason": "Idea expired before entry fill",
+        "max_loss": {
+            "amount": str(max_loss.amount) if max_loss.amount is not None else None,
+            "percent_of_account": (
+                str(max_loss.percent_of_account)
+                if max_loss.percent_of_account is not None
+                else None
+            ),
+            "assumptions": list(max_loss.assumptions),
+        },
+        "evidence": [],
+    }
+    payload.update(overrides)
+    service.closeout_log.path.parent.mkdir(parents=True, exist_ok=True)
+    service.closeout_log.path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
 
 
 def test_record_closeout_attribution_for_filled_idea(service: TradeIdeaService) -> None:
@@ -163,6 +197,66 @@ def test_record_closeout_attribution_rejects_malformed_numeric_payload(
         )
 
     assert service.get_closeout_attribution(idea.decision_id) is None
+
+
+def test_persisted_closeout_rejects_stale_terminal_event_id_against_current_event(
+    service: TradeIdeaService,
+) -> None:
+    idea = build_trade_idea()
+    service.propose(idea, actor_id="idea-generator-v1")
+    expired = service.expire(idea.decision_id)
+    _write_closeout_payload(service, expired, terminal_event_id="evt-stale")
+
+    with pytest.raises(
+        CloseoutAttributionIntegrityError,
+        match="terminal_event_id expected",
+    ) as get_exc_info:
+        service.get(idea.decision_id)
+    assert get_exc_info.value.context["field"] == "terminal_event_id"
+    assert get_exc_info.value.context["stored_terminal_event_id"] == "evt-stale"
+    assert get_exc_info.value.context["current_terminal_event_id"] == expired.events[-1].event_id
+
+    with pytest.raises(CloseoutAttributionIntegrityError, match="terminal_event_id expected"):
+        service.list_views()
+    with pytest.raises(CloseoutAttributionIntegrityError, match="terminal_event_id expected"):
+        service.get_closeout_attribution(idea.decision_id)
+    with pytest.raises(CloseoutAttributionIntegrityError, match="terminal_event_id expected"):
+        service.record_closeout_attribution(
+            idea.decision_id,
+            actor_id="rj",
+            resolution=CloseoutResolution.EXPIRY,
+            realized_profit_loss_unavailable_reason="Idea expired before entry fill",
+        )
+
+
+def test_persisted_closeout_rejects_stale_record_hash_against_current_event(
+    service: TradeIdeaService,
+) -> None:
+    idea = build_trade_idea()
+    service.propose(idea, actor_id="idea-generator-v1")
+    expired = service.expire(idea.decision_id)
+    _write_closeout_payload(service, expired, record_hash="stale-record-hash")
+
+    with pytest.raises(
+        CloseoutAttributionIntegrityError,
+        match="record_hash expected",
+    ) as get_exc_info:
+        service.get(idea.decision_id)
+    assert get_exc_info.value.context["field"] == "record_hash"
+    assert get_exc_info.value.context["stored_record_hash"] == "stale-record-hash"
+    assert get_exc_info.value.context["current_record_hash"] == expired.events[-1].record_hash
+
+    with pytest.raises(CloseoutAttributionIntegrityError, match="record_hash expected"):
+        service.list_views()
+    with pytest.raises(CloseoutAttributionIntegrityError, match="record_hash expected"):
+        service.get_closeout_attribution(idea.decision_id)
+    with pytest.raises(CloseoutAttributionIntegrityError, match="record_hash expected"):
+        service.record_closeout_attribution(
+            idea.decision_id,
+            actor_id="rj",
+            resolution=CloseoutResolution.EXPIRY,
+            realized_profit_loss_unavailable_reason="Idea expired before entry fill",
+        )
 
 
 def test_persisted_closeout_log_rejects_non_object_max_loss_with_line_context(

--- a/tests/unit/gpt_trader/features/trade_ideas/test_service_closeout.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_service_closeout.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+from tests.unit.gpt_trader.features.trade_ideas.conftest import build_trade_idea
+
+from gpt_trader.features.trade_ideas import (
+    ActorType,
+    AuditAction,
+    CloseoutResolution,
+    DuplicateCloseoutAttributionError,
+    InvalidTransitionError,
+    TradeIdeaService,
+    TradeIdeaState,
+    UnknownTradeIdeaError,
+)
+
+
+@pytest.fixture
+def service(tmp_path: Path) -> TradeIdeaService:
+    return TradeIdeaService(
+        tmp_path / "trade_ideas",
+        now_factory=lambda: datetime(2026, 6, 12, 10, 0, tzinfo=UTC),
+    )
+
+
+def test_record_closeout_attribution_for_filled_idea(service: TradeIdeaService) -> None:
+    idea = build_trade_idea()
+    service.propose(idea, actor_id="idea-generator-v1")
+    service.approve(idea.decision_id, actor_id="rj", reason="Thesis and risk verified")
+    service.record_submission(idea.decision_id, actor_id="executor", venue="coinbase")
+    filled = service.record_fill(
+        idea.decision_id,
+        actor_id="coinbase",
+        venue="coinbase",
+        external_order_id="abc-123",
+    )
+
+    closeout = service.record_closeout_attribution(
+        idea.decision_id,
+        actor_id="rj",
+        resolution=CloseoutResolution.THESIS_TARGET,
+        realized_profit_loss_amount=Decimal("125.50"),
+        realized_profit_loss_percent=Decimal("2.4"),
+        evidence=("broker-statement:abc-123", "chart:target-hit"),
+    )
+
+    assert closeout.decision_id == idea.decision_id
+    assert closeout.actor_type == ActorType.HUMAN.value
+    assert closeout.terminal_event_id == filled.events[-1].event_id
+    assert closeout.record_hash == filled.events[-1].record_hash
+    assert closeout.max_loss.amount == idea.max_loss.amount
+    assert closeout.max_loss.percent_of_account == idea.max_loss.percent_of_account
+    assert closeout.evidence == ("broker-statement:abc-123", "chart:target-hit")
+    view = service.get(idea.decision_id)
+    assert view.state is TradeIdeaState.FILLED
+    assert view.closeout_attribution == closeout
+    assert [event.action for event in view.events] == [
+        AuditAction.PROPOSED,
+        AuditAction.APPROVED,
+        AuditAction.SUBMITTED,
+        AuditAction.FILLED,
+    ]
+
+
+def test_record_closeout_attribution_for_expired_idea_without_profit_loss(
+    service: TradeIdeaService,
+) -> None:
+    idea = build_trade_idea()
+    service.propose(idea, actor_id="idea-generator-v1")
+    expired = service.expire(idea.decision_id)
+
+    closeout = service.record_closeout_attribution(
+        idea.decision_id,
+        actor_id="expiry-sweep",
+        actor_type=ActorType.SYSTEM,
+        resolution="expiry",
+        realized_profit_loss_unavailable_reason="Idea expired before entry fill",
+        evidence=("expiry-sweep:2026-06-12",),
+    )
+
+    assert closeout.actor_type == ActorType.SYSTEM.value
+    assert closeout.resolution is CloseoutResolution.EXPIRY
+    assert closeout.realized_profit_loss_amount is None
+    assert closeout.realized_profit_loss_percent is None
+    assert closeout.realized_profit_loss_unavailable_reason == "Idea expired before entry fill"
+    assert closeout.terminal_event_id == expired.events[-1].event_id
+
+
+def test_record_closeout_attribution_rejects_non_terminal_idea(
+    service: TradeIdeaService,
+) -> None:
+    idea = build_trade_idea()
+    service.propose(idea, actor_id="idea-generator-v1")
+
+    with pytest.raises(InvalidTransitionError, match="must be terminal"):
+        service.record_closeout_attribution(
+            idea.decision_id,
+            actor_id="rj",
+            resolution=CloseoutResolution.INVALIDATION,
+            realized_profit_loss_amount=Decimal("-250"),
+        )
+
+    assert service.get_closeout_attribution(idea.decision_id) is None
+
+
+def test_record_closeout_attribution_rejects_unknown_idea(
+    service: TradeIdeaService,
+) -> None:
+    with pytest.raises(UnknownTradeIdeaError):
+        service.record_closeout_attribution(
+            "trade-missing",
+            actor_id="rj",
+            resolution=CloseoutResolution.INVALIDATION,
+            realized_profit_loss_amount=Decimal("-250"),
+        )
+
+
+def test_record_closeout_attribution_rejects_duplicate_conflict(
+    service: TradeIdeaService,
+) -> None:
+    idea = build_trade_idea()
+    service.propose(idea, actor_id="idea-generator-v1")
+    service.expire(idea.decision_id)
+    original = service.record_closeout_attribution(
+        idea.decision_id,
+        actor_id="expiry-sweep",
+        actor_type=ActorType.SYSTEM,
+        resolution=CloseoutResolution.EXPIRY,
+        realized_profit_loss_unavailable_reason="Idea expired before entry fill",
+    )
+
+    with pytest.raises(DuplicateCloseoutAttributionError):
+        service.record_closeout_attribution(
+            idea.decision_id,
+            actor_id="rj",
+            resolution=CloseoutResolution.INVALIDATION,
+            realized_profit_loss_amount=Decimal("-250"),
+            evidence=("manual-review",),
+        )
+
+    assert service.get_closeout_attribution(idea.decision_id) == original
+
+
+def test_record_closeout_attribution_rejects_malformed_numeric_payload(
+    service: TradeIdeaService,
+) -> None:
+    idea = build_trade_idea()
+    service.propose(idea, actor_id="idea-generator-v1")
+    service.expire(idea.decision_id)
+
+    with pytest.raises(ValueError, match="realized_profit_loss_amount must be a finite decimal"):
+        service.record_closeout_attribution(
+            idea.decision_id,
+            actor_id="rj",
+            resolution=CloseoutResolution.INVALIDATION,
+            realized_profit_loss_amount="not-a-decimal",
+        )
+
+    assert service.get_closeout_attribution(idea.decision_id) is None

--- a/tests/unit/gpt_trader/features/trade_ideas/test_service_closeout.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_service_closeout.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
 from decimal import Decimal
 from pathlib import Path
@@ -10,6 +11,7 @@ from tests.unit.gpt_trader.features.trade_ideas.conftest import build_trade_idea
 from gpt_trader.features.trade_ideas import (
     ActorType,
     AuditAction,
+    CloseoutAttributionIntegrityError,
     CloseoutResolution,
     DuplicateCloseoutAttributionError,
     InvalidTransitionError,
@@ -161,3 +163,47 @@ def test_record_closeout_attribution_rejects_malformed_numeric_payload(
         )
 
     assert service.get_closeout_attribution(idea.decision_id) is None
+
+
+def test_persisted_closeout_log_rejects_non_object_max_loss_with_line_context(
+    service: TradeIdeaService,
+) -> None:
+    idea = build_trade_idea()
+    service.propose(idea, actor_id="idea-generator-v1")
+    expired = service.expire(idea.decision_id)
+    payload = {
+        "decision_id": idea.decision_id,
+        "timestamp": "2026-06-12T10:05:00+00:00",
+        "actor_type": "human",
+        "actor_id": "rj",
+        "terminal_event_id": expired.events[-1].event_id,
+        "record_hash": expired.events[-1].record_hash,
+        "resolution": CloseoutResolution.EXPIRY.value,
+        "realized_profit_loss_amount": None,
+        "realized_profit_loss_percent": None,
+        "realized_profit_loss_unavailable_reason": "Idea expired before entry fill",
+        "max_loss": None,
+        "evidence": [],
+    }
+    service.closeout_log.path.parent.mkdir(parents=True, exist_ok=True)
+    service.closeout_log.path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
+    with pytest.raises(
+        CloseoutAttributionIntegrityError,
+        match="Closeout attribution log line 1 is malformed: max_loss must be a JSON object",
+    ) as log_exc_info:
+        service.closeout_log.read_records()
+    assert log_exc_info.value.context["field"] == "line"
+    assert log_exc_info.value.context["value"] == 1
+
+    with pytest.raises(
+        CloseoutAttributionIntegrityError,
+        match="Closeout attribution log line 1 is malformed: max_loss must be a JSON object",
+    ):
+        service.get(idea.decision_id)
+
+    with pytest.raises(
+        CloseoutAttributionIntegrityError,
+        match="Closeout attribution log line 1 is malformed: max_loss must be a JSON object",
+    ):
+        service.list_views()

--- a/tests/unit/gpt_trader/features/trade_ideas/test_service_closeout.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_service_closeout.py
@@ -259,6 +259,46 @@ def test_persisted_closeout_rejects_stale_record_hash_against_current_event(
         )
 
 
+@pytest.mark.parametrize(
+    ("max_loss_override", "field_name", "message"),
+    [
+        ({"amount": "251"}, "max_loss.amount", "max_loss.amount expected '250'"),
+        ({"percent_of_account": "1.6"}, "max_loss.percent_of_account", "1.5"),
+        ({"assumptions": ["stale sizing note"]}, "max_loss.assumptions", "assumptions"),
+    ],
+)
+def test_persisted_closeout_rejects_current_event_with_stale_max_loss_snapshot(
+    service: TradeIdeaService,
+    max_loss_override: dict[str, object],
+    field_name: str,
+    message: str,
+) -> None:
+    idea = build_trade_idea()
+    service.propose(idea, actor_id="idea-generator-v1")
+    expired = service.expire(idea.decision_id)
+    current_max_loss = {
+        "amount": "250",
+        "percent_of_account": "1.5",
+        "assumptions": ["Fill at zone midpoint", "No slippage beyond 10 bps"],
+    }
+    _write_closeout_payload(
+        service,
+        expired,
+        max_loss={**current_max_loss, **max_loss_override},
+    )
+
+    with pytest.raises(CloseoutAttributionIntegrityError, match=message) as get_exc_info:
+        service.get(idea.decision_id)
+    context = get_exc_info.value.context
+    assert context["field"] == field_name
+    assert context["stored_terminal_event_id"] == expired.events[-1].event_id
+    assert context["current_terminal_event_id"] == expired.events[-1].event_id
+    assert context["stored_record_hash"] == expired.events[-1].record_hash
+    assert context["current_record_hash"] == expired.events[-1].record_hash
+    assert context["stored_max_loss"] == {**current_max_loss, **max_loss_override}
+    assert context["current_max_loss"] == current_max_loss
+
+
 def test_persisted_closeout_log_rejects_non_object_max_loss_with_line_context(
     service: TradeIdeaService,
 ) -> None:

--- a/tests/unit/gpt_trader/features/trade_ideas/test_service_closeout.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_service_closeout.py
@@ -207,3 +207,47 @@ def test_persisted_closeout_log_rejects_non_object_max_loss_with_line_context(
         match="Closeout attribution log line 1 is malformed: max_loss must be a JSON object",
     ):
         service.list_views()
+
+
+@pytest.mark.parametrize(
+    ("field_name", "message"),
+    [
+        ("amount", "max_loss.amount must be non-negative"),
+        ("percent_of_account", "max_loss.percent_of_account must be non-negative"),
+    ],
+)
+def test_persisted_closeout_log_rejects_negative_max_loss_values_with_line_context(
+    service: TradeIdeaService,
+    field_name: str,
+    message: str,
+) -> None:
+    idea = build_trade_idea()
+    service.propose(idea, actor_id="idea-generator-v1")
+    expired = service.expire(idea.decision_id)
+    max_loss = {"amount": "250", "percent_of_account": "1.5", "assumptions": []}
+    max_loss[field_name] = "-1"
+    payload = {
+        "decision_id": idea.decision_id,
+        "timestamp": "2026-06-12T10:05:00+00:00",
+        "actor_type": "human",
+        "actor_id": "rj",
+        "terminal_event_id": expired.events[-1].event_id,
+        "record_hash": expired.events[-1].record_hash,
+        "resolution": CloseoutResolution.EXPIRY.value,
+        "realized_profit_loss_amount": None,
+        "realized_profit_loss_percent": None,
+        "realized_profit_loss_unavailable_reason": "Idea expired before entry fill",
+        "max_loss": max_loss,
+        "evidence": [],
+    }
+    service.closeout_log.path.parent.mkdir(parents=True, exist_ok=True)
+    service.closeout_log.path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
+    expected = f"Closeout attribution log line 1 is malformed: {message}"
+    with pytest.raises(CloseoutAttributionIntegrityError, match=expected) as log_exc_info:
+        service.closeout_log.read_records()
+    assert log_exc_info.value.context["field"] == "line"
+    assert log_exc_info.value.context["value"] == 1
+
+    with pytest.raises(CloseoutAttributionIntegrityError, match=expected):
+        service.get(idea.decision_id)

--- a/var/agents/configuration/environment_variables.json
+++ b/var/agents/configuration/environment_variables.json
@@ -835,7 +835,7 @@
       ],
       "code_references": [
         {
-          "line": 103,
+          "line": 104,
           "path": "src/gpt_trader/features/trade_ideas/service.py",
           "reader": "os.environ.get"
         }
@@ -1224,7 +1224,7 @@
       ],
       "code_references": [
         {
-          "line": 93,
+          "line": 94,
           "path": "src/gpt_trader/features/trade_ideas/service.py",
           "reader": "os.environ.get"
         }

--- a/var/agents/configuration/environment_variables.json
+++ b/var/agents/configuration/environment_variables.json
@@ -835,7 +835,7 @@
       ],
       "code_references": [
         {
-          "line": 94,
+          "line": 103,
           "path": "src/gpt_trader/features/trade_ideas/service.py",
           "reader": "os.environ.get"
         }
@@ -1224,7 +1224,7 @@
       ],
       "code_references": [
         {
-          "line": 84,
+          "line": 93,
           "path": "src/gpt_trader/features/trade_ideas/service.py",
           "reader": "os.environ.get"
         }

--- a/var/agents/configuration/environment_variables.json
+++ b/var/agents/configuration/environment_variables.json
@@ -835,7 +835,7 @@
       ],
       "code_references": [
         {
-          "line": 104,
+          "line": 122,
           "path": "src/gpt_trader/features/trade_ideas/service.py",
           "reader": "os.environ.get"
         }
@@ -1224,7 +1224,7 @@
       ],
       "code_references": [
         {
-          "line": 94,
+          "line": 112,
           "path": "src/gpt_trader/features/trade_ideas/service.py",
           "reader": "os.environ.get"
         }

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,8 +7,8 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6752,
-    "total_files": 798,
+    "total_tests": 6762,
+    "total_files": 799,
     "markers_used": 16
   },
   "quick_commands": {

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6766,
+    "total_tests": 6767,
     "total_files": 799,
     "markers_used": 16
   },

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6764,
+    "total_tests": 6766,
     "total_files": 799,
     "markers_used": 16
   },

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6762,
+    "total_tests": 6763,
     "total_files": 799,
     "markers_used": 16
   },

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6763,
+    "total_tests": 6764,
     "total_files": 799,
     "markers_used": 16
   },

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,9 +95,9 @@
     ]
   },
   "counts": {
-    "unit": 6598,
+    "unit": 6599,
     "asyncio": 390,
-    "parametrize": 191,
+    "parametrize": 192,
     "endpoints": 83,
     "property": 82,
     "integration": 79,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6597,
+    "unit": 6598,
     "asyncio": 390,
     "parametrize": 191,
     "endpoints": 83,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6587,
+    "unit": 6597,
     "asyncio": 390,
     "parametrize": 191,
     "endpoints": 83,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6599,
+    "unit": 6601,
     "asyncio": 390,
     "parametrize": 192,
     "endpoints": 83,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,9 +95,9 @@
     ]
   },
   "counts": {
-    "unit": 6601,
+    "unit": 6602,
     "asyncio": 390,
-    "parametrize": 192,
+    "parametrize": 193,
     "endpoints": 83,
     "property": 82,
     "integration": 79,

--- a/var/agents/testing/source_test_map.json
+++ b/var/agents/testing/source_test_map.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "summary": {
-    "tests_scanned": 714,
+    "tests_scanned": 715,
     "source_modules": 372,
     "unresolved_modules": 3
   },
@@ -1289,6 +1289,7 @@
       "tests/unit/gpt_trader/features/trade_ideas/test_replay_runner.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_service.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_service_audit_integrity.py",
+      "tests/unit/gpt_trader/features/trade_ideas/test_service_closeout.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_service_preapproval_broker_ticket.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_snapshot.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_store.py",
@@ -3911,6 +3912,9 @@
       "gpt_trader.features.trade_ideas"
     ],
     "tests/unit/gpt_trader/features/trade_ideas/test_service_audit_integrity.py": [
+      "gpt_trader.features.trade_ideas"
+    ],
+    "tests/unit/gpt_trader/features/trade_ideas/test_service_closeout.py": [
       "gpt_trader.features.trade_ideas"
     ],
     "tests/unit/gpt_trader/features/trade_ideas/test_service_preapproval_broker_ticket.py": [

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6763,
+    "total_tests": 6764,
     "total_files": 799,
     "markers_used": 16
   },
@@ -102,9 +102,9 @@
     ]
   },
   "marker_counts": {
-    "unit": 6598,
+    "unit": 6599,
     "asyncio": 390,
-    "parametrize": 191,
+    "parametrize": 192,
     "endpoints": 83,
     "property": 82,
     "integration": 79,
@@ -32994,6 +32994,15 @@
         "name": "test_persisted_closeout_log_rejects_non_object_max_loss_with_line_context",
         "line": 168,
         "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_persisted_closeout_log_rejects_negative_max_loss_values_with_line_context",
+        "line": 219,
+        "markers": [
+          "parametrize",
           "unit"
         ],
         "docstring": ""

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,8 +2,8 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6752,
-    "total_files": 798,
+    "total_tests": 6762,
+    "total_files": 799,
     "markers_used": 16
   },
   "marker_definitions": {
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6587,
+    "unit": 6597,
     "asyncio": 390,
     "parametrize": 191,
     "endpoints": 83,
@@ -542,6 +542,7 @@
       "tests/unit/gpt_trader/features/trade_ideas/test_replay_runner.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_service.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_service_audit_integrity.py",
+      "tests/unit/gpt_trader/features/trade_ideas/test_service_closeout.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_service_preapproval_broker_ticket.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_snapshot.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_store.py",
@@ -32188,7 +32189,7 @@
     "tests/unit/gpt_trader/features/trade_ideas/test_models.py": [
       {
         "name": "test_round_trip_preserves_record",
-        "line": 20,
+        "line": 23,
         "markers": [
           "unit"
         ],
@@ -32196,7 +32197,7 @@
       },
       {
         "name": "test_to_dict_serializes_decimals_as_strings",
-        "line": 26,
+        "line": 29,
         "markers": [
           "unit"
         ],
@@ -32204,7 +32205,7 @@
       },
       {
         "name": "test_from_dict_restores_decimal_types",
-        "line": 34,
+        "line": 37,
         "markers": [
           "unit"
         ],
@@ -32212,7 +32213,7 @@
       },
       {
         "name": "test_time_horizon_rejects_timezone_naive_expiry",
-        "line": 42,
+        "line": 45,
         "markers": [
           "unit"
         ],
@@ -32220,7 +32221,7 @@
       },
       {
         "name": "test_broker_ticket_defaults_to_no_venue",
-        "line": 53,
+        "line": 56,
         "markers": [
           "unit"
         ],
@@ -32228,7 +32229,7 @@
       },
       {
         "name": "test_record_hash_is_stable",
-        "line": 59,
+        "line": 62,
         "markers": [
           "unit"
         ],
@@ -32236,7 +32237,7 @@
       },
       {
         "name": "test_record_hash_changes_when_content_changes",
-        "line": 64,
+        "line": 67,
         "markers": [
           "unit"
         ],
@@ -32244,7 +32245,7 @@
       },
       {
         "name": "test_optional_value_objects_round_trip_when_empty",
-        "line": 70,
+        "line": 73,
         "markers": [
           "unit"
         ],
@@ -32252,7 +32253,7 @@
       },
       {
         "name": "test_max_loss_rejects_negative_values",
-        "line": 80,
+        "line": 83,
         "markers": [
           "parametrize",
           "unit"
@@ -32261,7 +32262,7 @@
       },
       {
         "name": "test_from_dict_rejects_negative_max_loss_values",
-        "line": 86,
+        "line": 89,
         "markers": [
           "parametrize",
           "unit"
@@ -32270,7 +32271,7 @@
       },
       {
         "name": "test_from_dict_rejects_malformed_string_sequences",
-        "line": 132,
+        "line": 135,
         "markers": [
           "parametrize",
           "unit"
@@ -32279,9 +32280,33 @@
       },
       {
         "name": "test_from_dict_rejects_malformed_scalar_strings",
-        "line": 166,
+        "line": 169,
         "markers": [
           "parametrize",
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_closeout_attribution_round_trip_preserves_record",
+        "line": 187,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_closeout_attribution_rejects_malformed_numeric_payload",
+        "line": 215,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_closeout_attribution_requires_profit_loss_or_unavailable_reason",
+        "line": 235,
+        "markers": [
           "unit"
         ],
         "docstring": ""
@@ -32436,7 +32461,7 @@
     "tests/unit/gpt_trader/features/trade_ideas/test_replay.py": [
       {
         "name": "test_score_trade_idea_records_target_hit",
-        "line": 53,
+        "line": 55,
         "markers": [
           "unit"
         ],
@@ -32444,7 +32469,7 @@
       },
       {
         "name": "test_score_trade_idea_requires_midpoint_entry_fill",
-        "line": 70,
+        "line": 72,
         "markers": [
           "unit"
         ],
@@ -32452,7 +32477,7 @@
       },
       {
         "name": "test_score_trade_idea_reports_not_filled_when_only_entry_zone_edge_trades",
-        "line": 87,
+        "line": 89,
         "markers": [
           "unit"
         ],
@@ -32460,7 +32485,7 @@
       },
       {
         "name": "test_score_trade_idea_uses_conservative_stop_first_when_bar_hits_both",
-        "line": 102,
+        "line": 104,
         "markers": [
           "unit"
         ],
@@ -32468,7 +32493,7 @@
       },
       {
         "name": "test_score_trade_idea_defers_target_hit_on_entry_candle",
-        "line": 114,
+        "line": 116,
         "markers": [
           "unit"
         ],
@@ -32476,7 +32501,7 @@
       },
       {
         "name": "test_score_trade_idea_defers_prefill_long_stop_on_entry_candle",
-        "line": 130,
+        "line": 132,
         "markers": [
           "unit"
         ],
@@ -32484,7 +32509,7 @@
       },
       {
         "name": "test_score_trade_idea_defers_prefill_short_stop_on_entry_candle",
-        "line": 146,
+        "line": 148,
         "markers": [
           "unit"
         ],
@@ -32492,7 +32517,7 @@
       },
       {
         "name": "test_score_trade_idea_keeps_long_entry_candle_stop_when_not_pinned_to_open",
-        "line": 166,
+        "line": 168,
         "markers": [
           "unit"
         ],
@@ -32500,7 +32525,7 @@
       },
       {
         "name": "test_score_trade_idea_keeps_short_entry_candle_stop_when_not_pinned_to_open",
-        "line": 177,
+        "line": 179,
         "markers": [
           "unit"
         ],
@@ -32508,7 +32533,7 @@
       },
       {
         "name": "test_score_trade_idea_records_short_target_hit",
-        "line": 192,
+        "line": 194,
         "markers": [
           "unit"
         ],
@@ -32516,7 +32541,7 @@
       },
       {
         "name": "test_score_trade_idea_uses_conservative_short_stop_first_when_bar_hits_both",
-        "line": 212,
+        "line": 214,
         "markers": [
           "unit"
         ],
@@ -32524,7 +32549,7 @@
       },
       {
         "name": "test_score_trade_idea_times_out_at_last_close_before_expiry",
-        "line": 228,
+        "line": 230,
         "markers": [
           "unit"
         ],
@@ -32532,7 +32557,7 @@
       },
       {
         "name": "test_score_trade_idea_counts_waiting_bars_before_delayed_entry",
-        "line": 245,
+        "line": 247,
         "markers": [
           "unit"
         ],
@@ -32540,7 +32565,7 @@
       },
       {
         "name": "test_score_trade_idea_reports_not_filled_when_entry_zone_never_trades",
-        "line": 263,
+        "line": 265,
         "markers": [
           "unit"
         ],
@@ -32548,7 +32573,7 @@
       },
       {
         "name": "test_score_trade_idea_reports_no_future_data",
-        "line": 279,
+        "line": 281,
         "markers": [
           "unit"
         ],
@@ -32556,7 +32581,15 @@
       },
       {
         "name": "test_score_trade_idea_excludes_candles_that_extend_past_expiry",
-        "line": 286,
+        "line": 288,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_replay_scoring_does_not_mutate_live_closeout_records",
+        "line": 305,
         "markers": [
           "unit"
         ],
@@ -32902,6 +32935,56 @@
       {
         "name": "test_approval_count_ignores_unaudited_latest_for_nonapproved_records",
         "line": 50,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      }
+    ],
+    "tests/unit/gpt_trader/features/trade_ideas/test_service_closeout.py": [
+      {
+        "name": "test_record_closeout_attribution_for_filled_idea",
+        "line": 30,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_record_closeout_attribution_for_expired_idea_without_profit_loss",
+        "line": 69,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_record_closeout_attribution_rejects_non_terminal_idea",
+        "line": 93,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_record_closeout_attribution_rejects_unknown_idea",
+        "line": 110,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_record_closeout_attribution_rejects_duplicate_conflict",
+        "line": 122,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_record_closeout_attribution_rejects_malformed_numeric_payload",
+        "line": 148,
         "markers": [
           "unit"
         ],

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6764,
+    "total_tests": 6766,
     "total_files": 799,
     "markers_used": 16
   },
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6599,
+    "unit": 6601,
     "asyncio": 390,
     "parametrize": 192,
     "endpoints": 83,
@@ -32944,7 +32944,7 @@
     "tests/unit/gpt_trader/features/trade_ideas/test_service_closeout.py": [
       {
         "name": "test_record_closeout_attribution_for_filled_idea",
-        "line": 32,
+        "line": 66,
         "markers": [
           "unit"
         ],
@@ -32952,7 +32952,7 @@
       },
       {
         "name": "test_record_closeout_attribution_for_expired_idea_without_profit_loss",
-        "line": 71,
+        "line": 105,
         "markers": [
           "unit"
         ],
@@ -32960,7 +32960,7 @@
       },
       {
         "name": "test_record_closeout_attribution_rejects_non_terminal_idea",
-        "line": 95,
+        "line": 129,
         "markers": [
           "unit"
         ],
@@ -32968,7 +32968,7 @@
       },
       {
         "name": "test_record_closeout_attribution_rejects_unknown_idea",
-        "line": 112,
+        "line": 146,
         "markers": [
           "unit"
         ],
@@ -32976,7 +32976,7 @@
       },
       {
         "name": "test_record_closeout_attribution_rejects_duplicate_conflict",
-        "line": 124,
+        "line": 158,
         "markers": [
           "unit"
         ],
@@ -32984,7 +32984,23 @@
       },
       {
         "name": "test_record_closeout_attribution_rejects_malformed_numeric_payload",
-        "line": 150,
+        "line": 184,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_persisted_closeout_rejects_stale_terminal_event_id_against_current_event",
+        "line": 202,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_persisted_closeout_rejects_stale_record_hash_against_current_event",
+        "line": 232,
         "markers": [
           "unit"
         ],
@@ -32992,7 +33008,7 @@
       },
       {
         "name": "test_persisted_closeout_log_rejects_non_object_max_loss_with_line_context",
-        "line": 168,
+        "line": 262,
         "markers": [
           "unit"
         ],
@@ -33000,7 +33016,7 @@
       },
       {
         "name": "test_persisted_closeout_log_rejects_negative_max_loss_values_with_line_context",
-        "line": 219,
+        "line": 313,
         "markers": [
           "parametrize",
           "unit"

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6766,
+    "total_tests": 6767,
     "total_files": 799,
     "markers_used": 16
   },
@@ -102,9 +102,9 @@
     ]
   },
   "marker_counts": {
-    "unit": 6601,
+    "unit": 6602,
     "asyncio": 390,
-    "parametrize": 192,
+    "parametrize": 193,
     "endpoints": 83,
     "property": 82,
     "integration": 79,
@@ -33007,8 +33007,17 @@
         "docstring": ""
       },
       {
+        "name": "test_persisted_closeout_rejects_current_event_with_stale_max_loss_snapshot",
+        "line": 270,
+        "markers": [
+          "parametrize",
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
         "name": "test_persisted_closeout_log_rejects_non_object_max_loss_with_line_context",
-        "line": 262,
+        "line": 302,
         "markers": [
           "unit"
         ],
@@ -33016,7 +33025,7 @@
       },
       {
         "name": "test_persisted_closeout_log_rejects_negative_max_loss_values_with_line_context",
-        "line": 313,
+        "line": 353,
         "markers": [
           "parametrize",
           "unit"

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6762,
+    "total_tests": 6763,
     "total_files": 799,
     "markers_used": 16
   },
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6597,
+    "unit": 6598,
     "asyncio": 390,
     "parametrize": 191,
     "endpoints": 83,
@@ -32944,7 +32944,7 @@
     "tests/unit/gpt_trader/features/trade_ideas/test_service_closeout.py": [
       {
         "name": "test_record_closeout_attribution_for_filled_idea",
-        "line": 30,
+        "line": 32,
         "markers": [
           "unit"
         ],
@@ -32952,7 +32952,7 @@
       },
       {
         "name": "test_record_closeout_attribution_for_expired_idea_without_profit_loss",
-        "line": 69,
+        "line": 71,
         "markers": [
           "unit"
         ],
@@ -32960,7 +32960,7 @@
       },
       {
         "name": "test_record_closeout_attribution_rejects_non_terminal_idea",
-        "line": 93,
+        "line": 95,
         "markers": [
           "unit"
         ],
@@ -32968,7 +32968,7 @@
       },
       {
         "name": "test_record_closeout_attribution_rejects_unknown_idea",
-        "line": 110,
+        "line": 112,
         "markers": [
           "unit"
         ],
@@ -32976,7 +32976,7 @@
       },
       {
         "name": "test_record_closeout_attribution_rejects_duplicate_conflict",
-        "line": 122,
+        "line": 124,
         "markers": [
           "unit"
         ],
@@ -32984,7 +32984,15 @@
       },
       {
         "name": "test_record_closeout_attribution_rejects_malformed_numeric_payload",
-        "line": 148,
+        "line": 150,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_persisted_closeout_log_rejects_non_object_max_loss_with_line_context",
+        "line": 168,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary
Related issue / finding / RJ-routed package: Closes #943; finding `trade-idea-outcome-attribution-closeout`.

Adds a broker-neutral closeout attribution path for terminal trade ideas. The service now records a separate append-only `closeout_attributions.jsonl` record that stamps actor identity, terminal audit event id, record hash, resolution category, realized profit/loss or unavailable reason, max-loss snapshot, and evidence references.

## Type of change
- [x] Feature
- [ ] Bug fix
- [x] Tests only
- [x] CI/Docs/Tooling

## Scope & Impact
- Affected areas / components: `src/gpt_trader/features/trade_ideas/`, trade-idea unit tests, regenerated `var/agents` testing/config metadata.
- Behavior changes: adds `TradeIdeaService.record_closeout_attribution(...)`, `get_closeout_attribution(...)`, and `TradeIdeaView.closeout_attribution`; existing lifecycle state transitions and broker submission behavior are unchanged.
- Out of scope preserved: no broker/order submission, venue API calls, autonomy-mode changes, live trading controls, reporting UI, or strategy behavior.

## Test Plan
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Contract tests (if applicable)
- [x] Ran locally: `uv run pytest tests/unit/gpt_trader/features/trade_ideas/test_service.py tests/unit/gpt_trader/features/trade_ideas/test_audit.py tests/unit/gpt_trader/features/trade_ideas/test_models.py tests/unit/gpt_trader/features/trade_ideas/test_replay.py` -> 81 passed
- [x] Ran locally: `uv run pytest tests/unit/gpt_trader/features/trade_ideas/test_service_closeout.py` -> 6 passed
- [x] Markers used appropriately (`unit`/`integration`/`slow`/`perf`)

## Complexity & Quality Gates
- [x] Mypy/type-check passed via `uv run local-ci --profile quick`
- [x] Xenon/radon complexity gate passed (CC <= 15 on live_trade execution) - not touched
- [x] No `sys.path` hacks in tests
- [x] No `MagicMock` on `async def` (use `AsyncMock`)
- [x] Import-lint rules respected (no import up the stack)

## Observability & Errors
- [ ] Structured JSON logs for new/changed paths
- [x] Errors include diagnostic context where service validation raises existing `ValidationError` subclasses
- [ ] Added/updated sampling examples in tests (if applicable)

## Configuration
- [ ] If config changed: `python -m gpt_trader.cli.config validate --profile <name>` passes
- [x] Env docs re-generated where line-number metadata drifted: `uv run agent-regenerate` and `uv run agent-regenerate --verify`
- [x] No `ConfigLoader` usages introduced (ConfigManager-only)

## Breaking Changes
- [x] None
- [ ] Documented in PR body and release notes if any

## Verification
- `uv run pytest tests/unit/gpt_trader/features/trade_ideas/test_service.py tests/unit/gpt_trader/features/trade_ideas/test_audit.py tests/unit/gpt_trader/features/trade_ideas/test_models.py tests/unit/gpt_trader/features/trade_ideas/test_replay.py` -> 81 passed
- `uv run pytest tests/unit/gpt_trader/features/trade_ideas/test_service_closeout.py` -> 6 passed
- `uv run agent-regenerate --verify` -> all context files up-to-date
- `uv run local-ci --profile quick` -> passed; core unit leg 7024 passed, 8 skipped

## Known Risks / Follow-ups
None for this issue. CLI/reporting surfaces can be added in separate issue-backed work if needed.

## Checklist
- [x] Acceptance criteria in linked issue(s), finding packet, or routed package met
- [x] Affected paths listed in PR description
- [x] Changelog entry (if repo uses one) - none found for this scoped change
