### PR TITLE
[codex] Make durability directory fsync portable

### DIFF
--- a/src/gpt_trader/persistence/durability.py
+++ b/src/gpt_trader/persistence/durability.py
@@ -213,12 +213,32 @@ def verify_checksum(data: bytes | str | dict[str, Any], expected: str) -> bool:
     return actual == expected
 
 
+def _fsync_parent_directory(path: Path) -> None:
+    directory_flag = getattr(os, "O_DIRECTORY", None)
+    if directory_flag is None:
+        logger.debug("Skipping directory fsync because O_DIRECTORY is unavailable")
+        return
+
+    try:
+        dir_fd = os.open(path.parent, os.O_RDONLY | directory_flag)
+    except OSError as e:
+        logger.debug("Skipping directory fsync for %s: %s", path.parent, e)
+        return
+
+    try:
+        os.fsync(dir_fd)
+    except OSError as e:
+        logger.debug("Directory fsync failed for %s: %s", path.parent, e)
+    finally:
+        os.close(dir_fd)
+
+
 def atomic_write_file(path: Path, content: bytes | str, *, fsync: bool = True) -> None:
     """
-    Write file atomically using write-rename pattern.
+    Write file atomically using a write-replace pattern.
 
     Creates a temporary file in the same directory, writes content,
-    optionally fsyncs, then atomically renames to target path.
+    optionally fsyncs, then atomically replaces the target path.
 
     Args:
         path: Target file path
@@ -235,7 +255,7 @@ def atomic_write_file(path: Path, content: bytes | str, *, fsync: bool = True) -
     encoding = None if isinstance(content, bytes) else "utf-8"
 
     try:
-        # Create temp file in same directory for atomic rename
+        # Create temp file in same directory for atomic replacement
         fd, temp_path = tempfile.mkstemp(
             dir=path.parent,
             prefix=f".{path.name}.",
@@ -251,13 +271,9 @@ def atomic_write_file(path: Path, content: bytes | str, *, fsync: bool = True) -
             # Atomic replacement; unlike os.rename, this overwrites on Windows.
             os.replace(temp_path, path)
 
-            # Fsync directory to persist the rename
+            # Fsync directory to persist the replacement when supported.
             if fsync:
-                dir_fd = os.open(path.parent, os.O_RDONLY | os.O_DIRECTORY)
-                try:
-                    os.fsync(dir_fd)
-                finally:
-                    os.close(dir_fd)
+                _fsync_parent_directory(path)
 
         except Exception:
             # Clean up temp file on error

--- a/tests/unit/gpt_trader/persistence/test_durability.py
+++ b/tests/unit/gpt_trader/persistence/test_durability.py
@@ -131,6 +131,28 @@ class TestAtomicFileWrite:
             assert replace_calls[0][1] == path
             assert not list(path.parent.glob(f".{path.name}.*.tmp"))
 
+    def test_atomic_write_file_skips_directory_fsync_without_o_directory(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        open_calls: list[tuple[Path, int]] = []
+        original_open = durability.os.open
+
+        def open_spy(path: str | Path, flags: int, *args: object, **kwargs: object) -> int:
+            open_calls.append((Path(path), flags))
+            return original_open(path, flags, *args, **kwargs)
+
+        monkeypatch.delattr(durability.os, "O_DIRECTORY", raising=False)
+        monkeypatch.setattr(durability.os, "open", open_spy)
+
+        with TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "test.txt"
+
+            atomic_write_file(path, "content")
+
+            assert path.read_text() == "content"
+            assert path.parent not in {opened_path for opened_path, _ in open_calls}
+            assert not list(path.parent.glob(f".{path.name}.*.tmp"))
+
     def test_atomic_write_json(self) -> None:
         with TemporaryDirectory() as tmpdir:
             path = Path(tmpdir) / "test.json"

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6811,
+    "total_tests": 6812,
     "total_files": 803,
     "markers_used": 16
   },

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6646,
+    "unit": 6647,
     "asyncio": 411,
     "parametrize": 193,
     "endpoints": 83,

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6811,
+    "total_tests": 6812,
     "total_files": 803,
     "markers_used": 16
   },
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6646,
+    "unit": 6647,
     "asyncio": 411,
     "parametrize": 193,
     "endpoints": 83,
@@ -39632,7 +39632,7 @@
         "class": "TestAtomicFileWrite"
       },
       {
-        "name": "TestAtomicFileWrite::test_atomic_write_json",
+        "name": "TestAtomicFileWrite::test_atomic_write_file_skips_directory_fsync_without_o_directory",
         "line": 134,
         "markers": [
           "unit"
@@ -39641,8 +39641,17 @@
         "class": "TestAtomicFileWrite"
       },
       {
+        "name": "TestAtomicFileWrite::test_atomic_write_json",
+        "line": 156,
+        "markers": [
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestAtomicFileWrite"
+      },
+      {
         "name": "TestAtomicFileWrite::test_atomic_write_json_with_checksum",
-        "line": 145,
+        "line": 167,
         "markers": [
           "unit"
         ],
@@ -39651,24 +39660,6 @@
       },
       {
         "name": "TestReadJsonWithChecksum::test_read_valid_json_with_checksum",
-        "line": 162,
-        "markers": [
-          "unit"
-        ],
-        "docstring": "",
-        "class": "TestReadJsonWithChecksum"
-      },
-      {
-        "name": "TestReadJsonWithChecksum::test_read_json_without_checksum",
-        "line": 173,
-        "markers": [
-          "unit"
-        ],
-        "docstring": "",
-        "class": "TestReadJsonWithChecksum"
-      },
-      {
-        "name": "TestReadJsonWithChecksum::test_read_corrupted_json_detects_mismatch",
         "line": 184,
         "markers": [
           "unit"
@@ -39677,8 +39668,26 @@
         "class": "TestReadJsonWithChecksum"
       },
       {
+        "name": "TestReadJsonWithChecksum::test_read_json_without_checksum",
+        "line": 195,
+        "markers": [
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestReadJsonWithChecksum"
+      },
+      {
+        "name": "TestReadJsonWithChecksum::test_read_corrupted_json_detects_mismatch",
+        "line": 206,
+        "markers": [
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestReadJsonWithChecksum"
+      },
+      {
         "name": "TestReadJsonWithChecksum::test_read_invalid_json_raises_error",
-        "line": 201,
+        "line": 223,
         "markers": [
           "unit"
         ],
@@ -39687,7 +39696,7 @@
       },
       {
         "name": "TestSqliteIntegrity::test_check_integrity_valid_database",
-        "line": 213,
+        "line": 235,
         "markers": [
           "unit"
         ],
@@ -39696,7 +39705,7 @@
       },
       {
         "name": "TestSqliteIntegrity::test_check_integrity_nonexistent_database",
-        "line": 226,
+        "line": 248,
         "markers": [
           "unit"
         ],
@@ -39705,7 +39714,7 @@
       },
       {
         "name": "TestSqliteIntegrity::test_check_integrity_corrupted_file",
-        "line": 235,
+        "line": 257,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
Closes #949

## Summary
- split parent-directory fsync into a best-effort helper
- skip directory fsync when `os.O_DIRECTORY` is unavailable, preserving file fsync and atomic replacement
- add a regression test that simulates the missing `O_DIRECTORY` platform path
- refresh generated testing metadata after the new test

## Affected paths
- `src/gpt_trader/persistence/durability.py`
- `tests/unit/gpt_trader/persistence/test_durability.py`
- `var/agents/testing/index.json`
- `var/agents/testing/markers.json`
- `var/agents/testing/test_inventory.json`

## Verification
- `uv run pytest tests/unit/gpt_trader/persistence/test_durability.py::TestAtomicFileWrite::test_atomic_write_file_skips_directory_fsync_without_o_directory -q` passed
- `uv run pytest tests/unit/gpt_trader/persistence/test_durability.py -q` passed: 22 tests
- `uv run agent-regenerate --verify` passed after refreshing generated testing metadata
- `uv run local-ci --profile quick` passed: 7076 passed, 8 skipped
- `git diff --check` passed

## Guardrails
- No live broker/API checks, live trading commands, production preflight, canary operations, or order submission were run.
- This keeps the Windows fallback explicit: file fsync remains strict, while parent-directory fsync is best-effort where the OS exposes directory handles.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file-writing reliability by better handling directory syncing during atomic saves, including on systems without directory sync support.
  * Ensured temporary files are cleaned up after atomic write operations.

* **Tests**
  * Added coverage for atomic writes when directory syncing isn’t available.
  * Updated test metadata and inventory counts to reflect the latest test changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->