### PR TITLE
[codex] Prevent ephemeral-key secret file writes

### DIFF
--- a/src/gpt_trader/security/secrets_manager.py
+++ b/src/gpt_trader/security/secrets_manager.py
@@ -68,6 +68,7 @@ class SecretsManager:
     ) -> None:
         self._lock = threading.RLock()
         self._cipher_suite: FernetType | None = None
+        self._encryption_key_is_ephemeral = False
         self._secrets_cache: dict[str, dict[str, Any]] = {}
         self._vault_client: Any | None = None
         self._vault_enabled = vault_enabled
@@ -90,6 +91,7 @@ class SecretsManager:
             if environment == "development":
                 fernet_cls = _require_fernet()
                 encryption_key = fernet_cls.generate_key().decode()
+                self._encryption_key_is_ephemeral = True
                 logger.warning(
                     "Generated new encryption key for development",
                     operation="encryption_init",
@@ -124,6 +126,13 @@ class SecretsManager:
         if self._cipher_suite is None:
             raise RuntimeError("Encryption subsystem not initialised")
         return self._cipher_suite
+
+    def _require_durable_file_key(self) -> None:
+        if self._encryption_key_is_ephemeral:
+            raise RuntimeError(
+                "File-backed secret storage requires GPT_TRADER_ENCRYPTION_KEY; "
+                "development-generated encryption keys are ephemeral and cache-only."
+            )
 
     @staticmethod
     def _as_secret_dict(payload: Any) -> dict[str, Any] | None:
@@ -282,6 +291,7 @@ class SecretsManager:
 
     def _store_to_file(self, path: str, secret: dict[str, Any]) -> None:
         """Store secret to encrypted file"""
+        self._require_durable_file_key()
         secrets_dir = self._secrets_dir
         logger.debug(f"Using secrets directory: {secrets_dir}")
         secrets_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/unit/gpt_trader/security/secrets_manager/test_file_basic.py
+++ b/tests/unit/gpt_trader/security/secrets_manager/test_file_basic.py
@@ -34,6 +34,45 @@ class TestFileBasics:
         assert len(encrypted_data) > 0
         assert encrypted_data != json.dumps(secret_data).encode()
 
+    def test_ephemeral_development_key_rejects_file_storage_across_instances(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        patched_require_fernet: None,
+        secrets_bot_config: BotConfig,
+        secrets_dir: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        from gpt_trader.security.secrets_manager import SecretsManager
+
+        monkeypatch.setenv("ENV", "development")
+        monkeypatch.delenv("GPT_TRADER_ENCRYPTION_KEY", raising=False)
+
+        secret_path = "brokers/coinbase"
+        secret_data = {"api_key": "dummy-api-key"}
+
+        first_manager = SecretsManager(
+            vault_enabled=False,
+            config=secrets_bot_config,
+            secrets_dir=secrets_dir,
+        )
+        with caplog.at_level("ERROR"):
+            assert first_manager.store_secret(secret_path, secret_data) is False
+
+        expected_file = secrets_dir / "brokers_coinbase.enc"
+        assert not expected_file.exists()
+        assert any(
+            "File-backed secret storage requires GPT_TRADER_ENCRYPTION_KEY" in message
+            for message in caplog.messages
+        )
+        assert "dummy-api-key" not in caplog.text
+
+        second_manager = SecretsManager(
+            vault_enabled=False,
+            config=secrets_bot_config,
+            secrets_dir=secrets_dir,
+        )
+        assert second_manager.get_secret(secret_path) is None
+
     def test_file_retrieve_success(
         self, secrets_manager_with_fallback: Any, sample_secrets: dict[str, dict[str, Any]]
     ) -> None:

--- a/var/agents/configuration/environment_variables.json
+++ b/var/agents/configuration/environment_variables.json
@@ -761,7 +761,7 @@
       ],
       "code_references": [
         {
-          "line": 89,
+          "line": 90,
           "path": "src/gpt_trader/security/secrets_manager.py",
           "reader": "os.getenv"
         }
@@ -1027,7 +1027,7 @@
       ],
       "code_references": [
         {
-          "line": 85,
+          "line": 86,
           "path": "src/gpt_trader/security/secrets_manager.py",
           "reader": "os.getenv"
         }
@@ -3227,7 +3227,7 @@
       ],
       "code_references": [
         {
-          "line": 141,
+          "line": 150,
           "path": "src/gpt_trader/security/secrets_manager.py",
           "reader": "os.getenv"
         }
@@ -3250,7 +3250,7 @@
       ],
       "code_references": [
         {
-          "line": 142,
+          "line": 151,
           "path": "src/gpt_trader/security/secrets_manager.py",
           "reader": "os.getenv"
         }

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6812,
+    "total_tests": 6813,
     "total_files": 803,
     "markers_used": 16
   },

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6647,
+    "unit": 6648,
     "asyncio": 411,
     "parametrize": 193,
     "endpoints": 83,

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6812,
+    "total_tests": 6813,
     "total_files": 803,
     "markers_used": 16
   },
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6647,
+    "unit": 6648,
     "asyncio": 411,
     "parametrize": 193,
     "endpoints": 83,
@@ -43008,7 +43008,7 @@
         "class": "TestFileBasics"
       },
       {
-        "name": "TestFileBasics::test_file_retrieve_success",
+        "name": "TestFileBasics::test_ephemeral_development_key_rejects_file_storage_across_instances",
         "line": 37,
         "markers": [
           "unit"
@@ -43017,8 +43017,17 @@
         "class": "TestFileBasics"
       },
       {
+        "name": "TestFileBasics::test_file_retrieve_success",
+        "line": 76,
+        "markers": [
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestFileBasics"
+      },
+      {
         "name": "TestFileBasics::test_file_delete_success",
-        "line": 48,
+        "line": 87,
         "markers": [
           "unit"
         ],
@@ -43027,7 +43036,7 @@
       },
       {
         "name": "TestFileBasics::test_file_list_success",
-        "line": 65,
+        "line": 104,
         "markers": [
           "unit"
         ],
@@ -43036,7 +43045,7 @@
       },
       {
         "name": "TestFileBasics::test_file_retrieve_missing_secret",
-        "line": 81,
+        "line": 120,
         "markers": [
           "unit"
         ],
@@ -43045,7 +43054,7 @@
       },
       {
         "name": "TestFileBasics::test_file_delete_missing_secret",
-        "line": 85,
+        "line": 124,
         "markers": [
           "unit"
         ],
@@ -43054,7 +43063,7 @@
       },
       {
         "name": "TestFileBasics::test_file_path_sanitization",
-        "line": 89,
+        "line": 128,
         "markers": [
           "unit"
         ],
@@ -43063,7 +43072,7 @@
       },
       {
         "name": "TestFileBasics::test_file_directory_creation",
-        "line": 100,
+        "line": 139,
         "markers": [
           "unit"
         ],
@@ -43072,7 +43081,7 @@
       },
       {
         "name": "TestFileBasics::test_default_file_storage_uses_registry_secret_dir",
-        "line": 111,
+        "line": 150,
         "markers": [
           "unit"
         ],
@@ -43081,7 +43090,7 @@
       },
       {
         "name": "TestFileBasics::test_file_encryption_roundtrip",
-        "line": 134,
+        "line": 173,
         "markers": [
           "unit"
         ],
@@ -43090,7 +43099,7 @@
       },
       {
         "name": "TestFileBasics::test_file_overwrite_existing",
-        "line": 148,
+        "line": 187,
         "markers": [
           "unit"
         ],
@@ -43099,7 +43108,7 @@
       },
       {
         "name": "TestFileBasics::test_file_invalid_path_characters",
-        "line": 159,
+        "line": 198,
         "markers": [
           "unit"
         ],
@@ -43108,7 +43117,7 @@
       },
       {
         "name": "TestFileBasics::test_file_permissions_handling",
-        "line": 177,
+        "line": 216,
         "markers": [
           "unit"
         ],
@@ -43117,7 +43126,7 @@
       },
       {
         "name": "TestFileBasics::test_file_storage_with_different_data_types",
-        "line": 189,
+        "line": 228,
         "markers": [
           "unit"
         ],
@@ -43126,7 +43135,7 @@
       },
       {
         "name": "TestFileBasics::test_file_storage_empty_secret",
-        "line": 206,
+        "line": 245,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary
- Track when SecretsManager uses a generated development encryption key.
- Fail closed before file-backed secret writes when the key is ephemeral, requiring GPT_TRADER_ENCRYPTION_KEY for durable encrypted files.
- Add a two-manager regression test proving no unrecoverable encrypted file is created across manager instances.
- Refresh generated agent metadata after the added test.

Closes #957

## Affected paths
- src/gpt_trader/security/secrets_manager.py
- tests/unit/gpt_trader/security/secrets_manager/test_file_basic.py
- var/agents/configuration/environment_variables.json
- var/agents/testing/index.json
- var/agents/testing/markers.json
- var/agents/testing/test_inventory.json

## Verification
- `uv run pytest tests/unit/gpt_trader/security/secrets_manager/test_file_basic.py tests/unit/gpt_trader/security/secrets_manager/test_encryption_bootstrap.py tests/unit/gpt_trader/security/secrets_manager/test_error_bootstrap.py -q` - 30 passed
- `uv run pytest tests/unit/gpt_trader/security/secrets_manager -q` - 85 passed
- `uv run agent-regenerate --verify` - all context files up-to-date
- `uv run local-ci --profile quick` - passed, including 7077 passed / 8 skipped core unit tests

## Decision/routing notes
- This is issue-backed security/reliability work with no execution automation, broker/API, order routing, money movement, credentials, canary, or production preflight changes.
- No constructor or public API signature changes; `store_secret` preserves the existing boolean failure contract for file-fallback errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File-backed secret storage is now blocked when running with an automatically generated development encryption key, preventing secrets from being persisted in an unsafe configuration.
  * Error handling and logging were updated so failed secret storage is clearly reported without exposing secret values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->