### PR TITLE
[codex] Fix TickerCache TTL boundary

### DIFF
--- a/src/gpt_trader/features/brokerages/coinbase/market_data_service.py
+++ b/src/gpt_trader/features/brokerages/coinbase/market_data_service.py
@@ -60,7 +60,7 @@ class TickerCache:
             ticker = self._cache.get(symbol)
             if not ticker:
                 return True
-            return (self._clock.now() - ticker.ts).total_seconds() > self.ttl
+            return (self._clock.now() - ticker.ts).total_seconds() >= self.ttl
 
 
 class CoinbaseTickerService:

--- a/tests/unit/gpt_trader/features/brokerages/coinbase/test_market_data_ticker_cache.py
+++ b/tests/unit/gpt_trader/features/brokerages/coinbase/test_market_data_ticker_cache.py
@@ -119,15 +119,17 @@ class TestTickerCache:
 
         assert cache.is_stale("BTC-USD") is True
 
-    def test_cache_with_zero_ttl(self) -> None:
+    def test_cache_with_zero_ttl_is_stale_immediately(self) -> None:
         """Test cache with zero TTL (always stale)."""
-        cache = TickerCache(ttl_seconds=0)
+        base_time = datetime(2024, 1, 1, 0, 0, 0, tzinfo=UTC)
+        clock = FakeClock(base_time)
+        cache = TickerCache(ttl_seconds=0, clock=clock)
         ticker = Ticker(
             symbol="BTC-USD",
             bid=50000.0,
             ask=50100.0,
             last=50050.0,
-            ts=utc_now(),
+            ts=base_time,
         )
         cache.update(ticker)
 
@@ -175,7 +177,17 @@ class TestTickerCache:
 class TestTickerServiceEdges:
     """Edge case tests for ticker service and cache."""
 
-    def test_ticker_cache_stale_boundary(self) -> None:
+    def test_ticker_cache_fresh_just_before_ttl_boundary(self) -> None:
+        base_time = datetime(2024, 1, 1, 0, 0, 0, tzinfo=UTC)
+        clock = FakeClock(base_time)
+        cache = TickerCache(ttl_seconds=5, clock=clock)
+        cache.update(Ticker(symbol="BTC-USD", bid=1.0, ask=2.0, last=1.5, ts=base_time))
+
+        clock.advance(4.999)
+
+        assert cache.is_stale("BTC-USD") is False
+
+    def test_ticker_cache_stale_at_ttl_boundary(self) -> None:
         base_time = datetime(2024, 1, 1, 0, 0, 0, tzinfo=UTC)
         clock = FakeClock(base_time)
         cache = TickerCache(ttl_seconds=5, clock=clock)
@@ -183,7 +195,7 @@ class TestTickerServiceEdges:
 
         clock.advance(5)
 
-        assert cache.is_stale("BTC-USD") is False
+        assert cache.is_stale("BTC-USD") is True
 
     def test_ticker_cache_stale_after_ttl(self) -> None:
         base_time = datetime(2024, 1, 1, 0, 0, 0, tzinfo=UTC)

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6795,
+    "total_tests": 6796,
     "total_files": 803,
     "markers_used": 16
   },

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6630,
+    "unit": 6631,
     "asyncio": 403,
     "parametrize": 193,
     "endpoints": 83,

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6795,
+    "total_tests": 6796,
     "total_files": 803,
     "markers_used": 16
   },
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6630,
+    "unit": 6631,
     "asyncio": 403,
     "parametrize": 193,
     "endpoints": 83,
@@ -16494,7 +16494,7 @@
         "class": "TestTickerCache"
       },
       {
-        "name": "TestTickerCache::test_cache_with_zero_ttl",
+        "name": "TestTickerCache::test_cache_with_zero_ttl_is_stale_immediately",
         "line": 122,
         "markers": [
           "unit"
@@ -16504,7 +16504,7 @@
       },
       {
         "name": "TestTickerCache::test_empty_symbol_string",
-        "line": 136,
+        "line": 138,
         "markers": [
           "unit"
         ],
@@ -16513,7 +16513,7 @@
       },
       {
         "name": "TestTickerCache::test_get_last_ticker_timestamp_empty_cache",
-        "line": 146,
+        "line": 148,
         "markers": [
           "unit"
         ],
@@ -16522,7 +16522,7 @@
       },
       {
         "name": "TestTickerCache::test_get_last_ticker_timestamp_tracks_newest_value",
-        "line": 151,
+        "line": 153,
         "markers": [
           "unit"
         ],
@@ -16531,7 +16531,7 @@
       },
       {
         "name": "TestTickerCache::test_update_normalizes_naive_timestamp_to_utc",
-        "line": 161,
+        "line": 163,
         "markers": [
           "unit"
         ],
@@ -16539,8 +16539,17 @@
         "class": "TestTickerCache"
       },
       {
-        "name": "TestTickerServiceEdges::test_ticker_cache_stale_boundary",
-        "line": 178,
+        "name": "TestTickerServiceEdges::test_ticker_cache_fresh_just_before_ttl_boundary",
+        "line": 180,
+        "markers": [
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestTickerServiceEdges"
+      },
+      {
+        "name": "TestTickerServiceEdges::test_ticker_cache_stale_at_ttl_boundary",
+        "line": 190,
         "markers": [
           "unit"
         ],
@@ -16549,7 +16558,7 @@
       },
       {
         "name": "TestTickerServiceEdges::test_ticker_cache_stale_after_ttl",
-        "line": 188,
+        "line": 200,
         "markers": [
           "unit"
         ],
@@ -16558,7 +16567,7 @@
       },
       {
         "name": "TestTickerServiceEdges::test_ticker_service_start_creates_thread",
-        "line": 198,
+        "line": 210,
         "markers": [
           "unit"
         ],
@@ -16567,7 +16576,7 @@
       },
       {
         "name": "TestTickerServiceEdges::test_ticker_service_stop_joins_thread",
-        "line": 215,
+        "line": 227,
         "markers": [
           "unit"
         ],
@@ -16576,7 +16585,7 @@
       },
       {
         "name": "TestTickerServiceEdges::test_ticker_freshness_provider_not_advertised_until_cache_populated",
-        "line": 226,
+        "line": 238,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
Closes #952

## Summary
- Treat `TickerCache` entries as stale once `age >= ttl`, so `ttl_seconds=0` expires immediately.
- Add deterministic `FakeClock` tests for zero TTL, just-before-boundary freshness, exact-boundary staleness, and after-boundary staleness.
- Regenerate the tracked agent test inventory artifacts for the renamed/added tests.

## Risk / boundaries
- This is a Coinbase market-data freshness semantics fix only.
- No live broker/API calls, production preflight, canary operations, or order submission were run.

## Verification
- `uv run pytest tests/unit/gpt_trader/features/brokerages/coinbase/test_market_data_ticker_cache.py -q` -> 20 passed
- `uv run pytest tests/unit/gpt_trader/features/brokerages/coinbase/test_market_data_service.py tests/unit/gpt_trader/features/brokerages/coinbase/test_market_data_features.py tests/unit/gpt_trader/features/brokerages/coinbase/rest/test_product_service_ticker_and_mark_price.py -q` -> 41 passed
- `uv run agent-regenerate --verify` -> passed
- `uv run local-ci --profile quick` -> passed (7060 passed, 8 skipped)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tick data now becomes stale when it reaches the TTL boundary, not only after it passes it.
  * Improved time-based cache checks to handle edge cases more consistently.

* **Tests**
  * Expanded and stabilized cache freshness tests with deterministic time control.
  * Added clearer coverage for behavior just before expiry, at expiry, and after expiry.
  * Updated test inventory counts to match the latest test set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->