### PR TITLE
[codex] Avoid touching alert file during connection test

### DIFF
--- a/src/gpt_trader/monitoring/notifications/backends.py
+++ b/src/gpt_trader/monitoring/notifications/backends.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -299,8 +300,14 @@ class FileNotificationBackend:
 
     def _check_file_writable(self) -> None:
         self._ensure_parent_directory()
-        with open(self.file_path, "a"):
-            pass  # Just test if we can open for append
+        parent = Path(self.file_path).parent
+        with tempfile.NamedTemporaryFile(
+            mode="a",
+            dir=parent,
+            prefix=f".{Path(self.file_path).name}.connection-",
+            suffix=".tmp",
+        ):
+            pass
 
     def _ensure_parent_directory(self) -> None:
         Path(self.file_path).parent.mkdir(parents=True, exist_ok=True)

--- a/src/gpt_trader/monitoring/notifications/backends.py
+++ b/src/gpt_trader/monitoring/notifications/backends.py
@@ -299,12 +299,18 @@ class FileNotificationBackend:
             return False
 
     def _check_file_writable(self) -> None:
+        path = Path(self.file_path)
         self._ensure_parent_directory()
-        parent = Path(self.file_path).parent
+        if path.exists():
+            with open(path, "a"):
+                pass
+            return
+
+        parent = path.parent
         with tempfile.NamedTemporaryFile(
             mode="a",
             dir=parent,
-            prefix=f".{Path(self.file_path).name}.connection-",
+            prefix=f".{path.name}.connection-",
             suffix=".tmp",
         ):
             pass

--- a/src/gpt_trader/monitoring/notifications/backends.py
+++ b/src/gpt_trader/monitoring/notifications/backends.py
@@ -299,10 +299,13 @@ class FileNotificationBackend:
             return False
 
     def _check_file_writable(self) -> None:
+        if self.file_path.endswith(("/", "\\")):
+            raise IsADirectoryError(self.file_path)
+
         path = Path(self.file_path)
         self._ensure_parent_directory()
         if path.exists():
-            with open(path, "a"):
+            with open(self.file_path, "a"):
                 pass
             return
 

--- a/src/gpt_trader/monitoring/notifications/backends.py
+++ b/src/gpt_trader/monitoring/notifications/backends.py
@@ -25,6 +25,7 @@ COLORS = {
 }
 RESET = "\033[0m"
 BOLD = "\033[1m"
+FILE_CONNECTION_PROBE_PREFIX = ".connection-"
 
 
 @dataclass
@@ -313,16 +314,16 @@ class FileNotificationBackend:
             target = path.readlink()
             if not target.is_absolute():
                 target = path.parent / target
-            self._check_directory_writable(target.parent, target.name)
+            self._check_directory_writable(target.parent)
             return
 
-        self._check_directory_writable(path.parent, path.name)
+        self._check_directory_writable(path.parent)
 
-    def _check_directory_writable(self, parent: Path, file_name: str) -> None:
+    def _check_directory_writable(self, parent: Path) -> None:
         with tempfile.NamedTemporaryFile(
             mode="a",
             dir=parent,
-            prefix=f".{file_name}.connection-",
+            prefix=FILE_CONNECTION_PROBE_PREFIX,
             suffix=".tmp",
         ):
             pass

--- a/src/gpt_trader/monitoring/notifications/backends.py
+++ b/src/gpt_trader/monitoring/notifications/backends.py
@@ -306,11 +306,20 @@ class FileNotificationBackend:
                 pass
             return
 
-        parent = path.parent
+        if path.is_symlink():
+            target = path.readlink()
+            if not target.is_absolute():
+                target = path.parent / target
+            self._check_directory_writable(target.parent, target.name)
+            return
+
+        self._check_directory_writable(path.parent, path.name)
+
+    def _check_directory_writable(self, parent: Path, file_name: str) -> None:
         with tempfile.NamedTemporaryFile(
             mode="a",
             dir=parent,
-            prefix=f".{path.name}.connection-",
+            prefix=f".{file_name}.connection-",
             suffix=".tmp",
         ):
             pass

--- a/tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_core.py
+++ b/tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_core.py
@@ -124,6 +124,19 @@ class TestFileNotificationBackend:
         assert list(tmp_path.iterdir()) == [alert_path]
 
     @pytest.mark.asyncio
+    async def test_test_connection_rejects_trailing_separator_file_path(
+        self, tmp_path: Path
+    ) -> None:
+        alert_path = tmp_path / "alerts.jsonl"
+        alert_path.write_text("seed\n")
+        backend = FileNotificationBackend(file_path=f"{alert_path}/")
+
+        result = await backend.test_connection()
+
+        assert result is False
+        assert alert_path.read_text() == "seed\n"
+
+    @pytest.mark.asyncio
     async def test_test_connection_checks_broken_symlink_target_parent(
         self, tmp_path: Path
     ) -> None:

--- a/tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_core.py
+++ b/tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_core.py
@@ -124,6 +124,39 @@ class TestFileNotificationBackend:
         assert list(tmp_path.iterdir()) == [alert_path]
 
     @pytest.mark.asyncio
+    async def test_test_connection_checks_broken_symlink_target_parent(
+        self, tmp_path: Path
+    ) -> None:
+        target_path = tmp_path / "missing-target-parent" / "alerts.jsonl"
+        alert_path = tmp_path / "alerts-link.jsonl"
+        alert_path.symlink_to(target_path)
+        backend = FileNotificationBackend(file_path=str(alert_path))
+
+        result = await backend.test_connection()
+
+        assert result is False
+        assert alert_path.is_symlink()
+        assert not target_path.parent.exists()
+
+    @pytest.mark.asyncio
+    async def test_test_connection_checks_missing_symlink_target_without_creating_it(
+        self, tmp_path: Path
+    ) -> None:
+        target_parent = tmp_path / "target-parent"
+        target_parent.mkdir()
+        target_path = target_parent / "alerts.jsonl"
+        alert_path = tmp_path / "alerts-link.jsonl"
+        alert_path.symlink_to(target_path)
+        backend = FileNotificationBackend(file_path=str(alert_path))
+
+        result = await backend.test_connection()
+
+        assert result is True
+        assert alert_path.is_symlink()
+        assert not target_path.exists()
+        assert list(target_parent.iterdir()) == []
+
+    @pytest.mark.asyncio
     async def test_test_connection_creates_parent_without_alert_file(self, tmp_path: Path) -> None:
         alert_path = tmp_path / "nested" / "alerts.jsonl"
         backend = FileNotificationBackend(file_path=str(alert_path))

--- a/tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_core.py
+++ b/tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_core.py
@@ -111,6 +111,18 @@ class TestFileNotificationBackend:
             Path(file_path).unlink(missing_ok=True)
 
     @pytest.mark.asyncio
+    async def test_test_connection_creates_parent_without_alert_file(self, tmp_path: Path) -> None:
+        alert_path = tmp_path / "nested" / "alerts.jsonl"
+        backend = FileNotificationBackend(file_path=str(alert_path))
+
+        result = await backend.test_connection()
+
+        assert result is True
+        assert alert_path.parent.is_dir()
+        assert not alert_path.exists()
+        assert list(alert_path.parent.iterdir()) == []
+
+    @pytest.mark.asyncio
     async def test_test_connection_offloads_file_check_to_thread(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_core.py
+++ b/tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_core.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import tempfile
 from pathlib import Path
 from typing import Any
@@ -180,6 +181,21 @@ class TestFileNotificationBackend:
         assert alert_path.parent.is_dir()
         assert not alert_path.exists()
         assert list(alert_path.parent.iterdir()) == []
+
+    @pytest.mark.asyncio
+    async def test_test_connection_handles_long_missing_file_name_without_alert_file(
+        self, tmp_path: Path
+    ) -> None:
+        name_max = os.pathconf(tmp_path, "PC_NAME_MAX")
+        suffix = ".jsonl"
+        alert_path = tmp_path / f"{'a' * (name_max - len(suffix))}{suffix}"
+        backend = FileNotificationBackend(file_path=str(alert_path))
+
+        result = await backend.test_connection()
+
+        assert result is True
+        assert not alert_path.exists()
+        assert list(tmp_path.iterdir()) == []
 
     @pytest.mark.asyncio
     async def test_test_connection_offloads_file_check_to_thread(

--- a/tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_core.py
+++ b/tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_core.py
@@ -102,13 +102,26 @@ class TestFileNotificationBackend:
     async def test_test_connection_checks_writability(self) -> None:
         with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
             file_path = f.name
+            f.write("seed\n")
 
         try:
             backend = FileNotificationBackend(file_path=file_path)
             result = await backend.test_connection()
             assert result is True
+            assert Path(file_path).read_text() == "seed\n"
         finally:
             Path(file_path).unlink(missing_ok=True)
+
+    @pytest.mark.asyncio
+    async def test_test_connection_checks_existing_target_directly(self, tmp_path: Path) -> None:
+        alert_path = tmp_path / "alerts.jsonl"
+        alert_path.mkdir()
+        backend = FileNotificationBackend(file_path=str(alert_path))
+
+        result = await backend.test_connection()
+
+        assert result is False
+        assert list(tmp_path.iterdir()) == [alert_path]
 
     @pytest.mark.asyncio
     async def test_test_connection_creates_parent_without_alert_file(self, tmp_path: Path) -> None:

--- a/tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_edges.py
+++ b/tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_edges.py
@@ -75,7 +75,11 @@ async def test_file_backend_nested_path_creates_parents_and_writes_jsonl(tmp_pat
 
 @pytest.mark.asyncio
 async def test_file_backend_test_connection_creates_parent_without_alert_file(tmp_path) -> None:
-    nested_path = tmp_path / "connection" / "alerts" / "out.jsonl"
+    parent = tmp_path / "connection" / "alerts"
+    parent.mkdir(parents=True)
+    sibling = parent / "existing.jsonl"
+    sibling.write_text("keep\n")
+    nested_path = parent / "out.jsonl"
     backend = FileNotificationBackend(file_path=str(nested_path))
 
     result = await backend.test_connection()
@@ -83,4 +87,5 @@ async def test_file_backend_test_connection_creates_parent_without_alert_file(tm
     assert result is True
     assert nested_path.parent.is_dir()
     assert not nested_path.exists()
-    assert list(nested_path.parent.iterdir()) == []
+    assert sibling.read_text() == "keep\n"
+    assert list(nested_path.parent.iterdir()) == [sibling]

--- a/tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_edges.py
+++ b/tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_edges.py
@@ -74,7 +74,7 @@ async def test_file_backend_nested_path_creates_parents_and_writes_jsonl(tmp_pat
 
 
 @pytest.mark.asyncio
-async def test_file_backend_test_connection_creates_missing_parents(tmp_path) -> None:
+async def test_file_backend_test_connection_creates_parent_without_alert_file(tmp_path) -> None:
     nested_path = tmp_path / "connection" / "alerts" / "out.jsonl"
     backend = FileNotificationBackend(file_path=str(nested_path))
 
@@ -82,4 +82,5 @@ async def test_file_backend_test_connection_creates_missing_parents(tmp_path) ->
 
     assert result is True
     assert nested_path.parent.is_dir()
-    assert nested_path.exists()
+    assert not nested_path.exists()
+    assert list(nested_path.parent.iterdir()) == []

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6800,
+    "total_tests": 6801,
     "total_files": 803,
     "markers_used": 16
   },

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6797,
+    "total_tests": 6798,
     "total_files": 803,
     "markers_used": 16
   },

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6796,
+    "total_tests": 6797,
     "total_files": 803,
     "markers_used": 16
   },

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6801,
+    "total_tests": 6802,
     "total_files": 803,
     "markers_used": 16
   },

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6798,
+    "total_tests": 6800,
     "total_files": 803,
     "markers_used": 16
   },

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,8 +95,8 @@
     ]
   },
   "counts": {
-    "unit": 6632,
-    "asyncio": 404,
+    "unit": 6633,
+    "asyncio": 405,
     "parametrize": 193,
     "endpoints": 83,
     "property": 82,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,8 +95,8 @@
     ]
   },
   "counts": {
-    "unit": 6633,
-    "asyncio": 405,
+    "unit": 6635,
+    "asyncio": 407,
     "parametrize": 193,
     "endpoints": 83,
     "property": 82,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,8 +95,8 @@
     ]
   },
   "counts": {
-    "unit": 6636,
-    "asyncio": 408,
+    "unit": 6637,
+    "asyncio": 409,
     "parametrize": 193,
     "endpoints": 83,
     "property": 82,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,8 +95,8 @@
     ]
   },
   "counts": {
-    "unit": 6631,
-    "asyncio": 403,
+    "unit": 6632,
+    "asyncio": 404,
     "parametrize": 193,
     "endpoints": 83,
     "property": 82,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,8 +95,8 @@
     ]
   },
   "counts": {
-    "unit": 6635,
-    "asyncio": 407,
+    "unit": 6636,
+    "asyncio": 408,
     "parametrize": 193,
     "endpoints": 83,
     "property": 82,

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6797,
+    "total_tests": 6798,
     "total_files": 803,
     "markers_used": 16
   },
@@ -102,8 +102,8 @@
     ]
   },
   "marker_counts": {
-    "unit": 6632,
-    "asyncio": 404,
+    "unit": 6633,
+    "asyncio": 405,
     "parametrize": 193,
     "endpoints": 83,
     "property": 82,
@@ -35602,8 +35602,18 @@
         "class": "TestFileNotificationBackend"
       },
       {
+        "name": "TestFileNotificationBackend::test_test_connection_checks_existing_target_directly",
+        "line": 116,
+        "markers": [
+          "asyncio",
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestFileNotificationBackend"
+      },
+      {
         "name": "TestFileNotificationBackend::test_test_connection_creates_parent_without_alert_file",
-        "line": 114,
+        "line": 127,
         "markers": [
           "asyncio",
           "unit"
@@ -35613,7 +35623,7 @@
       },
       {
         "name": "TestFileNotificationBackend::test_test_connection_offloads_file_check_to_thread",
-        "line": 126,
+        "line": 139,
         "markers": [
           "asyncio",
           "unit"
@@ -35623,7 +35633,7 @@
       },
       {
         "name": "TestFileNotificationBackend::test_test_connection_fails_for_invalid_path",
-        "line": 150,
+        "line": 163,
         "markers": [
           "asyncio",
           "unit"

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6801,
+    "total_tests": 6802,
     "total_files": 803,
     "markers_used": 16
   },
@@ -102,8 +102,8 @@
     ]
   },
   "marker_counts": {
-    "unit": 6636,
-    "asyncio": 408,
+    "unit": 6637,
+    "asyncio": 409,
     "parametrize": 193,
     "endpoints": 83,
     "property": 82,
@@ -35526,7 +35526,7 @@
     "tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_core.py": [
       {
         "name": "TestConsoleNotificationBackend::test_name_property",
-        "line": 22,
+        "line": 23,
         "markers": [
           "unit"
         ],
@@ -35535,7 +35535,7 @@
       },
       {
         "name": "TestConsoleNotificationBackend::test_is_enabled_property",
-        "line": 26,
+        "line": 27,
         "markers": [
           "unit"
         ],
@@ -35544,7 +35544,7 @@
       },
       {
         "name": "TestConsoleNotificationBackend::test_send_prints_to_console",
-        "line": 34,
+        "line": 35,
         "markers": [
           "asyncio",
           "unit"
@@ -35554,7 +35554,7 @@
       },
       {
         "name": "TestConsoleNotificationBackend::test_send_filters_by_severity",
-        "line": 51,
+        "line": 52,
         "markers": [
           "asyncio",
           "unit"
@@ -35564,7 +35564,7 @@
       },
       {
         "name": "TestConsoleNotificationBackend::test_test_connection_always_true",
-        "line": 66,
+        "line": 67,
         "markers": [
           "asyncio",
           "unit"
@@ -35574,7 +35574,7 @@
       },
       {
         "name": "TestFileNotificationBackend::test_name_property",
-        "line": 75,
+        "line": 76,
         "markers": [
           "unit"
         ],
@@ -35583,7 +35583,7 @@
       },
       {
         "name": "TestFileNotificationBackend::test_send_writes_to_file",
-        "line": 80,
+        "line": 81,
         "markers": [
           "asyncio",
           "unit"
@@ -35593,7 +35593,7 @@
       },
       {
         "name": "TestFileNotificationBackend::test_test_connection_checks_writability",
-        "line": 102,
+        "line": 103,
         "markers": [
           "asyncio",
           "unit"
@@ -35603,7 +35603,7 @@
       },
       {
         "name": "TestFileNotificationBackend::test_test_connection_checks_existing_target_directly",
-        "line": 116,
+        "line": 117,
         "markers": [
           "asyncio",
           "unit"
@@ -35613,7 +35613,7 @@
       },
       {
         "name": "TestFileNotificationBackend::test_test_connection_rejects_trailing_separator_file_path",
-        "line": 127,
+        "line": 128,
         "markers": [
           "asyncio",
           "unit"
@@ -35623,7 +35623,7 @@
       },
       {
         "name": "TestFileNotificationBackend::test_test_connection_checks_broken_symlink_target_parent",
-        "line": 140,
+        "line": 141,
         "markers": [
           "asyncio",
           "unit"
@@ -35633,7 +35633,7 @@
       },
       {
         "name": "TestFileNotificationBackend::test_test_connection_checks_missing_symlink_target_without_creating_it",
-        "line": 155,
+        "line": 156,
         "markers": [
           "asyncio",
           "unit"
@@ -35643,7 +35643,17 @@
       },
       {
         "name": "TestFileNotificationBackend::test_test_connection_creates_parent_without_alert_file",
-        "line": 173,
+        "line": 174,
+        "markers": [
+          "asyncio",
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestFileNotificationBackend"
+      },
+      {
+        "name": "TestFileNotificationBackend::test_test_connection_handles_long_missing_file_name_without_alert_file",
+        "line": 186,
         "markers": [
           "asyncio",
           "unit"
@@ -35653,7 +35663,7 @@
       },
       {
         "name": "TestFileNotificationBackend::test_test_connection_offloads_file_check_to_thread",
-        "line": 185,
+        "line": 201,
         "markers": [
           "asyncio",
           "unit"
@@ -35663,7 +35673,7 @@
       },
       {
         "name": "TestFileNotificationBackend::test_test_connection_fails_for_invalid_path",
-        "line": 209,
+        "line": 225,
         "markers": [
           "asyncio",
           "unit"

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6796,
+    "total_tests": 6797,
     "total_files": 803,
     "markers_used": 16
   },
@@ -102,8 +102,8 @@
     ]
   },
   "marker_counts": {
-    "unit": 6631,
-    "asyncio": 403,
+    "unit": 6632,
+    "asyncio": 404,
     "parametrize": 193,
     "endpoints": 83,
     "property": 82,
@@ -35602,7 +35602,7 @@
         "class": "TestFileNotificationBackend"
       },
       {
-        "name": "TestFileNotificationBackend::test_test_connection_offloads_file_check_to_thread",
+        "name": "TestFileNotificationBackend::test_test_connection_creates_parent_without_alert_file",
         "line": 114,
         "markers": [
           "asyncio",
@@ -35612,8 +35612,18 @@
         "class": "TestFileNotificationBackend"
       },
       {
+        "name": "TestFileNotificationBackend::test_test_connection_offloads_file_check_to_thread",
+        "line": 126,
+        "markers": [
+          "asyncio",
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestFileNotificationBackend"
+      },
+      {
         "name": "TestFileNotificationBackend::test_test_connection_fails_for_invalid_path",
-        "line": 138,
+        "line": 150,
         "markers": [
           "asyncio",
           "unit"
@@ -35652,7 +35662,7 @@
         "docstring": ""
       },
       {
-        "name": "test_file_backend_test_connection_creates_missing_parents",
+        "name": "test_file_backend_test_connection_creates_parent_without_alert_file",
         "line": 77,
         "markers": [
           "asyncio",

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6800,
+    "total_tests": 6801,
     "total_files": 803,
     "markers_used": 16
   },
@@ -102,8 +102,8 @@
     ]
   },
   "marker_counts": {
-    "unit": 6635,
-    "asyncio": 407,
+    "unit": 6636,
+    "asyncio": 408,
     "parametrize": 193,
     "endpoints": 83,
     "property": 82,
@@ -35612,7 +35612,7 @@
         "class": "TestFileNotificationBackend"
       },
       {
-        "name": "TestFileNotificationBackend::test_test_connection_checks_broken_symlink_target_parent",
+        "name": "TestFileNotificationBackend::test_test_connection_rejects_trailing_separator_file_path",
         "line": 127,
         "markers": [
           "asyncio",
@@ -35622,8 +35622,18 @@
         "class": "TestFileNotificationBackend"
       },
       {
+        "name": "TestFileNotificationBackend::test_test_connection_checks_broken_symlink_target_parent",
+        "line": 140,
+        "markers": [
+          "asyncio",
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestFileNotificationBackend"
+      },
+      {
         "name": "TestFileNotificationBackend::test_test_connection_checks_missing_symlink_target_without_creating_it",
-        "line": 142,
+        "line": 155,
         "markers": [
           "asyncio",
           "unit"
@@ -35633,7 +35643,7 @@
       },
       {
         "name": "TestFileNotificationBackend::test_test_connection_creates_parent_without_alert_file",
-        "line": 160,
+        "line": 173,
         "markers": [
           "asyncio",
           "unit"
@@ -35643,7 +35653,7 @@
       },
       {
         "name": "TestFileNotificationBackend::test_test_connection_offloads_file_check_to_thread",
-        "line": 172,
+        "line": 185,
         "markers": [
           "asyncio",
           "unit"
@@ -35653,7 +35663,7 @@
       },
       {
         "name": "TestFileNotificationBackend::test_test_connection_fails_for_invalid_path",
-        "line": 196,
+        "line": 209,
         "markers": [
           "asyncio",
           "unit"

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6798,
+    "total_tests": 6800,
     "total_files": 803,
     "markers_used": 16
   },
@@ -102,8 +102,8 @@
     ]
   },
   "marker_counts": {
-    "unit": 6633,
-    "asyncio": 405,
+    "unit": 6635,
+    "asyncio": 407,
     "parametrize": 193,
     "endpoints": 83,
     "property": 82,
@@ -35612,7 +35612,7 @@
         "class": "TestFileNotificationBackend"
       },
       {
-        "name": "TestFileNotificationBackend::test_test_connection_creates_parent_without_alert_file",
+        "name": "TestFileNotificationBackend::test_test_connection_checks_broken_symlink_target_parent",
         "line": 127,
         "markers": [
           "asyncio",
@@ -35622,8 +35622,28 @@
         "class": "TestFileNotificationBackend"
       },
       {
+        "name": "TestFileNotificationBackend::test_test_connection_checks_missing_symlink_target_without_creating_it",
+        "line": 142,
+        "markers": [
+          "asyncio",
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestFileNotificationBackend"
+      },
+      {
+        "name": "TestFileNotificationBackend::test_test_connection_creates_parent_without_alert_file",
+        "line": 160,
+        "markers": [
+          "asyncio",
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestFileNotificationBackend"
+      },
+      {
         "name": "TestFileNotificationBackend::test_test_connection_offloads_file_check_to_thread",
-        "line": 139,
+        "line": 172,
         "markers": [
           "asyncio",
           "unit"
@@ -35633,7 +35653,7 @@
       },
       {
         "name": "TestFileNotificationBackend::test_test_connection_fails_for_invalid_path",
-        "line": 163,
+        "line": 196,
         "markers": [
           "asyncio",
           "unit"


### PR DESCRIPTION
Closes #954

## Summary
- Change `FileNotificationBackend.test_connection()` to verify writability with a temporary sibling file instead of opening the configured alert log path.
- Keep parent-directory creation aligned with `send()`, but avoid leaving a misleading empty alert file from connection testing.
- Update notification backend core/edge tests and regenerate tracked test inventory metadata.

## Risk / boundaries
- Monitoring notification backend behavior only.
- No live broker/API calls, production preflight, canary operations, or order submission were run.

## Verification
- `uv run pytest tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_core.py -q` -> 11 passed
- `uv run pytest tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_core.py tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_edges.py -q` -> 16 passed
- `uv run agent-regenerate --verify` -> passed
- `uv run local-ci --profile quick` -> passed after updating the existing edge-test expectation (7061 passed, 8 skipped)

## Pipeline note
- Initial quick CI correctly caught an existing edge test that still expected `test_connection()` to create the target file; that expectation was updated to the Issue #954 contract.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file-based notification “connection” validation with more reliable writability checks.
  * Correctly rejects directory paths and trailing separators, handles missing parent folders, and validates symlink targets (including broken/missing targets).
  * Ensures the target file is not modified and avoids creating the alert output file when only parent directory setup is needed.
* **Tests**
  * Strengthened and expanded async unit coverage for the above filesystem behaviors.
  * Renamed/updated tests to reflect “parent created, alert not created” behavior.
* **Chores**
  * Refreshed test inventory and marker counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->