### PR TITLE
[codex] Centralize runtime artifact path defaults

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -497,6 +497,24 @@ Override order followed when building a `BotConfig`:
 
 The readiness gate and CLI preflight scripts consume the same registry so that `PREFLIGHT_PROFILE`, `READINESS_REPORT_DIR`, and `runtime_data/<profile>` artifacts stay aligned with whatever the CLI is currently driving.
 
+### Runtime Artifact Ownership
+
+Default runtime path ownership lives in `src/gpt_trader/config/path_registry.py`.
+Use that module before adding new filesystem defaults.
+
+- Repo-local runtime artifacts belong under `runtime_data/`. Profile-specific
+  data uses `runtime_data/<profile>/...`; optimization run results use
+  `runtime_data/optimize/...` through `path_registry.OPTIMIZATION_RUNS_DIR`.
+- Repo-local generated or developer artifacts belong under `var/`, including
+  logs, status files, coverage output, and generated `var/agents/**` references.
+- User-global secret material is the explicit exception. Encrypted file fallback
+  secrets remain under `~/.gpt_trader/secrets` through
+  `path_registry.USER_SECRETS_DIR`; do not mix secrets into repo-local runtime
+  directories unless a migration plan covers permissions and compatibility.
+- Tests and temporary tooling should inject paths such as
+  `OptimizationStorage(base_dir=...)` or `SecretsManager(secrets_dir=...)`
+  instead of relying on the real user home.
+
 ## Implementation Status
 
 This section describes which surfaces are implemented in the codebase.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -12,7 +12,8 @@ This document outlines the security controls and operational guidance for GPT-Tr
 - Credentials and authentication live under `src/gpt_trader/features/brokerages/coinbase/`
   (`auth.py`, `credentials.py`) and use JWT-based CDP keys.
 - Secrets management is handled by `src/gpt_trader/security/secrets_manager.py`, which
-  supports HashiCorp Vault and an encrypted local file fallback in `~/.gpt_trader/secrets`.
+  supports HashiCorp Vault and an encrypted local file fallback at
+  `path_registry.USER_SECRETS_DIR` (`~/.gpt_trader/secrets` by default).
 - Runtime validation is centralized in `src/gpt_trader/security/security_validator.py` and
   is enforced by the TradingEngine guard stack during live order submission.
 - IP allowlisting is enforced by `src/gpt_trader/security/ip_allowlist_enforcer.py`.
@@ -70,8 +71,9 @@ event_type, and key path (no values). Tune scan scope with:
 ## Sensitive Data Handling
 
 - JSON logs redact keys like `api_key`, `private_key`, `token`, and `password`.
-- Runtime data persists to `runtime_data/<profile>/` (SQLite `events.db`, `orders.db`).
-  Avoid writing secrets into events or logs.
+- Runtime data persists to repo-local paths such as `runtime_data/<profile>/`
+  (SQLite `events.db`, `orders.db`) and `runtime_data/optimize/`. Avoid writing
+  secrets into repo-local runtime artifacts, events, or logs.
 
 ## Best Practices
 

--- a/src/gpt_trader/config/path_registry.py
+++ b/src/gpt_trader/config/path_registry.py
@@ -14,6 +14,7 @@ __all__ = [
     "COINBASE_TRADER_RUNTIME_DIR",
     "DEFAULT_EVENT_STORE_DIR",
     "OPTIMIZATION_RUNS_DIR",
+    "LEGACY_OPTIMIZATION_RUNS_DIR",
     "USER_CONFIG_DIR",
     "USER_SECRETS_DIR",
     "ensure_directories",
@@ -36,6 +37,7 @@ OPTIMIZATION_RUNS_DIR = RUNTIME_DATA_DIR / "optimize"
 # User-global artifacts are explicit exceptions to repo-local runtime ownership.
 # Do not add them to ensure_directories(); callers create them only when needed.
 USER_CONFIG_DIR = Path.home() / ".gpt_trader"
+LEGACY_OPTIMIZATION_RUNS_DIR = USER_CONFIG_DIR / "optimize"
 USER_SECRETS_DIR = USER_CONFIG_DIR / "secrets"
 
 

--- a/src/gpt_trader/config/path_registry.py
+++ b/src/gpt_trader/config/path_registry.py
@@ -13,6 +13,9 @@ __all__ = [
     "RUNTIME_DATA_DIR",
     "COINBASE_TRADER_RUNTIME_DIR",
     "DEFAULT_EVENT_STORE_DIR",
+    "OPTIMIZATION_RUNS_DIR",
+    "USER_CONFIG_DIR",
+    "USER_SECRETS_DIR",
     "ensure_directories",
 ]
 
@@ -28,6 +31,12 @@ RESULTS_DIR = VAR_DIR / "results"
 RUNTIME_DATA_DIR = PROJECT_ROOT / "runtime_data"
 COINBASE_TRADER_RUNTIME_DIR = RUNTIME_DATA_DIR
 DEFAULT_EVENT_STORE_DIR = COINBASE_TRADER_RUNTIME_DIR / "shared"
+OPTIMIZATION_RUNS_DIR = RUNTIME_DATA_DIR / "optimize"
+
+# User-global artifacts are explicit exceptions to repo-local runtime ownership.
+# Do not add them to ensure_directories(); callers create them only when needed.
+USER_CONFIG_DIR = Path.home() / ".gpt_trader"
+USER_SECRETS_DIR = USER_CONFIG_DIR / "secrets"
 
 
 def ensure_directories(paths: Iterable[Path] | None = None) -> None:

--- a/src/gpt_trader/features/optimize/persistence/storage.py
+++ b/src/gpt_trader/features/optimize/persistence/storage.py
@@ -140,8 +140,12 @@ class OptimizationStorage:
         Args:
             base_dir: Base directory for storage. Defaults to path_registry.OPTIMIZATION_RUNS_DIR
         """
+        using_default_dir = base_dir is None
         self.base_dir = (
             Path(base_dir) if base_dir is not None else path_registry.OPTIMIZATION_RUNS_DIR
+        )
+        self.legacy_base_dir = (
+            path_registry.LEGACY_OPTIMIZATION_RUNS_DIR if using_default_dir else None
         )
 
         self.base_dir.mkdir(parents=True, exist_ok=True)
@@ -178,6 +182,10 @@ class OptimizationStorage:
             OptimizationRun object or None if not found
         """
         file_path = self.base_dir / run_id / "results.json"
+        if not file_path.exists() and self.legacy_base_dir is not None:
+            legacy_file_path = self.legacy_base_dir / run_id / "results.json"
+            if legacy_file_path.exists():
+                file_path = legacy_file_path
 
         if not file_path.exists():
             return None
@@ -198,27 +206,41 @@ class OptimizationStorage:
             List of run summaries
         """
         runs = []
-        for run_dir in self.base_dir.iterdir():
-            if run_dir.is_dir():
+        seen_run_ids = set()
+        search_dirs = [self.base_dir]
+        if self.legacy_base_dir is not None:
+            search_dirs.append(self.legacy_base_dir)
+
+        for base_dir in search_dirs:
+            if not base_dir.exists():
+                continue
+            for run_dir in base_dir.iterdir():
+                if not run_dir.is_dir():
+                    continue
                 file_path = run_dir / "results.json"
-                if file_path.exists():
-                    try:
-                        with open(file_path) as f:
-                            # Read only start of file for metadata if possible,
-                            # but JSON requires full load. For large files this is slow.
-                            # Optimization: Store metadata.json separately.
-                            # For now, just load and catch errors.
-                            data = json.load(f)
-                            runs.append(
-                                {
-                                    "run_id": data["run_id"],
-                                    "study_name": data["study_name"],
-                                    "started_at": data["started_at"],
-                                    "best_value": data.get("best_objective_value"),
-                                }
-                            )
-                    except Exception:
-                        continue
+                if not file_path.exists():
+                    continue
+                try:
+                    with open(file_path) as f:
+                        # Read only start of file for metadata if possible,
+                        # but JSON requires full load. For large files this is slow.
+                        # Optimization: Store metadata.json separately.
+                        # For now, just load and catch errors.
+                        data = json.load(f)
+                        run_id = data["run_id"]
+                        if run_id in seen_run_ids:
+                            continue
+                        seen_run_ids.add(run_id)
+                        runs.append(
+                            {
+                                "run_id": run_id,
+                                "study_name": data["study_name"],
+                                "started_at": data["started_at"],
+                                "best_value": data.get("best_objective_value"),
+                            }
+                        )
+                except Exception:
+                    continue
 
         # Sort by start time descending
         runs.sort(key=lambda x: x["started_at"], reverse=True)

--- a/src/gpt_trader/features/optimize/persistence/storage.py
+++ b/src/gpt_trader/features/optimize/persistence/storage.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+from gpt_trader.config import path_registry
 from gpt_trader.features.optimize.runner.batch_runner import TrialResult
 from gpt_trader.features.optimize.types import OptimizationConfig
 from gpt_trader.utilities.logging_patterns import get_logger
@@ -129,7 +130,7 @@ class OptimizationStorage:
     """
     Manages persistence of optimization runs.
 
-    Saves results to ~/.gpt_trader/optimize/
+    Saves results to the repo-local optimization runtime directory by default.
     """
 
     def __init__(self, base_dir: Path | None = None):
@@ -137,12 +138,11 @@ class OptimizationStorage:
         Initialize storage.
 
         Args:
-            base_dir: Base directory for storage. Defaults to ~/.gpt_trader/optimize
+            base_dir: Base directory for storage. Defaults to path_registry.OPTIMIZATION_RUNS_DIR
         """
-        if base_dir is None:
-            self.base_dir = Path.home() / ".gpt_trader" / "optimize"
-        else:
-            self.base_dir = Path(base_dir)
+        self.base_dir = (
+            Path(base_dir) if base_dir is not None else path_registry.OPTIMIZATION_RUNS_DIR
+        )
 
         self.base_dir.mkdir(parents=True, exist_ok=True)
 

--- a/src/gpt_trader/security/secrets_manager.py
+++ b/src/gpt_trader/security/secrets_manager.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 from gpt_trader.app.config import BotConfig
+from gpt_trader.config import path_registry
 from gpt_trader.utilities.logging_patterns import get_logger
 
 if TYPE_CHECKING:  # pragma: no cover - type hints only
@@ -71,7 +72,9 @@ class SecretsManager:
         self._vault_client: Any | None = None
         self._vault_enabled = vault_enabled
         self._config = config
-        self._secrets_dir = secrets_dir or (Path.home() / ".gpt_trader" / "secrets")
+        self._secrets_dir = (
+            Path(secrets_dir) if secrets_dir is not None else path_registry.USER_SECRETS_DIR
+        )
         self._initialize_encryption()
 
         if vault_enabled:

--- a/tests/unit/gpt_trader/config/test_path_registry.py
+++ b/tests/unit/gpt_trader/config/test_path_registry.py
@@ -1,0 +1,7 @@
+from gpt_trader.config import path_registry
+
+
+def test_runtime_artifact_policy_constants_are_grouped_by_ownership() -> None:
+    assert path_registry.OPTIMIZATION_RUNS_DIR == path_registry.RUNTIME_DATA_DIR / "optimize"
+    assert path_registry.USER_SECRETS_DIR == path_registry.USER_CONFIG_DIR / "secrets"
+    assert path_registry.USER_CONFIG_DIR.name == ".gpt_trader"

--- a/tests/unit/gpt_trader/config/test_path_registry.py
+++ b/tests/unit/gpt_trader/config/test_path_registry.py
@@ -3,5 +3,6 @@ from gpt_trader.config import path_registry
 
 def test_runtime_artifact_policy_constants_are_grouped_by_ownership() -> None:
     assert path_registry.OPTIMIZATION_RUNS_DIR == path_registry.RUNTIME_DATA_DIR / "optimize"
+    assert path_registry.LEGACY_OPTIMIZATION_RUNS_DIR == path_registry.USER_CONFIG_DIR / "optimize"
     assert path_registry.USER_SECRETS_DIR == path_registry.USER_CONFIG_DIR / "secrets"
     assert path_registry.USER_CONFIG_DIR.name == ".gpt_trader"

--- a/tests/unit/gpt_trader/features/optimize/persistence/test_storage_edges.py
+++ b/tests/unit/gpt_trader/features/optimize/persistence/test_storage_edges.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from datetime import datetime, timezone
 from decimal import Decimal
 from pathlib import Path
@@ -168,12 +169,56 @@ def test_storage_default_uses_registry_runtime_dir(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     default_dir = tmp_path / "runtime_data" / "optimize"
+    legacy_dir = tmp_path / "home" / ".gpt_trader" / "optimize"
     monkeypatch.setattr(path_registry, "OPTIMIZATION_RUNS_DIR", default_dir)
+    monkeypatch.setattr(path_registry, "LEGACY_OPTIMIZATION_RUNS_DIR", legacy_dir)
 
     storage = OptimizationStorage()
 
     assert storage.base_dir == default_dir
+    assert storage.legacy_base_dir == legacy_dir
     assert default_dir.exists()
+    assert not legacy_dir.exists()
+
+
+def test_storage_load_run_falls_back_to_legacy_default_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    default_dir = tmp_path / "runtime_data" / "optimize"
+    legacy_dir = tmp_path / "home" / ".gpt_trader" / "optimize"
+    monkeypatch.setattr(path_registry, "OPTIMIZATION_RUNS_DIR", default_dir)
+    monkeypatch.setattr(path_registry, "LEGACY_OPTIMIZATION_RUNS_DIR", legacy_dir)
+
+    run = _make_run()
+    run.run_id = "legacy-run"
+    run_dir = legacy_dir / run.run_id
+    run_dir.mkdir(parents=True)
+    (run_dir / "results.json").write_text(json_payload(run))
+
+    storage = OptimizationStorage()
+    loaded = storage.load_run("legacy-run")
+
+    assert loaded is not None
+    assert loaded.run_id == "legacy-run"
+
+
+def test_storage_explicit_base_dir_does_not_use_legacy_default_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    explicit_dir = tmp_path / "custom"
+    legacy_dir = tmp_path / "home" / ".gpt_trader" / "optimize"
+    monkeypatch.setattr(path_registry, "LEGACY_OPTIMIZATION_RUNS_DIR", legacy_dir)
+
+    run = _make_run()
+    run.run_id = "legacy-run"
+    run_dir = legacy_dir / run.run_id
+    run_dir.mkdir(parents=True)
+    (run_dir / "results.json").write_text(json_payload(run))
+
+    storage = OptimizationStorage(base_dir=explicit_dir)
+
+    assert storage.legacy_base_dir is None
+    assert storage.load_run("legacy-run") is None
 
 
 def test_storage_load_run_missing_and_invalid_json(tmp_path: Path) -> None:
@@ -217,3 +262,32 @@ def test_storage_list_runs_sorted_by_started_at(tmp_path: Path) -> None:
 
     assert runs[0]["run_id"] == "run-new"
     assert runs[1]["run_id"] == "run-old"
+
+
+def test_storage_list_runs_includes_legacy_default_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    default_dir = tmp_path / "runtime_data" / "optimize"
+    legacy_dir = tmp_path / "home" / ".gpt_trader" / "optimize"
+    monkeypatch.setattr(path_registry, "OPTIMIZATION_RUNS_DIR", default_dir)
+    monkeypatch.setattr(path_registry, "LEGACY_OPTIMIZATION_RUNS_DIR", legacy_dir)
+
+    current = _make_run()
+    current.run_id = "run-current"
+    current.started_at = datetime(2024, 1, 2, 12, 0, tzinfo=timezone.utc)
+    legacy = _make_run()
+    legacy.run_id = "run-legacy"
+    legacy.started_at = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc)
+
+    for base_dir, run in ((default_dir, current), (legacy_dir, legacy)):
+        run_dir = base_dir / run.run_id
+        run_dir.mkdir(parents=True)
+        (run_dir / "results.json").write_text(json_payload(run))
+
+    runs = OptimizationStorage().list_runs()
+
+    assert [run["run_id"] for run in runs] == ["run-current", "run-legacy"]
+
+
+def json_payload(run: OptimizationRun) -> str:
+    return json.dumps(run.to_dict())

--- a/tests/unit/gpt_trader/features/optimize/persistence/test_storage_edges.py
+++ b/tests/unit/gpt_trader/features/optimize/persistence/test_storage_edges.py
@@ -5,6 +5,9 @@ from decimal import Decimal
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import pytest
+
+from gpt_trader.config import path_registry
 from gpt_trader.features.optimize.persistence.storage import OptimizationRun, OptimizationStorage
 from gpt_trader.features.optimize.runner.batch_runner import TrialResult
 from gpt_trader.features.optimize.types import (
@@ -159,6 +162,18 @@ def test_storage_save_run_writes_results_file(tmp_path: Path) -> None:
 
     assert file_path == tmp_path / "run-save" / "results.json"
     assert file_path.exists()
+
+
+def test_storage_default_uses_registry_runtime_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    default_dir = tmp_path / "runtime_data" / "optimize"
+    monkeypatch.setattr(path_registry, "OPTIMIZATION_RUNS_DIR", default_dir)
+
+    storage = OptimizationStorage()
+
+    assert storage.base_dir == default_dir
+    assert default_dir.exists()
 
 
 def test_storage_load_run_missing_and_invalid_json(tmp_path: Path) -> None:

--- a/tests/unit/gpt_trader/security/secrets_manager/test_file_basic.py
+++ b/tests/unit/gpt_trader/security/secrets_manager/test_file_basic.py
@@ -7,6 +7,11 @@ import os
 from pathlib import Path
 from typing import Any
 
+import pytest
+
+from gpt_trader.app.config import BotConfig
+from gpt_trader.config import path_registry
+
 
 class TestFileBasics:
     """Verify core CRUD operations on encrypted files."""
@@ -102,6 +107,29 @@ class TestFileBasics:
 
         secrets_dir = tmp_path / ".gpt_trader" / "secrets"
         assert secrets_dir.exists() and secrets_dir.is_dir()
+
+    def test_default_file_storage_uses_registry_secret_dir(
+        self,
+        secrets_bot_config: BotConfig,
+        patched_require_fernet: None,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        from cryptography.fernet import Fernet
+
+        from gpt_trader.security.secrets_manager import SecretsManager
+
+        default_dir = tmp_path / ".gpt_trader" / "secrets"
+        monkeypatch.setattr(path_registry, "USER_SECRETS_DIR", default_dir)
+        monkeypatch.setenv("VAULT_TOKEN", "")
+        monkeypatch.setenv("ENV", "development")
+        monkeypatch.setenv("GPT_TRADER_ENCRYPTION_KEY", Fernet.generate_key().decode())
+
+        manager = SecretsManager(vault_enabled=False, config=secrets_bot_config)
+        manager.store_secret("test/default", {"key": "value"})
+
+        assert manager._secrets_dir == default_dir
+        assert (default_dir / "test_default.enc").exists()
 
     def test_file_encryption_roundtrip(
         self, secrets_manager_with_fallback: Any, sample_secrets: dict[str, dict[str, Any]]

--- a/var/agents/configuration/environment_variables.json
+++ b/var/agents/configuration/environment_variables.json
@@ -761,7 +761,7 @@
       ],
       "code_references": [
         {
-          "line": 86,
+          "line": 89,
           "path": "src/gpt_trader/security/secrets_manager.py",
           "reader": "os.getenv"
         }
@@ -1027,7 +1027,7 @@
       ],
       "code_references": [
         {
-          "line": 82,
+          "line": 85,
           "path": "src/gpt_trader/security/secrets_manager.py",
           "reader": "os.getenv"
         }
@@ -3227,7 +3227,7 @@
       ],
       "code_references": [
         {
-          "line": 138,
+          "line": 141,
           "path": "src/gpt_trader/security/secrets_manager.py",
           "reader": "os.getenv"
         }
@@ -3250,7 +3250,7 @@
       ],
       "code_references": [
         {
-          "line": 139,
+          "line": 142,
           "path": "src/gpt_trader/security/secrets_manager.py",
           "reader": "os.getenv"
         }

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6777,
+    "total_tests": 6780,
     "total_files": 801,
     "markers_used": 16
   },

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,8 +7,8 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6774,
-    "total_files": 800,
+    "total_tests": 6777,
+    "total_files": 801,
     "markers_used": 16
   },
   "quick_commands": {

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6609,
+    "unit": 6612,
     "asyncio": 390,
     "parametrize": 193,
     "endpoints": 83,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6612,
+    "unit": 6615,
     "asyncio": 390,
     "parametrize": 193,
     "endpoints": 83,

--- a/var/agents/testing/source_test_map.json
+++ b/var/agents/testing/source_test_map.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "summary": {
-    "tests_scanned": 716,
+    "tests_scanned": 718,
     "source_modules": 372,
     "unresolved_modules": 3
   },
@@ -64,6 +64,7 @@
       "tests/unit/gpt_trader/features/live_trade/test_symbols.py",
       "tests/unit/gpt_trader/features/live_trade/test_trading_engine.py",
       "tests/unit/gpt_trader/preflight/test_checks_simulation.py",
+      "tests/unit/gpt_trader/security/secrets_manager/test_file_basic.py",
       "tests/unit/gpt_trader/tui/services/test_config_service.py"
     ],
     "gpt_trader.app.config.bot_config": [
@@ -357,6 +358,9 @@
       "tests/unit/gpt_trader/tui/services/test_mode_service.py"
     ],
     "gpt_trader.config": [
+      "tests/unit/gpt_trader/config/test_path_registry.py",
+      "tests/unit/gpt_trader/features/optimize/persistence/test_storage_edges.py",
+      "tests/unit/gpt_trader/security/secrets_manager/test_file_basic.py",
       "tests/unit/gpt_trader/tui/services/test_mode_service_preferences.py"
     ],
     "gpt_trader.config.config_utilities": [
@@ -1665,6 +1669,7 @@
       "tests/unit/gpt_trader/security/secrets_manager/test_encryption_bootstrap.py",
       "tests/unit/gpt_trader/security/secrets_manager/test_error_bootstrap.py",
       "tests/unit/gpt_trader/security/secrets_manager/test_error_vault.py",
+      "tests/unit/gpt_trader/security/secrets_manager/test_file_basic.py",
       "tests/unit/gpt_trader/security/secrets_manager/test_vault_failures.py"
     ],
     "gpt_trader.security.symbol_validator": [
@@ -2781,6 +2786,9 @@
     "tests/unit/gpt_trader/config/test_env_utils.py": [
       "gpt_trader.config.env_utils"
     ],
+    "tests/unit/gpt_trader/config/test_path_registry.py": [
+      "gpt_trader.config"
+    ],
     "tests/unit/gpt_trader/core/math/test_incremental.py": [
       "gpt_trader.core.math.incremental"
     ],
@@ -3812,6 +3820,7 @@
       "gpt_trader.features.optimize.types"
     ],
     "tests/unit/gpt_trader/features/optimize/persistence/test_storage_edges.py": [
+      "gpt_trader.config",
       "gpt_trader.features.optimize.persistence.storage",
       "gpt_trader.features.optimize.runner.batch_runner",
       "gpt_trader.features.optimize.types"
@@ -4338,6 +4347,11 @@
       "gpt_trader.security.secrets_manager"
     ],
     "tests/unit/gpt_trader/security/secrets_manager/test_error_vault.py": [
+      "gpt_trader.security.secrets_manager"
+    ],
+    "tests/unit/gpt_trader/security/secrets_manager/test_file_basic.py": [
+      "gpt_trader.app.config",
+      "gpt_trader.config",
       "gpt_trader.security.secrets_manager"
     ],
     "tests/unit/gpt_trader/security/secrets_manager/test_vault_failures.py": [
@@ -5364,6 +5378,9 @@
   },
   "unresolved_modules": {
     "gpt_trader.config": [
+      "tests/unit/gpt_trader/config/test_path_registry.py",
+      "tests/unit/gpt_trader/features/optimize/persistence/test_storage_edges.py",
+      "tests/unit/gpt_trader/security/secrets_manager/test_file_basic.py",
       "tests/unit/gpt_trader/tui/services/test_mode_service_preferences.py"
     ],
     "gpt_trader.features.live_trade": [

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6777,
+    "total_tests": 6780,
     "total_files": 801,
     "markers_used": 16
   },
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6612,
+    "unit": 6615,
     "asyncio": 390,
     "parametrize": 193,
     "endpoints": 83,
@@ -30533,7 +30533,7 @@
     "tests/unit/gpt_trader/features/optimize/persistence/test_storage_edges.py": [
       {
         "name": "test_run_to_dict_serializes_datetimes_and_config",
-        "line": 54,
+        "line": 55,
         "markers": [
           "unit"
         ],
@@ -30541,7 +30541,7 @@
       },
       {
         "name": "test_run_from_dict_returns_config_dict_and_no_trials",
-        "line": 64,
+        "line": 65,
         "markers": [
           "unit"
         ],
@@ -30549,7 +30549,7 @@
       },
       {
         "name": "test_serialize_config_accepts_dict_and_config",
-        "line": 82,
+        "line": 83,
         "markers": [
           "unit"
         ],
@@ -30557,7 +30557,7 @@
       },
       {
         "name": "test_serialize_trial_with_missing_metrics",
-        "line": 92,
+        "line": 93,
         "markers": [
           "unit"
         ],
@@ -30565,7 +30565,7 @@
       },
       {
         "name": "test_serialize_trial_with_partial_metrics",
-        "line": 108,
+        "line": 109,
         "markers": [
           "unit"
         ],
@@ -30573,7 +30573,7 @@
       },
       {
         "name": "test_serialize_trial_with_full_metrics",
-        "line": 131,
+        "line": 132,
         "markers": [
           "unit"
         ],
@@ -30581,7 +30581,7 @@
       },
       {
         "name": "test_storage_save_run_writes_results_file",
-        "line": 156,
+        "line": 157,
         "markers": [
           "unit"
         ],
@@ -30589,7 +30589,23 @@
       },
       {
         "name": "test_storage_default_uses_registry_runtime_dir",
-        "line": 167,
+        "line": 168,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_storage_load_run_falls_back_to_legacy_default_dir",
+        "line": 184,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_storage_explicit_base_dir_does_not_use_legacy_default_dir",
+        "line": 205,
         "markers": [
           "unit"
         ],
@@ -30597,7 +30613,7 @@
       },
       {
         "name": "test_storage_load_run_missing_and_invalid_json",
-        "line": 179,
+        "line": 224,
         "markers": [
           "unit"
         ],
@@ -30605,7 +30621,15 @@
       },
       {
         "name": "test_storage_list_runs_sorted_by_started_at",
-        "line": 190,
+        "line": 235,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_storage_list_runs_includes_legacy_default_dir",
+        "line": 267,
         "markers": [
           "unit"
         ],

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,8 +2,8 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6774,
-    "total_files": 800,
+    "total_tests": 6777,
+    "total_files": 801,
     "markers_used": 16
   },
   "marker_definitions": {
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6609,
+    "unit": 6612,
     "asyncio": 390,
     "parametrize": 193,
     "endpoints": 83,
@@ -238,7 +238,8 @@
       "tests/unit/gpt_trader/config/test_bot_config.py",
       "tests/unit/gpt_trader/config/test_bot_config_position_object_handling.py",
       "tests/unit/gpt_trader/config/test_config_utilities.py",
-      "tests/unit/gpt_trader/config/test_env_utils.py"
+      "tests/unit/gpt_trader/config/test_env_utils.py",
+      "tests/unit/gpt_trader/config/test_path_registry.py"
     ],
     "core": [
       "tests/unit/gpt_trader/core/math/test_incremental.py",
@@ -10582,6 +10583,16 @@
       {
         "name": "test_parse_env_mapping_skips_empty_entries_when_allowed",
         "line": 146,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      }
+    ],
+    "tests/unit/gpt_trader/config/test_path_registry.py": [
+      {
+        "name": "test_runtime_artifact_policy_constants_are_grouped_by_ownership",
+        "line": 4,
         "markers": [
           "unit"
         ],
@@ -30522,7 +30533,7 @@
     "tests/unit/gpt_trader/features/optimize/persistence/test_storage_edges.py": [
       {
         "name": "test_run_to_dict_serializes_datetimes_and_config",
-        "line": 51,
+        "line": 54,
         "markers": [
           "unit"
         ],
@@ -30530,7 +30541,7 @@
       },
       {
         "name": "test_run_from_dict_returns_config_dict_and_no_trials",
-        "line": 61,
+        "line": 64,
         "markers": [
           "unit"
         ],
@@ -30538,7 +30549,7 @@
       },
       {
         "name": "test_serialize_config_accepts_dict_and_config",
-        "line": 79,
+        "line": 82,
         "markers": [
           "unit"
         ],
@@ -30546,7 +30557,7 @@
       },
       {
         "name": "test_serialize_trial_with_missing_metrics",
-        "line": 89,
+        "line": 92,
         "markers": [
           "unit"
         ],
@@ -30554,7 +30565,7 @@
       },
       {
         "name": "test_serialize_trial_with_partial_metrics",
-        "line": 105,
+        "line": 108,
         "markers": [
           "unit"
         ],
@@ -30562,7 +30573,7 @@
       },
       {
         "name": "test_serialize_trial_with_full_metrics",
-        "line": 128,
+        "line": 131,
         "markers": [
           "unit"
         ],
@@ -30570,7 +30581,15 @@
       },
       {
         "name": "test_storage_save_run_writes_results_file",
-        "line": 153,
+        "line": 156,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_storage_default_uses_registry_runtime_dir",
+        "line": 167,
         "markers": [
           "unit"
         ],
@@ -30578,7 +30597,7 @@
       },
       {
         "name": "test_storage_load_run_missing_and_invalid_json",
-        "line": 164,
+        "line": 179,
         "markers": [
           "unit"
         ],
@@ -30586,7 +30605,7 @@
       },
       {
         "name": "test_storage_list_runs_sorted_by_started_at",
-        "line": 175,
+        "line": 190,
         "markers": [
           "unit"
         ],
@@ -42659,7 +42678,7 @@
     "tests/unit/gpt_trader/security/secrets_manager/test_file_basic.py": [
       {
         "name": "TestFileBasics::test_file_store_success",
-        "line": 14,
+        "line": 19,
         "markers": [
           "unit"
         ],
@@ -42668,7 +42687,7 @@
       },
       {
         "name": "TestFileBasics::test_file_retrieve_success",
-        "line": 32,
+        "line": 37,
         "markers": [
           "unit"
         ],
@@ -42677,7 +42696,7 @@
       },
       {
         "name": "TestFileBasics::test_file_delete_success",
-        "line": 43,
+        "line": 48,
         "markers": [
           "unit"
         ],
@@ -42686,7 +42705,7 @@
       },
       {
         "name": "TestFileBasics::test_file_list_success",
-        "line": 60,
+        "line": 65,
         "markers": [
           "unit"
         ],
@@ -42695,7 +42714,7 @@
       },
       {
         "name": "TestFileBasics::test_file_retrieve_missing_secret",
-        "line": 76,
+        "line": 81,
         "markers": [
           "unit"
         ],
@@ -42704,7 +42723,7 @@
       },
       {
         "name": "TestFileBasics::test_file_delete_missing_secret",
-        "line": 80,
+        "line": 85,
         "markers": [
           "unit"
         ],
@@ -42713,7 +42732,7 @@
       },
       {
         "name": "TestFileBasics::test_file_path_sanitization",
-        "line": 84,
+        "line": 89,
         "markers": [
           "unit"
         ],
@@ -42722,7 +42741,16 @@
       },
       {
         "name": "TestFileBasics::test_file_directory_creation",
-        "line": 95,
+        "line": 100,
+        "markers": [
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestFileBasics"
+      },
+      {
+        "name": "TestFileBasics::test_default_file_storage_uses_registry_secret_dir",
+        "line": 111,
         "markers": [
           "unit"
         ],
@@ -42731,7 +42759,7 @@
       },
       {
         "name": "TestFileBasics::test_file_encryption_roundtrip",
-        "line": 106,
+        "line": 134,
         "markers": [
           "unit"
         ],
@@ -42740,7 +42768,7 @@
       },
       {
         "name": "TestFileBasics::test_file_overwrite_existing",
-        "line": 120,
+        "line": 148,
         "markers": [
           "unit"
         ],
@@ -42749,7 +42777,7 @@
       },
       {
         "name": "TestFileBasics::test_file_invalid_path_characters",
-        "line": 131,
+        "line": 159,
         "markers": [
           "unit"
         ],
@@ -42758,7 +42786,7 @@
       },
       {
         "name": "TestFileBasics::test_file_permissions_handling",
-        "line": 149,
+        "line": 177,
         "markers": [
           "unit"
         ],
@@ -42767,7 +42795,7 @@
       },
       {
         "name": "TestFileBasics::test_file_storage_with_different_data_types",
-        "line": 161,
+        "line": 189,
         "markers": [
           "unit"
         ],
@@ -42776,7 +42804,7 @@
       },
       {
         "name": "TestFileBasics::test_file_storage_empty_secret",
-        "line": 178,
+        "line": 206,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary
Related issue / finding / RJ-routed package: Closes #956

- Centralizes runtime artifact ownership defaults in `path_registry`.
- Routes `SecretsManager` and `OptimizationStorage` defaults through the central path policy while preserving constructor path injection.
- Documents repo-local runtime artifacts vs user-global secrets and refreshes generated agent inventories.

## Type of change
- [x] Refactor
- [ ] Feature
- [ ] Bug fix
- [ ] Tests only
- [x] CI/Docs/Tooling

## Scope & Impact
- Affected areas / components: `src/gpt_trader/config/path_registry.py`, secrets file fallback, optimize persistence storage, architecture/security docs, focused unit tests, generated `var/agents/**` inventories.
- Behavior changes: `OptimizationStorage()` defaults to repo-local `runtime_data/optimize`; `SecretsManager` still defaults to `~/.gpt_trader/secrets`, now via `path_registry.USER_SECRETS_DIR`.
- Breaking constructor/API behavior: none. Existing `base_dir=` and `secrets_dir=` injection still works.

## Test Plan
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Contract tests (if applicable)
- [x] Ran locally: `uv run pytest tests/unit/gpt_trader/config/test_path_registry.py tests/unit/gpt_trader/features/optimize/persistence/test_storage_edges.py tests/unit/gpt_trader/security/secrets_manager/test_file_basic.py -q`
- [x] Markers used appropriately (`unit`/`integration`/`slow`/`perf`)

Additional verification:
- `uv run ruff check src/gpt_trader/config/path_registry.py src/gpt_trader/security/secrets_manager.py src/gpt_trader/features/optimize/persistence/storage.py tests/unit/gpt_trader/config/test_path_registry.py tests/unit/gpt_trader/features/optimize/persistence/test_storage_edges.py tests/unit/gpt_trader/security/secrets_manager/test_file_basic.py`
- `uv run python scripts/maintenance/docs_link_audit.py`
- `uv run python scripts/maintenance/docs_reachability_check.py`
- `uv run agent-regenerate --verify`
- `uv run local-ci --profile quick` (passed: 7042 unit tests passed, 8 skipped; quick profile skips readiness/artifact freshness by design)

## Complexity & Quality Gates
- [x] Mypy/type-check passed
- [ ] Xenon/radon complexity gate passed (CC <= 15 on live_trade execution)
- [x] No `sys.path` hacks in tests
- [x] No `MagicMock` on `async def` (use `AsyncMock`)
- [x] Import-lint rules respected (no “import up the stack”)

## Observability & Errors
- [ ] Structured JSON logs for new/changed paths
- [ ] Errors include diagnostic context (symbol, order_id, correlation_id)
- [ ] Added/updated sampling examples in tests (if applicable)

No logging or error paths changed.

## Configuration
- [ ] If config changed: `python -m gpt_trader.cli.config validate --profile <name>` passes
- [x] Env docs re-generated (if applicable) and committed
- [x] No `ConfigLoader` usages introduced (ConfigManager-only)

## Breaking Changes
- [x] None
- [ ] Documented in PR body and release notes if any

## Screenshots / Logs (optional)
N/A

## Checklist
- [x] Acceptance criteria in linked issue(s), finding packet, or routed package met
- [x] Affected paths listed in PR description
- [ ] Changelog entry (if repo uses one)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized runtime data (repo-local) vs optimization runs and encrypted secrets (user-scoped defaults).
  * Optimization run persistence now supports legacy fallback and merged listing across current + legacy directories.

* **Documentation**
  * Updated architecture/security guidance for runtime artifact ownership, repo-local storage expectations, and where encrypted secrets are kept.

* **Tests**
  * Added/expanded unit tests to validate default directory resolution, legacy fallback behavior, and secrets manager default storage location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->