### PR TITLE
[codex] Handle health-status write failures in MetricsPublisher

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -1,8 +1,0 @@
-def write_health_status(self, health_status: dict) -> None:
-    try:
-        with open(self.health_file, 'w') as f:
-            json.dump(health_status, f)
-    except OSError as e:
-        self.logger.error(f'Failed to write health status: {e}
-')
-        # Best-effort write, continue running

--- a/metrics.py
+++ b/metrics.py
@@ -1,0 +1,8 @@
+def write_health_status(self, health_status: dict) -> None:
+    try:
+        with open(self.health_file, 'w') as f:
+            json.dump(health_status, f)
+    except OSError as e:
+        self.logger.error(f'Failed to write health status: {e}
+')
+        # Best-effort write, continue running

--- a/src/gpt_trader/monitoring/system/metrics.py
+++ b/src/gpt_trader/monitoring/system/metrics.py
@@ -99,11 +99,20 @@ class MetricsPublisher:
             "message": message,
             "error": error,
         }
-        for target_dir in self._target_dirs():
-            status_path = target_dir / "health.json"
-            status_path.parent.mkdir(parents=True, exist_ok=True)
-            with status_path.open("w") as fh:
-                json.dump(status, fh, indent=2)
+        try:
+            for target_dir in self._target_dirs():
+                status_path = target_dir / "health.json"
+                status_path.parent.mkdir(parents=True, exist_ok=True)
+                with status_path.open("w") as fh:
+                    json.dump(status, fh, indent=2)
+        except Exception as exc:
+            logger.debug(
+                "Failed to write health status snapshot",
+                operation="system_monitor_metrics",
+                stage="write_health_status",
+                error=str(exc),
+                exc_info=True,
+            )
 
 
 __all__ = ["MetricsPublisher"]

--- a/tests/unit/gpt_trader/monitoring/system/test_metrics.py
+++ b/tests/unit/gpt_trader/monitoring/system/test_metrics.py
@@ -180,6 +180,22 @@ class TestMetricsPublisherWriteHealthStatus:
             assert data["ok"] is False
             assert data["error"] == "Connection lost"
 
+    def test_handles_health_status_write_errors(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        metrics_logger: MagicMock,
+        publisher: MetricsPublisher,
+    ) -> None:
+        blocking_file = tmp_path / "not-a-directory"
+        blocking_file.write_text("blocks directory creation")
+        monkeypatch.setattr(publisher, "_target_dirs", lambda: [blocking_file])
+
+        publisher.write_health_status(ok=False, error="disk unavailable")
+
+        metrics_logger.debug.assert_called_once()
+        assert not (blocking_file / "health.json").exists()
+
 
 class TestTargetDirs:
     """Tests for MetricsPublisher._target_dirs method."""

--- a/var/agents/logging/event_catalog.json
+++ b/var/agents/logging/event_catalog.json
@@ -2188,7 +2188,7 @@
       "levels": [
         "DEBUG"
       ],
-      "occurrence_count": 2,
+      "occurrence_count": 3,
       "source_files": [
         "monitoring/system/metrics.py"
       ],
@@ -2570,7 +2570,7 @@
     "client_order_id": 12,
     "consecutive_failures": 5,
     "details": 5,
-    "error": 44,
+    "error": 45,
     "error_message": 92,
     "error_msg": 5,
     "error_type": 84,
@@ -2590,12 +2590,12 @@
     "service": 9,
     "severity": 4,
     "side": 25,
-    "stage": 167,
+    "stage": 168,
     "symbol": 77
   },
   "level_distribution": {
     "CRITICAL": 1,
-    "DEBUG": 51,
+    "DEBUG": 52,
     "ERROR": 97,
     "INFO": 118,
     "WARNING": 76

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6780,
+    "total_tests": 6781,
     "total_files": 801,
     "markers_used": 16
   },

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6615,
+    "unit": 6616,
     "asyncio": 390,
     "parametrize": 193,
     "endpoints": 83,

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6780,
+    "total_tests": 6781,
     "total_files": 801,
     "markers_used": 16
   },
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6615,
+    "unit": 6616,
     "asyncio": 390,
     "parametrize": 193,
     "endpoints": 83,
@@ -35925,8 +35925,17 @@
         "class": "TestMetricsPublisherWriteHealthStatus"
       },
       {
+        "name": "TestMetricsPublisherWriteHealthStatus::test_handles_health_status_write_errors",
+        "line": 183,
+        "markers": [
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestMetricsPublisherWriteHealthStatus"
+      },
+      {
         "name": "TestTargetDirs::test_returns_profile_specific_path",
-        "line": 187,
+        "line": 203,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary
- replaces the invalid root-level `metrics.py` change from #973 with a bounded fix in `MetricsPublisher.write_health_status`
- keeps health-status writes best-effort by logging filesystem failures instead of propagating them
- adds a deterministic unit test for directory-creation/write-path failure and refreshes generated agent metadata

Closes #971
Supersedes #973

## Verification
- `uv run pytest tests/unit/gpt_trader/monitoring/system/test_metrics.py -q` -> 12 passed
- `uv run ruff check src/gpt_trader/monitoring/system/metrics.py tests/unit/gpt_trader/monitoring/system/test_metrics.py` -> passed
- `uv run agent-regenerate --verify` -> passed after regeneration
- `uv run local-ci --profile quick` -> passed; 7046 passed, 8 skipped

## Pipeline
- Pipeline id: `goal-pipeline-20260625-gpt-trader-health-status-write-failures`
- Replacement for cross-fork PR #973 because the fork head could not be pushed with the available base-repo deploy key.

## Risk
- Execution-free monitoring hardening only. No broker/API/live trading commands run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when saving health status snapshots so failures are logged clearly and do not create partial output.
  * Added coverage for failed write scenarios to confirm graceful handling.

* **Tests**
  * Updated test counts and inventory data to reflect the new unit test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->