### PR TITLE
[codex] Close OrdersStore SQLite handles

### DIFF
--- a/src/gpt_trader/persistence/orders_store.py
+++ b/src/gpt_trader/persistence/orders_store.py
@@ -221,11 +221,16 @@ class OrdersStore:
             connection.execute("PRAGMA busy_timeout=5000")
             connection.row_factory = sqlite3.Row
 
+            retry_connection = False
             with self._connection_lock:
                 if generation != self._connection_generation:
-                    connection.close()
-                    return self._get_connection()
-                self._connections[(threading.get_ident(), generation)] = connection
+                    retry_connection = True
+                else:
+                    self._connections[(threading.get_ident(), generation)] = connection
+
+            if retry_connection:
+                connection.close()
+                return self._get_connection()
 
             self._local.connection = connection
             self._local.connection_generation = generation

--- a/src/gpt_trader/persistence/orders_store.py
+++ b/src/gpt_trader/persistence/orders_store.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import json
 import sqlite3
 import threading
+import weakref
 from contextlib import suppress
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -30,6 +31,40 @@ from gpt_trader.persistence.durability import (
 from gpt_trader.utilities.logging_patterns import get_logger
 
 logger = get_logger(__name__, component="orders_store")
+
+
+class _ConnectionHolder:
+    """Thread-local SQLite connection wrapper that unregisters itself on teardown."""
+
+    __slots__ = ("_closed", "_store_ref", "connection", "__weakref__")
+
+    def __init__(self, store: OrdersStore, connection: sqlite3.Connection) -> None:
+        self._closed = False
+        self._store_ref = weakref.ref(store)
+        self.connection = connection
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    def close(self, *, checkpoint: bool = False, unregister: bool = True) -> None:
+        if self._closed:
+            return
+
+        self._closed = True
+        if unregister:
+            store = self._store_ref()
+            if store is not None:
+                store._unregister_connection(self)
+
+        if checkpoint:
+            with suppress(sqlite3.Error):
+                self.connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        with suppress(sqlite3.Error):
+            self.connection.close()
+
+    def __del__(self) -> None:
+        self.close()
 
 
 class OrderStatus(str, Enum):
@@ -188,24 +223,27 @@ class OrdersStore:
         self._database_path = self.storage_path / "orders.db"
         self._lock = threading.Lock()
         self._connection_lock = threading.Lock()
-        self._connections: dict[int, sqlite3.Connection] = {}
+        self._connections: weakref.WeakValueDictionary[int, _ConnectionHolder] = (
+            weakref.WeakValueDictionary()
+        )
         self._connection_generation = 0
         self._initialized = False
         self._local = threading.local()
 
     def _get_connection(self) -> sqlite3.Connection:
         """Get thread-local database connection."""
-        connection: sqlite3.Connection | None = getattr(self._local, "connection", None)
+        holder: _ConnectionHolder | None = getattr(self._local, "connection_holder", None)
         connection_generation: int | None = getattr(self._local, "connection_generation", None)
-        if connection is not None and connection_generation == self._connection_generation:
-            return connection
+        if (
+            holder is not None
+            and not holder.closed
+            and connection_generation == self._connection_generation
+        ):
+            return holder.connection
 
-        if connection is not None:
-            with self._connection_lock:
-                self._connections.pop(id(connection), None)
-            with suppress(sqlite3.Error):
-                connection.close()
-            del self._local.connection
+        if holder is not None:
+            holder.close()
+            del self._local.connection_holder
             if hasattr(self._local, "connection_generation"):
                 del self._local.connection_generation
 
@@ -217,6 +255,7 @@ class OrdersStore:
             check_same_thread=False,
             isolation_level=None,  # Autocommit mode
         )
+        new_holder: _ConnectionHolder | None = None
         try:
             connection.execute("PRAGMA journal_mode=WAL")
             connection.execute("PRAGMA synchronous=NORMAL")
@@ -224,24 +263,31 @@ class OrdersStore:
             connection.row_factory = sqlite3.Row
 
             retry_connection = False
+            new_holder = _ConnectionHolder(self, connection)
             with self._connection_lock:
                 if generation != self._connection_generation:
                     retry_connection = True
                 else:
-                    self._connections[id(connection)] = connection
+                    self._connections[id(new_holder)] = new_holder
 
             if retry_connection:
-                connection.close()
+                new_holder.close()
                 return self._get_connection()
 
-            self._local.connection = connection
+            self._local.connection_holder = new_holder
             self._local.connection_generation = generation
             return connection
         except Exception:
-            with self._connection_lock:
-                self._connections.pop(id(connection), None)
-            connection.close()
+            if new_holder is not None:
+                new_holder.close()
+            else:
+                with suppress(sqlite3.Error):
+                    connection.close()
             raise
+
+    def _unregister_connection(self, holder: _ConnectionHolder) -> None:
+        with self._connection_lock:
+            self._connections.pop(id(holder), None)
 
     def initialize(self, *, check_integrity: bool = True) -> None:
         """
@@ -783,18 +829,15 @@ class OrdersStore:
         `orders.db` and its WAL side files before cleanup or rotation.
         """
         with self._connection_lock:
-            connections = list(self._connections.values())
+            holders = list(self._connections.values())
             self._connections.clear()
             self._connection_generation += 1
 
-        for connection in connections:
-            with suppress(sqlite3.Error):
-                connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
-            with suppress(sqlite3.Error):
-                connection.close()
+        for holder in holders:
+            holder.close(checkpoint=True, unregister=False)
 
-        if hasattr(self._local, "connection"):
-            del self._local.connection
+        if hasattr(self._local, "connection_holder"):
+            del self._local.connection_holder
         if hasattr(self._local, "connection_generation"):
             del self._local.connection_generation
         self._initialized = False

--- a/src/gpt_trader/persistence/orders_store.py
+++ b/src/gpt_trader/persistence/orders_store.py
@@ -188,7 +188,7 @@ class OrdersStore:
         self._database_path = self.storage_path / "orders.db"
         self._lock = threading.Lock()
         self._connection_lock = threading.Lock()
-        self._connections: dict[tuple[int, int], sqlite3.Connection] = {}
+        self._connections: dict[int, sqlite3.Connection] = {}
         self._connection_generation = 0
         self._initialized = False
         self._local = threading.local()
@@ -201,6 +201,8 @@ class OrdersStore:
             return connection
 
         if connection is not None:
+            with self._connection_lock:
+                self._connections.pop(id(connection), None)
             with suppress(sqlite3.Error):
                 connection.close()
             del self._local.connection
@@ -226,7 +228,7 @@ class OrdersStore:
                 if generation != self._connection_generation:
                     retry_connection = True
                 else:
-                    self._connections[(threading.get_ident(), generation)] = connection
+                    self._connections[id(connection)] = connection
 
             if retry_connection:
                 connection.close()
@@ -236,6 +238,8 @@ class OrdersStore:
             self._local.connection_generation = generation
             return connection
         except Exception:
+            with self._connection_lock:
+                self._connections.pop(id(connection), None)
             connection.close()
             raise
 

--- a/src/gpt_trader/persistence/orders_store.py
+++ b/src/gpt_trader/persistence/orders_store.py
@@ -269,13 +269,21 @@ class OrdersStore:
                     retry_connection = True
                 else:
                     self._connections[id(new_holder)] = new_holder
+                    self._local.connection_holder = new_holder
+                    self._local.connection_generation = generation
 
             if retry_connection:
                 new_holder.close()
                 return self._get_connection()
 
-            self._local.connection_holder = new_holder
-            self._local.connection_generation = generation
+            if new_holder.closed or generation != self._connection_generation:
+                if getattr(self._local, "connection_holder", None) is new_holder:
+                    del self._local.connection_holder
+                if hasattr(self._local, "connection_generation"):
+                    del self._local.connection_generation
+                new_holder.close()
+                return self._get_connection()
+
             return connection
         except Exception:
             if new_holder is not None:

--- a/src/gpt_trader/persistence/orders_store.py
+++ b/src/gpt_trader/persistence/orders_store.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import json
 import sqlite3
 import threading
+from contextlib import suppress
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from decimal import Decimal
@@ -186,23 +187,52 @@ class OrdersStore:
         self.storage_path = Path(storage_path)
         self._database_path = self.storage_path / "orders.db"
         self._lock = threading.Lock()
+        self._connection_lock = threading.Lock()
+        self._connections: dict[tuple[int, int], sqlite3.Connection] = {}
+        self._connection_generation = 0
         self._initialized = False
         self._local = threading.local()
 
     def _get_connection(self) -> sqlite3.Connection:
         """Get thread-local database connection."""
-        if not hasattr(self._local, "connection"):
-            connection = sqlite3.connect(
-                str(self._database_path),
-                check_same_thread=False,
-                isolation_level=None,  # Autocommit mode
-            )
+        connection: sqlite3.Connection | None = getattr(self._local, "connection", None)
+        connection_generation: int | None = getattr(self._local, "connection_generation", None)
+        if connection is not None and connection_generation == self._connection_generation:
+            return connection
+
+        if connection is not None:
+            with suppress(sqlite3.Error):
+                connection.close()
+            del self._local.connection
+            if hasattr(self._local, "connection_generation"):
+                del self._local.connection_generation
+
+        with self._connection_lock:
+            generation = self._connection_generation
+
+        connection = sqlite3.connect(
+            str(self._database_path),
+            check_same_thread=False,
+            isolation_level=None,  # Autocommit mode
+        )
+        try:
             connection.execute("PRAGMA journal_mode=WAL")
             connection.execute("PRAGMA synchronous=NORMAL")
             connection.execute("PRAGMA busy_timeout=5000")
             connection.row_factory = sqlite3.Row
+
+            with self._connection_lock:
+                if generation != self._connection_generation:
+                    connection.close()
+                    return self._get_connection()
+                self._connections[(threading.get_ident(), generation)] = connection
+
             self._local.connection = connection
-        return self._local.connection  # type: ignore[no-any-return]
+            self._local.connection_generation = generation
+            return connection
+        except Exception:
+            connection.close()
+            raise
 
     def initialize(self, *, check_integrity: bool = True) -> None:
         """
@@ -736,10 +766,29 @@ class OrdersStore:
         )
 
     def close(self) -> None:
-        """Close database connection for current thread."""
+        """
+        Close all SQLite connections created by this store.
+
+        `OrdersStore` keeps one connection per thread. Explicit close is required
+        for initialize-only or short-lived usage so Windows can release
+        `orders.db` and its WAL side files before cleanup or rotation.
+        """
+        with self._connection_lock:
+            connections = list(self._connections.values())
+            self._connections.clear()
+            self._connection_generation += 1
+
+        for connection in connections:
+            with suppress(sqlite3.Error):
+                connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+            with suppress(sqlite3.Error):
+                connection.close()
+
         if hasattr(self._local, "connection"):
-            self._local.connection.close()
             del self._local.connection
+        if hasattr(self._local, "connection_generation"):
+            del self._local.connection_generation
+        self._initialized = False
 
     def __enter__(self) -> OrdersStore:
         """Context manager entry."""

--- a/tests/unit/gpt_trader/persistence/test_orders_store.py
+++ b/tests/unit/gpt_trader/persistence/test_orders_store.py
@@ -11,6 +11,7 @@ from tempfile import TemporaryDirectory
 
 import pytest
 
+from gpt_trader.persistence import orders_store as orders_store_module
 from gpt_trader.persistence.orders_store import OrdersStore, OrderStatus
 from tests.unit.gpt_trader.persistence.orders_store_test_helpers import create_test_order
 
@@ -143,6 +144,33 @@ class TestOrdersStore:
                 raise errors[0]
             assert connect_count == 2
             assert store.get_order("retry-order") is not None
+            store.close()
+
+    def test_closed_holder_after_publish_retries_before_return(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        real_holder = orders_store_module._ConnectionHolder
+
+        class ClosingOnceHolder(real_holder):
+            closed_once = False
+
+            @property
+            def closed(self) -> bool:
+                if not ClosingOnceHolder.closed_once:
+                    ClosingOnceHolder.closed_once = True
+                    self.close()
+                return super().closed
+
+        monkeypatch.setattr(orders_store_module, "_ConnectionHolder", ClosingOnceHolder)
+
+        with TemporaryDirectory() as tmpdir:
+            store = OrdersStore(tmpdir)
+            store.initialize()
+            result = store.save_order(create_test_order(order_id="publish-race-order"))
+
+            assert ClosingOnceHolder.closed_once is True
+            assert result.success is True
+            assert store.get_order("publish-race-order") is not None
             store.close()
 
     def test_save_and_get_order(self) -> None:

--- a/tests/unit/gpt_trader/persistence/test_orders_store.py
+++ b/tests/unit/gpt_trader/persistence/test_orders_store.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import sqlite3
+import threading
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from pathlib import Path
@@ -23,6 +25,43 @@ class TestOrdersStore:
 
             db_path = Path(tmpdir) / "orders.db"
             assert db_path.exists()
+            store.close()
+
+    def test_explicit_close_allows_reinitialize_and_reuse(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            store = OrdersStore(tmpdir)
+            store.initialize()
+            store.close()
+
+            order = create_test_order()
+            result = store.save_order(order)
+
+            assert result.success is True
+            assert store.get_order(order.order_id) is not None
+            store.close()
+
+    def test_close_releases_thread_local_connections(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            store = OrdersStore(tmpdir)
+            store.initialize()
+            main_connection = store._get_connection()
+            worker_connections: list[sqlite3.Connection] = []
+
+            def save_in_worker() -> None:
+                store.save_order(create_test_order(order_id="worker-order"))
+                worker_connections.append(store._get_connection())
+
+            worker = threading.Thread(target=save_in_worker)
+            worker.start()
+            worker.join()
+
+            assert len(worker_connections) == 1
+
+            store.close()
+
+            for connection in [main_connection, *worker_connections]:
+                with pytest.raises(sqlite3.ProgrammingError, match="closed"):
+                    connection.execute("SELECT 1")
 
     def test_save_and_get_order(self) -> None:
         with TemporaryDirectory() as tmpdir:

--- a/tests/unit/gpt_trader/persistence/test_orders_store.py
+++ b/tests/unit/gpt_trader/persistence/test_orders_store.py
@@ -63,17 +63,40 @@ class TestOrdersStore:
                 with pytest.raises(sqlite3.ProgrammingError, match="closed"):
                     connection.execute("SELECT 1")
 
+    def test_worker_thread_connection_closes_when_thread_exits(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            store = OrdersStore(tmpdir)
+            store.initialize()
+            worker_connections: list[sqlite3.Connection] = []
+
+            def save_in_worker() -> None:
+                store.save_order(create_test_order(order_id="worker-exit-order"))
+                worker_connections.append(store._get_connection())
+
+            worker = threading.Thread(target=save_in_worker)
+            worker.start()
+            worker.join()
+
+            assert len(worker_connections) == 1
+            with pytest.raises(sqlite3.ProgrammingError, match="closed"):
+                worker_connections[0].execute("SELECT 1")
+
+            store.close()
+
     def test_reconnect_in_same_generation_keeps_previous_handle_registered(self) -> None:
         with TemporaryDirectory() as tmpdir:
             store = OrdersStore(tmpdir)
             store.initialize()
             first_connection = store._get_connection()
-            del store._local.connection
+            first_holder = store._local.connection_holder
+            del store._local.connection_holder
             del store._local.connection_generation
 
             second_connection = store._get_connection()
+            second_holder = store._local.connection_holder
 
             assert first_connection is not second_connection
+            assert first_holder is not second_holder
             assert len(store._connections) == 2
 
             store.close()

--- a/tests/unit/gpt_trader/persistence/test_orders_store.py
+++ b/tests/unit/gpt_trader/persistence/test_orders_store.py
@@ -63,6 +63,25 @@ class TestOrdersStore:
                 with pytest.raises(sqlite3.ProgrammingError, match="closed"):
                     connection.execute("SELECT 1")
 
+    def test_reconnect_in_same_generation_keeps_previous_handle_registered(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            store = OrdersStore(tmpdir)
+            store.initialize()
+            first_connection = store._get_connection()
+            del store._local.connection
+            del store._local.connection_generation
+
+            second_connection = store._get_connection()
+
+            assert first_connection is not second_connection
+            assert len(store._connections) == 2
+
+            store.close()
+
+            for connection in [first_connection, second_connection]:
+                with pytest.raises(sqlite3.ProgrammingError, match="closed"):
+                    connection.execute("SELECT 1")
+
     def test_connection_generation_retry_releases_lock_before_reconnect(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/gpt_trader/persistence/test_orders_store.py
+++ b/tests/unit/gpt_trader/persistence/test_orders_store.py
@@ -63,6 +63,33 @@ class TestOrdersStore:
                 with pytest.raises(sqlite3.ProgrammingError, match="closed"):
                     connection.execute("SELECT 1")
 
+    def test_connection_generation_retry_releases_lock_before_reconnect(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            store = OrdersStore(tmpdir)
+            real_connect = sqlite3.connect
+            connect_count = 0
+
+            def connect_with_generation_change(
+                *args: object, **kwargs: object
+            ) -> sqlite3.Connection:
+                nonlocal connect_count
+                connect_count += 1
+                connection = real_connect(*args, **kwargs)
+                if connect_count == 1:
+                    store.close()
+                return connection
+
+            monkeypatch.setattr(sqlite3, "connect", connect_with_generation_change)
+
+            store.initialize()
+            store.save_order(create_test_order(order_id="retry-order"))
+
+            assert connect_count == 2
+            assert store.get_order("retry-order") is not None
+            store.close()
+
     def test_save_and_get_order(self) -> None:
         with TemporaryDirectory() as tmpdir:
             with OrdersStore(tmpdir) as store:

--- a/tests/unit/gpt_trader/persistence/test_orders_store.py
+++ b/tests/unit/gpt_trader/persistence/test_orders_store.py
@@ -102,9 +102,22 @@ class TestOrdersStore:
 
             monkeypatch.setattr(sqlite3, "connect", connect_with_generation_change)
 
-            store.initialize()
-            store.save_order(create_test_order(order_id="retry-order"))
+            errors: list[BaseException] = []
 
+            def save_with_generation_retry() -> None:
+                try:
+                    store.initialize()
+                    store.save_order(create_test_order(order_id="retry-order"))
+                except BaseException as exc:
+                    errors.append(exc)
+
+            worker = threading.Thread(target=save_with_generation_retry, daemon=True)
+            worker.start()
+            worker.join(timeout=2)
+
+            assert not worker.is_alive()
+            if errors:
+                raise errors[0]
             assert connect_count == 2
             assert store.get_order("retry-order") is not None
             store.close()

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6807,
+    "total_tests": 6808,
     "total_files": 803,
     "markers_used": 16
   },

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6809,
+    "total_tests": 6810,
     "total_files": 803,
     "markers_used": 16
   },

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6804,
+    "total_tests": 6806,
     "total_files": 803,
     "markers_used": 16
   },

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6806,
+    "total_tests": 6807,
     "total_files": 803,
     "markers_used": 16
   },

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6808,
+    "total_tests": 6809,
     "total_files": 803,
     "markers_used": 16
   },

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6644,
+    "unit": 6645,
     "asyncio": 411,
     "parametrize": 193,
     "endpoints": 83,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6639,
+    "unit": 6641,
     "asyncio": 411,
     "parametrize": 193,
     "endpoints": 83,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6642,
+    "unit": 6643,
     "asyncio": 411,
     "parametrize": 193,
     "endpoints": 83,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6643,
+    "unit": 6644,
     "asyncio": 411,
     "parametrize": 193,
     "endpoints": 83,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6641,
+    "unit": 6642,
     "asyncio": 411,
     "parametrize": 193,
     "endpoints": 83,

--- a/var/agents/testing/source_test_map.json
+++ b/var/agents/testing/source_test_map.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "summary": {
     "tests_scanned": 720,
-    "source_modules": 372,
+    "source_modules": 373,
     "unresolved_modules": 3
   },
   "source_to_tests": {
@@ -1530,6 +1530,9 @@
     "gpt_trader.observability.tracing": [
       "tests/unit/gpt_trader/observability/test_tracing.py",
       "tests/unit/gpt_trader/observability/test_tracing_edges.py"
+    ],
+    "gpt_trader.persistence": [
+      "tests/unit/gpt_trader/persistence/test_orders_store.py"
     ],
     "gpt_trader.persistence.database": [
       "tests/unit/gpt_trader/persistence/test_database_engine.py",
@@ -4266,6 +4269,7 @@
       "gpt_trader.persistence.event_store"
     ],
     "tests/unit/gpt_trader/persistence/test_orders_store.py": [
+      "gpt_trader.persistence",
       "gpt_trader.persistence.orders_store"
     ],
     "tests/unit/gpt_trader/persistence/test_orders_store_edges.py": [
@@ -5268,6 +5272,7 @@
     "gpt_trader.monitoring.two_person_rule.manager": "src/gpt_trader/monitoring/two_person_rule/manager.py",
     "gpt_trader.monitoring.two_person_rule.models": "src/gpt_trader/monitoring/two_person_rule/models.py",
     "gpt_trader.observability.tracing": "src/gpt_trader/observability/tracing.py",
+    "gpt_trader.persistence": "src/gpt_trader/persistence/__init__.py",
     "gpt_trader.persistence.database": "src/gpt_trader/persistence/database.py",
     "gpt_trader.persistence.durability": "src/gpt_trader/persistence/durability.py",
     "gpt_trader.persistence.event_store": "src/gpt_trader/persistence/event_store.py",

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6808,
+    "total_tests": 6809,
     "total_files": 803,
     "markers_used": 16
   },
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6643,
+    "unit": 6644,
     "asyncio": 411,
     "parametrize": 193,
     "endpoints": 83,
@@ -39953,7 +39953,7 @@
         "class": "TestOrdersStore"
       },
       {
-        "name": "TestOrdersStore::test_reconnect_in_same_generation_keeps_previous_handle_registered",
+        "name": "TestOrdersStore::test_worker_thread_connection_closes_when_thread_exits",
         "line": 66,
         "markers": [
           "unit"
@@ -39962,8 +39962,17 @@
         "class": "TestOrdersStore"
       },
       {
+        "name": "TestOrdersStore::test_reconnect_in_same_generation_keeps_previous_handle_registered",
+        "line": 86,
+        "markers": [
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestOrdersStore"
+      },
+      {
         "name": "TestOrdersStore::test_connection_generation_retry_releases_lock_before_reconnect",
-        "line": 85,
+        "line": 108,
         "markers": [
           "unit"
         ],
@@ -39972,7 +39981,7 @@
       },
       {
         "name": "TestOrdersStore::test_save_and_get_order",
-        "line": 125,
+        "line": 148,
         "markers": [
           "unit"
         ],
@@ -39981,7 +39990,7 @@
       },
       {
         "name": "TestOrdersStore::test_get_order_by_client_order_id",
-        "line": 140,
+        "line": 163,
         "markers": [
           "unit"
         ],
@@ -39990,7 +39999,7 @@
       },
       {
         "name": "TestOrdersStore::test_get_order_not_found",
-        "line": 153,
+        "line": 176,
         "markers": [
           "unit"
         ],
@@ -39999,7 +40008,7 @@
       },
       {
         "name": "TestOrdersStore::test_save_order_upsert",
-        "line": 159,
+        "line": 182,
         "markers": [
           "unit"
         ],
@@ -40008,7 +40017,7 @@
       },
       {
         "name": "TestOrdersStore::test_upsert_by_client_id_updates_order_id",
-        "line": 173,
+        "line": 196,
         "markers": [
           "unit"
         ],
@@ -40017,7 +40026,7 @@
       },
       {
         "name": "TestOrdersStore::test_get_pending_orders",
-        "line": 195,
+        "line": 218,
         "markers": [
           "unit"
         ],
@@ -40026,7 +40035,7 @@
       },
       {
         "name": "TestOrdersStore::test_get_pending_orders_by_bot",
-        "line": 214,
+        "line": 237,
         "markers": [
           "unit"
         ],
@@ -40035,7 +40044,7 @@
       },
       {
         "name": "TestOrdersStore::test_get_orders_by_symbol",
-        "line": 227,
+        "line": 250,
         "markers": [
           "unit"
         ],
@@ -40044,7 +40053,7 @@
       },
       {
         "name": "TestOrdersStore::test_list_orders_filters_and_limit",
-        "line": 240,
+        "line": 263,
         "markers": [
           "unit"
         ],
@@ -40053,7 +40062,7 @@
       },
       {
         "name": "TestOrdersStore::test_list_orders_requires_positive_limit",
-        "line": 280,
+        "line": 303,
         "markers": [
           "unit"
         ],
@@ -40062,7 +40071,7 @@
       },
       {
         "name": "TestOrdersStore::test_update_status",
-        "line": 286,
+        "line": 309,
         "markers": [
           "unit"
         ],
@@ -40071,7 +40080,7 @@
       },
       {
         "name": "TestOrdersStore::test_verify_integrity_valid",
-        "line": 306,
+        "line": 329,
         "markers": [
           "unit"
         ],
@@ -40080,7 +40089,7 @@
       },
       {
         "name": "TestOrdersStore::test_cleanup_old_orders",
-        "line": 317,
+        "line": 340,
         "markers": [
           "unit"
         ],
@@ -40089,7 +40098,7 @@
       },
       {
         "name": "TestOrdersStore::test_context_manager",
-        "line": 327,
+        "line": 350,
         "markers": [
           "unit"
         ],

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6809,
+    "total_tests": 6810,
     "total_files": 803,
     "markers_used": 16
   },
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6644,
+    "unit": 6645,
     "asyncio": 411,
     "parametrize": 193,
     "endpoints": 83,
@@ -39927,7 +39927,7 @@
     "tests/unit/gpt_trader/persistence/test_orders_store.py": [
       {
         "name": "TestOrdersStore::test_initialize_creates_database",
-        "line": 21,
+        "line": 22,
         "markers": [
           "unit"
         ],
@@ -39936,7 +39936,7 @@
       },
       {
         "name": "TestOrdersStore::test_explicit_close_allows_reinitialize_and_reuse",
-        "line": 30,
+        "line": 31,
         "markers": [
           "unit"
         ],
@@ -39945,7 +39945,7 @@
       },
       {
         "name": "TestOrdersStore::test_close_releases_thread_local_connections",
-        "line": 43,
+        "line": 44,
         "markers": [
           "unit"
         ],
@@ -39954,7 +39954,7 @@
       },
       {
         "name": "TestOrdersStore::test_worker_thread_connection_closes_when_thread_exits",
-        "line": 66,
+        "line": 67,
         "markers": [
           "unit"
         ],
@@ -39963,7 +39963,7 @@
       },
       {
         "name": "TestOrdersStore::test_reconnect_in_same_generation_keeps_previous_handle_registered",
-        "line": 86,
+        "line": 87,
         "markers": [
           "unit"
         ],
@@ -39972,7 +39972,16 @@
       },
       {
         "name": "TestOrdersStore::test_connection_generation_retry_releases_lock_before_reconnect",
-        "line": 108,
+        "line": 109,
+        "markers": [
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestOrdersStore"
+      },
+      {
+        "name": "TestOrdersStore::test_closed_holder_after_publish_retries_before_return",
+        "line": 149,
         "markers": [
           "unit"
         ],
@@ -39981,24 +39990,6 @@
       },
       {
         "name": "TestOrdersStore::test_save_and_get_order",
-        "line": 148,
-        "markers": [
-          "unit"
-        ],
-        "docstring": "",
-        "class": "TestOrdersStore"
-      },
-      {
-        "name": "TestOrdersStore::test_get_order_by_client_order_id",
-        "line": 163,
-        "markers": [
-          "unit"
-        ],
-        "docstring": "",
-        "class": "TestOrdersStore"
-      },
-      {
-        "name": "TestOrdersStore::test_get_order_not_found",
         "line": 176,
         "markers": [
           "unit"
@@ -40007,8 +39998,26 @@
         "class": "TestOrdersStore"
       },
       {
+        "name": "TestOrdersStore::test_get_order_by_client_order_id",
+        "line": 191,
+        "markers": [
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestOrdersStore"
+      },
+      {
+        "name": "TestOrdersStore::test_get_order_not_found",
+        "line": 204,
+        "markers": [
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestOrdersStore"
+      },
+      {
         "name": "TestOrdersStore::test_save_order_upsert",
-        "line": 182,
+        "line": 210,
         "markers": [
           "unit"
         ],
@@ -40017,7 +40026,7 @@
       },
       {
         "name": "TestOrdersStore::test_upsert_by_client_id_updates_order_id",
-        "line": 196,
+        "line": 224,
         "markers": [
           "unit"
         ],
@@ -40026,7 +40035,7 @@
       },
       {
         "name": "TestOrdersStore::test_get_pending_orders",
-        "line": 218,
+        "line": 246,
         "markers": [
           "unit"
         ],
@@ -40035,7 +40044,7 @@
       },
       {
         "name": "TestOrdersStore::test_get_pending_orders_by_bot",
-        "line": 237,
+        "line": 265,
         "markers": [
           "unit"
         ],
@@ -40044,7 +40053,7 @@
       },
       {
         "name": "TestOrdersStore::test_get_orders_by_symbol",
-        "line": 250,
+        "line": 278,
         "markers": [
           "unit"
         ],
@@ -40053,7 +40062,7 @@
       },
       {
         "name": "TestOrdersStore::test_list_orders_filters_and_limit",
-        "line": 263,
+        "line": 291,
         "markers": [
           "unit"
         ],
@@ -40062,7 +40071,7 @@
       },
       {
         "name": "TestOrdersStore::test_list_orders_requires_positive_limit",
-        "line": 303,
+        "line": 331,
         "markers": [
           "unit"
         ],
@@ -40071,7 +40080,7 @@
       },
       {
         "name": "TestOrdersStore::test_update_status",
-        "line": 309,
+        "line": 337,
         "markers": [
           "unit"
         ],
@@ -40080,7 +40089,7 @@
       },
       {
         "name": "TestOrdersStore::test_verify_integrity_valid",
-        "line": 329,
+        "line": 357,
         "markers": [
           "unit"
         ],
@@ -40089,7 +40098,7 @@
       },
       {
         "name": "TestOrdersStore::test_cleanup_old_orders",
-        "line": 340,
+        "line": 368,
         "markers": [
           "unit"
         ],
@@ -40098,7 +40107,7 @@
       },
       {
         "name": "TestOrdersStore::test_context_manager",
-        "line": 350,
+        "line": 378,
         "markers": [
           "unit"
         ],

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6807,
+    "total_tests": 6808,
     "total_files": 803,
     "markers_used": 16
   },
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6642,
+    "unit": 6643,
     "asyncio": 411,
     "parametrize": 193,
     "endpoints": 83,
@@ -39953,7 +39953,7 @@
         "class": "TestOrdersStore"
       },
       {
-        "name": "TestOrdersStore::test_connection_generation_retry_releases_lock_before_reconnect",
+        "name": "TestOrdersStore::test_reconnect_in_same_generation_keeps_previous_handle_registered",
         "line": 66,
         "markers": [
           "unit"
@@ -39962,8 +39962,17 @@
         "class": "TestOrdersStore"
       },
       {
+        "name": "TestOrdersStore::test_connection_generation_retry_releases_lock_before_reconnect",
+        "line": 85,
+        "markers": [
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestOrdersStore"
+      },
+      {
         "name": "TestOrdersStore::test_save_and_get_order",
-        "line": 93,
+        "line": 112,
         "markers": [
           "unit"
         ],
@@ -39972,24 +39981,6 @@
       },
       {
         "name": "TestOrdersStore::test_get_order_by_client_order_id",
-        "line": 108,
-        "markers": [
-          "unit"
-        ],
-        "docstring": "",
-        "class": "TestOrdersStore"
-      },
-      {
-        "name": "TestOrdersStore::test_get_order_not_found",
-        "line": 121,
-        "markers": [
-          "unit"
-        ],
-        "docstring": "",
-        "class": "TestOrdersStore"
-      },
-      {
-        "name": "TestOrdersStore::test_save_order_upsert",
         "line": 127,
         "markers": [
           "unit"
@@ -39998,8 +39989,26 @@
         "class": "TestOrdersStore"
       },
       {
+        "name": "TestOrdersStore::test_get_order_not_found",
+        "line": 140,
+        "markers": [
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestOrdersStore"
+      },
+      {
+        "name": "TestOrdersStore::test_save_order_upsert",
+        "line": 146,
+        "markers": [
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestOrdersStore"
+      },
+      {
         "name": "TestOrdersStore::test_upsert_by_client_id_updates_order_id",
-        "line": 141,
+        "line": 160,
         "markers": [
           "unit"
         ],
@@ -40008,15 +40017,6 @@
       },
       {
         "name": "TestOrdersStore::test_get_pending_orders",
-        "line": 163,
-        "markers": [
-          "unit"
-        ],
-        "docstring": "",
-        "class": "TestOrdersStore"
-      },
-      {
-        "name": "TestOrdersStore::test_get_pending_orders_by_bot",
         "line": 182,
         "markers": [
           "unit"
@@ -40025,8 +40025,17 @@
         "class": "TestOrdersStore"
       },
       {
+        "name": "TestOrdersStore::test_get_pending_orders_by_bot",
+        "line": 201,
+        "markers": [
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestOrdersStore"
+      },
+      {
         "name": "TestOrdersStore::test_get_orders_by_symbol",
-        "line": 195,
+        "line": 214,
         "markers": [
           "unit"
         ],
@@ -40035,7 +40044,7 @@
       },
       {
         "name": "TestOrdersStore::test_list_orders_filters_and_limit",
-        "line": 208,
+        "line": 227,
         "markers": [
           "unit"
         ],
@@ -40044,7 +40053,7 @@
       },
       {
         "name": "TestOrdersStore::test_list_orders_requires_positive_limit",
-        "line": 248,
+        "line": 267,
         "markers": [
           "unit"
         ],
@@ -40053,7 +40062,7 @@
       },
       {
         "name": "TestOrdersStore::test_update_status",
-        "line": 254,
+        "line": 273,
         "markers": [
           "unit"
         ],
@@ -40062,7 +40071,7 @@
       },
       {
         "name": "TestOrdersStore::test_verify_integrity_valid",
-        "line": 274,
+        "line": 293,
         "markers": [
           "unit"
         ],
@@ -40071,7 +40080,7 @@
       },
       {
         "name": "TestOrdersStore::test_cleanup_old_orders",
-        "line": 285,
+        "line": 304,
         "markers": [
           "unit"
         ],
@@ -40080,7 +40089,7 @@
       },
       {
         "name": "TestOrdersStore::test_context_manager",
-        "line": 295,
+        "line": 314,
         "markers": [
           "unit"
         ],

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -39972,7 +39972,7 @@
       },
       {
         "name": "TestOrdersStore::test_save_and_get_order",
-        "line": 112,
+        "line": 125,
         "markers": [
           "unit"
         ],
@@ -39981,15 +39981,6 @@
       },
       {
         "name": "TestOrdersStore::test_get_order_by_client_order_id",
-        "line": 127,
-        "markers": [
-          "unit"
-        ],
-        "docstring": "",
-        "class": "TestOrdersStore"
-      },
-      {
-        "name": "TestOrdersStore::test_get_order_not_found",
         "line": 140,
         "markers": [
           "unit"
@@ -39998,8 +39989,17 @@
         "class": "TestOrdersStore"
       },
       {
+        "name": "TestOrdersStore::test_get_order_not_found",
+        "line": 153,
+        "markers": [
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestOrdersStore"
+      },
+      {
         "name": "TestOrdersStore::test_save_order_upsert",
-        "line": 146,
+        "line": 159,
         "markers": [
           "unit"
         ],
@@ -40008,7 +40008,7 @@
       },
       {
         "name": "TestOrdersStore::test_upsert_by_client_id_updates_order_id",
-        "line": 160,
+        "line": 173,
         "markers": [
           "unit"
         ],
@@ -40017,7 +40017,7 @@
       },
       {
         "name": "TestOrdersStore::test_get_pending_orders",
-        "line": 182,
+        "line": 195,
         "markers": [
           "unit"
         ],
@@ -40026,15 +40026,6 @@
       },
       {
         "name": "TestOrdersStore::test_get_pending_orders_by_bot",
-        "line": 201,
-        "markers": [
-          "unit"
-        ],
-        "docstring": "",
-        "class": "TestOrdersStore"
-      },
-      {
-        "name": "TestOrdersStore::test_get_orders_by_symbol",
         "line": 214,
         "markers": [
           "unit"
@@ -40043,7 +40034,7 @@
         "class": "TestOrdersStore"
       },
       {
-        "name": "TestOrdersStore::test_list_orders_filters_and_limit",
+        "name": "TestOrdersStore::test_get_orders_by_symbol",
         "line": 227,
         "markers": [
           "unit"
@@ -40052,8 +40043,17 @@
         "class": "TestOrdersStore"
       },
       {
+        "name": "TestOrdersStore::test_list_orders_filters_and_limit",
+        "line": 240,
+        "markers": [
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestOrdersStore"
+      },
+      {
         "name": "TestOrdersStore::test_list_orders_requires_positive_limit",
-        "line": 267,
+        "line": 280,
         "markers": [
           "unit"
         ],
@@ -40062,7 +40062,7 @@
       },
       {
         "name": "TestOrdersStore::test_update_status",
-        "line": 273,
+        "line": 286,
         "markers": [
           "unit"
         ],
@@ -40071,7 +40071,7 @@
       },
       {
         "name": "TestOrdersStore::test_verify_integrity_valid",
-        "line": 293,
+        "line": 306,
         "markers": [
           "unit"
         ],
@@ -40080,7 +40080,7 @@
       },
       {
         "name": "TestOrdersStore::test_cleanup_old_orders",
-        "line": 304,
+        "line": 317,
         "markers": [
           "unit"
         ],
@@ -40089,7 +40089,7 @@
       },
       {
         "name": "TestOrdersStore::test_context_manager",
-        "line": 314,
+        "line": 327,
         "markers": [
           "unit"
         ],

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6806,
+    "total_tests": 6807,
     "total_files": 803,
     "markers_used": 16
   },
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6641,
+    "unit": 6642,
     "asyncio": 411,
     "parametrize": 193,
     "endpoints": 83,
@@ -39953,7 +39953,7 @@
         "class": "TestOrdersStore"
       },
       {
-        "name": "TestOrdersStore::test_save_and_get_order",
+        "name": "TestOrdersStore::test_connection_generation_retry_releases_lock_before_reconnect",
         "line": 66,
         "markers": [
           "unit"
@@ -39962,8 +39962,17 @@
         "class": "TestOrdersStore"
       },
       {
+        "name": "TestOrdersStore::test_save_and_get_order",
+        "line": 93,
+        "markers": [
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestOrdersStore"
+      },
+      {
         "name": "TestOrdersStore::test_get_order_by_client_order_id",
-        "line": 81,
+        "line": 108,
         "markers": [
           "unit"
         ],
@@ -39972,7 +39981,7 @@
       },
       {
         "name": "TestOrdersStore::test_get_order_not_found",
-        "line": 94,
+        "line": 121,
         "markers": [
           "unit"
         ],
@@ -39981,7 +39990,7 @@
       },
       {
         "name": "TestOrdersStore::test_save_order_upsert",
-        "line": 100,
+        "line": 127,
         "markers": [
           "unit"
         ],
@@ -39990,7 +39999,7 @@
       },
       {
         "name": "TestOrdersStore::test_upsert_by_client_id_updates_order_id",
-        "line": 114,
+        "line": 141,
         "markers": [
           "unit"
         ],
@@ -39999,7 +40008,7 @@
       },
       {
         "name": "TestOrdersStore::test_get_pending_orders",
-        "line": 136,
+        "line": 163,
         "markers": [
           "unit"
         ],
@@ -40008,7 +40017,7 @@
       },
       {
         "name": "TestOrdersStore::test_get_pending_orders_by_bot",
-        "line": 155,
+        "line": 182,
         "markers": [
           "unit"
         ],
@@ -40017,7 +40026,7 @@
       },
       {
         "name": "TestOrdersStore::test_get_orders_by_symbol",
-        "line": 168,
+        "line": 195,
         "markers": [
           "unit"
         ],
@@ -40026,7 +40035,7 @@
       },
       {
         "name": "TestOrdersStore::test_list_orders_filters_and_limit",
-        "line": 181,
+        "line": 208,
         "markers": [
           "unit"
         ],
@@ -40035,7 +40044,7 @@
       },
       {
         "name": "TestOrdersStore::test_list_orders_requires_positive_limit",
-        "line": 221,
+        "line": 248,
         "markers": [
           "unit"
         ],
@@ -40044,7 +40053,7 @@
       },
       {
         "name": "TestOrdersStore::test_update_status",
-        "line": 227,
+        "line": 254,
         "markers": [
           "unit"
         ],
@@ -40053,7 +40062,7 @@
       },
       {
         "name": "TestOrdersStore::test_verify_integrity_valid",
-        "line": 247,
+        "line": 274,
         "markers": [
           "unit"
         ],
@@ -40062,7 +40071,7 @@
       },
       {
         "name": "TestOrdersStore::test_cleanup_old_orders",
-        "line": 258,
+        "line": 285,
         "markers": [
           "unit"
         ],
@@ -40071,7 +40080,7 @@
       },
       {
         "name": "TestOrdersStore::test_context_manager",
-        "line": 268,
+        "line": 295,
         "markers": [
           "unit"
         ],

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6804,
+    "total_tests": 6806,
     "total_files": 803,
     "markers_used": 16
   },
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6639,
+    "unit": 6641,
     "asyncio": 411,
     "parametrize": 193,
     "endpoints": 83,
@@ -39927,7 +39927,25 @@
     "tests/unit/gpt_trader/persistence/test_orders_store.py": [
       {
         "name": "TestOrdersStore::test_initialize_creates_database",
-        "line": 19,
+        "line": 21,
+        "markers": [
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestOrdersStore"
+      },
+      {
+        "name": "TestOrdersStore::test_explicit_close_allows_reinitialize_and_reuse",
+        "line": 30,
+        "markers": [
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestOrdersStore"
+      },
+      {
+        "name": "TestOrdersStore::test_close_releases_thread_local_connections",
+        "line": 43,
         "markers": [
           "unit"
         ],
@@ -39936,7 +39954,7 @@
       },
       {
         "name": "TestOrdersStore::test_save_and_get_order",
-        "line": 27,
+        "line": 66,
         "markers": [
           "unit"
         ],
@@ -39945,7 +39963,7 @@
       },
       {
         "name": "TestOrdersStore::test_get_order_by_client_order_id",
-        "line": 42,
+        "line": 81,
         "markers": [
           "unit"
         ],
@@ -39954,7 +39972,7 @@
       },
       {
         "name": "TestOrdersStore::test_get_order_not_found",
-        "line": 55,
+        "line": 94,
         "markers": [
           "unit"
         ],
@@ -39963,7 +39981,7 @@
       },
       {
         "name": "TestOrdersStore::test_save_order_upsert",
-        "line": 61,
+        "line": 100,
         "markers": [
           "unit"
         ],
@@ -39972,7 +39990,7 @@
       },
       {
         "name": "TestOrdersStore::test_upsert_by_client_id_updates_order_id",
-        "line": 75,
+        "line": 114,
         "markers": [
           "unit"
         ],
@@ -39981,7 +39999,7 @@
       },
       {
         "name": "TestOrdersStore::test_get_pending_orders",
-        "line": 97,
+        "line": 136,
         "markers": [
           "unit"
         ],
@@ -39990,7 +40008,7 @@
       },
       {
         "name": "TestOrdersStore::test_get_pending_orders_by_bot",
-        "line": 116,
+        "line": 155,
         "markers": [
           "unit"
         ],
@@ -39999,7 +40017,7 @@
       },
       {
         "name": "TestOrdersStore::test_get_orders_by_symbol",
-        "line": 129,
+        "line": 168,
         "markers": [
           "unit"
         ],
@@ -40008,7 +40026,7 @@
       },
       {
         "name": "TestOrdersStore::test_list_orders_filters_and_limit",
-        "line": 142,
+        "line": 181,
         "markers": [
           "unit"
         ],
@@ -40017,7 +40035,7 @@
       },
       {
         "name": "TestOrdersStore::test_list_orders_requires_positive_limit",
-        "line": 182,
+        "line": 221,
         "markers": [
           "unit"
         ],
@@ -40026,7 +40044,7 @@
       },
       {
         "name": "TestOrdersStore::test_update_status",
-        "line": 188,
+        "line": 227,
         "markers": [
           "unit"
         ],
@@ -40035,7 +40053,7 @@
       },
       {
         "name": "TestOrdersStore::test_verify_integrity_valid",
-        "line": 208,
+        "line": 247,
         "markers": [
           "unit"
         ],
@@ -40044,7 +40062,7 @@
       },
       {
         "name": "TestOrdersStore::test_cleanup_old_orders",
-        "line": 219,
+        "line": 258,
         "markers": [
           "unit"
         ],
@@ -40053,7 +40071,7 @@
       },
       {
         "name": "TestOrdersStore::test_context_manager",
-        "line": 229,
+        "line": 268,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
Closes #951

## Summary
- close every SQLite connection created by an `OrdersStore`, across thread-local handles
- reset store initialization on close so explicit-close usage can reinitialize safely
- add regression coverage for explicit close/reuse and worker-thread connection release

## Affected paths
- `src/gpt_trader/persistence/orders_store.py`
- `tests/unit/gpt_trader/persistence/test_orders_store.py`
- `var/agents/testing/index.json`
- `var/agents/testing/markers.json`
- `var/agents/testing/test_inventory.json`

## Verification
- `uv run pytest tests/unit/gpt_trader/persistence/test_orders_store.py -q` - 17 passed
- `uv run mypy src/gpt_trader/persistence/orders_store.py` - passed
- `uv run agent-regenerate --verify` - passed
- `git diff --check` - passed
- `uv run local-ci --profile quick` - passed, 7070 passed and 8 skipped

## Notes
- This is a persistence lifecycle change only. It does not run or enable broker/API calls, live trading commands, production preflight, canary operations, or order submission.
- The first local-CI attempt exposed a mypy typing issue in `_get_connection`; the branch includes the fix and the final quick local CI passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of order persistence by strengthening SQLite connection reuse across threads, handling stale cached connections, and ensuring robust behavior after shutdown.
  * Store shutdown now fully terminates tracked connections, invalidates cached thread-local connections, and safely performs WAL checkpoint/truncation.
* **Tests**
  * Added/expanded unit tests for re-initialization after close, multi-thread connection lifecycle, reconnection after forced close during connect, and proper shutdown behavior when worker threads exit.
  * Updated test inventory and marker counts to reflect the added coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->