### PR TITLE
[codex] Add trade-idea track-record report

### DIFF
--- a/docs/specs/TRADE_IDEA_CLI_SPEC.md
+++ b/docs/specs/TRADE_IDEA_CLI_SPEC.md
@@ -58,6 +58,7 @@ gpt-trader ideas
 ├── resubmit         --file PATH | --stdin   [--actor-type {ai,human}] [--reason TEXT]
 ├── list             [--state STATE]
 ├── show             DECISION_ID [--events]
+├── report
 ├── approve          DECISION_ID --reason TEXT
 ├── reject           DECISION_ID --reason TEXT
 ├── request-changes  DECISION_ID --reason TEXT
@@ -114,6 +115,29 @@ already exist (`IDEA_NOT_FOUND` otherwise). Service/audit layer enforces the
   (`[e.to_dict() for e in view.events]`).
 - Text: field-per-line record rendering; with `--events`, a chronological
   `timestamp  actor_type/actor_id  action  before→after  reason` table.
+
+### `ideas report`
+
+- Read-only track-record report over the local `--ideas-root` records, audit
+  events, and closeout attribution log. It does not call broker, account,
+  venue, preflight, canary, or live-trading surfaces.
+- Empty stores return success with zero counts and `was_noop=True`.
+- JSON `data` contains:
+  - `proposal_volume`: idea count, proposal event count, resubmission count,
+    and monthly volume/approval/closeout buckets.
+  - `workflow`: lifecycle event counts, current-state counts, ever-approved /
+    submitted / filled counts, and rates.
+  - `quality`: eligibility and approval-policy quality counts evaluated
+    read-only against stored records and the default risk-budget constants,
+    without seeding `risk_budget.jsonl`.
+  - `closeouts`: terminal closeout coverage, missing terminal closeout ids,
+    resolution counts, profit/loss outcome distribution, and realized P/L
+    versus max-loss comparisons when closeout records include numeric data.
+- Text starts with:
+
+  ```text
+  ✓ ideas report OK (3 ideas, approval_rate=33.33%, closeout_coverage=66.67%)
+  ```
 
 ### `ideas approve DECISION_ID --reason TEXT`
 
@@ -205,21 +229,23 @@ Required cases:
 2. `propose` with missing required field → `INVALID_ARGUMENT`, names field.
 3. `list` empty store → success, empty list. `list --state proposed` filters.
 4. `show` unknown id → `IDEA_NOT_FOUND`. `show --events` includes history.
-5. `approve` happy path → state `approved`, human actor in audit event.
-6. `approve` over-budget idea → exit 1, `POLICY_VIOLATION`, all violations in
+5. `report` empty store, normal records, missing closeout coverage, JSON
+   output, and read-only behavior that does not create `risk_budget.jsonl`.
+6. `approve` happy path → state `approved`, human actor in audit event.
+7. `approve` over-budget idea → exit 1, `POLICY_VIOLATION`, all violations in
    `data["violations"]` (assert ≥2 violations both present).
-7. `request-changes` → `resubmit` (revised record) → `approve` full loop.
-8. `reject`, `cancel`, `expire` single, `expire --sweep` with explicit expiry
+8. `request-changes` → `resubmit` (revised record) → `approve` full loop.
+9. `reject`, `cancel`, `expire` single, `expire --sweep` with explicit expiry
    coverage (one stale + one fresh idea: only stale expires; `was_noop` when
    none) plus review-latency sweep coverage for a far-future idea whose review
    deadline exceeds `max_review_latency_hours`.
-9. `mark-submitted` then `mark-filled` with venue/external id recorded in
+10. `mark-submitted` then `mark-filled` with venue/external id recorded in
    audit events.
-10. `budget show` seeds defaults; `budget set --max-loss-per-idea-pct 2
+11. `budget show` seeds defaults; `budget set --max-loss-per-idea-pct 2
     --reason ...` bumps version; `budget set` with no field flags →
     `MISSING_ARGUMENT`.
-11. `audit verify` OK path; tampered line in `audit.jsonl` → failure.
-12. JSON mode for at least propose/approve/list asserting the
+12. `audit verify` OK path; tampered line in `audit.jsonl` → failure.
+13. JSON mode for at least propose/approve/list/report asserting the
     `CliResponse` envelope per CLAUDE.md patterns
     (`result.errors[0].code == CliErrorCode.POLICY_VIOLATION.value`).
 

--- a/src/gpt_trader/cli/commands/ideas.py
+++ b/src/gpt_trader/cli/commands/ideas.py
@@ -33,6 +33,10 @@ from gpt_trader.features.trade_ideas import (
     is_safe_decision_id,
     resolve_trade_idea_actor_id,
 )
+from gpt_trader.features.trade_ideas.report import (
+    build_trade_idea_track_record_report,
+    format_trade_idea_track_record_report,
+)
 
 VENUE_CHOICES = ("coinbase", "manual")
 BUDGET_FIELDS = (
@@ -112,6 +116,17 @@ def register(subparsers: Any) -> None:
     show.add_argument("decision_id", help="Trade idea decision identifier")
     show.add_argument("--events", action="store_true", help="Include audit history")
     show.set_defaults(handler=_handle_show, subcommand="show")
+
+    report = ideas_subparsers.add_parser(
+        "report",
+        help="Summarize proposal quality, workflow rates, and closeout coverage",
+        description=(
+            "Read-only track-record report over local trade-idea records, audit events, "
+            "and closeout attribution. This command never contacts a broker or account."
+        ),
+    )
+    _add_common_options(report)
+    report.set_defaults(handler=_handle_report, subcommand="report")
 
     approve = ideas_subparsers.add_parser("approve", help="Approve a proposed trade idea")
     _add_common_options(approve)
@@ -417,6 +432,18 @@ def _handle_show(args: Namespace) -> CliResponse:
     payload = _view_record(view, include_events=args.events)
     text = _record_text(payload, include_events=args.events)
     return _success(command, args, payload, text)
+
+
+def _handle_report(args: Namespace) -> CliResponse:
+    command = "ideas report"
+    try:
+        payload = build_trade_idea_track_record_report(_service(args))
+    except Exception as error:
+        return _mapped_error(command, args, error)
+
+    text = format_trade_idea_track_record_report(payload)
+    idea_count = payload["proposal_volume"]["idea_count"]
+    return _success(command, args, payload, text, was_noop=idea_count == 0)
 
 
 def _handle_approve(args: Namespace) -> CliResponse:

--- a/src/gpt_trader/features/trade_ideas/__init__.py
+++ b/src/gpt_trader/features/trade_ideas/__init__.py
@@ -63,6 +63,10 @@ from gpt_trader.features.trade_ideas.replay import (
     extract_numeric_scoring_levels,
     score_trade_idea,
 )
+from gpt_trader.features.trade_ideas.report import (
+    build_trade_idea_track_record_report,
+    format_trade_idea_track_record_report,
+)
 from gpt_trader.features.trade_ideas.service import (
     ACTOR_ENV_VAR,
     DEFAULT_IDEAS_ROOT,
@@ -148,9 +152,11 @@ __all__ = [
     "TradeIdeaStore",
     "TradeIdeaView",
     "UnknownTradeIdeaError",
+    "build_trade_idea_track_record_report",
     "create_trade_idea_service",
     "evaluate_eligibility",
     "extract_numeric_scoring_levels",
+    "format_trade_idea_track_record_report",
     "is_eligible",
     "is_safe_decision_id",
     "new_event_id",

--- a/src/gpt_trader/features/trade_ideas/report.py
+++ b/src/gpt_trader/features/trade_ideas/report.py
@@ -1,0 +1,396 @@
+"""Read-only trade-idea track-record reporting."""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+
+from gpt_trader.features.trade_ideas.audit import ActorType, AuditAction
+from gpt_trader.features.trade_ideas.budget import DEFAULT_RISK_BUDGET
+from gpt_trader.features.trade_ideas.closeout import CloseoutResolution
+from gpt_trader.features.trade_ideas.eligibility import evaluate_eligibility
+from gpt_trader.features.trade_ideas.models import ConfidenceLabel
+from gpt_trader.features.trade_ideas.policy import ApprovalPolicy
+from gpt_trader.features.trade_ideas.service import TradeIdeaService, TradeIdeaView
+from gpt_trader.features.trade_ideas.workflow import TERMINAL_STATES, TradeIdeaState
+
+_RATE_QUANT = Decimal("0.0000")
+_PERCENT_QUANT = Decimal("0.01")
+_ACTION_KEYS = {
+    AuditAction.PROPOSED: "proposed",
+    AuditAction.CHANGED: "requested_changes",
+    AuditAction.APPROVED: "approved",
+    AuditAction.REJECTED: "rejected",
+    AuditAction.SUBMITTED: "submitted",
+    AuditAction.FILLED: "filled",
+    AuditAction.CANCELLED: "cancelled",
+    AuditAction.EXPIRED: "expired",
+}
+
+
+def build_trade_idea_track_record_report(
+    service: TradeIdeaService,
+    *,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Build a read-only report from stored records, audit events, and closeouts."""
+    current_time = now or datetime.now(UTC)
+    views = service.list_views()
+    total_ideas = len(views)
+
+    event_counts = _zero_action_counts()
+    state_counts = {state.value: 0 for state in TradeIdeaState}
+    confidence_counts = {label.value: 0 for label in ConfidenceLabel}
+
+    for view in views:
+        state_counts[view.state.value] += 1
+        confidence_counts[view.idea.confidence.label.value] += 1
+        for event in view.events:
+            event_counts[_ACTION_KEYS[event.action]] += 1
+
+    quality = _quality_summary(views, now=current_time)
+    workflow = _workflow_summary(views, event_counts, state_counts)
+    closeouts = _closeout_summary(views)
+    monthly = _monthly_summary(views)
+
+    return {
+        "proposal_volume": {
+            "idea_count": total_ideas,
+            "proposal_event_count": event_counts["proposed"],
+            "resubmission_count": max(event_counts["proposed"] - total_ideas, 0),
+            "by_month": monthly,
+        },
+        "workflow": workflow,
+        "quality": {
+            **quality,
+            "confidence_counts": confidence_counts,
+        },
+        "closeouts": closeouts,
+    }
+
+
+def format_trade_idea_track_record_report(report: Mapping[str, Any]) -> str:
+    """Render a compact text report for operators."""
+    proposal_volume = report["proposal_volume"]
+    workflow = report["workflow"]
+    quality = report["quality"]
+    closeouts = report["closeouts"]
+    profit_loss = closeouts["realized_profit_loss"]
+
+    lines = [
+        "✓ ideas report OK "
+        f"({proposal_volume['idea_count']} ideas, "
+        f"approval_rate={workflow['approval_rate_pct']}%, "
+        f"closeout_coverage={closeouts['coverage_rate_pct']}%)",
+        "",
+        "Workflow",
+        _counts_line("events", workflow["event_counts"]),
+        _counts_line("current_states", workflow["current_state_counts"]),
+        (
+            f"approval_rate: {workflow['ever_approved_count']}/"
+            f"{proposal_volume['idea_count']} ({workflow['approval_rate_pct']}%)"
+        ),
+        (
+            f"submitted_rate: {workflow['ever_submitted_count']}/"
+            f"{proposal_volume['idea_count']} ({workflow['submitted_rate_pct']}%)"
+        ),
+        (
+            f"filled_rate: {workflow['ever_filled_count']}/"
+            f"{proposal_volume['idea_count']} ({workflow['filled_rate_pct']}%)"
+        ),
+        "",
+        "Quality",
+        (
+            f"eligible_records: {quality['eligible_count']}/"
+            f"{proposal_volume['idea_count']} ({quality['eligible_rate_pct']}%)"
+        ),
+        (
+            f"approval_ready_records: {quality['approval_ready_count']}/"
+            f"{proposal_volume['idea_count']} ({quality['approval_ready_rate_pct']}%)"
+        ),
+        _counts_line("missing_quality_fields", quality["missing_field_counts"]),
+        _counts_line("approval_policy_violations", quality["approval_policy_violation_counts"]),
+        "",
+        "Closeouts",
+        (
+            f"coverage: {closeouts['with_closeout_count']}/"
+            f"{closeouts['terminal_count']} terminal "
+            f"({closeouts['coverage_rate_pct']}%)"
+        ),
+        f"missing_closeout_count: {closeouts['missing_closeout_count']}",
+        _counts_line("resolutions", closeouts["resolution_counts"]),
+        _counts_line("outcomes", closeouts["outcome_distribution"]),
+        (
+            f"realized_profit_loss_total: {profit_loss['total_amount']} "
+            f"across {profit_loss['available_amount_count']} closeouts"
+        ),
+        (
+            "realized_vs_max_loss: "
+            f"{profit_loss['max_loss_comparison']['total_realized_to_max_loss_ratio']} "
+            f"across {profit_loss['max_loss_comparison']['comparable_count']} comparable closeouts"
+        ),
+    ]
+    return "\n".join(lines)
+
+
+def _workflow_summary(
+    views: list[TradeIdeaView],
+    event_counts: dict[str, int],
+    state_counts: dict[str, int],
+) -> dict[str, Any]:
+    total_ideas = len(views)
+    ever_approved = _ever_count(views, AuditAction.APPROVED)
+    ever_submitted = _ever_count(views, AuditAction.SUBMITTED)
+    ever_filled = _ever_count(views, AuditAction.FILLED)
+    return {
+        "event_counts": event_counts,
+        "current_state_counts": state_counts,
+        "ever_approved_count": ever_approved,
+        "approval_rate": _rate(ever_approved, total_ideas),
+        "approval_rate_pct": _percentage(ever_approved, total_ideas),
+        "ever_submitted_count": ever_submitted,
+        "submitted_rate": _rate(ever_submitted, total_ideas),
+        "submitted_rate_pct": _percentage(ever_submitted, total_ideas),
+        "ever_filled_count": ever_filled,
+        "filled_rate": _rate(ever_filled, total_ideas),
+        "filled_rate_pct": _percentage(ever_filled, total_ideas),
+    }
+
+
+def _quality_summary(views: list[TradeIdeaView], *, now: datetime) -> dict[str, Any]:
+    policy = ApprovalPolicy()
+    missing_fields: Counter[str] = Counter()
+    eligibility_violations: Counter[str] = Counter()
+    policy_violations: Counter[str] = Counter()
+    eligible_count = 0
+    approval_ready_count = 0
+
+    for view in views:
+        idea = view.idea
+        if idea.max_loss.amount is None:
+            missing_fields["max_loss.amount"] += 1
+        if idea.max_loss.percent_of_account is None:
+            missing_fields["max_loss.percent_of_account"] += 1
+        if idea.time_horizon.expires_at is None:
+            missing_fields["time_horizon.expires_at"] += 1
+        if not idea.data_used:
+            missing_fields["data_used"] += 1
+
+        eligibility = evaluate_eligibility(idea)
+        if not eligibility:
+            eligible_count += 1
+        eligibility_violations.update(eligibility)
+
+        approval = policy.approval_violations(
+            idea,
+            actor_type=ActorType.HUMAN,
+            budget=DEFAULT_RISK_BUDGET,
+            open_approved_count=0,
+            now=now,
+            review_started_at=None,
+        )
+        if not approval:
+            approval_ready_count += 1
+        policy_violations.update(approval)
+
+    total_ideas = len(views)
+    return {
+        "eligible_count": eligible_count,
+        "eligible_rate": _rate(eligible_count, total_ideas),
+        "eligible_rate_pct": _percentage(eligible_count, total_ideas),
+        "approval_ready_count": approval_ready_count,
+        "approval_ready_rate": _rate(approval_ready_count, total_ideas),
+        "approval_ready_rate_pct": _percentage(approval_ready_count, total_ideas),
+        "missing_field_counts": _sorted_counter(missing_fields),
+        "eligibility_violation_counts": _sorted_counter(eligibility_violations),
+        "approval_policy_violation_counts": _sorted_counter(policy_violations),
+    }
+
+
+def _closeout_summary(views: list[TradeIdeaView]) -> dict[str, Any]:
+    terminal_views = [view for view in views if view.state in TERMINAL_STATES]
+    terminal_count = len(terminal_views)
+    resolution_counts = {resolution.value: 0 for resolution in CloseoutResolution}
+    missing_closeout_ids: list[str] = []
+    outcome_distribution = {
+        "profit": 0,
+        "loss": 0,
+        "flat": 0,
+        "unavailable": 0,
+    }
+    total_amount = Decimal("0")
+    available_amount_count = 0
+    max_loss_comparisons: list[dict[str, Any]] = []
+
+    for view in terminal_views:
+        closeout = view.closeout_attribution
+        if closeout is None:
+            missing_closeout_ids.append(view.idea.decision_id)
+            continue
+
+        resolution_counts[closeout.resolution.value] += 1
+        realized_amount = closeout.realized_profit_loss_amount
+        if realized_amount is None:
+            outcome_distribution["unavailable"] += 1
+        else:
+            available_amount_count += 1
+            total_amount += realized_amount
+            if realized_amount > 0:
+                outcome_distribution["profit"] += 1
+            elif realized_amount < 0:
+                outcome_distribution["loss"] += 1
+            else:
+                outcome_distribution["flat"] += 1
+
+        max_loss_amount = closeout.max_loss.amount
+        if realized_amount is not None and max_loss_amount is not None and max_loss_amount > 0:
+            max_loss_comparisons.append(
+                {
+                    "decision_id": closeout.decision_id,
+                    "realized_profit_loss_amount": _decimal_to_str(realized_amount),
+                    "max_loss_amount": _decimal_to_str(max_loss_amount),
+                    "realized_to_max_loss_ratio": _decimal_ratio(
+                        realized_amount,
+                        max_loss_amount,
+                    ),
+                }
+            )
+
+    comparable_max_loss_total = sum(
+        (Decimal(comparison["max_loss_amount"]) for comparison in max_loss_comparisons),
+        Decimal("0"),
+    )
+    comparable_realized_total = sum(
+        (Decimal(comparison["realized_profit_loss_amount"]) for comparison in max_loss_comparisons),
+        Decimal("0"),
+    )
+
+    with_closeout_count = terminal_count - len(missing_closeout_ids)
+    return {
+        "terminal_count": terminal_count,
+        "with_closeout_count": with_closeout_count,
+        "missing_closeout_count": len(missing_closeout_ids),
+        "missing_closeout_decision_ids": sorted(missing_closeout_ids),
+        "coverage_rate": _rate(with_closeout_count, terminal_count),
+        "coverage_rate_pct": _percentage(with_closeout_count, terminal_count),
+        "resolution_counts": resolution_counts,
+        "outcome_distribution": outcome_distribution,
+        "realized_profit_loss": {
+            "available_amount_count": available_amount_count,
+            "total_amount": _decimal_to_str(total_amount),
+            "average_amount": _average_decimal(total_amount, available_amount_count),
+            "max_loss_comparison": {
+                "comparable_count": len(max_loss_comparisons),
+                "total_realized_amount": _decimal_to_str(comparable_realized_total),
+                "total_max_loss_amount": _decimal_to_str(comparable_max_loss_total),
+                "total_realized_to_max_loss_ratio": _decimal_ratio(
+                    comparable_realized_total,
+                    comparable_max_loss_total,
+                ),
+                "by_decision_id": sorted(
+                    max_loss_comparisons,
+                    key=lambda item: item["decision_id"],
+                ),
+            },
+        },
+    }
+
+
+def _monthly_summary(views: list[TradeIdeaView]) -> dict[str, dict[str, Any]]:
+    monthly: dict[str, dict[str, Any]] = {}
+    for view in views:
+        if not view.events:
+            continue
+        month = view.events[0].timestamp.strftime("%Y-%m")
+        bucket = monthly.setdefault(
+            month,
+            {
+                "idea_count": 0,
+                "approved_count": 0,
+                "terminal_count": 0,
+                "with_closeout_count": 0,
+                "realized_profit_loss_amount": Decimal("0"),
+            },
+        )
+        bucket["idea_count"] += 1
+        if _has_event(view, AuditAction.APPROVED):
+            bucket["approved_count"] += 1
+        if view.state in TERMINAL_STATES:
+            bucket["terminal_count"] += 1
+            if view.closeout_attribution is not None:
+                bucket["with_closeout_count"] += 1
+                realized_amount = view.closeout_attribution.realized_profit_loss_amount
+                if realized_amount is not None:
+                    bucket["realized_profit_loss_amount"] += realized_amount
+
+    return {
+        month: {
+            **bucket,
+            "realized_profit_loss_amount": _decimal_to_str(bucket["realized_profit_loss_amount"]),
+            "approval_rate": _rate(bucket["approved_count"], bucket["idea_count"]),
+            "approval_rate_pct": _percentage(bucket["approved_count"], bucket["idea_count"]),
+            "closeout_coverage_rate": _rate(
+                bucket["with_closeout_count"],
+                bucket["terminal_count"],
+            ),
+            "closeout_coverage_rate_pct": _percentage(
+                bucket["with_closeout_count"],
+                bucket["terminal_count"],
+            ),
+        }
+        for month, bucket in sorted(monthly.items())
+    }
+
+
+def _zero_action_counts() -> dict[str, int]:
+    return {key: 0 for key in _ACTION_KEYS.values()}
+
+
+def _ever_count(views: list[TradeIdeaView], action: AuditAction) -> int:
+    return sum(1 for view in views if _has_event(view, action))
+
+
+def _has_event(view: TradeIdeaView, action: AuditAction) -> bool:
+    return any(event.action is action for event in view.events)
+
+
+def _rate(numerator: int, denominator: int) -> str:
+    if denominator == 0:
+        return "0.0000"
+    return str((Decimal(numerator) / Decimal(denominator)).quantize(_RATE_QUANT))
+
+
+def _percentage(numerator: int, denominator: int) -> str:
+    if denominator == 0:
+        return "0.00"
+    value = (Decimal(numerator) / Decimal(denominator) * Decimal("100")).quantize(_PERCENT_QUANT)
+    return str(value)
+
+
+def _decimal_ratio(numerator: Decimal, denominator: Decimal) -> str | None:
+    if denominator == 0:
+        return None
+    return str((numerator / denominator).quantize(_RATE_QUANT))
+
+
+def _decimal_to_str(value: Decimal) -> str:
+    return str(value)
+
+
+def _average_decimal(total: Decimal, count: int) -> str | None:
+    if count == 0:
+        return None
+    return str(total / Decimal(count))
+
+
+def _sorted_counter(counter: Counter[str]) -> dict[str, int]:
+    return {key: counter[key] for key in sorted(counter)}
+
+
+def _counts_line(label: str, counts: Mapping[str, Any]) -> str:
+    if not counts:
+        return f"{label}: none"
+    return f"{label}: " + ", ".join(f"{key}={value}" for key, value in counts.items())

--- a/src/gpt_trader/features/trade_ideas/report.py
+++ b/src/gpt_trader/features/trade_ideas/report.py
@@ -234,16 +234,13 @@ def _closeout_summary(views: list[TradeIdeaView]) -> dict[str, Any]:
         resolution_counts[closeout.resolution.value] += 1
         realized_amount = closeout.realized_profit_loss_amount
         if realized_amount is None:
-            outcome_distribution["unavailable"] += 1
+            outcome_distribution[
+                _realized_profit_loss_outcome(closeout.realized_profit_loss_percent)
+            ] += 1
         else:
             available_amount_count += 1
             total_amount += realized_amount
-            if realized_amount > 0:
-                outcome_distribution["profit"] += 1
-            elif realized_amount < 0:
-                outcome_distribution["loss"] += 1
-            else:
-                outcome_distribution["flat"] += 1
+            outcome_distribution[_realized_profit_loss_outcome(realized_amount)] += 1
 
         max_loss_amount = closeout.max_loss.amount
         if realized_amount is not None and max_loss_amount is not None and max_loss_amount > 0:
@@ -297,6 +294,16 @@ def _closeout_summary(views: list[TradeIdeaView]) -> dict[str, Any]:
             },
         },
     }
+
+
+def _realized_profit_loss_outcome(value: Decimal | None) -> str:
+    if value is None:
+        return "unavailable"
+    if value > 0:
+        return "profit"
+    if value < 0:
+        return "loss"
+    return "flat"
 
 
 def _monthly_summary(views: list[TradeIdeaView]) -> dict[str, dict[str, Any]]:

--- a/tests/unit/gpt_trader/cli/commands/test_ideas_queries.py
+++ b/tests/unit/gpt_trader/cli/commands/test_ideas_queries.py
@@ -226,6 +226,7 @@ def test_help_lists_ideas_subcommands(capsys: pytest.CaptureFixture[str]) -> Non
     output = capsys.readouterr().out
     assert "propose" in output
     assert "request-changes" in output
+    assert "report" in output
     assert "mark-submitted" in output
     assert "budget" in output
     assert "audit" in output

--- a/tests/unit/gpt_trader/cli/commands/test_ideas_report.py
+++ b/tests/unit/gpt_trader/cli/commands/test_ideas_report.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from gpt_trader import cli
+from gpt_trader.features.trade_ideas import (
+    CloseoutResolution,
+    MaxLoss,
+    TimeHorizon,
+    TradeIdeaService,
+)
+from tests.unit.gpt_trader.features.trade_ideas.conftest import build_trade_idea
+
+
+def _future_horizon() -> TimeHorizon:
+    return TimeHorizon(
+        expected_hold="3-10 days",
+        expires_at=datetime(2035, 6, 19, 16, 0, tzinfo=UTC),
+    )
+
+
+def _idea(decision_id: str, **overrides: Any) -> Any:
+    return build_trade_idea(
+        decision_id=decision_id,
+        time_horizon=_future_horizon(),
+        **overrides,
+    )
+
+
+def _service(root: Path) -> TradeIdeaService:
+    return TradeIdeaService(
+        root,
+        now_factory=lambda: datetime(2026, 6, 12, 10, 0, tzinfo=UTC),
+    )
+
+
+def _root_args(root: Path) -> list[str]:
+    return ["--ideas-root", str(root), "--format", "json"]
+
+
+def _run_json(capsys: pytest.CaptureFixture[str], argv: list[str]) -> tuple[int, dict[str, Any]]:
+    exit_code = cli.main(argv)
+    output = capsys.readouterr().out
+    assert output
+    return exit_code, json.loads(output)
+
+
+def _snapshot_files(root: Path) -> dict[str, str]:
+    if not root.exists():
+        return {}
+    return {
+        str(path.relative_to(root)): path.read_text(encoding="utf-8")
+        for path in sorted(root.rglob("*"))
+        if path.is_file()
+    }
+
+
+def test_report_empty_store_returns_zero_counts(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    root = tmp_path / "ideas"
+
+    exit_code, response = _run_json(capsys, ["ideas", "report", *_root_args(root)])
+
+    assert exit_code == 0
+    assert response["success"] is True
+    assert response["metadata"]["was_noop"] is True
+    data = response["data"]
+    assert data["proposal_volume"]["idea_count"] == 0
+    assert data["proposal_volume"]["proposal_event_count"] == 0
+    assert data["workflow"]["approval_rate_pct"] == "0.00"
+    assert data["closeouts"]["terminal_count"] == 0
+    assert data["closeouts"]["missing_closeout_count"] == 0
+
+
+def test_report_summarizes_workflow_quality_closeouts_and_profit_loss(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    root = tmp_path / "ideas"
+    service = _service(root)
+
+    filled = _idea("trade-report-filled")
+    service.propose(filled, actor_id="idea-generator-v1")
+    service.approve(filled.decision_id, actor_id="rj", reason="Risk verified")
+    service.record_submission(filled.decision_id, actor_id="operator", venue="manual")
+    service.record_fill(filled.decision_id, actor_id="operator", venue="manual")
+    service.record_closeout_attribution(
+        filled.decision_id,
+        actor_id="rj",
+        resolution=CloseoutResolution.THESIS_TARGET,
+        realized_profit_loss_amount=Decimal("125.50"),
+        realized_profit_loss_percent=Decimal("2.4"),
+        evidence=("broker-statement:manual",),
+    )
+
+    rejected = _idea("trade-report-rejected")
+    service.propose(rejected, actor_id="idea-generator-v1")
+    service.request_changes(rejected.decision_id, actor_id="rj", reason="Need tighter risk")
+    service.resubmit(
+        _idea(rejected.decision_id, thesis="Revised BTC thesis with tighter invalidation"),
+        actor_id="idea-generator-v1",
+    )
+    service.reject(rejected.decision_id, actor_id="rj", reason="Setup invalidated")
+    service.record_closeout_attribution(
+        rejected.decision_id,
+        actor_id="rj",
+        resolution=CloseoutResolution.INVALIDATION,
+        realized_profit_loss_unavailable_reason="Rejected before entry",
+    )
+
+    expired = _idea(
+        "trade-report-expired",
+        max_loss=MaxLoss(
+            amount=Decimal("250"),
+            percent_of_account=None,
+            assumptions=("Missing percent for quality reporting",),
+        ),
+    )
+    service.propose(expired, actor_id="idea-generator-v1")
+    service.expire(expired.decision_id)
+
+    exit_code, response = _run_json(capsys, ["ideas", "report", *_root_args(root)])
+
+    assert exit_code == 0
+    data = response["data"]
+    assert data["proposal_volume"]["idea_count"] == 3
+    assert data["proposal_volume"]["proposal_event_count"] == 4
+    assert data["proposal_volume"]["resubmission_count"] == 1
+    assert data["workflow"]["event_counts"] == {
+        "approved": 1,
+        "cancelled": 0,
+        "expired": 1,
+        "filled": 1,
+        "proposed": 4,
+        "rejected": 1,
+        "requested_changes": 1,
+        "submitted": 1,
+    }
+    assert data["workflow"]["current_state_counts"]["filled"] == 1
+    assert data["workflow"]["current_state_counts"]["rejected"] == 1
+    assert data["workflow"]["current_state_counts"]["expired"] == 1
+    assert data["workflow"]["ever_approved_count"] == 1
+    assert data["workflow"]["approval_rate_pct"] == "33.33"
+    assert data["quality"]["missing_field_counts"]["max_loss.percent_of_account"] == 1
+    assert data["quality"]["approval_ready_count"] == 2
+    assert data["quality"]["confidence_counts"]["medium"] == 3
+    assert data["closeouts"]["terminal_count"] == 3
+    assert data["closeouts"]["with_closeout_count"] == 2
+    assert data["closeouts"]["missing_closeout_count"] == 1
+    assert data["closeouts"]["missing_closeout_decision_ids"] == ["trade-report-expired"]
+    assert data["closeouts"]["resolution_counts"]["thesis_target"] == 1
+    assert data["closeouts"]["resolution_counts"]["invalidation"] == 1
+    assert data["closeouts"]["outcome_distribution"] == {
+        "flat": 0,
+        "loss": 0,
+        "profit": 1,
+        "unavailable": 1,
+    }
+    profit_loss = data["closeouts"]["realized_profit_loss"]
+    assert profit_loss["total_amount"] == "125.50"
+    assert profit_loss["average_amount"] == "125.50"
+    assert profit_loss["max_loss_comparison"]["total_max_loss_amount"] == "250"
+    assert profit_loss["max_loss_comparison"]["total_realized_to_max_loss_ratio"] == "0.5020"
+
+
+def test_report_missing_closeout_coverage_lists_terminal_ids(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    root = tmp_path / "ideas"
+    service = _service(root)
+    expired = _idea("trade-report-no-closeout")
+    service.propose(expired, actor_id="idea-generator-v1")
+    service.expire(expired.decision_id)
+
+    exit_code, response = _run_json(capsys, ["ideas", "report", *_root_args(root)])
+
+    assert exit_code == 0
+    closeouts = response["data"]["closeouts"]
+    assert closeouts["terminal_count"] == 1
+    assert closeouts["with_closeout_count"] == 0
+    assert closeouts["missing_closeout_count"] == 1
+    assert closeouts["coverage_rate_pct"] == "0.00"
+    assert closeouts["missing_closeout_decision_ids"] == ["trade-report-no-closeout"]
+
+
+def test_report_is_read_only_and_does_not_seed_budget(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    root = tmp_path / "ideas"
+    service = _service(root)
+    idea = _idea("trade-report-read-only")
+    service.propose(idea, actor_id="idea-generator-v1")
+    before = _snapshot_files(root)
+
+    exit_code, response = _run_json(capsys, ["ideas", "report", *_root_args(root)])
+
+    assert exit_code == 0
+    assert response["success"] is True
+    assert _snapshot_files(root) == before
+    assert not (root / "risk_budget.jsonl").exists()
+    assert response["data"]["proposal_volume"]["idea_count"] == 1
+    assert response["data"]["workflow"]["current_state_counts"]["proposed"] == 1

--- a/tests/unit/gpt_trader/cli/commands/test_ideas_report.py
+++ b/tests/unit/gpt_trader/cli/commands/test_ideas_report.py
@@ -192,6 +192,53 @@ def test_report_missing_closeout_coverage_lists_terminal_ids(
     assert closeouts["missing_closeout_decision_ids"] == ["trade-report-no-closeout"]
 
 
+def test_report_classifies_percent_only_closeout_outcomes_without_amount_totals(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    root = tmp_path / "ideas"
+    service = _service(root)
+
+    for decision_id, realized_percent in (
+        ("trade-report-percent-profit", Decimal("4.5")),
+        ("trade-report-percent-loss", Decimal("-1.25")),
+        ("trade-report-percent-flat", Decimal("0")),
+    ):
+        idea = _idea(decision_id)
+        service.propose(idea, actor_id="idea-generator-v1")
+        service.approve(decision_id, actor_id="rj", reason="Risk verified")
+        service.record_submission(decision_id, actor_id="operator", venue="manual")
+        service.record_fill(decision_id, actor_id="operator", venue="manual")
+        service.record_closeout_attribution(
+            decision_id,
+            actor_id="rj",
+            resolution=CloseoutResolution.THESIS_TARGET,
+            realized_profit_loss_percent=realized_percent,
+        )
+
+    exit_code, response = _run_json(capsys, ["ideas", "report", *_root_args(root)])
+
+    assert exit_code == 0
+    closeouts = response["data"]["closeouts"]
+    assert closeouts["outcome_distribution"] == {
+        "flat": 1,
+        "loss": 1,
+        "profit": 1,
+        "unavailable": 0,
+    }
+    profit_loss = closeouts["realized_profit_loss"]
+    assert profit_loss["available_amount_count"] == 0
+    assert profit_loss["total_amount"] == "0"
+    assert profit_loss["average_amount"] is None
+    assert profit_loss["max_loss_comparison"] == {
+        "by_decision_id": [],
+        "comparable_count": 0,
+        "total_max_loss_amount": "0",
+        "total_realized_amount": "0",
+        "total_realized_to_max_loss_ratio": None,
+    }
+
+
 def test_report_is_read_only_and_does_not_seed_budget(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,8 +7,8 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6767,
-    "total_files": 799,
+    "total_tests": 6771,
+    "total_files": 800,
     "markers_used": 16
   },
   "quick_commands": {

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6771,
+    "total_tests": 6772,
     "total_files": 800,
     "markers_used": 16
   },

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6602,
+    "unit": 6606,
     "asyncio": 390,
     "parametrize": 193,
     "endpoints": 83,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6606,
+    "unit": 6607,
     "asyncio": 390,
     "parametrize": 193,
     "endpoints": 83,

--- a/var/agents/testing/source_test_map.json
+++ b/var/agents/testing/source_test_map.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "summary": {
-    "tests_scanned": 715,
+    "tests_scanned": 716,
     "source_modules": 372,
     "unresolved_modules": 3
   },
@@ -15,6 +15,7 @@
       "tests/unit/gpt_trader/cli/commands/test_ideas_max_loss_validation.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_propose_integrity.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_queries.py",
+      "tests/unit/gpt_trader/cli/commands/test_ideas_report.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_resubmit_integrity.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_review_latency.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_short_budget.py"
@@ -1275,6 +1276,7 @@
       "tests/unit/gpt_trader/cli/commands/test_ideas_max_loss_validation.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_propose_integrity.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_queries.py",
+      "tests/unit/gpt_trader/cli/commands/test_ideas_report.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_resubmit_integrity.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_review_latency.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_short_budget.py",
@@ -2680,6 +2682,10 @@
     "tests/unit/gpt_trader/cli/commands/test_ideas_queries.py": [
       "gpt_trader",
       "gpt_trader.cli.response",
+      "gpt_trader.features.trade_ideas"
+    ],
+    "tests/unit/gpt_trader/cli/commands/test_ideas_report.py": [
+      "gpt_trader",
       "gpt_trader.features.trade_ideas"
     ],
     "tests/unit/gpt_trader/cli/commands/test_ideas_resubmit_integrity.py": [

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6771,
+    "total_tests": 6772,
     "total_files": 800,
     "markers_used": 16
   },
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6606,
+    "unit": 6607,
     "asyncio": 390,
     "parametrize": 193,
     "endpoints": 83,
@@ -9272,7 +9272,7 @@
     "tests/unit/gpt_trader/cli/commands/test_ideas_report.py": [
       {
         "name": "test_report_empty_store_returns_zero_counts",
-        "line": 65,
+        "line": 64,
         "markers": [
           "unit"
         ],
@@ -9280,7 +9280,7 @@
       },
       {
         "name": "test_report_summarizes_workflow_quality_closeouts_and_profit_loss",
-        "line": 84,
+        "line": 83,
         "markers": [
           "unit"
         ],
@@ -9288,7 +9288,15 @@
       },
       {
         "name": "test_report_missing_closeout_coverage_lists_terminal_ids",
-        "line": 175,
+        "line": 174,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_report_classifies_percent_only_closeout_outcomes_without_amount_totals",
+        "line": 195,
         "markers": [
           "unit"
         ],
@@ -9296,7 +9304,7 @@
       },
       {
         "name": "test_report_is_read_only_and_does_not_seed_budget",
-        "line": 196,
+        "line": 242,
         "markers": [
           "unit"
         ],

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,8 +2,8 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6767,
-    "total_files": 799,
+    "total_tests": 6771,
+    "total_files": 800,
     "markers_used": 16
   },
   "marker_definitions": {
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6602,
+    "unit": 6606,
     "asyncio": 390,
     "parametrize": 193,
     "endpoints": 83,
@@ -211,6 +211,7 @@
       "tests/unit/gpt_trader/cli/commands/test_ideas_max_loss_validation.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_propose_integrity.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_queries.py",
+      "tests/unit/gpt_trader/cli/commands/test_ideas_report.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_resubmit_integrity.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_review_latency.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_short_budget.py",
@@ -9262,6 +9263,40 @@
       {
         "name": "test_help_lists_ideas_subcommands",
         "line": 221,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      }
+    ],
+    "tests/unit/gpt_trader/cli/commands/test_ideas_report.py": [
+      {
+        "name": "test_report_empty_store_returns_zero_counts",
+        "line": 65,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_report_summarizes_workflow_quality_closeouts_and_profit_loss",
+        "line": 84,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_report_missing_closeout_coverage_lists_terminal_ids",
+        "line": 175,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_report_is_read_only_and_does_not_seed_budget",
+        "line": 196,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
Closes #945

## Summary
- add read-only `gpt-trader ideas report` over local trade-idea records, audit events, and closeout attribution
- summarize proposal volume, workflow counts/rates, quality/policy signals, closeout coverage, outcome distribution, and realized P/L versus max-loss when available
- update implemented CLI spec/help tests and regenerate testing inventory artifacts

## Affected paths
- `src/gpt_trader/cli/commands/ideas.py`
- `src/gpt_trader/features/trade_ideas/report.py`
- `tests/unit/gpt_trader/cli/commands/test_ideas_report.py`
- `docs/specs/TRADE_IDEA_CLI_SPEC.md`
- `var/agents/testing/**`

## Verification
- `uv run pytest tests/unit/gpt_trader/cli/commands/test_ideas_report.py tests/unit/gpt_trader/cli/commands/test_ideas_queries.py -q` - passed, 11 tests
- `uv run agent-regenerate --verify` - initially found stale generated testing inventory after adding tests; `uv run agent-regenerate` refreshed artifacts; rerun passed
- `uv run pytest tests/unit/gpt_trader/cli/commands/test_ideas_* tests/unit/gpt_trader/features/trade_ideas -q` - passed, 308 tests
- `uv run local-ci --profile quick` - initial run failed only Ruff for an unused test import; fixed; final rerun passed, including 7036 unit tests with 8 expected OTel skips

## Trading boundary
This is broker-neutral, read-only reporting over existing local records. It does not contact broker/account/venue APIs, does not run preflight/canary/live trading commands, and does not submit, modify, cancel, or place orders.

## Breaking behavior
None. New command only.