### PR TITLE
Redact secrets manager log paths

### DIFF
--- a/src/gpt_trader/security/secrets_manager.py
+++ b/src/gpt_trader/security/secrets_manager.py
@@ -10,6 +10,7 @@ import base64
 
 # Removed unused imports - Fernet handles encryption directly
 import hashlib
+import hmac
 import json
 import os
 import threading
@@ -80,6 +81,7 @@ class SecretsManager:
         self._lock = threading.RLock()
         self._cipher_suite: FernetType | None = None
         self._encryption_key_is_ephemeral = False
+        self._log_fingerprint_key: bytes | None = None
         self._secrets_cache: dict[str, dict[str, Any]] = {}
         self._vault_client: Any | None = None
         self._vault_enabled = vault_enabled
@@ -134,6 +136,9 @@ class SecretsManager:
                 key_material = encryption_key
 
             self._cipher_suite = fernet_cls(key_material)
+            self._log_fingerprint_key = hashlib.sha256(
+                b"gpt-trader-secrets-log-ref-v1:" + bytes(key_material)
+            ).digest()
         except Exception as e:
             raise ValueError(f"Invalid encryption key: {e}")
 
@@ -155,17 +160,20 @@ class SecretsManager:
             return dict(payload)
         return None
 
-    @staticmethod
-    def _fingerprint_for_log(value: str) -> str:
-        return hashlib.sha256(value.encode("utf-8")).hexdigest()[:LOG_FINGERPRINT_LENGTH]
+    def _fingerprint_for_log(self, value: str) -> str:
+        if self._log_fingerprint_key is None:
+            raise RuntimeError("Log fingerprinting key not initialised")
+        return hmac.new(
+            self._log_fingerprint_key,
+            value.encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest()[:LOG_FINGERPRINT_LENGTH]
 
-    @classmethod
-    def _secret_log_ref(cls, path: str) -> str:
-        return f"secret:{cls._fingerprint_for_log(str(path))}"
+    def _secret_log_ref(self, path: str) -> str:
+        return f"secret:{self._fingerprint_for_log(str(path))}"
 
-    @classmethod
-    def _encrypted_file_log_ref(cls, file_path: Path) -> str:
-        return f"encrypted-file:{cls._fingerprint_for_log(str(file_path))}"
+    def _encrypted_file_log_ref(self, file_path: Path) -> str:
+        return f"encrypted-file:{self._fingerprint_for_log(str(file_path))}"
 
     def _current_environment(self) -> str:
         if self._config is not None:

--- a/src/gpt_trader/security/secrets_manager.py
+++ b/src/gpt_trader/security/secrets_manager.py
@@ -9,6 +9,7 @@ with explicit encrypted file fallback outside development.
 import base64
 
 # Removed unused imports - Fernet handles encryption directly
+import hashlib
 import json
 import os
 import threading
@@ -38,6 +39,7 @@ logger = get_logger(__name__, component="security")
 DEFAULT_DEVELOPMENT_VAULT_ADDRESS = "http://localhost:8200"
 FILE_SECRET_FALLBACK_ENVIRONMENT_VARIABLE = "GPT_TRADER_ALLOW_FILE_SECRET_FALLBACK"
 DEVELOPMENT_ENVIRONMENTS = frozenset({"development", "dev", "local", "paper", "test", "testing"})
+LOG_FINGERPRINT_LENGTH = 12
 
 
 class VaultConfigurationError(RuntimeError):
@@ -152,6 +154,18 @@ class SecretsManager:
         if isinstance(payload, dict):
             return dict(payload)
         return None
+
+    @staticmethod
+    def _fingerprint_for_log(value: str) -> str:
+        return hashlib.sha256(value.encode("utf-8")).hexdigest()[:LOG_FINGERPRINT_LENGTH]
+
+    @classmethod
+    def _secret_log_ref(cls, path: str) -> str:
+        return f"secret:{cls._fingerprint_for_log(str(path))}"
+
+    @classmethod
+    def _encrypted_file_log_ref(cls, file_path: Path) -> str:
+        return f"encrypted-file:{cls._fingerprint_for_log(str(file_path))}"
 
     def _current_environment(self) -> str:
         if self._config is not None:
@@ -380,17 +394,21 @@ class SecretsManager:
                         path=path, secret=validated_secret
                     )
                     logger.info(
-                        f"Secret stored in Vault: {path}",
+                        "Secret stored in Vault",
                         operation="secret_store",
                         status="success",
+                        storage_backend="vault",
+                        secret_ref=self._secret_log_ref(path),
                     )
                 else:
                     # Fallback to encrypted file
                     self._store_to_file(path, validated_secret)
                     logger.info(
-                        f"Secret stored in encrypted file: {path}",
+                        "Secret stored in encrypted file",
                         operation="secret_store",
                         status="success",
+                        storage_backend="encrypted_file",
+                        secret_ref=self._secret_log_ref(path),
                     )
 
                 # Update cache
@@ -399,9 +417,11 @@ class SecretsManager:
 
             except Exception as e:
                 logger.error(
-                    f"Failed to store secret: {e}",
+                    "Failed to store secret",
                     operation="secret_store",
                     status="error",
+                    error_type=type(e).__name__,
+                    secret_ref=self._secret_log_ref(path),
                 )
                 return False
 
@@ -438,9 +458,11 @@ class SecretsManager:
 
             except Exception as e:
                 logger.error(
-                    f"Failed to retrieve secret: {e}",
+                    "Failed to retrieve secret",
                     operation="secret_retrieve",
                     status="error",
+                    error_type=type(e).__name__,
+                    secret_ref=self._secret_log_ref(path),
                 )
 
             return None
@@ -449,11 +471,17 @@ class SecretsManager:
         """Store secret to encrypted file"""
         self._require_durable_file_key()
         secrets_dir = self._secrets_dir
-        logger.debug(f"Using secrets directory: {secrets_dir}")
+        secret_ref = self._secret_log_ref(path)
+        logger.debug("Using encrypted file storage directory", secret_ref=secret_ref)
         secrets_dir.mkdir(parents=True, exist_ok=True)
 
         file_path = secrets_dir / f"{path.replace('/', '_')}.enc"
-        logger.debug(f"Storing secret to file: {file_path}")
+        file_ref = self._encrypted_file_log_ref(file_path)
+        logger.debug(
+            "Storing secret to encrypted file",
+            secret_ref=secret_ref,
+            encrypted_file_ref=file_ref,
+        )
 
         # Encrypt data
         cipher = self._require_cipher()
@@ -462,16 +490,31 @@ class SecretsManager:
 
         # Write to file
         file_path.write_bytes(encrypted)
-        logger.debug(f"Successfully wrote {len(encrypted)} bytes to {file_path}")
+        logger.debug(
+            "Successfully wrote encrypted secret file",
+            byte_count=len(encrypted),
+            secret_ref=secret_ref,
+            encrypted_file_ref=file_ref,
+        )
 
     def _load_from_file(self, path: str) -> dict[str, Any] | None:
         """Load secret from encrypted file"""
         secrets_dir = self._secrets_dir
         file_path = secrets_dir / f"{path.replace('/', '_')}.enc"
-        logger.debug(f"Loading secret from file: {file_path}")
+        secret_ref = self._secret_log_ref(path)
+        file_ref = self._encrypted_file_log_ref(file_path)
+        logger.debug(
+            "Loading secret from encrypted file",
+            secret_ref=secret_ref,
+            encrypted_file_ref=file_ref,
+        )
 
         if not file_path.exists():
-            logger.debug(f"Secret file does not exist: {file_path}")
+            logger.debug(
+                "Encrypted secret file does not exist",
+                secret_ref=secret_ref,
+                encrypted_file_ref=file_ref,
+            )
             return None
 
         try:
@@ -479,30 +522,59 @@ class SecretsManager:
             cipher = self._require_cipher()
             try:
                 encrypted = file_path.read_bytes()
-                logger.debug(f"Read {len(encrypted)} bytes from {file_path}")
+                logger.debug(
+                    "Read encrypted secret file",
+                    byte_count=len(encrypted),
+                    secret_ref=secret_ref,
+                    encrypted_file_ref=file_ref,
+                )
             except OSError as exc:
-                logger.error("Failed to read file %s: %s", path, exc)
+                logger.error(
+                    "Failed to read encrypted secret file",
+                    error_type=type(exc).__name__,
+                    secret_ref=secret_ref,
+                    encrypted_file_ref=file_ref,
+                )
                 return None
 
             try:
                 decrypted = cipher.decrypt(encrypted)
             except Exception as exc:
-                logger.error("Failed to decrypt file %s: %s", path, exc)
+                logger.error(
+                    "Failed to decrypt encrypted secret file",
+                    error_type=type(exc).__name__,
+                    secret_ref=secret_ref,
+                    encrypted_file_ref=file_ref,
+                )
                 return None
 
             try:
                 payload = json.loads(decrypted.decode())
-                logger.debug(f"Successfully decrypted and loaded secret from {file_path}")
+                logger.debug(
+                    "Successfully decrypted and loaded secret",
+                    secret_ref=secret_ref,
+                    encrypted_file_ref=file_ref,
+                )
                 result = self._as_secret_dict(payload)
                 # Handle empty dict case - ensure we return {} instead of None
                 if result is None and payload == {}:
                     return {}
                 return result
             except ValueError as exc:
-                logger.error("Invalid JSON in file %s: %s", path, exc)
+                logger.error(
+                    "Invalid JSON in encrypted secret file",
+                    error_type=type(exc).__name__,
+                    secret_ref=secret_ref,
+                    encrypted_file_ref=file_ref,
+                )
                 return None
         except Exception as e:
-            logger.error(f"Unexpected error loading secret {path}: {e}")
+            logger.error(
+                "Unexpected error loading secret",
+                error_type=type(e).__name__,
+                secret_ref=secret_ref,
+                encrypted_file_ref=file_ref,
+            )
             return None
 
     def rotate_key(self, path: str) -> bool:
@@ -538,9 +610,8 @@ class SecretsManager:
                 logger.error(
                     "Failed to store rotated secret",
                     error_type=type(exc).__name__,
-                    error_message=str(exc),
                     operation="rotate_key",
-                    path=path,
+                    secret_ref=self._secret_log_ref(path),
                 )
                 return False
 
@@ -561,7 +632,13 @@ class SecretsManager:
                 return True
 
             except Exception as e:
-                logger.error(f"Failed to delete secret: {e}")
+                logger.error(
+                    "Failed to delete secret",
+                    operation="secret_delete",
+                    status="error",
+                    error_type=type(e).__name__,
+                    secret_ref=self._secret_log_ref(path),
+                )
                 return False
 
     def list_secrets(self) -> list[str]:

--- a/tests/unit/gpt_trader/security/secrets_manager/test_file_basic.py
+++ b/tests/unit/gpt_trader/security/secrets_manager/test_file_basic.py
@@ -60,9 +60,9 @@ class TestFileBasics:
 
         expected_file = secrets_dir / "brokers_coinbase.enc"
         assert not expected_file.exists()
+        assert "Failed to store secret" in caplog.messages
         assert any(
-            "File-backed secret storage requires GPT_TRADER_ENCRYPTION_KEY" in message
-            for message in caplog.messages
+            getattr(record, "error_type", None) == "RuntimeError" for record in caplog.records
         )
         assert "dummy-api-key" not in caplog.text
 

--- a/tests/unit/gpt_trader/security/secrets_manager/test_log_redaction.py
+++ b/tests/unit/gpt_trader/security/secrets_manager/test_log_redaction.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+import hashlib
 import logging
+import re
 from pathlib import Path
 from typing import Any
 
 import pytest
 
 LOGGER_NAME = "gpt_trader.security.secrets_manager"
+LOG_REF_PATTERN = re.compile(r"\b(?:secret|encrypted-file):[0-9a-f]{12}\b")
 
 
 def _captured_log_text(caplog: pytest.LogCaptureFixture) -> str:
@@ -39,6 +42,9 @@ def test_file_store_and_load_logs_redact_secret_namespace_and_file_path(
         assert manager.get_secret("brokers/coinbase-missing") is None
 
     captured_logs = _captured_log_text(caplog)
+    raw_secret_digest = hashlib.sha256(secret_path.encode("utf-8")).hexdigest()[:12]
+    raw_file_digest = hashlib.sha256(str(expected_file).encode("utf-8")).hexdigest()[:12]
+
     assert secret_path not in captured_logs
     assert str(expected_file) not in captured_logs
     assert "brokers_coinbase.enc" not in captured_logs
@@ -46,6 +52,9 @@ def test_file_store_and_load_logs_redact_secret_namespace_and_file_path(
     assert "test-secret-456" not in captured_logs
     assert "secret:" in captured_logs
     assert "encrypted-file:" in captured_logs
+    assert f"secret:{raw_secret_digest}" not in captured_logs
+    assert f"encrypted-file:{raw_file_digest}" not in captured_logs
+    assert LOG_REF_PATTERN.search(captured_logs) is not None
     assert "Successfully wrote encrypted secret file" in caplog.messages
     assert "Successfully decrypted and loaded secret" in caplog.messages
     assert "Encrypted secret file does not exist" in caplog.messages
@@ -77,9 +86,15 @@ def test_file_read_error_logs_redact_secret_namespace_and_os_error_path(
         assert manager.get_secret(secret_path) is None
 
     captured_logs = _captured_log_text(caplog)
+    raw_secret_digest = hashlib.sha256(secret_path.encode("utf-8")).hexdigest()[:12]
+    raw_file_digest = hashlib.sha256(str(expected_file).encode("utf-8")).hexdigest()[:12]
+
     assert secret_path not in captured_logs
     assert str(expected_file) not in captured_logs
     assert "brokers_coinbase.enc" not in captured_logs
     assert "secret-value" not in captured_logs
+    assert f"secret:{raw_secret_digest}" not in captured_logs
+    assert f"encrypted-file:{raw_file_digest}" not in captured_logs
+    assert LOG_REF_PATTERN.search(captured_logs) is not None
     assert "Failed to read encrypted secret file" in caplog.messages
     assert "OSError" in captured_logs

--- a/tests/unit/gpt_trader/security/secrets_manager/test_log_redaction.py
+++ b/tests/unit/gpt_trader/security/secrets_manager/test_log_redaction.py
@@ -1,0 +1,85 @@
+"""SecretsManager log redaction behaviours."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+LOGGER_NAME = "gpt_trader.security.secrets_manager"
+
+
+def _captured_log_text(caplog: pytest.LogCaptureFixture) -> str:
+    record_fragments: list[str] = [caplog.text]
+    for record in caplog.records:
+        record_fragments.append(record.getMessage())
+        for value in record.__dict__.values():
+            if isinstance(value, str):
+                record_fragments.append(value)
+    return "\n".join(record_fragments)
+
+
+def test_file_store_and_load_logs_redact_secret_namespace_and_file_path(
+    secrets_manager_with_fallback: Any,
+    sample_secrets: dict[str, dict[str, Any]],
+    secrets_dir: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    manager = secrets_manager_with_fallback
+    secret_path = "brokers/coinbase"
+    expected_file = secrets_dir / "brokers_coinbase.enc"
+
+    with caplog.at_level(logging.DEBUG, logger=LOGGER_NAME):
+        assert manager.store_secret(secret_path, sample_secrets[secret_path]) is True
+        manager.clear_cache()
+        assert manager.get_secret(secret_path) == sample_secrets[secret_path]
+        manager.clear_cache()
+        assert manager.get_secret("brokers/coinbase-missing") is None
+
+    captured_logs = _captured_log_text(caplog)
+    assert secret_path not in captured_logs
+    assert str(expected_file) not in captured_logs
+    assert "brokers_coinbase.enc" not in captured_logs
+    assert "test-api-key-123" not in captured_logs
+    assert "test-secret-456" not in captured_logs
+    assert "secret:" in captured_logs
+    assert "encrypted-file:" in captured_logs
+    assert "Successfully wrote encrypted secret file" in caplog.messages
+    assert "Successfully decrypted and loaded secret" in caplog.messages
+    assert "Encrypted secret file does not exist" in caplog.messages
+
+
+def test_file_read_error_logs_redact_secret_namespace_and_os_error_path(
+    secrets_manager_with_fallback: Any,
+    secrets_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    manager = secrets_manager_with_fallback
+    secret_path = "brokers/coinbase"
+    expected_file = secrets_dir / "brokers_coinbase.enc"
+
+    assert manager.store_secret(secret_path, {"api_key": "secret-value"}) is True
+    manager.clear_cache()
+
+    original_read_bytes = Path.read_bytes
+
+    def failing_read_bytes(self: Path) -> bytes:
+        if self.name.endswith(".enc"):
+            raise OSError(f"Read error for {self}")
+        return original_read_bytes(self)
+
+    monkeypatch.setattr(Path, "read_bytes", failing_read_bytes)
+
+    with caplog.at_level(logging.DEBUG, logger=LOGGER_NAME):
+        assert manager.get_secret(secret_path) is None
+
+    captured_logs = _captured_log_text(caplog)
+    assert secret_path not in captured_logs
+    assert str(expected_file) not in captured_logs
+    assert "brokers_coinbase.enc" not in captured_logs
+    assert "secret-value" not in captured_logs
+    assert "Failed to read encrypted secret file" in caplog.messages
+    assert "OSError" in captured_logs

--- a/var/agents/configuration/environment_variables.json
+++ b/var/agents/configuration/environment_variables.json
@@ -761,7 +761,7 @@
       ],
       "code_references": [
         {
-          "line": 175,
+          "line": 183,
           "path": "src/gpt_trader/security/secrets_manager.py",
           "reader": "os.getenv"
         }
@@ -867,7 +867,7 @@
       ],
       "code_references": [
         {
-          "line": 88,
+          "line": 90,
           "path": "src/gpt_trader/security/secrets_manager.py",
           "reader": "parse_bool_env"
         }
@@ -1050,7 +1050,7 @@
       ],
       "code_references": [
         {
-          "line": 102,
+          "line": 104,
           "path": "src/gpt_trader/security/secrets_manager.py",
           "reader": "os.getenv"
         }
@@ -3250,7 +3250,7 @@
       ],
       "code_references": [
         {
-          "line": 316,
+          "line": 324,
           "path": "src/gpt_trader/security/secrets_manager.py",
           "reader": "os.getenv"
         }
@@ -3273,7 +3273,7 @@
       ],
       "code_references": [
         {
-          "line": 343,
+          "line": 351,
           "path": "src/gpt_trader/security/secrets_manager.py",
           "reader": "os.getenv"
         }

--- a/var/agents/configuration/environment_variables.json
+++ b/var/agents/configuration/environment_variables.json
@@ -761,7 +761,7 @@
       ],
       "code_references": [
         {
-          "line": 161,
+          "line": 175,
           "path": "src/gpt_trader/security/secrets_manager.py",
           "reader": "os.getenv"
         }
@@ -867,7 +867,7 @@
       ],
       "code_references": [
         {
-          "line": 86,
+          "line": 88,
           "path": "src/gpt_trader/security/secrets_manager.py",
           "reader": "parse_bool_env"
         }
@@ -1050,7 +1050,7 @@
       ],
       "code_references": [
         {
-          "line": 100,
+          "line": 102,
           "path": "src/gpt_trader/security/secrets_manager.py",
           "reader": "os.getenv"
         }
@@ -3250,7 +3250,7 @@
       ],
       "code_references": [
         {
-          "line": 302,
+          "line": 316,
           "path": "src/gpt_trader/security/secrets_manager.py",
           "reader": "os.getenv"
         }
@@ -3273,7 +3273,7 @@
       ],
       "code_references": [
         {
-          "line": 329,
+          "line": 343,
           "path": "src/gpt_trader/security/secrets_manager.py",
           "reader": "os.getenv"
         }

--- a/var/agents/logging/event_catalog.json
+++ b/var/agents/logging/event_catalog.json
@@ -95,6 +95,7 @@
       "check_ip",
       "encryption_init",
       "enforce_slippage_guard",
+      "secret_delete",
       "secret_retrieve",
       "secret_store",
       "suspicious_activity",
@@ -1852,9 +1853,8 @@
     },
     "rotate_key": {
       "common_fields": [
-        "error_message",
         "error_type",
-        "path"
+        "secret_ref"
       ],
       "components": null,
       "levels": [
@@ -1950,8 +1950,28 @@
       ],
       "statuses": null
     },
+    "secret_delete": {
+      "common_fields": [
+        "error_type",
+        "secret_ref"
+      ],
+      "components": null,
+      "levels": [
+        "ERROR"
+      ],
+      "occurrence_count": 1,
+      "source_files": [
+        "security/secrets_manager.py"
+      ],
+      "statuses": [
+        "error"
+      ]
+    },
     "secret_retrieve": {
-      "common_fields": [],
+      "common_fields": [
+        "error_type",
+        "secret_ref"
+      ],
       "components": null,
       "levels": [
         "ERROR"
@@ -1965,7 +1985,11 @@
       ]
     },
     "secret_store": {
-      "common_fields": [],
+      "common_fields": [
+        "error_type",
+        "secret_ref",
+        "storage_backend"
+      ],
       "components": null,
       "levels": [
         "ERROR",
@@ -2489,8 +2513,8 @@
     "details": 4,
     "environment": 12,
     "error": 64,
-    "error_message": 90,
-    "error_type": 84,
+    "error_message": 89,
+    "error_type": 87,
     "event_type": 5,
     "flatten_operation_id": 9,
     "granularity": 6,
@@ -2501,13 +2525,13 @@
     "mode": 4,
     "order_id": 29,
     "outcome": 5,
-    "path": 12,
+    "path": 11,
     "portfolio_id": 4,
     "price": 4,
     "quantity": 10,
     "reason": 27,
+    "secret_ref": 6,
     "service": 9,
-    "severity": 4,
     "side": 26,
     "stage": 167,
     "symbol": 84
@@ -2515,10 +2539,10 @@
   "level_distribution": {
     "CRITICAL": 2,
     "DEBUG": 49,
-    "ERROR": 121,
+    "ERROR": 122,
     "INFO": 90,
     "WARNING": 101
   },
-  "total_event_types": 135,
+  "total_event_types": 136,
   "version": "1.0"
 }

--- a/var/agents/logging/index.json
+++ b/var/agents/logging/index.json
@@ -27,7 +27,7 @@
       "cleanup_orders",
       "collateral_update"
     ],
-    "total_events": 135
+    "total_events": 136
   },
   "usage": {
     "correlation": "Use correlation_id field to trace requests across logs",

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,8 +7,8 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6820,
-    "total_files": 803,
+    "total_tests": 6822,
+    "total_files": 804,
     "markers_used": 16
   },
   "quick_commands": {

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6655,
+    "unit": 6657,
     "asyncio": 411,
     "parametrize": 195,
     "endpoints": 83,

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -43270,7 +43270,7 @@
     "tests/unit/gpt_trader/security/secrets_manager/test_log_redaction.py": [
       {
         "name": "test_file_store_and_load_logs_redact_secret_namespace_and_file_path",
-        "line": 24,
+        "line": 27,
         "markers": [
           "unit"
         ],
@@ -43278,7 +43278,7 @@
       },
       {
         "name": "test_file_read_error_logs_redact_secret_namespace_and_os_error_path",
-        "line": 54,
+        "line": 63,
         "markers": [
           "unit"
         ],

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,8 +2,8 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6820,
-    "total_files": 803,
+    "total_tests": 6822,
+    "total_files": 804,
     "markers_used": 16
   },
   "marker_definitions": {
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6655,
+    "unit": 6657,
     "asyncio": 411,
     "parametrize": 195,
     "endpoints": 83,
@@ -684,6 +684,7 @@
       "tests/unit/gpt_trader/security/secrets_manager/test_file_concurrency.py",
       "tests/unit/gpt_trader/security/secrets_manager/test_key_rotation_basic.py",
       "tests/unit/gpt_trader/security/secrets_manager/test_key_rotation_scenarios.py",
+      "tests/unit/gpt_trader/security/secrets_manager/test_log_redaction.py",
       "tests/unit/gpt_trader/security/secrets_manager/test_vault_basic.py",
       "tests/unit/gpt_trader/security/secrets_manager/test_vault_failures.py",
       "tests/unit/gpt_trader/security/security_validator/test_convenience_wrappers.py",
@@ -43264,6 +43265,24 @@
         ],
         "docstring": "",
         "class": "TestKeyRotationScenarios"
+      }
+    ],
+    "tests/unit/gpt_trader/security/secrets_manager/test_log_redaction.py": [
+      {
+        "name": "test_file_store_and_load_logs_redact_secret_namespace_and_file_path",
+        "line": 24,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_file_read_error_logs_redact_secret_namespace_and_os_error_path",
+        "line": 54,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
       }
     ],
     "tests/unit/gpt_trader/security/secrets_manager/test_vault_basic.py": [


### PR DESCRIPTION
## Summary
Redacts secrets-manager namespace and encrypted-file path details from operational logs while preserving useful event context through stable non-reversible fingerprints, backend/status fields, byte counts, and exception types.

Related issue / finding / RJ-routed package: Closes #966; GPTREV-019; pipeline `goal-pipeline-20260625-gpt-trader-secrets-log-redaction`.

## Type of change
- [ ] Refactor
- [ ] Feature
- [x] Bug fix
- [x] Tests only
- [x] CI/Docs/Tooling

## Scope & Impact
- Affected areas / components: `src/gpt_trader/security/secrets_manager.py`, secrets-manager unit tests, generated `var/agents/**` logging/configuration/testing catalogs.
- Behavior changes: secret store/load/delete/rotation logging no longer emits raw secret namespaces, encrypted file paths, or exception strings that can contain those paths. Logs now use `secret:<hash>` and `encrypted-file:<hash>` references plus safe context such as backend, status, byte count, and error type.

## Test Plan
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Contract tests (if applicable)
- [x] Ran locally: `uv run pytest tests/unit/gpt_trader/security/secrets_manager/test_log_redaction.py -q` -> 2 passed
- [x] Ran locally: `uv run pytest tests/unit/gpt_trader/security/secrets_manager -q` -> 96 passed
- [x] Ran locally: `uv run local-ci --profile quick` -> passed; 7088 unit tests passed, 8 skipped
- [x] Markers used appropriately (`unit`/`integration`/`slow`/`perf`)

## Complexity & Quality Gates
- [x] Mypy/type-check passed via `uv run local-ci --profile quick`
- [x] Xenon/radon complexity gate passed (CC ≤ 15 on live_trade execution): not applicable to this security logging change; local CI guards passed
- [x] No `sys.path` hacks in tests
- [x] No `MagicMock` on `async def` (use `AsyncMock`)
- [x] Import-lint rules respected (no “import up the stack”)

## Observability & Errors
- [x] Structured JSON logs for new/changed paths
- [x] Errors include diagnostic context: `secret_ref`, `encrypted_file_ref` where applicable, `storage_backend`, `status`, `byte_count`, and `error_type`
- [x] Added/updated sampling examples in tests (if applicable): focused `caplog` coverage for `brokers/coinbase` store/load/missing/read-error paths

## Configuration
- [ ] If config changed: `python -m gpt_trader.cli.config validate --profile <name>` passes
- [x] Env docs re-generated (if applicable) and committed: generated line-reference updates from `uv run agent-regenerate`
- [x] No `ConfigLoader` usages introduced (ConfigManager-only)

## Breaking Changes
- [x] None
- [ ] Documented in PR body and release notes if any

## Screenshots / Logs (optional)
Not applicable. Tests assert raw `brokers/coinbase`, `brokers_coinbase.enc`, full encrypted-file paths, and sample secret values are absent from captured log messages and structured extras.

## Checklist
- [x] Acceptance criteria in linked issue(s), finding packet, or routed package met
- [x] Affected paths listed in PR description
- [x] Changelog entry (if repo uses one): not applicable

## Generated Artifacts
`uv run agent-regenerate --verify` initially reported stale generated context after the source/test changes. `uv run agent-regenerate` updated scoped logging/configuration/testing catalogs, and the follow-up `uv run agent-regenerate --verify` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secrets-related logging to prevent leaking sensitive namespaces, file paths, and plaintext values in error/debug messages.
  * Standardized structured log fields for secret operations (store, retrieve, rotate, delete), making failures easier to diagnose without exposing exception text.
  * Refined encrypted file load error handling while keeping prior return behavior.
* **Tests**
  * Added new unit coverage to verify log redaction during secret store/load and encrypted-file read failures.
  * Updated existing log assertions to match the new structured logging output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->