### PR TITLE
[codex] Show monthly trade idea report trends

### DIFF
--- a/docs/specs/TRADE_IDEA_CLI_SPEC.md
+++ b/docs/specs/TRADE_IDEA_CLI_SPEC.md
@@ -139,6 +139,11 @@ already exist (`IDEA_NOT_FOUND` otherwise). Service/audit layer enforces the
   ✓ ideas report OK (3 ideas, approval_rate=33.33%, closeout_coverage=66.67%)
   ```
 
+  When `proposal_volume.by_month` has buckets, text output also includes a
+  compact `Monthly` section with one line per month showing idea count, approval
+  rate, closeout coverage, and realized P/L amount. Empty stores and reports
+  without monthly buckets omit the section while still returning success.
+
 ### `ideas approve DECISION_ID --reason TEXT`
 
 - `actor_type` hard-coded `HUMAN`. `--reason` required and non-empty.

--- a/src/gpt_trader/features/trade_ideas/report.py
+++ b/src/gpt_trader/features/trade_ideas/report.py
@@ -75,6 +75,7 @@ def build_trade_idea_track_record_report(
 def format_trade_idea_track_record_report(report: Mapping[str, Any]) -> str:
     """Render a compact text report for operators."""
     proposal_volume = report["proposal_volume"]
+    monthly = proposal_volume["by_month"]
     workflow = report["workflow"]
     quality = report["quality"]
     closeouts = report["closeouts"]
@@ -133,6 +134,14 @@ def format_trade_idea_track_record_report(report: Mapping[str, Any]) -> str:
             f"across {profit_loss['max_loss_comparison']['comparable_count']} comparable closeouts"
         ),
     ]
+    if monthly:
+        lines.extend(
+            [
+                "",
+                "Monthly",
+                *_monthly_lines(monthly),
+            ]
+        )
     return "\n".join(lines)
 
 
@@ -401,3 +410,15 @@ def _counts_line(label: str, counts: Mapping[str, Any]) -> str:
     if not counts:
         return f"{label}: none"
     return f"{label}: " + ", ".join(f"{key}={value}" for key, value in counts.items())
+
+
+def _monthly_lines(monthly: Mapping[str, Mapping[str, Any]]) -> list[str]:
+    return [
+        (
+            f"{month}: ideas={bucket['idea_count']}, "
+            f"approval_rate={bucket['approval_rate_pct']}%, "
+            f"closeout_coverage={bucket['closeout_coverage_rate_pct']}%, "
+            f"realized_profit_loss={bucket['realized_profit_loss_amount']}"
+        )
+        for month, bucket in monthly.items()
+    ]

--- a/tests/unit/gpt_trader/cli/commands/test_ideas_report.py
+++ b/tests/unit/gpt_trader/cli/commands/test_ideas_report.py
@@ -51,6 +51,13 @@ def _run_json(capsys: pytest.CaptureFixture[str], argv: list[str]) -> tuple[int,
     return exit_code, json.loads(output)
 
 
+def _run_text(capsys: pytest.CaptureFixture[str], argv: list[str]) -> tuple[int, str]:
+    exit_code = cli.main(argv)
+    output = capsys.readouterr().out
+    assert output
+    return exit_code, output
+
+
 def _snapshot_files(root: Path) -> dict[str, str]:
     if not root.exists():
         return {}
@@ -78,6 +85,23 @@ def test_report_empty_store_returns_zero_counts(
     assert data["workflow"]["approval_rate_pct"] == "0.00"
     assert data["closeouts"]["terminal_count"] == 0
     assert data["closeouts"]["missing_closeout_count"] == 0
+
+
+def test_report_empty_store_text_omits_monthly_section_and_stays_read_only(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    root = tmp_path / "ideas"
+
+    exit_code, output = _run_text(
+        capsys,
+        ["ideas", "report", "--ideas-root", str(root), "--format", "text"],
+    )
+
+    assert exit_code == 0
+    assert "ideas report OK (0 ideas, approval_rate=0.00%, closeout_coverage=0.00%)" in output
+    assert "Monthly" not in output
+    assert _snapshot_files(root) == {}
 
 
 def test_report_summarizes_workflow_quality_closeouts_and_profit_loss(
@@ -169,6 +193,52 @@ def test_report_summarizes_workflow_quality_closeouts_and_profit_loss(
     assert profit_loss["average_amount"] == "125.50"
     assert profit_loss["max_loss_comparison"]["total_max_loss_amount"] == "250"
     assert profit_loss["max_loss_comparison"]["total_realized_to_max_loss_ratio"] == "0.5020"
+
+
+def test_report_text_includes_monthly_trend_buckets_and_is_read_only(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    root = tmp_path / "ideas"
+    current_time = [datetime(2026, 5, 8, 12, 0, tzinfo=UTC)]
+    service = TradeIdeaService(root, now_factory=lambda: current_time[0])
+
+    filled = _idea("trade-report-may-filled")
+    service.propose(filled, actor_id="idea-generator-v1")
+    service.approve(filled.decision_id, actor_id="rj", reason="Risk verified")
+    service.record_submission(filled.decision_id, actor_id="operator", venue="manual")
+    service.record_fill(filled.decision_id, actor_id="operator", venue="manual")
+    service.record_closeout_attribution(
+        filled.decision_id,
+        actor_id="rj",
+        resolution=CloseoutResolution.THESIS_TARGET,
+        realized_profit_loss_amount=Decimal("125.50"),
+        realized_profit_loss_percent=Decimal("2.4"),
+        evidence=("broker-statement:manual",),
+    )
+
+    current_time[0] = datetime(2026, 6, 4, 12, 0, tzinfo=UTC)
+    rejected = _idea("trade-report-june-rejected")
+    service.propose(rejected, actor_id="idea-generator-v1")
+    service.reject(rejected.decision_id, actor_id="rj", reason="Setup invalidated")
+    before = _snapshot_files(root)
+    expected_june_line = (
+        "2026-06: ideas=1, approval_rate=0.00%, " "closeout_coverage=0.00%, realized_profit_loss=0"
+    )
+
+    exit_code, output = _run_text(
+        capsys,
+        ["ideas", "report", "--ideas-root", str(root), "--format", "text"],
+    )
+
+    assert exit_code == 0
+    assert "Monthly" in output
+    assert (
+        "2026-05: ideas=1, approval_rate=100.00%, "
+        "closeout_coverage=100.00%, realized_profit_loss=125.50"
+    ) in output
+    assert expected_june_line in output
+    assert _snapshot_files(root) == before
 
 
 def test_report_missing_closeout_coverage_lists_terminal_ids(

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6772,
+    "total_tests": 6774,
     "total_files": 800,
     "markers_used": 16
   },

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6607,
+    "unit": 6609,
     "asyncio": 390,
     "parametrize": 193,
     "endpoints": 83,

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6772,
+    "total_tests": 6774,
     "total_files": 800,
     "markers_used": 16
   },
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6607,
+    "unit": 6609,
     "asyncio": 390,
     "parametrize": 193,
     "endpoints": 83,
@@ -9272,7 +9272,15 @@
     "tests/unit/gpt_trader/cli/commands/test_ideas_report.py": [
       {
         "name": "test_report_empty_store_returns_zero_counts",
-        "line": 64,
+        "line": 71,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_report_empty_store_text_omits_monthly_section_and_stays_read_only",
+        "line": 90,
         "markers": [
           "unit"
         ],
@@ -9280,7 +9288,15 @@
       },
       {
         "name": "test_report_summarizes_workflow_quality_closeouts_and_profit_loss",
-        "line": 83,
+        "line": 107,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_report_text_includes_monthly_trend_buckets_and_is_read_only",
+        "line": 198,
         "markers": [
           "unit"
         ],
@@ -9288,7 +9304,7 @@
       },
       {
         "name": "test_report_missing_closeout_coverage_lists_terminal_ids",
-        "line": 174,
+        "line": 244,
         "markers": [
           "unit"
         ],
@@ -9296,7 +9312,7 @@
       },
       {
         "name": "test_report_classifies_percent_only_closeout_outcomes_without_amount_totals",
-        "line": 195,
+        "line": 265,
         "markers": [
           "unit"
         ],
@@ -9304,7 +9320,7 @@
       },
       {
         "name": "test_report_is_read_only_and_does_not_seed_budget",
-        "line": 242,
+        "line": 312,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary
Related issue / finding / RJ-routed package: Closes #947; finding `ideas-report-monthly-text-visibility-20260625`; pipeline `goal-pipeline-20260625-gpt-trader-ideas-report-monthly-text`.

Adds the existing monthly `proposal_volume.by_month` buckets to the default text report output for `gpt-trader ideas report`, so operators can see idea count, approval rate, closeout coverage, and realized P/L by month without switching to JSON.

## Type of change
- [ ] Refactor
- [ ] Feature
- [ ] Bug fix
- [x] Tests only
- [x] CI/Docs/Tooling

## Scope & Impact
- Affected areas / components: `src/gpt_trader/features/trade_ideas/report.py`, `tests/unit/gpt_trader/cli/commands/test_ideas_report.py`, `docs/specs/TRADE_IDEA_CLI_SPEC.md`, generated `var/agents/testing/*` inventory files.
- Behavior changes: text report output now includes a `Monthly` section only when `proposal_volume.by_month` has buckets. JSON output remains backward compatible and unchanged.
- Execution boundary: read-only report/operator visibility only; no broker adapters, execution policy, live trading behavior, readiness gates, broker/API checks, canary operations, or order submission touched.

## Test Plan
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Contract tests (if applicable)
- [x] Ran locally: `uv run pytest tests/unit/gpt_trader/cli/commands/test_ideas_report.py -q` -> 7 passed
- [x] Ran locally: `uv run agent-regenerate --verify` -> all context files up-to-date
- [x] Ran locally: `uv run local-ci --profile quick` -> passed; core unit tests 7039 passed, 8 skipped
- [x] Markers used appropriately (`unit`/`integration`/`slow`/`perf`)

## Complexity & Quality Gates
- [x] Mypy/type-check passed via `uv run local-ci --profile quick`
- [x] Xenon/radon complexity gate passed (CC <= 15 on live_trade execution) via quick profile scope
- [x] No `sys.path` hacks in tests
- [x] No `MagicMock` on `async def` (use `AsyncMock`)
- [x] Import-lint rules respected (no "import up the stack")

## Observability & Errors
- [x] Structured JSON logs for new/changed paths not applicable; report formatter only
- [x] Errors include diagnostic context not applicable; no error path changed
- [x] Added/updated sampling examples in tests (if applicable) not applicable

## Configuration
- [x] If config changed: not applicable
- [x] Env docs re-generated (if applicable) not applicable
- [x] No `ConfigLoader` usages introduced (ConfigManager-only)

## Breaking Changes
- [x] None
- [ ] Documented in PR body and release notes if any

## Screenshots / Logs (optional)
Focused verification:

```text
uv run pytest tests/unit/gpt_trader/cli/commands/test_ideas_report.py -q
7 passed in 0.87s

uv run agent-regenerate --verify
All context files are up-to-date.

uv run local-ci --profile quick
Local CI passed.
```

## Checklist
- [x] Acceptance criteria in linked issue(s), finding packet, or routed package met
- [x] Affected paths listed in PR description
- [x] Changelog entry (if repo uses one) not applicable
