### PR TITLE
[codex] Route console notifications through output sink

### DIFF
--- a/src/gpt_trader/monitoring/notifications/backends.py
+++ b/src/gpt_trader/monitoring/notifications/backends.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any, Protocol
 
 from gpt_trader.monitoring.alert_types import Alert, AlertSeverity
-from gpt_trader.utilities.console_logging import get_console_logger
+from gpt_trader.utilities.console_logging import ConsoleLogger
 from gpt_trader.utilities.logging_patterns import get_logger
 
 logger = get_logger(__name__, component="notifications")
@@ -69,7 +69,7 @@ class ConsoleNotificationBackend:
 
         try:
             formatted = self._format_alert(alert)
-            output_sink = self.output_sink or get_console_logger()
+            output_sink = self.output_sink or ConsoleLogger()
             if not output_sink.write(formatted):
                 logger.error("Console notification output sink declined alert")
                 return False

--- a/src/gpt_trader/monitoring/notifications/backends.py
+++ b/src/gpt_trader/monitoring/notifications/backends.py
@@ -7,9 +7,10 @@ import json
 import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol
 
 from gpt_trader.monitoring.alert_types import Alert, AlertSeverity
+from gpt_trader.utilities.console_logging import get_console_logger
 from gpt_trader.utilities.logging_patterns import get_logger
 
 logger = get_logger(__name__, component="notifications")
@@ -28,6 +29,14 @@ BOLD = "\033[1m"
 FILE_CONNECTION_PROBE_PREFIX = ".connection-"
 
 
+class ConsoleOutputSink(Protocol):
+    """Minimal project console output surface used by notification backends."""
+
+    def write(self, message: str) -> bool:
+        """Emit a preformatted user-facing message."""
+        ...
+
+
 @dataclass
 class ConsoleNotificationBackend:
     """
@@ -40,6 +49,7 @@ class ConsoleNotificationBackend:
     enabled: bool = True
     use_colors: bool = True
     min_severity: AlertSeverity = AlertSeverity.WARNING
+    output_sink: ConsoleOutputSink | None = None
 
     @property
     def name(self) -> str:
@@ -59,7 +69,10 @@ class ConsoleNotificationBackend:
 
         try:
             formatted = self._format_alert(alert)
-            print(formatted)
+            output_sink = self.output_sink or get_console_logger()
+            if not output_sink.write(formatted):
+                logger.error("Console notification output sink declined alert")
+                return False
             return True
         except Exception as e:
             logger.error(f"Console notification failed: {e}")

--- a/src/gpt_trader/utilities/console_logging.py
+++ b/src/gpt_trader/utilities/console_logging.py
@@ -24,6 +24,10 @@ class ConsoleLogger(UnifiedLogger):
             output_stream=output_stream,
         )
 
+    def write(self, message: str) -> bool:
+        """Emit a preformatted console message through the configured output stream."""
+        return self._write(message)
+
 
 # Global console logger instance
 _console_logger: ConsoleLogger | None = None

--- a/tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_core.py
+++ b/tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_core.py
@@ -77,6 +77,27 @@ class TestConsoleNotificationBackend:
             console_logging_module._console_logger = None
 
     @pytest.mark.asyncio
+    async def test_send_default_sink_does_not_reuse_cached_stdout(self, capsys) -> None:
+        stale_stream = StringIO()
+        console_logging_module._console_logger = ConsoleLogger(output_stream=stale_stream)
+        try:
+            backend = ConsoleNotificationBackend(use_colors=False)
+            alert = Alert(
+                severity=AlertSeverity.WARNING,
+                title="Fresh Stdout Alert",
+                message="This should use the active stdout stream",
+            )
+
+            result = await backend.send(alert)
+
+            assert result is True
+            captured = capsys.readouterr()
+            assert "Fresh Stdout Alert" in captured.out
+            assert stale_stream.getvalue() == ""
+        finally:
+            console_logging_module._console_logger = None
+
+    @pytest.mark.asyncio
     async def test_send_filters_by_severity(self, capsys) -> None:
         backend = ConsoleNotificationBackend(min_severity=AlertSeverity.ERROR)
         alert = Alert(

--- a/tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_core.py
+++ b/tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_core.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import tempfile
+from io import StringIO
 from pathlib import Path
 from typing import Any
 
@@ -15,6 +16,8 @@ from gpt_trader.monitoring.notifications.backends import (
     ConsoleNotificationBackend,
     FileNotificationBackend,
 )
+from gpt_trader.utilities import console_logging as console_logging_module
+from gpt_trader.utilities.console_logging import ConsoleLogger
 
 
 class TestConsoleNotificationBackend:
@@ -32,8 +35,10 @@ class TestConsoleNotificationBackend:
         assert backend.is_enabled is False
 
     @pytest.mark.asyncio
-    async def test_send_prints_to_console(self, capsys) -> None:
-        backend = ConsoleNotificationBackend(use_colors=False)
+    async def test_send_writes_to_project_console_sink(self, capsys) -> None:
+        output_stream = StringIO()
+        output_sink = ConsoleLogger(output_stream=output_stream)
+        backend = ConsoleNotificationBackend(use_colors=False, output_sink=output_sink)
         alert = Alert(
             severity=AlertSeverity.WARNING,
             title="Test Alert",
@@ -44,9 +49,32 @@ class TestConsoleNotificationBackend:
 
         assert result is True
         captured = capsys.readouterr()
-        assert "WARNING" in captured.out
-        assert "Test Alert" in captured.out
-        assert "This is a test message" in captured.out
+        assert captured.out == ""
+        output = output_stream.getvalue()
+        assert "WARNING" in output
+        assert "Test Alert" in output
+        assert "This is a test message" in output
+
+    @pytest.mark.asyncio
+    async def test_send_uses_default_console_sink_for_cli_fallback(self, capsys) -> None:
+        console_logging_module._console_logger = None
+        try:
+            backend = ConsoleNotificationBackend(use_colors=False)
+            alert = Alert(
+                severity=AlertSeverity.WARNING,
+                title="Fallback Alert",
+                message="This is a fallback message",
+            )
+
+            result = await backend.send(alert)
+
+            assert result is True
+            captured = capsys.readouterr()
+            assert "WARNING" in captured.out
+            assert "Fallback Alert" in captured.out
+            assert "This is a fallback message" in captured.out
+        finally:
+            console_logging_module._console_logger = None
 
     @pytest.mark.asyncio
     async def test_send_filters_by_severity(self, capsys) -> None:

--- a/tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_edges.py
+++ b/tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_edges.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from io import StringIO
 from unittest.mock import Mock
 
 import pytest
@@ -12,12 +13,17 @@ from gpt_trader.monitoring.notifications.backends import (
     ConsoleNotificationBackend,
     FileNotificationBackend,
 )
+from gpt_trader.utilities.console_logging import ConsoleLogger
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("message", ["", "\x00\x01"])
 async def test_console_backend_handles_empty_or_nonprintable_messages(message: str, capsys) -> None:
-    backend = ConsoleNotificationBackend(use_colors=False)
+    output_stream = StringIO()
+    backend = ConsoleNotificationBackend(
+        use_colors=False,
+        output_sink=ConsoleLogger(output_stream=output_stream),
+    )
     alert = Alert(
         severity=AlertSeverity.WARNING,
         title="Edge Message",
@@ -29,7 +35,8 @@ async def test_console_backend_handles_empty_or_nonprintable_messages(message: s
 
     assert result is True
     captured = capsys.readouterr()
-    assert "Edge Message" in captured.out
+    assert captured.out == ""
+    assert "Edge Message" in output_stream.getvalue()
 
 
 @pytest.mark.asyncio

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6802,
+    "total_tests": 6803,
     "total_files": 803,
     "markers_used": 16
   },

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6803,
+    "total_tests": 6804,
     "total_files": 803,
     "markers_used": 16
   },

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,8 +95,8 @@
     ]
   },
   "counts": {
-    "unit": 6638,
-    "asyncio": 410,
+    "unit": 6639,
+    "asyncio": 411,
     "parametrize": 193,
     "endpoints": 83,
     "property": 82,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,8 +95,8 @@
     ]
   },
   "counts": {
-    "unit": 6637,
-    "asyncio": 409,
+    "unit": 6638,
+    "asyncio": 410,
     "parametrize": 193,
     "endpoints": 83,
     "property": 82,

--- a/var/agents/testing/source_test_map.json
+++ b/var/agents/testing/source_test_map.json
@@ -2039,6 +2039,7 @@
       "tests/unit/gpt_trader/tui/widgets/test_validation_indicator.py"
     ],
     "gpt_trader.utilities": [
+      "tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_core.py",
       "tests/unit/gpt_trader/utilities/test_logging_patterns.py",
       "tests/unit/gpt_trader/utilities/test_logging_patterns_domain.py"
     ],
@@ -2055,6 +2056,8 @@
       "tests/unit/gpt_trader/utilities/test_backoff_policy.py"
     ],
     "gpt_trader.utilities.console_logging": [
+      "tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_core.py",
+      "tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_edges.py",
       "tests/unit/gpt_trader/utilities/test_console_logging.py",
       "tests/unit/gpt_trader/utilities/test_console_logging_functions.py"
     ],
@@ -4075,11 +4078,14 @@
     "tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_core.py": [
       "gpt_trader.monitoring.alert_types",
       "gpt_trader.monitoring.notifications",
-      "gpt_trader.monitoring.notifications.backends"
+      "gpt_trader.monitoring.notifications.backends",
+      "gpt_trader.utilities",
+      "gpt_trader.utilities.console_logging"
     ],
     "tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_edges.py": [
       "gpt_trader.monitoring.alert_types",
-      "gpt_trader.monitoring.notifications.backends"
+      "gpt_trader.monitoring.notifications.backends",
+      "gpt_trader.utilities.console_logging"
     ],
     "tests/unit/gpt_trader/monitoring/notifications/test_notification_service.py": [
       "gpt_trader.monitoring.alert_types",

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6802,
+    "total_tests": 6803,
     "total_files": 803,
     "markers_used": 16
   },
@@ -102,8 +102,8 @@
     ]
   },
   "marker_counts": {
-    "unit": 6637,
-    "asyncio": 409,
+    "unit": 6638,
+    "asyncio": 410,
     "parametrize": 193,
     "endpoints": 83,
     "property": 82,
@@ -35526,7 +35526,7 @@
     "tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_core.py": [
       {
         "name": "TestConsoleNotificationBackend::test_name_property",
-        "line": 23,
+        "line": 26,
         "markers": [
           "unit"
         ],
@@ -35535,7 +35535,7 @@
       },
       {
         "name": "TestConsoleNotificationBackend::test_is_enabled_property",
-        "line": 27,
+        "line": 30,
         "markers": [
           "unit"
         ],
@@ -35543,8 +35543,18 @@
         "class": "TestConsoleNotificationBackend"
       },
       {
-        "name": "TestConsoleNotificationBackend::test_send_prints_to_console",
-        "line": 35,
+        "name": "TestConsoleNotificationBackend::test_send_writes_to_project_console_sink",
+        "line": 38,
+        "markers": [
+          "asyncio",
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestConsoleNotificationBackend"
+      },
+      {
+        "name": "TestConsoleNotificationBackend::test_send_uses_default_console_sink_for_cli_fallback",
+        "line": 59,
         "markers": [
           "asyncio",
           "unit"
@@ -35554,7 +35564,7 @@
       },
       {
         "name": "TestConsoleNotificationBackend::test_send_filters_by_severity",
-        "line": 52,
+        "line": 80,
         "markers": [
           "asyncio",
           "unit"
@@ -35564,7 +35574,7 @@
       },
       {
         "name": "TestConsoleNotificationBackend::test_test_connection_always_true",
-        "line": 67,
+        "line": 95,
         "markers": [
           "asyncio",
           "unit"
@@ -35574,7 +35584,7 @@
       },
       {
         "name": "TestFileNotificationBackend::test_name_property",
-        "line": 76,
+        "line": 104,
         "markers": [
           "unit"
         ],
@@ -35583,7 +35593,7 @@
       },
       {
         "name": "TestFileNotificationBackend::test_send_writes_to_file",
-        "line": 81,
+        "line": 109,
         "markers": [
           "asyncio",
           "unit"
@@ -35593,7 +35603,7 @@
       },
       {
         "name": "TestFileNotificationBackend::test_test_connection_checks_writability",
-        "line": 103,
+        "line": 131,
         "markers": [
           "asyncio",
           "unit"
@@ -35603,7 +35613,7 @@
       },
       {
         "name": "TestFileNotificationBackend::test_test_connection_checks_existing_target_directly",
-        "line": 117,
+        "line": 145,
         "markers": [
           "asyncio",
           "unit"
@@ -35613,26 +35623,6 @@
       },
       {
         "name": "TestFileNotificationBackend::test_test_connection_rejects_trailing_separator_file_path",
-        "line": 128,
-        "markers": [
-          "asyncio",
-          "unit"
-        ],
-        "docstring": "",
-        "class": "TestFileNotificationBackend"
-      },
-      {
-        "name": "TestFileNotificationBackend::test_test_connection_checks_broken_symlink_target_parent",
-        "line": 141,
-        "markers": [
-          "asyncio",
-          "unit"
-        ],
-        "docstring": "",
-        "class": "TestFileNotificationBackend"
-      },
-      {
-        "name": "TestFileNotificationBackend::test_test_connection_checks_missing_symlink_target_without_creating_it",
         "line": 156,
         "markers": [
           "asyncio",
@@ -35642,8 +35632,28 @@
         "class": "TestFileNotificationBackend"
       },
       {
+        "name": "TestFileNotificationBackend::test_test_connection_checks_broken_symlink_target_parent",
+        "line": 169,
+        "markers": [
+          "asyncio",
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestFileNotificationBackend"
+      },
+      {
+        "name": "TestFileNotificationBackend::test_test_connection_checks_missing_symlink_target_without_creating_it",
+        "line": 184,
+        "markers": [
+          "asyncio",
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestFileNotificationBackend"
+      },
+      {
         "name": "TestFileNotificationBackend::test_test_connection_creates_parent_without_alert_file",
-        "line": 174,
+        "line": 202,
         "markers": [
           "asyncio",
           "unit"
@@ -35653,7 +35663,7 @@
       },
       {
         "name": "TestFileNotificationBackend::test_test_connection_handles_long_missing_file_name_without_alert_file",
-        "line": 186,
+        "line": 214,
         "markers": [
           "asyncio",
           "unit"
@@ -35663,7 +35673,7 @@
       },
       {
         "name": "TestFileNotificationBackend::test_test_connection_offloads_file_check_to_thread",
-        "line": 201,
+        "line": 229,
         "markers": [
           "asyncio",
           "unit"
@@ -35673,7 +35683,7 @@
       },
       {
         "name": "TestFileNotificationBackend::test_test_connection_fails_for_invalid_path",
-        "line": 225,
+        "line": 253,
         "markers": [
           "asyncio",
           "unit"
@@ -35685,7 +35695,7 @@
     "tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_edges.py": [
       {
         "name": "test_console_backend_handles_empty_or_nonprintable_messages",
-        "line": 19,
+        "line": 21,
         "markers": [
           "asyncio",
           "parametrize",
@@ -35695,7 +35705,7 @@
       },
       {
         "name": "test_file_backend_handles_json_serialization_failure",
-        "line": 36,
+        "line": 43,
         "markers": [
           "asyncio",
           "unit"
@@ -35704,7 +35714,7 @@
       },
       {
         "name": "test_file_backend_nested_path_creates_parents_and_writes_jsonl",
-        "line": 55,
+        "line": 62,
         "markers": [
           "asyncio",
           "unit"
@@ -35713,7 +35723,7 @@
       },
       {
         "name": "test_file_backend_test_connection_creates_parent_without_alert_file",
-        "line": 77,
+        "line": 84,
         "markers": [
           "asyncio",
           "unit"

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6803,
+    "total_tests": 6804,
     "total_files": 803,
     "markers_used": 16
   },
@@ -102,8 +102,8 @@
     ]
   },
   "marker_counts": {
-    "unit": 6638,
-    "asyncio": 410,
+    "unit": 6639,
+    "asyncio": 411,
     "parametrize": 193,
     "endpoints": 83,
     "property": 82,
@@ -35563,7 +35563,7 @@
         "class": "TestConsoleNotificationBackend"
       },
       {
-        "name": "TestConsoleNotificationBackend::test_send_filters_by_severity",
+        "name": "TestConsoleNotificationBackend::test_send_default_sink_does_not_reuse_cached_stdout",
         "line": 80,
         "markers": [
           "asyncio",
@@ -35573,8 +35573,18 @@
         "class": "TestConsoleNotificationBackend"
       },
       {
+        "name": "TestConsoleNotificationBackend::test_send_filters_by_severity",
+        "line": 101,
+        "markers": [
+          "asyncio",
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestConsoleNotificationBackend"
+      },
+      {
         "name": "TestConsoleNotificationBackend::test_test_connection_always_true",
-        "line": 95,
+        "line": 116,
         "markers": [
           "asyncio",
           "unit"
@@ -35584,7 +35594,7 @@
       },
       {
         "name": "TestFileNotificationBackend::test_name_property",
-        "line": 104,
+        "line": 125,
         "markers": [
           "unit"
         ],
@@ -35593,7 +35603,7 @@
       },
       {
         "name": "TestFileNotificationBackend::test_send_writes_to_file",
-        "line": 109,
+        "line": 130,
         "markers": [
           "asyncio",
           "unit"
@@ -35603,7 +35613,7 @@
       },
       {
         "name": "TestFileNotificationBackend::test_test_connection_checks_writability",
-        "line": 131,
+        "line": 152,
         "markers": [
           "asyncio",
           "unit"
@@ -35613,7 +35623,7 @@
       },
       {
         "name": "TestFileNotificationBackend::test_test_connection_checks_existing_target_directly",
-        "line": 145,
+        "line": 166,
         "markers": [
           "asyncio",
           "unit"
@@ -35623,7 +35633,7 @@
       },
       {
         "name": "TestFileNotificationBackend::test_test_connection_rejects_trailing_separator_file_path",
-        "line": 156,
+        "line": 177,
         "markers": [
           "asyncio",
           "unit"
@@ -35633,7 +35643,7 @@
       },
       {
         "name": "TestFileNotificationBackend::test_test_connection_checks_broken_symlink_target_parent",
-        "line": 169,
+        "line": 190,
         "markers": [
           "asyncio",
           "unit"
@@ -35643,7 +35653,7 @@
       },
       {
         "name": "TestFileNotificationBackend::test_test_connection_checks_missing_symlink_target_without_creating_it",
-        "line": 184,
+        "line": 205,
         "markers": [
           "asyncio",
           "unit"
@@ -35653,7 +35663,7 @@
       },
       {
         "name": "TestFileNotificationBackend::test_test_connection_creates_parent_without_alert_file",
-        "line": 202,
+        "line": 223,
         "markers": [
           "asyncio",
           "unit"
@@ -35663,7 +35673,7 @@
       },
       {
         "name": "TestFileNotificationBackend::test_test_connection_handles_long_missing_file_name_without_alert_file",
-        "line": 214,
+        "line": 235,
         "markers": [
           "asyncio",
           "unit"
@@ -35673,7 +35683,7 @@
       },
       {
         "name": "TestFileNotificationBackend::test_test_connection_offloads_file_check_to_thread",
-        "line": 229,
+        "line": 250,
         "markers": [
           "asyncio",
           "unit"
@@ -35683,7 +35693,7 @@
       },
       {
         "name": "TestFileNotificationBackend::test_test_connection_fails_for_invalid_path",
-        "line": 253,
+        "line": 274,
         "markers": [
           "asyncio",
           "unit"


### PR DESCRIPTION
## Summary
Related issue / finding / RJ-routed package: Closes #970

Routes `ConsoleNotificationBackend` output through the existing project console output abstraction instead of calling `print` directly. The backend now accepts an injectable output sink and defaults to the project `ConsoleLogger`, preserving CLI/dev stdout fallback while allowing tests and other callers to capture output without global stdout noise.

## Type of change
- [x] Refactor
- [ ] Feature
- [ ] Bug fix
- [x] Tests only
- [ ] CI/Docs/Tooling

## Scope & Impact
- Affected areas / components:
  - `src/gpt_trader/monitoring/notifications/backends.py`
  - `src/gpt_trader/utilities/console_logging.py`
  - `tests/unit/gpt_trader/monitoring/notifications/`
  - `var/agents/testing/`
- Behavior changes: console notifications use an injectable project output sink. The default sink still writes to stdout for explicit console backend usage.

## Test Plan
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Contract tests (if applicable)
- [x] Ran locally: `uv run pytest tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_core.py tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_edges.py tests/unit/gpt_trader/utilities/test_console_logging.py tests/unit/gpt_trader/utilities/test_console_logging_functions.py -q` -> 69 passed
- [x] Markers used appropriately (`unit`/`integration`/`slow`/`perf`)

## Complexity & Quality Gates
- [x] Mypy/type-check passed via `uv run local-ci --profile quick`
- [x] Xenon/radon complexity gate not applicable; no live_trade execution changes
- [x] No `sys.path` hacks in tests
- [x] No `MagicMock` on `async def` (use `AsyncMock`)
- [x] Import-lint rules respected (no “import up the stack”)

## Observability & Errors
- [x] Structured JSON logs for new/changed paths not changed; existing notification logger records sink failures
- [x] Errors include diagnostic context where relevant through existing notification logger
- [ ] Added/updated sampling examples in tests (if applicable)

## Configuration
- [ ] If config changed: `python -m gpt_trader.cli.config validate --profile <name>` passes
- [x] Env docs re-generated not applicable; test metadata regenerated
- [x] No `ConfigLoader` usages introduced (ConfigManager-only)

## Breaking Changes
- [x] None
- [ ] Documented in PR body and release notes if any

## Verification
- `uv run pytest tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_core.py tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_edges.py tests/unit/gpt_trader/utilities/test_console_logging.py tests/unit/gpt_trader/utilities/test_console_logging_functions.py -q` -> 69 passed
- `uv run agent-regenerate --verify` -> passed
- `git diff --check` -> passed
- `uv run local-ci --profile quick` -> passed, 7067 passed / 8 skipped

## Checklist
- [x] Acceptance criteria in linked issue(s), finding packet, or routed package met
- [x] Affected paths listed in PR description
- [x] Changelog entry not applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Console alerts now support pluggable output destinations via an injectable output sink.
  * Console logging exposes a `write(message: str) -> bool` method for consistent message output.

* **Bug Fixes**
  * Alert delivery now correctly reports failures when output writing is unsuccessful.

* **Tests**
  * Updated console notification tests to assert output using in-memory streams instead of console capture.

* **Chores**
  * Refreshed test inventory counts and source/test mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->