### PR TITLE
[ci] Make local-ci triage check portable

### DIFF
--- a/src/gpt_trader/ci/local_ci.py
+++ b/src/gpt_trader/ci/local_ci.py
@@ -278,7 +278,7 @@ def build_steps(profile: LocalCIProfile, args: argparse.Namespace) -> list[Plann
         ),
         PlannedStep(
             label="Check triage backlog",
-            command=["make", "test-triage-check"],
+            command=["uv", "run", "python", "scripts/maintenance/test_legacy_triage.py", "--check"],
         ),
         PlannedStep(
             label="Unit tests (core)",

--- a/tests/unit/scripts/test_local_ci.py
+++ b/tests/unit/scripts/test_local_ci.py
@@ -71,6 +71,22 @@ def test_snapshot_step_expands_test_files_before_subprocess() -> None:
     assert any("test_snapshots_main_screen.py" in part for part in snapshot_step.command)
 
 
+def test_triage_backlog_step_uses_portable_python_command() -> None:
+    args = _make_args("quick")
+    profile = local_ci.resolve_profile(args.profile)
+    steps = local_ci.build_steps(profile, args)
+
+    triage_step = _find_step(steps, "Check triage backlog")
+
+    assert triage_step.command == [
+        "uv",
+        "run",
+        "python",
+        "scripts/maintenance/test_legacy_triage.py",
+        "--check",
+    ]
+
+
 def test_print_profile_banner_reports_alias_and_status(capsys) -> None:
     selection = "dev"
     profile = local_ci.resolve_profile(selection)

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6822,
+    "total_tests": 6823,
     "total_files": 804,
     "markers_used": 16
   },

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6657,
+    "unit": 6658,
     "asyncio": 411,
     "parametrize": 195,
     "endpoints": 83,

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6822,
+    "total_tests": 6823,
     "total_files": 804,
     "markers_used": 16
   },
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6657,
+    "unit": 6658,
     "asyncio": 411,
     "parametrize": 195,
     "endpoints": 83,
@@ -62459,7 +62459,7 @@
         "docstring": ""
       },
       {
-        "name": "test_print_profile_banner_reports_alias_and_status",
+        "name": "test_triage_backlog_step_uses_portable_python_command",
         "line": 74,
         "markers": [
           "unit"
@@ -62467,8 +62467,16 @@
         "docstring": ""
       },
       {
+        "name": "test_print_profile_banner_reports_alias_and_status",
+        "line": 90,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
         "name": "test_strict_profile_banner_distinguishes_pull_request_ci",
-        "line": 85,
+        "line": 101,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary
- replace the local-ci triage backlog step's `make test-triage-check` wrapper with the underlying portable Python checker
- add local-CI regression coverage for the planned triage command
- refresh generated testing inventory for the new unit test

Closes #948

## Validation
- `uv run pytest tests/unit/scripts/test_local_ci.py -q`
- `uv run python scripts/maintenance/test_legacy_triage.py --check`
- `uv run agent-regenerate --verify`
- `uv run local-ci --profile quick`
- `git diff --check`

## Notes
- GitHub CI can continue using `make test-triage-check`; this PR changes the Python local-ci entry point so Windows hosts do not need a `make` binary for the quick profile triage backlog step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The quick CI profile now runs the triage backlog check using a more portable Python-based command, improving consistency across environments.
  * Added test coverage to verify the CI step uses the expected command path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->