### PR TITLE
[tests] Make metrics snapshot error coverage portable

### DIFF
--- a/tests/unit/gpt_trader/monitoring/system/test_metrics.py
+++ b/tests/unit/gpt_trader/monitoring/system/test_metrics.py
@@ -107,15 +107,19 @@ class TestMetricsPublisherWriteSnapshot:
 
     def test_handles_write_errors(
         self,
+        tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
         metrics_logger: MagicMock,
         publisher: MetricsPublisher,
     ) -> None:
-        # Mock _target_dirs to return an unwritable path
-        monkeypatch.setattr(publisher, "_target_dirs", lambda: [Path("/nonexistent/path")])
-        # Should not raise, just log
+        blocking_file = tmp_path / "not-a-directory"
+        blocking_file.write_text("blocks directory creation")
+        monkeypatch.setattr(publisher, "_target_dirs", lambda: [blocking_file])
+
         publisher._write_snapshot({"test": "data"})
+
         metrics_logger.debug.assert_called_once()
+        assert not (blocking_file / "metrics.json").exists()
 
 
 class TestMetricsPublisherLogUpdate:

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -36099,7 +36099,7 @@
       },
       {
         "name": "TestMetricsPublisherLogUpdate::test_logs_metrics",
-        "line": 124,
+        "line": 128,
         "markers": [
           "unit"
         ],
@@ -36108,7 +36108,7 @@
       },
       {
         "name": "TestMetricsPublisherLogUpdate::test_filters_large_fields",
-        "line": 129,
+        "line": 133,
         "markers": [
           "unit"
         ],
@@ -36117,7 +36117,7 @@
       },
       {
         "name": "TestMetricsPublisherLogUpdate::test_handles_log_errors",
-        "line": 145,
+        "line": 149,
         "markers": [
           "unit"
         ],
@@ -36126,7 +36126,7 @@
       },
       {
         "name": "TestMetricsPublisherWriteHealthStatus::test_writes_health_status",
-        "line": 160,
+        "line": 164,
         "markers": [
           "unit"
         ],
@@ -36135,7 +36135,7 @@
       },
       {
         "name": "TestMetricsPublisherWriteHealthStatus::test_writes_unhealthy_status",
-        "line": 173,
+        "line": 177,
         "markers": [
           "unit"
         ],
@@ -36144,7 +36144,7 @@
       },
       {
         "name": "TestMetricsPublisherWriteHealthStatus::test_handles_health_status_write_errors",
-        "line": 183,
+        "line": 187,
         "markers": [
           "unit"
         ],
@@ -36153,7 +36153,7 @@
       },
       {
         "name": "TestTargetDirs::test_returns_profile_specific_path",
-        "line": 203,
+        "line": 207,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary
- Replace the metrics snapshot write-error test's `/nonexistent/path` dependency with a deterministic `tmp_path` blocking-file failure.
- Keep the assertion that snapshot write failures are swallowed and logged.
- Refresh generated testing inventory line numbers after the test edit.

Closes #953

## Affected paths
- `tests/unit/gpt_trader/monitoring/system/test_metrics.py`
- `var/agents/testing/test_inventory.json`

## Verification
- `uv run pytest tests/unit/gpt_trader/monitoring/system/test_metrics.py -q` -> 12 passed
- `uv run agent-regenerate --verify` -> all context files up-to-date
- `uv run local-ci --profile quick` -> passed; core unit suite 7088 passed, 8 skipped
- `git diff --check` -> passed

## Boundaries
- No production runtime behavior changed.
- No broker/API, live trading, readiness, canary, or account-capability commands were run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for snapshot-writing error handling, including cases where the target location can’t be written to.
  * Added assertions that failed writes are logged appropriately and do not create unexpected output files.
* **Chores**
  * Updated internal test inventory metadata to match current source locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->