### PR TITLE
Pin workflow actions to immutable SHAs

### DIFF
--- a/.github/workflows/agent-artifacts-refresh.yml
+++ b/.github/workflows/agent-artifacts-refresh.yml
@@ -42,18 +42,21 @@ jobs:
       publication_branch: ${{ env.AGENT_ARTIFACTS_BRANCH }}
     steps:
       - name: Checkout source ref
-        uses: actions/checkout@v7
+        # actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           ref: ${{ env.SOURCE_REF }}
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        # astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
         with:
           enable-cache: true
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        # actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with:
           python-version-file: ".python-version"
 
@@ -117,7 +120,8 @@ jobs:
           fi
 
       - name: Upload packaged agent artifacts
-        uses: actions/upload-artifact@v7
+        # actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: ${{ steps.package.outputs.package_name }}
           path: |
@@ -188,7 +192,8 @@ jobs:
     needs: refresh
     steps:
       - name: Checkout workflow scripts
-        uses: actions/checkout@v7
+        # actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           ref: ${{ env.SOURCE_REF }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,15 +19,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v7
+      # actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        # astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
         with:
           enable-cache: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        # actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version-file: ".python-version"
 
@@ -63,15 +66,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v7
+      # actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        # astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
         with:
           enable-cache: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        # actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version-file: ".python-version"
 
@@ -118,15 +124,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
+      # actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        # astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
         with:
           enable-cache: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        # actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version-file: ".python-version"
 
@@ -141,15 +150,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
+      # actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        # astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
         with:
           enable-cache: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        # actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version-file: ".python-version"
 
@@ -178,7 +190,8 @@ jobs:
 
       - name: Upload agent-health artifact
         if: always()
-        uses: actions/upload-artifact@v7
+        # actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: agent-health-report
           path: var/agents/health/health_report.json
@@ -197,15 +210,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v7
+      # actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        # astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
         with:
           enable-cache: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        # actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version-file: ".python-version"
 
@@ -274,15 +290,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v7
+      # actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        # astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
         with:
           enable-cache: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        # actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version-file: ".python-version"
 
@@ -297,15 +316,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v7
+      # actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        # astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
         with:
           enable-cache: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        # actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version-file: ".python-version"
 
@@ -338,15 +360,18 @@ jobs:
       GPT_TRADER_STRICT_CONTAINER: "1"
       PYTHONWARNINGS: default
     steps:
-      - uses: actions/checkout@v7
+      # actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        # astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
         with:
           enable-cache: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        # actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version-file: ".python-version"
 
@@ -364,15 +389,18 @@ jobs:
       GPT_TRADER_STRICT_CONTAINER: "1"
       PYTHONWARNINGS: default
     steps:
-      - uses: actions/checkout@v7
+      # actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        # astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
         with:
           enable-cache: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        # actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version-file: ".python-version"
 
@@ -390,15 +418,18 @@ jobs:
       GPT_TRADER_STRICT_CONTAINER: "1"
       PYTHONWARNINGS: default
     steps:
-      - uses: actions/checkout@v7
+      # actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        # astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
         with:
           enable-cache: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        # actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version-file: ".python-version"
 
@@ -416,15 +447,18 @@ jobs:
       GPT_TRADER_STRICT_CONTAINER: "1"
       PYTHONWARNINGS: default
     steps:
-      - uses: actions/checkout@v7
+      # actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        # astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
         with:
           enable-cache: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        # actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version-file: ".python-version"
 
@@ -439,9 +473,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v7
+      # actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Review dependencies
-        uses: actions/dependency-review-action@v5
+        # actions/dependency-review-action@v5.0.0
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294
         with:
           fail-on-severity: high

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,12 +20,15 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        # actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        # github/codeql-action/init@v4
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e
         with:
           languages: python
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        # github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -23,15 +23,18 @@ jobs:
       PYTHONWARNINGS: default
 
     steps:
-      - uses: actions/checkout@v7
+      # actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        # astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
         with:
           enable-cache: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        # actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version-file: ".python-version"
 

--- a/.github/workflows/uv_lock_upgrade.yml
+++ b/.github/workflows/uv_lock_upgrade.yml
@@ -14,15 +14,18 @@ jobs:
     name: Upgrade uv.lock
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      # actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        # astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
         with:
           enable-cache: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        # actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version-file: ".python-version"
 
@@ -32,7 +35,8 @@ jobs:
           uv sync --all-extras --dev --frozen
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8
+        # peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
         with:
           commit-message: "chore(deps): upgrade uv.lock"
           title: "chore(deps): upgrade uv.lock"


### PR DESCRIPTION
## Summary
Pins the remaining non-deploy GitHub Actions workflow `uses:` references to immutable full 40-character commit SHAs while keeping readable version comments for maintenance.

Related issue / finding / RJ-routed package: Closes #960
Pipeline id: `goal-pipeline-20260625-gpt-trader-workflow-action-pinning`

## Type of change
- [ ] Refactor
- [ ] Feature
- [ ] Bug fix
- [ ] Tests only
- [x] CI/Docs/Tooling

## Scope & Impact
- Affected areas / components: `.github/workflows/agent-artifacts-refresh.yml`, `.github/workflows/ci.yml`, `.github/workflows/codeql.yml`, `.github/workflows/integration.yml`, `.github/workflows/uv_lock_upgrade.yml`
- Any behavior changes? No runtime product behavior changes. CI workflow action references now resolve to immutable commit SHAs.
- Maintenance path: existing `.github/dependabot.yml` has weekly `github-actions` updates, and each pinned `uses:` keeps the human-readable version comment above it.
- Note: `actions/dependency-review-action@v5` did not resolve as a tag; this PR pins the published `v5.0.0` commit instead.

## Test Plan
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Contract tests (if applicable)
- [x] Ran locally: `uv run local-ci --profile quick`
- [x] Markers used appropriately (`unit`/`integration`/`slow`/`perf`)

Additional verification:
- `python` YAML parse over `.github/workflows/*.yml` -> passed
- workflow `uses:` recount -> 65 total, 65 pinned, 0 mutable
- `uv run agent-regenerate --verify` -> passed
- `uv run local-ci --profile quick` -> passed; 7088 passed, 8 skipped
- `git diff --check` -> passed

## Complexity & Quality Gates
- [x] Mypy/type-check passed via `uv run local-ci --profile quick`
- [ ] Xenon/radon complexity gate passed (CC <= 15 on live_trade execution)
- [x] No `sys.path` hacks in tests
- [x] No `MagicMock` on `async def` (use `AsyncMock`)
- [x] Import-lint rules respected (no "import up the stack")

## Observability & Errors
- [ ] Structured JSON logs for new/changed paths
- [ ] Errors include diagnostic context (symbol, order_id, correlation_id)
- [ ] Added/updated sampling examples in tests (if applicable)

## Configuration
- [ ] If config changed: `python -m gpt_trader.cli.config validate --profile <name>` passes
- [ ] Env docs re-generated (if applicable) and committed
- [x] No `ConfigLoader` usages introduced (ConfigManager-only)

## Breaking Changes
- [x] None
- [ ] Documented in PR body and release notes if any

## Screenshots / Logs (optional)
N/A

## Checklist
- [x] Acceptance criteria in linked issue(s), finding packet, or routed package met
- [x] Affected paths listed in PR description
- [ ] Changelog entry (if repo uses one)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated several automated workflows to use fixed, pinned versions of external actions.
  * This improves workflow reliability and reduces the risk of unexpected changes from third-party updates.
  * No end-user-facing product behavior was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->