### PR TITLE
[codex] Persist emergency flatten audit trail

### DIFF
--- a/src/gpt_trader/features/live_trade/bot.py
+++ b/src/gpt_trader/features/live_trade/bot.py
@@ -7,18 +7,27 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from decimal import Decimal
 from typing import TYPE_CHECKING, Any
+from uuid import uuid4
 
 from gpt_trader.app.config import BotConfig
 from gpt_trader.app.runtime_ui_adapter import NullUIAdapter, RuntimeUIAdapter
 from gpt_trader.features.live_trade.engines.base import CoordinatorContext
 from gpt_trader.features.live_trade.engines.strategy import TradingEngine
+from gpt_trader.features.live_trade.execution.status_codec import (
+    ExecutionStatusCodecError,
+    execution_status_for_store,
+)
 from gpt_trader.features.live_trade.lifecycle import (
     TRADING_BOT_TRANSITIONS,
     LifecycleStateMachine,
     TradingBotState,
 )
 from gpt_trader.monitoring.alert_types import AlertSeverity
+from gpt_trader.persistence.orders_store import OrderRecord, OrderStatus
 from gpt_trader.utilities.async_tools import BoundedToThread
 from gpt_trader.utilities.logging_patterns import get_logger
 
@@ -259,21 +268,36 @@ class TradingBot:
         )
         messages = ["Bot stopping."]
         failed_closes: list[dict[str, str]] = []
+        flatten_operation_id = f"flatten-{uuid4().hex}"
 
         if not self.broker:
             error = "No broker connection available."
             messages.append(f"Error: {error}")
             failed_closes.append(
                 {
+                    "flatten_operation_id": flatten_operation_id,
                     "symbol": "unknown",
                     "quantity": "unknown",
                     "error": error,
                 }
             )
+            self._record_emergency_close_audit(
+                flatten_operation_id=flatten_operation_id,
+                symbol="unknown",
+                side="unknown",
+                order_type="unknown",
+                quantity="unknown",
+                status="failed",
+                error=error,
+            )
             self._preserve_flatten_failure_state = True
             self._preserve_engine_broker_calls_on_shutdown()
             await self.engine.shutdown()
-            await self._handle_flatten_failure(failed_closes, messages)
+            await self._handle_flatten_failure(
+                failed_closes,
+                messages,
+                flatten_operation_id=flatten_operation_id,
+            )
             return messages
 
         try:
@@ -292,16 +316,27 @@ class TradingBot:
                 from gpt_trader.core import OrderSide, OrderType
 
                 for pos in positions:
+                    order_type: Any = OrderType.MARKET
+                    side: Any = "unknown"
                     try:
                         side = self._emergency_close_side(pos, OrderSide)
                         # Use absolute quantity for order
                         quantity = abs(pos.quantity)
 
-                        await self._place_reduce_only_emergency_close(
+                        order = await self._place_reduce_only_emergency_close(
                             symbol=pos.symbol,
                             side=side,
-                            order_type=OrderType.MARKET,
+                            order_type=order_type,
                             quantity=quantity,
+                        )
+                        self._record_emergency_close_audit(
+                            flatten_operation_id=flatten_operation_id,
+                            symbol=pos.symbol,
+                            side=side,
+                            order_type=order_type,
+                            quantity=quantity,
+                            status="submitted",
+                            order=order,
                         )
                         logger.info(
                             "Emergency close submitted",
@@ -328,10 +363,20 @@ class TradingBot:
                         messages.append(f"Failed to close {symbol}: {e}")
                         failed_closes.append(
                             {
+                                "flatten_operation_id": flatten_operation_id,
                                 "symbol": symbol,
                                 "quantity": quantity,
                                 "error": str(e),
                             }
+                        )
+                        self._record_emergency_close_audit(
+                            flatten_operation_id=flatten_operation_id,
+                            symbol=symbol,
+                            side=side,
+                            order_type=order_type,
+                            quantity=quantity,
+                            status="failed",
+                            error=str(e),
                         )
 
         except Exception as e:
@@ -339,10 +384,20 @@ class TradingBot:
             messages.append(f"Critical Error during flatten: {e}")
             failed_closes.append(
                 {
+                    "flatten_operation_id": flatten_operation_id,
                     "symbol": "unknown",
                     "quantity": "unknown",
                     "error": str(e),
                 }
+            )
+            self._record_emergency_close_audit(
+                flatten_operation_id=flatten_operation_id,
+                symbol="unknown",
+                side="unknown",
+                order_type="unknown",
+                quantity="unknown",
+                status="failed",
+                error=str(e),
             )
 
         if failed_closes:
@@ -350,7 +405,11 @@ class TradingBot:
             self._preserve_engine_broker_calls_on_shutdown()
         await self.engine.shutdown()
         if failed_closes:
-            await self._handle_flatten_failure(failed_closes, messages)
+            await self._handle_flatten_failure(
+                failed_closes,
+                messages,
+                flatten_operation_id=flatten_operation_id,
+            )
             return messages
 
         self._shutdown_broker_calls()
@@ -363,6 +422,8 @@ class TradingBot:
         self,
         failed_closes: list[dict[str, str]],
         messages: list[str],
+        *,
+        flatten_operation_id: str,
     ) -> None:
         self._preserve_flatten_failure_state = True
         failed_symbols = [
@@ -371,6 +432,7 @@ class TradingBot:
             if failure.get("symbol") and failure["symbol"] != "unknown"
         ]
         details = {
+            "flatten_operation_id": flatten_operation_id,
             "failed_close_count": len(failed_closes),
             "failed_symbols": failed_symbols,
             "failed_closes": failed_closes,
@@ -412,6 +474,142 @@ class TradingBot:
                 operation="flatten_and_stop",
                 error=str(exc),
             )
+
+    def _record_emergency_close_audit(
+        self,
+        *,
+        flatten_operation_id: str,
+        symbol: Any,
+        side: Any,
+        order_type: Any,
+        quantity: Any,
+        status: str,
+        order: Any | None = None,
+        error: str | None = None,
+    ) -> None:
+        order_id = self._extract_order_identifier(order, ("id", "order_id"))
+        client_order_id = self._extract_order_identifier(
+            order,
+            ("client_order_id", "client_id", "client_oid"),
+        )
+        broker_status = self._extract_order_identifier(order, ("status",)) or status
+        payload: dict[str, Any] = {
+            "flatten_operation_id": flatten_operation_id,
+            "symbol": str(symbol),
+            "side": self._stringify_order_value(side),
+            "order_type": self._stringify_order_value(order_type),
+            "quantity": str(quantity),
+            "reduce_only": True,
+            "status": status,
+            "broker_status": broker_status,
+        }
+        if order_id:
+            payload["order_id"] = order_id
+        if client_order_id:
+            payload["client_order_id"] = client_order_id
+        if error:
+            payload["error"] = error
+
+        self._append_emergency_close_audit_event(payload)
+        if error is None:
+            self._persist_emergency_close_order(payload)
+
+    def _append_emergency_close_audit_event(self, payload: dict[str, Any]) -> None:
+        event_store = self._event_store
+        append = getattr(event_store, "append", None)
+        if not callable(append):
+            return
+        try:
+            append("emergency_flatten_close_order", payload)
+        except Exception as exc:
+            logger.error(
+                "Failed to record emergency flatten close-order audit event",
+                operation="flatten_and_stop",
+                error=str(exc),
+                flatten_operation_id=payload.get("flatten_operation_id"),
+                symbol=payload.get("symbol"),
+            )
+
+    def _persist_emergency_close_order(self, payload: dict[str, Any]) -> None:
+        order_id = payload.get("order_id") or payload.get("client_order_id")
+        if not order_id:
+            return
+        client_order_id = payload.get("client_order_id") or order_id
+        upsert = getattr(self._orders_store, "upsert_by_client_id", None)
+        if not callable(upsert):
+            return
+        status = self._emergency_close_store_status(payload.get("broker_status"))
+        now = datetime.now(timezone.utc)
+        metadata = {
+            "source": "emergency_flatten",
+            "flatten_operation_id": payload["flatten_operation_id"],
+            "reduce_only": True,
+            "audit_status": payload["status"],
+            "broker_status": payload.get("broker_status"),
+        }
+        record = OrderRecord(
+            order_id=str(order_id),
+            client_order_id=str(client_order_id),
+            symbol=str(payload["symbol"]),
+            side=str(payload["side"]).lower(),
+            order_type=str(payload["order_type"]).lower(),
+            quantity=self._decimal_or_zero(payload.get("quantity")),
+            price=None,
+            status=status,
+            filled_quantity=Decimal("0"),
+            average_fill_price=None,
+            created_at=now,
+            updated_at=now,
+            bot_id=str(getattr(self.config, "bot_id", "trading-bot")),
+            metadata=metadata,
+        )
+        try:
+            upsert(record)
+        except Exception as exc:
+            logger.error(
+                "Failed to persist emergency flatten close-order record",
+                operation="flatten_and_stop",
+                error=str(exc),
+                order_id=str(order_id),
+                client_order_id=str(client_order_id),
+            )
+
+    @staticmethod
+    def _emergency_close_store_status(status: Any) -> OrderStatus:
+        try:
+            return execution_status_for_store(
+                status,
+                context="emergency_flatten_close_order",
+            )
+        except ExecutionStatusCodecError:
+            return OrderStatus.OPEN
+
+    @staticmethod
+    def _extract_order_identifier(order: Any | None, field_names: tuple[str, ...]) -> str | None:
+        if order is None:
+            return None
+        if isinstance(order, Mapping):
+            for field_name in field_names:
+                value = order.get(field_name)
+                if value is not None:
+                    return str(getattr(value, "value", value))
+            return None
+        for field_name in field_names:
+            value = getattr(order, field_name, None)
+            if value is not None:
+                return str(getattr(value, "value", value))
+        return None
+
+    @staticmethod
+    def _stringify_order_value(value: Any) -> str:
+        return str(getattr(value, "value", value))
+
+    @staticmethod
+    def _decimal_or_zero(value: Any) -> Decimal:
+        try:
+            return Decimal(str(value))
+        except Exception:
+            return Decimal("0")
 
     async def _notify_flatten_failure(self, details: dict[str, Any]) -> None:
         if self._notification_service is None:

--- a/src/gpt_trader/features/live_trade/bot.py
+++ b/src/gpt_trader/features/live_trade/bot.py
@@ -635,7 +635,7 @@ class TradingBot:
             average_fill_price=self._decimal_or_none(payload.get("average_fill_price")),
             created_at=now,
             updated_at=now,
-            bot_id=str(getattr(self.config, "bot_id", "trading-bot")),
+            bot_id=self._emergency_close_bot_id(),
             metadata=metadata,
         )
         try:
@@ -648,6 +648,9 @@ class TradingBot:
                 order_id=str(order_id),
                 client_order_id=str(client_order_id),
             )
+
+    def _emergency_close_bot_id(self) -> str:
+        return str(self.context.bot_id or self.context.config.profile or "live")
 
     @staticmethod
     def _emergency_close_store_status(

--- a/src/gpt_trader/features/live_trade/bot.py
+++ b/src/gpt_trader/features/live_trade/bot.py
@@ -256,23 +256,33 @@ class TradingBot:
         even when guards would block normal trading.
         """
         self._preserve_flatten_failure_state = False
+        flatten_operation_id = f"flatten-{uuid4().hex}"
         self._transition_state(
             TradingBotState.STOPPING,
             reason="flatten_and_stop",
-            details={"bypass_reason": "emergency_shutdown"},
+            details={
+                "bypass_reason": "emergency_shutdown",
+                "flatten_operation_id": flatten_operation_id,
+            },
         )
         logger.warning(
             "EMERGENCY: Initiating Flatten & Stop",
             bypass_reason="emergency_shutdown",
+            flatten_operation_id=flatten_operation_id,
             operation="flatten_and_stop",
         )
         messages = ["Bot stopping."]
         failed_closes: list[dict[str, str]] = []
-        flatten_operation_id = f"flatten-{uuid4().hex}"
 
         if not self.broker:
             error = "No broker connection available."
             messages.append(f"Error: {error}")
+            logger.error(
+                "Emergency flatten cannot close positions without broker connection",
+                operation="flatten_and_stop",
+                flatten_operation_id=flatten_operation_id,
+                error=error,
+            )
             failed_closes.append(
                 {
                     "flatten_operation_id": flatten_operation_id,
@@ -329,6 +339,40 @@ class TradingBot:
                             order_type=order_type,
                             quantity=quantity,
                         )
+                        close_error = self._emergency_close_rejection_error(order)
+                        if close_error is not None:
+                            logger.error(
+                                "Emergency close returned non-accepted broker status",
+                                operation="flatten_and_stop",
+                                flatten_operation_id=flatten_operation_id,
+                                symbol=pos.symbol,
+                                quantity=str(quantity),
+                                broker_status=self._extract_order_identifier(
+                                    order,
+                                    ("status",),
+                                ),
+                                error=close_error,
+                            )
+                            messages.append(f"Failed to close {pos.symbol}: {close_error}")
+                            failed_closes.append(
+                                {
+                                    "flatten_operation_id": flatten_operation_id,
+                                    "symbol": str(pos.symbol),
+                                    "quantity": str(quantity),
+                                    "error": close_error,
+                                }
+                            )
+                            self._record_emergency_close_audit(
+                                flatten_operation_id=flatten_operation_id,
+                                symbol=pos.symbol,
+                                side=side,
+                                order_type=order_type,
+                                quantity=quantity,
+                                status="failed",
+                                order=order,
+                                error=close_error,
+                            )
+                            continue
                         self._record_emergency_close_audit(
                             flatten_operation_id=flatten_operation_id,
                             symbol=pos.symbol,
@@ -345,6 +389,7 @@ class TradingBot:
                             reduce_only=True,
                             bypass_reason="emergency_shutdown",
                             operation="flatten_and_stop",
+                            flatten_operation_id=flatten_operation_id,
                         )
                         messages.append(
                             f"Submitted CLOSE for {pos.symbol} ({quantity}) reduce-only"
@@ -359,7 +404,14 @@ class TradingBot:
                                 quantity = str(abs(raw_quantity))
                             except TypeError:
                                 quantity = str(raw_quantity)
-                        logger.error(f"Failed to close {symbol}: {e}")
+                        logger.error(
+                            "Failed to close position during emergency flatten",
+                            operation="flatten_and_stop",
+                            flatten_operation_id=flatten_operation_id,
+                            symbol=symbol,
+                            quantity=quantity,
+                            error=str(e),
+                        )
                         messages.append(f"Failed to close {symbol}: {e}")
                         failed_closes.append(
                             {
@@ -380,7 +432,12 @@ class TradingBot:
                         )
 
         except Exception as e:
-            logger.error(f"Flatten failed: {e}")
+            logger.error(
+                "Flatten failed",
+                operation="flatten_and_stop",
+                flatten_operation_id=flatten_operation_id,
+                error=str(e),
+            )
             messages.append(f"Critical Error during flatten: {e}")
             failed_closes.append(
                 {
@@ -449,6 +506,7 @@ class TradingBot:
         logger.critical(
             "Emergency flatten incomplete",
             operation="flatten_and_stop",
+            flatten_operation_id=flatten_operation_id,
             failed_close_count=len(failed_closes),
             failed_symbols=failed_symbols,
             monitoring_state=details["monitoring_state"],
@@ -472,6 +530,7 @@ class TradingBot:
             logger.error(
                 "Failed to record emergency flatten failure event",
                 operation="flatten_and_stop",
+                flatten_operation_id=details.get("flatten_operation_id"),
                 error=str(exc),
             )
 
@@ -609,6 +668,26 @@ class TradingBot:
         }:
             return OrderStatus.OPEN
         return store_status
+
+    def _emergency_close_rejection_error(self, order: Any | None) -> str | None:
+        broker_status = self._extract_order_identifier(order, ("status",))
+        if broker_status is None:
+            return None
+        try:
+            store_status = execution_status_for_store(
+                broker_status,
+                context="emergency_flatten_close_order",
+            )
+        except ExecutionStatusCodecError:
+            return f"Broker returned unsupported emergency close status: {broker_status}"
+        if store_status in {
+            OrderStatus.CANCELLED,
+            OrderStatus.REJECTED,
+            OrderStatus.EXPIRED,
+            OrderStatus.FAILED,
+        }:
+            return f"Broker returned non-accepted emergency close status: {store_status.value}"
+        return None
 
     @staticmethod
     def _extract_order_identifier(order: Any | None, field_names: tuple[str, ...]) -> str | None:

--- a/src/gpt_trader/features/live_trade/bot.py
+++ b/src/gpt_trader/features/live_trade/bot.py
@@ -493,6 +493,14 @@ class TradingBot:
             ("client_order_id", "client_id", "client_oid"),
         )
         broker_status = self._extract_order_identifier(order, ("status",)) or status
+        filled_quantity = self._extract_order_decimal(
+            order,
+            ("filled_quantity", "filled_size", "fill_size", "filled_qty"),
+        )
+        average_fill_price = self._extract_order_decimal(
+            order,
+            ("average_filled_price", "average_fill_price", "avg_fill_price", "fill_price"),
+        )
         payload: dict[str, Any] = {
             "flatten_operation_id": flatten_operation_id,
             "symbol": str(symbol),
@@ -503,6 +511,10 @@ class TradingBot:
             "status": status,
             "broker_status": broker_status,
         }
+        if filled_quantity is not None:
+            payload["filled_quantity"] = str(filled_quantity)
+        if average_fill_price is not None:
+            payload["average_fill_price"] = str(average_fill_price)
         if order_id:
             payload["order_id"] = order_id
         if client_order_id:
@@ -538,7 +550,11 @@ class TradingBot:
         upsert = getattr(self._orders_store, "upsert_by_client_id", None)
         if not callable(upsert):
             return
-        status = self._emergency_close_store_status(payload.get("broker_status"))
+        filled_quantity = self._decimal_or_none(payload.get("filled_quantity"))
+        status = self._emergency_close_store_status(
+            payload.get("broker_status"),
+            filled_quantity_known=filled_quantity is not None,
+        )
         now = datetime.now(timezone.utc)
         metadata = {
             "source": "emergency_flatten",
@@ -556,8 +572,8 @@ class TradingBot:
             quantity=self._decimal_or_zero(payload.get("quantity")),
             price=None,
             status=status,
-            filled_quantity=Decimal("0"),
-            average_fill_price=None,
+            filled_quantity=filled_quantity or Decimal("0"),
+            average_fill_price=self._decimal_or_none(payload.get("average_fill_price")),
             created_at=now,
             updated_at=now,
             bot_id=str(getattr(self.config, "bot_id", "trading-bot")),
@@ -575,14 +591,24 @@ class TradingBot:
             )
 
     @staticmethod
-    def _emergency_close_store_status(status: Any) -> OrderStatus:
+    def _emergency_close_store_status(
+        status: Any,
+        *,
+        filled_quantity_known: bool,
+    ) -> OrderStatus:
         try:
-            return execution_status_for_store(
+            store_status = execution_status_for_store(
                 status,
                 context="emergency_flatten_close_order",
             )
         except ExecutionStatusCodecError:
             return OrderStatus.OPEN
+        if not filled_quantity_known and store_status in {
+            OrderStatus.FILLED,
+            OrderStatus.PARTIALLY_FILLED,
+        }:
+            return OrderStatus.OPEN
+        return store_status
 
     @staticmethod
     def _extract_order_identifier(order: Any | None, field_names: tuple[str, ...]) -> str | None:
@@ -601,15 +627,38 @@ class TradingBot:
         return None
 
     @staticmethod
+    def _extract_order_decimal(
+        order: Any | None,
+        field_names: tuple[str, ...],
+    ) -> Decimal | None:
+        if order is None:
+            return None
+        if isinstance(order, Mapping):
+            values = (order.get(field_name) for field_name in field_names)
+        else:
+            values = (getattr(order, field_name, None) for field_name in field_names)
+        for value in values:
+            decimal_value = TradingBot._decimal_or_none(value)
+            if decimal_value is not None:
+                return decimal_value
+        return None
+
+    @staticmethod
     def _stringify_order_value(value: Any) -> str:
         return str(getattr(value, "value", value))
 
     @staticmethod
-    def _decimal_or_zero(value: Any) -> Decimal:
+    def _decimal_or_none(value: Any) -> Decimal | None:
+        if value is None or value == "":
+            return None
         try:
-            return Decimal(str(value))
+            return Decimal(str(getattr(value, "value", value)))
         except Exception:
-            return Decimal("0")
+            return None
+
+    @staticmethod
+    def _decimal_or_zero(value: Any) -> Decimal:
+        return TradingBot._decimal_or_none(value) or Decimal("0")
 
     async def _notify_flatten_failure(self, details: dict[str, Any]) -> None:
         if self._notification_service is None:

--- a/src/gpt_trader/features/live_trade/bot.py
+++ b/src/gpt_trader/features/live_trade/bot.py
@@ -612,7 +612,7 @@ class TradingBot:
         filled_quantity = self._decimal_or_none(payload.get("filled_quantity"))
         status = self._emergency_close_store_status(
             payload.get("broker_status"),
-            filled_quantity_known=filled_quantity is not None,
+            filled_quantity_known=filled_quantity is not None and filled_quantity > 0,
         )
         now = datetime.now(timezone.utc)
         metadata = {

--- a/tests/unit/gpt_trader/features/live_trade/test_bot_flatten_and_stop.py
+++ b/tests/unit/gpt_trader/features/live_trade/test_bot_flatten_and_stop.py
@@ -331,12 +331,20 @@ class TestTradingBotFlattenAndStop:
         assert notify_kwargs["severity"] is AlertSeverity.CRITICAL
         assert notify_kwargs["force"] is True
         assert notify_kwargs["context"]["failed_symbols"] == ["ETH-USD"]
-        event_store.append.assert_called_once()
-        event_type, payload = event_store.append.call_args.args
-        assert event_type == "emergency_flatten_failed"
+        flatten_failure_events = [
+            call.args[1]
+            for call in event_store.append.call_args_list
+            if call.args[0] == "emergency_flatten_failed"
+        ]
+        assert len(flatten_failure_events) == 1
+        payload = flatten_failure_events[0]
+        flatten_operation_id = payload["flatten_operation_id"]
+        assert flatten_operation_id.startswith("flatten-")
+        assert payload["flatten_operation_id"] == flatten_operation_id
         assert payload["monitoring_state"] == "alerting_active_until_reconciliation"
         assert payload["failed_closes"] == [
             {
+                "flatten_operation_id": flatten_operation_id,
                 "symbol": "ETH-USD",
                 "quantity": "2",
                 "error": "venue rejected emergency close",

--- a/tests/unit/gpt_trader/features/live_trade/test_bot_flatten_and_stop.py
+++ b/tests/unit/gpt_trader/features/live_trade/test_bot_flatten_and_stop.py
@@ -35,7 +35,7 @@ class TestTradingBotFlattenAndStop:
         broker.list_positions.return_value = [
             SimpleNamespace(symbol="BTC-USD", quantity=Decimal("1"))
         ]
-        broker.place_order = Mock()
+        broker.place_order = Mock(return_value=None)
 
         container = SimpleNamespace(
             broker=broker,
@@ -90,7 +90,7 @@ class TestTradingBotFlattenAndStop:
         broker.list_positions.return_value = [
             SimpleNamespace(symbol="BTC-USD", quantity=Decimal("-2"))
         ]
-        broker.place_order = Mock()
+        broker.place_order = Mock(return_value=None)
 
         container = SimpleNamespace(
             broker=broker,
@@ -140,7 +140,7 @@ class TestTradingBotFlattenAndStop:
         broker.list_positions.return_value = [
             SimpleNamespace(symbol="BTC-USD", quantity=Decimal("2"), side="short")
         ]
-        broker.place_order = Mock()
+        broker.place_order = Mock(return_value=None)
 
         container = SimpleNamespace(
             broker=broker,

--- a/tests/unit/gpt_trader/features/live_trade/test_bot_flatten_and_stop_audit.py
+++ b/tests/unit/gpt_trader/features/live_trade/test_bot_flatten_and_stop_audit.py
@@ -41,7 +41,9 @@ async def test_flatten_and_stop_persists_submitted_close_order_audit(
         return_value={
             "order_id": "close-btc-123",
             "client_order_id": "client-close-btc-123",
-            "status": "OPEN",
+            "status": "FILLED",
+            "filled_size": "1",
+            "average_filled_price": "50000.12",
         }
     )
     event_store = Mock()
@@ -86,7 +88,9 @@ async def test_flatten_and_stop_persists_submitted_close_order_audit(
     assert audit_payload["quantity"] == "1"
     assert audit_payload["reduce_only"] is True
     assert audit_payload["status"] == "submitted"
-    assert audit_payload["broker_status"] == "OPEN"
+    assert audit_payload["broker_status"] == "FILLED"
+    assert audit_payload["filled_quantity"] == "1"
+    assert audit_payload["average_fill_price"] == "50000.12"
     assert audit_payload["order_id"] == "close-btc-123"
     assert audit_payload["client_order_id"] == "client-close-btc-123"
 
@@ -97,7 +101,9 @@ async def test_flatten_and_stop_persists_submitted_close_order_audit(
     assert order_record.symbol == "BTC-USD"
     assert order_record.side == "sell"
     assert order_record.order_type == "market"
-    assert order_record.status.value == "open"
+    assert order_record.status.value == "filled"
+    assert order_record.filled_quantity == Decimal("1")
+    assert order_record.average_fill_price == Decimal("50000.12")
     assert order_record.metadata["source"] == "emergency_flatten"
     assert order_record.metadata["flatten_operation_id"] == audit_payload["flatten_operation_id"]
 
@@ -172,3 +178,50 @@ async def test_flatten_and_stop_links_partial_failure_audit_events(
     payload = flatten_failure_events[0]
     assert payload["flatten_operation_id"] == flatten_operation_id
     assert payload["failed_closes"][0]["flatten_operation_id"] == flatten_operation_id
+
+
+@pytest.mark.asyncio
+async def test_flatten_and_stop_avoids_filled_record_without_fill_quantity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    broker = Mock()
+    broker.list_positions.return_value = [SimpleNamespace(symbol="BTC-USD", quantity=Decimal("1"))]
+    broker.place_order = Mock(
+        return_value={
+            "order_id": "close-btc-123",
+            "client_order_id": "client-close-btc-123",
+            "status": "FILLED",
+        }
+    )
+    event_store = Mock()
+    orders_store = Mock()
+    container = SimpleNamespace(
+        broker=broker,
+        risk_manager=Mock(),
+        event_store=event_store,
+        orders_store=orders_store,
+        notification_service=Mock(),
+    )
+    _install_mock_engine(monkeypatch)
+
+    bot = TradingBot(
+        config=BotConfig(symbols=["BTC-USD"], interval=1),
+        container=container,
+    )
+    bot._broker_calls = _DirectBrokerCalls()
+
+    await bot.flatten_and_stop()
+
+    orders_store.upsert_by_client_id.assert_called_once()
+    order_record = orders_store.upsert_by_client_id.call_args.args[0]
+    assert order_record.status.value == "open"
+    assert order_record.filled_quantity == Decimal("0")
+    assert order_record.average_fill_price is None
+    audit_payload = next(
+        call.args[1]
+        for call in event_store.append.call_args_list
+        if call.args[0] == "emergency_flatten_close_order"
+    )
+    assert audit_payload["broker_status"] == "FILLED"
+    assert "filled_quantity" not in audit_payload
+    assert "average_fill_price" not in audit_payload

--- a/tests/unit/gpt_trader/features/live_trade/test_bot_flatten_and_stop_audit.py
+++ b/tests/unit/gpt_trader/features/live_trade/test_bot_flatten_and_stop_audit.py
@@ -1,0 +1,174 @@
+"""Tests for emergency flatten close-order audit records."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, Mock
+
+import pytest
+
+import gpt_trader.features.live_trade.bot as bot_module
+from gpt_trader.app.config import BotConfig
+from gpt_trader.features.live_trade.bot import TradingBot
+
+
+class _DirectBrokerCalls:
+    def __init__(self) -> None:
+        self.shutdown = Mock()
+
+    async def __call__(self, fn, *args, **kwargs):
+        return fn(*args, **kwargs)
+
+
+def _install_mock_engine(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    engine = AsyncMock()
+    engine.shutdown = AsyncMock()
+    engine.preserve_broker_calls_on_shutdown = MagicMock()
+    monkeypatch.setattr(bot_module, "TradingEngine", MagicMock(return_value=engine))
+    return engine
+
+
+@pytest.mark.asyncio
+async def test_flatten_and_stop_persists_submitted_close_order_audit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from gpt_trader.core import OrderSide, OrderType
+
+    broker = Mock()
+    broker.list_positions.return_value = [SimpleNamespace(symbol="BTC-USD", quantity=Decimal("1"))]
+    broker.place_order = Mock(
+        return_value={
+            "order_id": "close-btc-123",
+            "client_order_id": "client-close-btc-123",
+            "status": "OPEN",
+        }
+    )
+    event_store = Mock()
+    orders_store = Mock()
+    container = SimpleNamespace(
+        broker=broker,
+        risk_manager=Mock(),
+        event_store=event_store,
+        orders_store=orders_store,
+        notification_service=Mock(),
+    )
+    engine = _install_mock_engine(monkeypatch)
+
+    bot = TradingBot(
+        config=BotConfig(symbols=["BTC-USD"], interval=1),
+        container=container,
+    )
+    bot._broker_calls = _DirectBrokerCalls()
+
+    messages = await bot.flatten_and_stop()
+
+    assert messages[-1] == "Bot stopped."
+    broker.place_order.assert_called_once_with(
+        symbol="BTC-USD",
+        side=OrderSide.SELL,
+        order_type=OrderType.MARKET,
+        quantity=Decimal("1"),
+        reduce_only=True,
+    )
+    engine.shutdown.assert_called_once()
+    close_order_events = [
+        call.args[1]
+        for call in event_store.append.call_args_list
+        if call.args[0] == "emergency_flatten_close_order"
+    ]
+    assert len(close_order_events) == 1
+    audit_payload = close_order_events[0]
+    assert audit_payload["flatten_operation_id"].startswith("flatten-")
+    assert audit_payload["symbol"] == "BTC-USD"
+    assert audit_payload["side"] == "SELL"
+    assert audit_payload["order_type"] == "MARKET"
+    assert audit_payload["quantity"] == "1"
+    assert audit_payload["reduce_only"] is True
+    assert audit_payload["status"] == "submitted"
+    assert audit_payload["broker_status"] == "OPEN"
+    assert audit_payload["order_id"] == "close-btc-123"
+    assert audit_payload["client_order_id"] == "client-close-btc-123"
+
+    orders_store.upsert_by_client_id.assert_called_once()
+    order_record = orders_store.upsert_by_client_id.call_args.args[0]
+    assert order_record.order_id == "close-btc-123"
+    assert order_record.client_order_id == "client-close-btc-123"
+    assert order_record.symbol == "BTC-USD"
+    assert order_record.side == "sell"
+    assert order_record.order_type == "market"
+    assert order_record.status.value == "open"
+    assert order_record.metadata["source"] == "emergency_flatten"
+    assert order_record.metadata["flatten_operation_id"] == audit_payload["flatten_operation_id"]
+
+
+@pytest.mark.asyncio
+async def test_flatten_and_stop_links_partial_failure_audit_events(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def place_order(**kwargs):
+        if kwargs["symbol"] == "ETH-USD":
+            raise RuntimeError("venue rejected emergency close")
+        return SimpleNamespace(
+            id="close-btc-123",
+            client_order_id="client-close-btc-123",
+            status="OPEN",
+        )
+
+    broker = Mock()
+    broker.list_positions.return_value = [
+        SimpleNamespace(symbol="BTC-USD", quantity=Decimal("1")),
+        SimpleNamespace(symbol="ETH-USD", quantity=Decimal("-2")),
+    ]
+    broker.place_order = Mock(side_effect=place_order)
+    event_store = Mock()
+    orders_store = Mock()
+    notification_service = Mock()
+    notification_service.notify = AsyncMock(return_value=True)
+    container = SimpleNamespace(
+        broker=broker,
+        risk_manager=Mock(),
+        event_store=event_store,
+        orders_store=orders_store,
+        notification_service=notification_service,
+    )
+    _install_mock_engine(monkeypatch)
+
+    bot = TradingBot(
+        config=BotConfig(symbols=["BTC-USD", "ETH-USD"], interval=1),
+        container=container,
+    )
+    bot._broker_calls = _DirectBrokerCalls()
+
+    messages = await bot.flatten_and_stop()
+
+    assert any("Emergency flatten incomplete" in msg for msg in messages)
+    close_order_events = [
+        call.args[1]
+        for call in event_store.append.call_args_list
+        if call.args[0] == "emergency_flatten_close_order"
+    ]
+    assert len(close_order_events) == 2
+    success_event = next(event for event in close_order_events if event["symbol"] == "BTC-USD")
+    failed_event = next(event for event in close_order_events if event["symbol"] == "ETH-USD")
+    flatten_operation_id = success_event["flatten_operation_id"]
+    assert failed_event["flatten_operation_id"] == flatten_operation_id
+    assert success_event["order_id"] == "close-btc-123"
+    assert success_event["client_order_id"] == "client-close-btc-123"
+    assert success_event["status"] == "submitted"
+    assert failed_event["status"] == "failed"
+    assert failed_event["error"] == "venue rejected emergency close"
+
+    orders_store.upsert_by_client_id.assert_called_once()
+    order_record = orders_store.upsert_by_client_id.call_args.args[0]
+    assert order_record.metadata["flatten_operation_id"] == flatten_operation_id
+
+    flatten_failure_events = [
+        call.args[1]
+        for call in event_store.append.call_args_list
+        if call.args[0] == "emergency_flatten_failed"
+    ]
+    assert len(flatten_failure_events) == 1
+    payload = flatten_failure_events[0]
+    assert payload["flatten_operation_id"] == flatten_operation_id
+    assert payload["failed_closes"][0]["flatten_operation_id"] == flatten_operation_id

--- a/tests/unit/gpt_trader/features/live_trade/test_bot_flatten_and_stop_audit.py
+++ b/tests/unit/gpt_trader/features/live_trade/test_bot_flatten_and_stop_audit.py
@@ -187,11 +187,12 @@ async def test_flatten_and_stop_avoids_filled_record_without_fill_quantity(
     broker = Mock()
     broker.list_positions.return_value = [SimpleNamespace(symbol="BTC-USD", quantity=Decimal("1"))]
     broker.place_order = Mock(
-        return_value={
-            "order_id": "close-btc-123",
-            "client_order_id": "client-close-btc-123",
-            "status": "FILLED",
-        }
+        return_value=SimpleNamespace(
+            id="close-btc-123",
+            client_order_id="client-close-btc-123",
+            status="FILLED",
+            filled_quantity=Decimal("0"),
+        )
     )
     event_store = Mock()
     orders_store = Mock()
@@ -223,7 +224,7 @@ async def test_flatten_and_stop_avoids_filled_record_without_fill_quantity(
         if call.args[0] == "emergency_flatten_close_order"
     )
     assert audit_payload["broker_status"] == "FILLED"
-    assert "filled_quantity" not in audit_payload
+    assert audit_payload["filled_quantity"] == "0"
     assert "average_fill_price" not in audit_payload
 
 

--- a/tests/unit/gpt_trader/features/live_trade/test_bot_flatten_and_stop_audit.py
+++ b/tests/unit/gpt_trader/features/live_trade/test_bot_flatten_and_stop_audit.py
@@ -225,3 +225,96 @@ async def test_flatten_and_stop_avoids_filled_record_without_fill_quantity(
     assert audit_payload["broker_status"] == "FILLED"
     assert "filled_quantity" not in audit_payload
     assert "average_fill_price" not in audit_payload
+
+
+@pytest.mark.asyncio
+async def test_flatten_and_stop_threads_operation_id_into_failure_logs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logger = Mock()
+    monkeypatch.setattr(bot_module, "logger", logger)
+    event_store = Mock()
+    notification_service = Mock()
+    notification_service.notify = AsyncMock(return_value=True)
+    container = SimpleNamespace(
+        broker=None,
+        risk_manager=Mock(),
+        event_store=event_store,
+        orders_store=Mock(),
+        notification_service=notification_service,
+    )
+    _install_mock_engine(monkeypatch)
+
+    bot = TradingBot(
+        config=BotConfig(symbols=["BTC-USD"], interval=1),
+        container=container,
+    )
+
+    await bot.flatten_and_stop()
+
+    flatten_operation_id = logger.warning.call_args.kwargs["flatten_operation_id"]
+    assert flatten_operation_id.startswith("flatten-")
+    assert logger.error.call_args_list[0].kwargs["flatten_operation_id"] == flatten_operation_id
+    assert logger.critical.call_args.kwargs["flatten_operation_id"] == flatten_operation_id
+    failure_payload = next(
+        call.args[1]
+        for call in event_store.append.call_args_list
+        if call.args[0] == "emergency_flatten_failed"
+    )
+    assert failure_payload["flatten_operation_id"] == flatten_operation_id
+
+
+@pytest.mark.asyncio
+async def test_flatten_and_stop_treats_rejected_close_response_as_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    broker = Mock()
+    broker.list_positions.return_value = [SimpleNamespace(symbol="BTC-USD", quantity=Decimal("1"))]
+    broker.place_order = Mock(
+        return_value={
+            "order_id": "close-btc-rejected",
+            "client_order_id": "client-close-btc-rejected",
+            "status": "REJECTED",
+        }
+    )
+    event_store = Mock()
+    orders_store = Mock()
+    notification_service = Mock()
+    notification_service.notify = AsyncMock(return_value=True)
+    container = SimpleNamespace(
+        broker=broker,
+        risk_manager=Mock(),
+        event_store=event_store,
+        orders_store=orders_store,
+        notification_service=notification_service,
+    )
+    _install_mock_engine(monkeypatch)
+
+    bot = TradingBot(
+        config=BotConfig(symbols=["BTC-USD"], interval=1),
+        container=container,
+    )
+    bot._broker_calls = _DirectBrokerCalls()
+
+    messages = await bot.flatten_and_stop()
+
+    assert any("non-accepted emergency close status: rejected" in msg for msg in messages)
+    orders_store.upsert_by_client_id.assert_not_called()
+    close_order_event = next(
+        call.args[1]
+        for call in event_store.append.call_args_list
+        if call.args[0] == "emergency_flatten_close_order"
+    )
+    assert close_order_event["status"] == "failed"
+    assert close_order_event["broker_status"] == "REJECTED"
+    assert close_order_event["order_id"] == "close-btc-rejected"
+    assert close_order_event["client_order_id"] == "client-close-btc-rejected"
+    flatten_failure_event = next(
+        call.args[1]
+        for call in event_store.append.call_args_list
+        if call.args[0] == "emergency_flatten_failed"
+    )
+    assert flatten_failure_event["failed_symbols"] == ["BTC-USD"]
+    assert flatten_failure_event["failed_closes"][0]["error"] == (
+        "Broker returned non-accepted emergency close status: rejected"
+    )

--- a/tests/unit/gpt_trader/features/live_trade/test_bot_flatten_and_stop_audit.py
+++ b/tests/unit/gpt_trader/features/live_trade/test_bot_flatten_and_stop_audit.py
@@ -58,7 +58,7 @@ async def test_flatten_and_stop_persists_submitted_close_order_audit(
     engine = _install_mock_engine(monkeypatch)
 
     bot = TradingBot(
-        config=BotConfig(symbols=["BTC-USD"], interval=1),
+        config=BotConfig(symbols=["BTC-USD"], interval=1, profile="canary"),
         container=container,
     )
     bot._broker_calls = _DirectBrokerCalls()
@@ -104,6 +104,7 @@ async def test_flatten_and_stop_persists_submitted_close_order_audit(
     assert order_record.status.value == "filled"
     assert order_record.filled_quantity == Decimal("1")
     assert order_record.average_fill_price == Decimal("50000.12")
+    assert order_record.bot_id == "canary"
     assert order_record.metadata["source"] == "emergency_flatten"
     assert order_record.metadata["flatten_operation_id"] == audit_payload["flatten_operation_id"]
 

--- a/var/agents/logging/event_catalog.json
+++ b/var/agents/logging/event_catalog.json
@@ -694,10 +694,13 @@
     "flatten_and_stop": {
       "common_fields": [
         "bypass_reason",
+        "client_order_id",
         "error",
         "failed_close_count",
         "failed_symbols",
+        "flatten_operation_id",
         "monitoring_state",
+        "order_id",
         "quantity",
         "reduce_only",
         "symbol"
@@ -709,7 +712,7 @@
         "INFO",
         "WARNING"
       ],
-      "occurrence_count": 5,
+      "occurrence_count": 7,
       "source_files": [
         "features/live_trade/bot.py"
       ],
@@ -2476,10 +2479,10 @@
     "action": 10,
     "attempt": 4,
     "client_ip": 4,
-    "client_order_id": 19,
+    "client_order_id": 20,
     "consecutive_failures": 6,
     "details": 4,
-    "error": 58,
+    "error": 60,
     "error_message": 90,
     "error_type": 84,
     "event_type": 5,
@@ -2489,7 +2492,7 @@
     "latency_seconds": 5,
     "max_attempts": 4,
     "mode": 4,
-    "order_id": 28,
+    "order_id": 29,
     "order_type": 3,
     "outcome": 5,
     "path": 12,
@@ -2501,13 +2504,13 @@
     "severity": 4,
     "side": 26,
     "stage": 167,
-    "symbol": 81,
+    "symbol": 82,
     "timestamp": 4
   },
   "level_distribution": {
     "CRITICAL": 2,
     "DEBUG": 49,
-    "ERROR": 110,
+    "ERROR": 112,
     "INFO": 91,
     "WARNING": 97
   },

--- a/var/agents/logging/event_catalog.json
+++ b/var/agents/logging/event_catalog.json
@@ -693,6 +693,7 @@
     },
     "flatten_and_stop": {
       "common_fields": [
+        "broker_status",
         "bypass_reason",
         "client_order_id",
         "error",
@@ -712,7 +713,7 @@
         "INFO",
         "WARNING"
       ],
-      "occurrence_count": 7,
+      "occurrence_count": 11,
       "source_files": [
         "features/live_trade/bot.py"
       ],
@@ -2482,10 +2483,11 @@
     "client_order_id": 20,
     "consecutive_failures": 6,
     "details": 4,
-    "error": 60,
+    "error": 64,
     "error_message": 90,
     "error_type": 84,
     "event_type": 5,
+    "flatten_operation_id": 9,
     "granularity": 6,
     "guard_name": 9,
     "issue_type": 4,
@@ -2493,24 +2495,23 @@
     "max_attempts": 4,
     "mode": 4,
     "order_id": 29,
-    "order_type": 3,
     "outcome": 5,
     "path": 12,
     "portfolio_id": 4,
     "price": 4,
-    "quantity": 8,
+    "quantity": 10,
     "reason": 27,
     "service": 9,
     "severity": 4,
     "side": 26,
     "stage": 167,
-    "symbol": 82,
+    "symbol": 84,
     "timestamp": 4
   },
   "level_distribution": {
     "CRITICAL": 2,
     "DEBUG": 49,
-    "ERROR": 112,
+    "ERROR": 116,
     "INFO": 91,
     "WARNING": 97
   },

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,8 +7,8 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6790,
-    "total_files": 802,
+    "total_tests": 6792,
+    "total_files": 803,
     "markers_used": 16
   },
   "quick_commands": {

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6793,
+    "total_tests": 6795,
     "total_files": 803,
     "markers_used": 16
   },

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6792,
+    "total_tests": 6793,
     "total_files": 803,
     "markers_used": 16
   },

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,8 +95,8 @@
     ]
   },
   "counts": {
-    "unit": 6625,
-    "asyncio": 398,
+    "unit": 6627,
+    "asyncio": 400,
     "parametrize": 193,
     "endpoints": 83,
     "property": 82,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,8 +95,8 @@
     ]
   },
   "counts": {
-    "unit": 6628,
-    "asyncio": 401,
+    "unit": 6630,
+    "asyncio": 403,
     "parametrize": 193,
     "endpoints": 83,
     "property": 82,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,8 +95,8 @@
     ]
   },
   "counts": {
-    "unit": 6627,
-    "asyncio": 400,
+    "unit": 6628,
+    "asyncio": 401,
     "parametrize": 193,
     "endpoints": 83,
     "property": 82,

--- a/var/agents/testing/source_test_map.json
+++ b/var/agents/testing/source_test_map.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "summary": {
-    "tests_scanned": 719,
+    "tests_scanned": 720,
     "source_modules": 372,
     "unresolved_modules": 3
   },
@@ -60,6 +60,7 @@
       "tests/unit/gpt_trader/features/live_trade/strategies/mean_reversion/test_strategy_sizing_and_trend_filter.py",
       "tests/unit/gpt_trader/features/live_trade/strategies/mean_reversion/test_strategy_zscore_and_signals.py",
       "tests/unit/gpt_trader/features/live_trade/test_bot_flatten_and_stop.py",
+      "tests/unit/gpt_trader/features/live_trade/test_bot_flatten_and_stop_audit.py",
       "tests/unit/gpt_trader/features/live_trade/test_bot_flatten_and_stop_run_race.py",
       "tests/unit/gpt_trader/features/live_trade/test_strategy_factory.py",
       "tests/unit/gpt_trader/features/live_trade/test_symbols.py",
@@ -466,6 +467,7 @@
       "tests/unit/gpt_trader/features/live_trade/execution/test_validation_preview.py",
       "tests/unit/gpt_trader/features/live_trade/strategies/test_stateful.py",
       "tests/unit/gpt_trader/features/live_trade/test_bot_flatten_and_stop.py",
+      "tests/unit/gpt_trader/features/live_trade/test_bot_flatten_and_stop_audit.py",
       "tests/unit/gpt_trader/features/live_trade/test_risk.py",
       "tests/unit/gpt_trader/features/live_trade/test_risk_time_windows.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_baseline_proposer.py",
@@ -815,6 +817,7 @@
       "tests/unit/gpt_trader/app/test_bootstrap.py",
       "tests/unit/gpt_trader/features/live_trade/test_bot_engine_delegation.py",
       "tests/unit/gpt_trader/features/live_trade/test_bot_flatten_and_stop.py",
+      "tests/unit/gpt_trader/features/live_trade/test_bot_flatten_and_stop_audit.py",
       "tests/unit/gpt_trader/features/live_trade/test_bot_flatten_and_stop_run_race.py",
       "tests/unit/gpt_trader/features/live_trade/test_bot_initialization.py",
       "tests/unit/gpt_trader/features/live_trade/test_bot_lifecycle.py"
@@ -3673,6 +3676,11 @@
       "gpt_trader.features.live_trade.bot",
       "gpt_trader.features.live_trade.lifecycle",
       "gpt_trader.monitoring.alert_types"
+    ],
+    "tests/unit/gpt_trader/features/live_trade/test_bot_flatten_and_stop_audit.py": [
+      "gpt_trader.app.config",
+      "gpt_trader.core",
+      "gpt_trader.features.live_trade.bot"
     ],
     "tests/unit/gpt_trader/features/live_trade/test_bot_flatten_and_stop_run_race.py": [
       "gpt_trader.app.config",

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,8 +2,8 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6790,
-    "total_files": 802,
+    "total_tests": 6792,
+    "total_files": 803,
     "markers_used": 16
   },
   "marker_definitions": {
@@ -102,8 +102,8 @@
     ]
   },
   "marker_counts": {
-    "unit": 6625,
-    "asyncio": 398,
+    "unit": 6627,
+    "asyncio": 400,
     "parametrize": 193,
     "endpoints": 83,
     "property": 82,
@@ -475,6 +475,7 @@
       "tests/unit/gpt_trader/features/live_trade/telemetry/test_account_telemetry_lifecycle.py",
       "tests/unit/gpt_trader/features/live_trade/test_bot_engine_delegation.py",
       "tests/unit/gpt_trader/features/live_trade/test_bot_flatten_and_stop.py",
+      "tests/unit/gpt_trader/features/live_trade/test_bot_flatten_and_stop_audit.py",
       "tests/unit/gpt_trader/features/live_trade/test_bot_flatten_and_stop_run_race.py",
       "tests/unit/gpt_trader/features/live_trade/test_bot_initialization.py",
       "tests/unit/gpt_trader/features/live_trade/test_bot_lifecycle.py",
@@ -27183,6 +27184,26 @@
         ],
         "docstring": "",
         "class": "TestTradingBotFlattenAndStop"
+      }
+    ],
+    "tests/unit/gpt_trader/features/live_trade/test_bot_flatten_and_stop_audit.py": [
+      {
+        "name": "test_flatten_and_stop_persists_submitted_close_order_audit",
+        "line": 33,
+        "markers": [
+          "asyncio",
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_flatten_and_stop_links_partial_failure_audit_events",
+        "line": 106,
+        "markers": [
+          "asyncio",
+          "unit"
+        ],
+        "docstring": ""
       }
     ],
     "tests/unit/gpt_trader/features/live_trade/test_bot_flatten_and_stop_run_race.py": [

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -27198,7 +27198,7 @@
       },
       {
         "name": "test_flatten_and_stop_links_partial_failure_audit_events",
-        "line": 112,
+        "line": 113,
         "markers": [
           "asyncio",
           "unit"
@@ -27207,7 +27207,7 @@
       },
       {
         "name": "test_flatten_and_stop_avoids_filled_record_without_fill_quantity",
-        "line": 184,
+        "line": 185,
         "markers": [
           "asyncio",
           "unit"
@@ -27216,7 +27216,7 @@
       },
       {
         "name": "test_flatten_and_stop_threads_operation_id_into_failure_logs",
-        "line": 232,
+        "line": 233,
         "markers": [
           "asyncio",
           "unit"
@@ -27225,7 +27225,7 @@
       },
       {
         "name": "test_flatten_and_stop_treats_rejected_close_response_as_failed",
-        "line": 269,
+        "line": 270,
         "markers": [
           "asyncio",
           "unit"

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -27216,7 +27216,7 @@
       },
       {
         "name": "test_flatten_and_stop_threads_operation_id_into_failure_logs",
-        "line": 231,
+        "line": 232,
         "markers": [
           "asyncio",
           "unit"
@@ -27225,7 +27225,7 @@
       },
       {
         "name": "test_flatten_and_stop_treats_rejected_close_response_as_failed",
-        "line": 268,
+        "line": 269,
         "markers": [
           "asyncio",
           "unit"

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6792,
+    "total_tests": 6793,
     "total_files": 803,
     "markers_used": 16
   },
@@ -102,8 +102,8 @@
     ]
   },
   "marker_counts": {
-    "unit": 6627,
-    "asyncio": 400,
+    "unit": 6628,
+    "asyncio": 401,
     "parametrize": 193,
     "endpoints": 83,
     "property": 82,
@@ -27198,7 +27198,16 @@
       },
       {
         "name": "test_flatten_and_stop_links_partial_failure_audit_events",
-        "line": 106,
+        "line": 112,
+        "markers": [
+          "asyncio",
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_flatten_and_stop_avoids_filled_record_without_fill_quantity",
+        "line": 184,
         "markers": [
           "asyncio",
           "unit"

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6793,
+    "total_tests": 6795,
     "total_files": 803,
     "markers_used": 16
   },
@@ -102,8 +102,8 @@
     ]
   },
   "marker_counts": {
-    "unit": 6628,
-    "asyncio": 401,
+    "unit": 6630,
+    "asyncio": 403,
     "parametrize": 193,
     "endpoints": 83,
     "property": 82,
@@ -27208,6 +27208,24 @@
       {
         "name": "test_flatten_and_stop_avoids_filled_record_without_fill_quantity",
         "line": 184,
+        "markers": [
+          "asyncio",
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_flatten_and_stop_threads_operation_id_into_failure_logs",
+        "line": 231,
+        "markers": [
+          "asyncio",
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_flatten_and_stop_treats_rejected_close_response_as_failed",
+        "line": 268,
         "markers": [
           "asyncio",
           "unit"


### PR DESCRIPTION
## Summary
- add a `flatten_operation_id` for emergency flatten runs and include it in close-order audit/failure payloads
- record `emergency_flatten_close_order` audit events for submitted and failed close attempts
- persist submitted emergency close order identifiers into the orders store for reconciliation
- add focused mock-only regression coverage and refresh generated agent artifacts

Closes #965

## Decision packet
- https://github.com/Solders-Girdles/GPT-Trader/issues/965#issuecomment-4798864045

## Validation
- `uv run pytest tests/unit/gpt_trader/features/live_trade/test_bot_flatten_and_stop.py tests/unit/gpt_trader/features/live_trade/test_bot_flatten_and_stop_audit.py -q`
- `uv run mypy src/gpt_trader/features/live_trade/bot.py`
- `uv run agent-regenerate --verify`
- `uv run local-ci --profile quick`

## Risk / gates
- mock-only source/test change; no live broker/API/order/preflight/canary commands were run
- emergency audit persistence is best-effort and does not interrupt flatten shutdown flow


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Emergency position-close shutdown now generates a per-run **flatten_operation_id** and propagates it across logs, alerts, audit events, and persisted order records.
  * Added emergency close audit/persistence with per-position/per-order outcomes, including detailed reconciliation metadata.
* **Bug Fixes**
  * Improved no-broker and per-position emergency close handling (explicit order intent, failure aggregation, and consistent user-facing messaging).
  * If a close is **FILLED** without fill details, it’s persisted as **filled_quantity = 0** and omits average fill price.
* **Tests**
  * Expanded/strengthened flatten-and-stop and audit tests, including multi-position partial failures and payload assertions.
* **Documentation**
  * Updated event catalog metadata to reflect new/changed flatten-and-stop fields (including **flatten_operation_id**).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->