### PR TITLE
[codex] Use atomic replace for durability writes

### DIFF
--- a/src/gpt_trader/persistence/durability.py
+++ b/src/gpt_trader/persistence/durability.py
@@ -248,8 +248,8 @@ def atomic_write_file(path: Path, content: bytes | str, *, fsync: bool = True) -
                     f.flush()
                     os.fsync(f.fileno())
 
-            # Atomic rename
-            os.rename(temp_path, path)
+            # Atomic replacement; unlike os.rename, this overwrites on Windows.
+            os.replace(temp_path, path)
 
             # Fsync directory to persist the rename
             if fsync:

--- a/tests/unit/gpt_trader/persistence/test_durability.py
+++ b/tests/unit/gpt_trader/persistence/test_durability.py
@@ -9,6 +9,7 @@ from tempfile import TemporaryDirectory
 
 import pytest
 
+import gpt_trader.persistence.durability as durability
 from gpt_trader.persistence.durability import (
     CorruptionError,
     WriteResult,
@@ -102,6 +103,33 @@ class TestAtomicFileWrite:
 
             atomic_write_file(path, "updated")
             assert path.read_text() == "updated"
+
+    def test_atomic_write_file_overwrite_uses_replace(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        replace_calls: list[tuple[Path, Path]] = []
+        original_replace = durability.os.replace
+
+        def replace_spy(src: str | Path, dst: str | Path) -> None:
+            replace_calls.append((Path(src), Path(dst)))
+            original_replace(src, dst)
+
+        def rename_disallowed(src: str | Path, dst: str | Path) -> None:
+            raise AssertionError(f"unexpected os.rename call: {src} -> {dst}")
+
+        monkeypatch.setattr(durability.os, "replace", replace_spy)
+        monkeypatch.setattr(durability.os, "rename", rename_disallowed)
+
+        with TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "test.txt"
+            path.write_text("original")
+
+            atomic_write_file(path, "updated")
+
+            assert path.read_text() == "updated"
+            assert replace_calls
+            assert replace_calls[0][1] == path
+            assert not list(path.parent.glob(f".{path.name}.*.tmp"))
 
     def test_atomic_write_json(self) -> None:
         with TemporaryDirectory() as tmpdir:

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6810,
+    "total_tests": 6811,
     "total_files": 803,
     "markers_used": 16
   },

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6645,
+    "unit": 6646,
     "asyncio": 411,
     "parametrize": 193,
     "endpoints": 83,

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6810,
+    "total_tests": 6811,
     "total_files": 803,
     "markers_used": 16
   },
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6645,
+    "unit": 6646,
     "asyncio": 411,
     "parametrize": 193,
     "endpoints": 83,
@@ -39525,7 +39525,7 @@
     "tests/unit/gpt_trader/persistence/test_durability.py": [
       {
         "name": "TestWriteResult::test_ok_result",
-        "line": 27,
+        "line": 28,
         "markers": [
           "unit"
         ],
@@ -39534,7 +39534,7 @@
       },
       {
         "name": "TestWriteResult::test_fail_result",
-        "line": 34,
+        "line": 35,
         "markers": [
           "unit"
         ],
@@ -39543,7 +39543,7 @@
       },
       {
         "name": "TestChecksum::test_compute_checksum_bytes",
-        "line": 44,
+        "line": 45,
         "markers": [
           "unit"
         ],
@@ -39552,7 +39552,7 @@
       },
       {
         "name": "TestChecksum::test_compute_checksum_string",
-        "line": 49,
+        "line": 50,
         "markers": [
           "unit"
         ],
@@ -39561,7 +39561,7 @@
       },
       {
         "name": "TestChecksum::test_compute_checksum_dict",
-        "line": 53,
+        "line": 54,
         "markers": [
           "unit"
         ],
@@ -39570,7 +39570,7 @@
       },
       {
         "name": "TestChecksum::test_verify_checksum_valid",
-        "line": 62,
+        "line": 63,
         "markers": [
           "unit"
         ],
@@ -39579,7 +39579,7 @@
       },
       {
         "name": "TestChecksum::test_verify_checksum_invalid",
-        "line": 67,
+        "line": 68,
         "markers": [
           "unit"
         ],
@@ -39588,7 +39588,7 @@
       },
       {
         "name": "TestAtomicFileWrite::test_atomic_write_file_bytes",
-        "line": 75,
+        "line": 76,
         "markers": [
           "unit"
         ],
@@ -39597,7 +39597,7 @@
       },
       {
         "name": "TestAtomicFileWrite::test_atomic_write_file_string",
-        "line": 83,
+        "line": 84,
         "markers": [
           "unit"
         ],
@@ -39606,7 +39606,7 @@
       },
       {
         "name": "TestAtomicFileWrite::test_atomic_write_file_creates_directories",
-        "line": 91,
+        "line": 92,
         "markers": [
           "unit"
         ],
@@ -39615,7 +39615,16 @@
       },
       {
         "name": "TestAtomicFileWrite::test_atomic_write_file_overwrites",
-        "line": 98,
+        "line": 99,
+        "markers": [
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestAtomicFileWrite"
+      },
+      {
+        "name": "TestAtomicFileWrite::test_atomic_write_file_overwrite_uses_replace",
+        "line": 107,
         "markers": [
           "unit"
         ],
@@ -39624,7 +39633,7 @@
       },
       {
         "name": "TestAtomicFileWrite::test_atomic_write_json",
-        "line": 106,
+        "line": 134,
         "markers": [
           "unit"
         ],
@@ -39633,7 +39642,7 @@
       },
       {
         "name": "TestAtomicFileWrite::test_atomic_write_json_with_checksum",
-        "line": 117,
+        "line": 145,
         "markers": [
           "unit"
         ],
@@ -39642,7 +39651,7 @@
       },
       {
         "name": "TestReadJsonWithChecksum::test_read_valid_json_with_checksum",
-        "line": 134,
+        "line": 162,
         "markers": [
           "unit"
         ],
@@ -39651,24 +39660,6 @@
       },
       {
         "name": "TestReadJsonWithChecksum::test_read_json_without_checksum",
-        "line": 145,
-        "markers": [
-          "unit"
-        ],
-        "docstring": "",
-        "class": "TestReadJsonWithChecksum"
-      },
-      {
-        "name": "TestReadJsonWithChecksum::test_read_corrupted_json_detects_mismatch",
-        "line": 156,
-        "markers": [
-          "unit"
-        ],
-        "docstring": "",
-        "class": "TestReadJsonWithChecksum"
-      },
-      {
-        "name": "TestReadJsonWithChecksum::test_read_invalid_json_raises_error",
         "line": 173,
         "markers": [
           "unit"
@@ -39677,8 +39668,26 @@
         "class": "TestReadJsonWithChecksum"
       },
       {
+        "name": "TestReadJsonWithChecksum::test_read_corrupted_json_detects_mismatch",
+        "line": 184,
+        "markers": [
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestReadJsonWithChecksum"
+      },
+      {
+        "name": "TestReadJsonWithChecksum::test_read_invalid_json_raises_error",
+        "line": 201,
+        "markers": [
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestReadJsonWithChecksum"
+      },
+      {
         "name": "TestSqliteIntegrity::test_check_integrity_valid_database",
-        "line": 185,
+        "line": 213,
         "markers": [
           "unit"
         ],
@@ -39687,7 +39696,7 @@
       },
       {
         "name": "TestSqliteIntegrity::test_check_integrity_nonexistent_database",
-        "line": 198,
+        "line": 226,
         "markers": [
           "unit"
         ],
@@ -39696,7 +39705,7 @@
       },
       {
         "name": "TestSqliteIntegrity::test_check_integrity_corrupted_file",
-        "line": 207,
+        "line": 235,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
Closes #950

## Summary
- replace the durability overwrite swap from `os.rename` to `os.replace`
- add a focused regression that fails if the overwrite path uses `os.rename`
- refresh generated testing metadata after the new test

## Affected paths
- `src/gpt_trader/persistence/durability.py`
- `tests/unit/gpt_trader/persistence/test_durability.py`
- `var/agents/testing/index.json`
- `var/agents/testing/markers.json`
- `var/agents/testing/test_inventory.json`

## Verification
- `uv run pytest tests/unit/gpt_trader/persistence/test_durability.py::TestAtomicFileWrite::test_atomic_write_file_overwrites -q` passed
- `uv run pytest tests/unit/gpt_trader/persistence/test_durability.py::TestAtomicFileWrite::test_atomic_write_file_overwrite_uses_replace -q` passed
- `uv run pytest tests/unit/gpt_trader/persistence/test_durability.py -q` passed: 21 tests
- `uv run agent-regenerate --verify` passed after refreshing generated testing metadata
- `uv run local-ci --profile quick` passed: 7075 passed, 8 skipped
- `git diff --check` passed

## Guardrails
- No live broker/API checks, live trading commands, production preflight, canary operations, or order submission were run.
- The related Windows directory fsync issue remains out of scope for this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file overwrite behavior during atomic saves, making writes more reliable across platforms, including Windows.
  * Reduced the chance of leftover temporary files after a save completes.

* **Tests**
  * Updated automated coverage to verify overwrite behavior and confirm temporary files are cleaned up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->