### PR TITLE
[trade-ideas] Enforce service audit venue boundary

### DIFF
--- a/src/gpt_trader/features/trade_ideas/service.py
+++ b/src/gpt_trader/features/trade_ideas/service.py
@@ -59,6 +59,7 @@ EXPIRABLE_STATES = frozenset(
         TradeIdeaState.APPROVED,
     }
 )
+_AUDIT_VENUES = frozenset({TicketVenue.COINBASE, TicketVenue.MANUAL})
 
 
 class UnknownTradeIdeaError(ValidationError):
@@ -391,6 +392,7 @@ class TradeIdeaService:
         reason: str = "Approved ticket submitted",
         actor_type: ActorType = ActorType.SYSTEM,
     ) -> TradeIdeaView:
+        venue = _validate_audit_venue(venue)
         idea = self._require_idea(decision_id)
         self._append(
             idea,
@@ -413,6 +415,7 @@ class TradeIdeaService:
         reason: str = "Venue confirmed fill",
         actor_type: ActorType = ActorType.VENUE,
     ) -> TradeIdeaView:
+        venue = _validate_audit_venue(venue)
         idea = self._require_idea(decision_id)
         self._append(
             idea,
@@ -720,3 +723,23 @@ def create_trade_idea_service(
 ) -> TradeIdeaService:
     """Resolve root (arg > GPT_TRADER_IDEAS_ROOT > default) and build the service."""
     return TradeIdeaService(resolve_ideas_root(root), policy=policy, now_factory=now_factory)
+
+
+def _validate_audit_venue(venue: str) -> str:
+    try:
+        parsed = TicketVenue(venue)
+    except ValueError as error:
+        allowed = ", ".join(sorted(item.value for item in _AUDIT_VENUES))
+        raise ValidationError(
+            f"Unsupported trade-idea venue '{venue}'; expected one of: {allowed}",
+            field="venue",
+            value=venue,
+        ) from error
+    if parsed in _AUDIT_VENUES:
+        return parsed.value
+    allowed = ", ".join(sorted(item.value for item in _AUDIT_VENUES))
+    raise ValidationError(
+        f"Unsupported trade-idea venue '{venue}'; expected one of: {allowed}",
+        field="venue",
+        value=venue,
+    )

--- a/tests/unit/gpt_trader/features/trade_ideas/test_service_venue_boundary.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_service_venue_boundary.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from tests.unit.gpt_trader.features.trade_ideas.conftest import build_trade_idea
+
+from gpt_trader.errors import ValidationError
+from gpt_trader.features.trade_ideas import TradeIdeaService, TradeIdeaState
+
+
+@pytest.fixture
+def service(tmp_path: Path) -> TradeIdeaService:
+    return TradeIdeaService(
+        tmp_path / "trade_ideas",
+        now_factory=lambda: datetime(2026, 6, 12, 10, 0, tzinfo=UTC),
+    )
+
+
+def test_manual_venue_submission_and_fill_remain_supported(
+    service: TradeIdeaService,
+) -> None:
+    idea = build_trade_idea()
+    service.propose(idea, actor_id="idea-generator-v1")
+    service.approve(idea.decision_id, actor_id="rj", reason="Thesis and risk verified")
+    service.record_submission(idea.decision_id, actor_id="operator", venue="manual")
+
+    view = service.record_fill(idea.decision_id, actor_id="operator", venue="manual")
+
+    assert view.state is TradeIdeaState.FILLED
+    assert [event.venue for event in view.events[-2:]] == ["manual", "manual"]
+
+
+def test_record_submission_rejects_unsupported_venue_before_audit_mutation(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "trade_ideas"
+    service = TradeIdeaService(
+        root,
+        now_factory=lambda: datetime(2026, 6, 12, 10, 0, tzinfo=UTC),
+    )
+    idea = build_trade_idea()
+    service.propose(idea, actor_id="idea-generator-v1")
+    service.approve(idea.decision_id, actor_id="rj", reason="Thesis and risk verified")
+    audit_path = root / "audit.jsonl"
+    original_audit = audit_path.read_text(encoding="utf-8")
+
+    with pytest.raises(ValidationError, match="Unsupported trade-idea venue") as exc_info:
+        service.record_submission(idea.decision_id, actor_id="executor", venue="robinhood")
+
+    assert exc_info.value.context["field"] == "venue"
+    assert exc_info.value.context["value"] == "robinhood"
+    assert audit_path.read_text(encoding="utf-8") == original_audit
+    assert service.get(idea.decision_id).state is TradeIdeaState.APPROVED
+
+
+def test_record_fill_rejects_unsupported_venue_before_audit_mutation(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "trade_ideas"
+    service = TradeIdeaService(
+        root,
+        now_factory=lambda: datetime(2026, 6, 12, 10, 0, tzinfo=UTC),
+    )
+    idea = build_trade_idea()
+    service.propose(idea, actor_id="idea-generator-v1")
+    service.approve(idea.decision_id, actor_id="rj", reason="Thesis and risk verified")
+    service.record_submission(idea.decision_id, actor_id="executor", venue="coinbase")
+    audit_path = root / "audit.jsonl"
+    original_audit = audit_path.read_text(encoding="utf-8")
+
+    with pytest.raises(ValidationError, match="Unsupported trade-idea venue") as exc_info:
+        service.record_fill(idea.decision_id, actor_id="executor", venue="robinhood")
+
+    assert exc_info.value.context["field"] == "venue"
+    assert exc_info.value.context["value"] == "robinhood"
+    assert audit_path.read_text(encoding="utf-8") == original_audit
+    assert service.get(idea.decision_id).state is TradeIdeaState.SUBMITTED

--- a/var/agents/configuration/environment_variables.json
+++ b/var/agents/configuration/environment_variables.json
@@ -835,7 +835,7 @@
       ],
       "code_references": [
         {
-          "line": 122,
+          "line": 123,
           "path": "src/gpt_trader/features/trade_ideas/service.py",
           "reader": "os.environ.get"
         }
@@ -1247,7 +1247,7 @@
       ],
       "code_references": [
         {
-          "line": 112,
+          "line": 113,
           "path": "src/gpt_trader/features/trade_ideas/service.py",
           "reader": "os.environ.get"
         }

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,8 +7,8 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6823,
-    "total_files": 804,
+    "total_tests": 6826,
+    "total_files": 805,
     "markers_used": 16
   },
   "quick_commands": {

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6658,
+    "unit": 6661,
     "asyncio": 411,
     "parametrize": 195,
     "endpoints": 83,

--- a/var/agents/testing/source_test_map.json
+++ b/var/agents/testing/source_test_map.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "summary": {
-    "tests_scanned": 720,
+    "tests_scanned": 721,
     "source_modules": 373,
     "unresolved_modules": 3
   },
@@ -495,6 +495,7 @@
       "tests/unit/gpt_trader/errors/test_handler.py",
       "tests/unit/gpt_trader/features/brokerages/coinbase/rest/test_base_build.py",
       "tests/unit/gpt_trader/features/brokerages/coinbase/rest/test_base_execute_order_payload.py",
+      "tests/unit/gpt_trader/features/trade_ideas/test_service_venue_boundary.py",
       "tests/unit/gpt_trader/validation/test_base_validator.py",
       "tests/unit/gpt_trader/validation/test_composite_validators.py",
       "tests/unit/gpt_trader/validation/test_config_validators.py",
@@ -1304,6 +1305,7 @@
       "tests/unit/gpt_trader/features/trade_ideas/test_service_audit_integrity.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_service_closeout.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_service_preapproval_broker_ticket.py",
+      "tests/unit/gpt_trader/features/trade_ideas/test_service_venue_boundary.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_snapshot.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_store.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_workflow.py",
@@ -3959,6 +3961,10 @@
       "gpt_trader.features.trade_ideas"
     ],
     "tests/unit/gpt_trader/features/trade_ideas/test_service_preapproval_broker_ticket.py": [
+      "gpt_trader.features.trade_ideas"
+    ],
+    "tests/unit/gpt_trader/features/trade_ideas/test_service_venue_boundary.py": [
+      "gpt_trader.errors",
       "gpt_trader.features.trade_ideas"
     ],
     "tests/unit/gpt_trader/features/trade_ideas/test_snapshot.py": [

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,8 +2,8 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6823,
-    "total_files": 804,
+    "total_tests": 6826,
+    "total_files": 805,
     "markers_used": 16
   },
   "marker_definitions": {
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6658,
+    "unit": 6661,
     "asyncio": 411,
     "parametrize": 195,
     "endpoints": 83,
@@ -548,6 +548,7 @@
       "tests/unit/gpt_trader/features/trade_ideas/test_service_audit_integrity.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_service_closeout.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_service_preapproval_broker_ticket.py",
+      "tests/unit/gpt_trader/features/trade_ideas/test_service_venue_boundary.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_snapshot.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_store.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_workflow.py"
@@ -33312,6 +33313,32 @@
         "line": 110,
         "markers": [
           "parametrize",
+          "unit"
+        ],
+        "docstring": ""
+      }
+    ],
+    "tests/unit/gpt_trader/features/trade_ideas/test_service_venue_boundary.py": [
+      {
+        "name": "test_manual_venue_submission_and_fill_remain_supported",
+        "line": 21,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_record_submission_rejects_unsupported_venue_before_audit_mutation",
+        "line": 35,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_record_fill_rejects_unsupported_venue_before_audit_mutation",
+        "line": 58,
+        "markers": [
           "unit"
         ],
         "docstring": ""


### PR DESCRIPTION
Closes #994

## Summary

- Enforce the trade-idea audit venue boundary inside `TradeIdeaService`, not only in the CLI adapter.
- Keep `coinbase` and `manual` as the supported submission/fill audit venues.
- Add service-level tests proving unsupported venues fail before audit mutation.

## Affected Paths

- `src/gpt_trader/features/trade_ideas/service.py`
- `tests/unit/gpt_trader/features/trade_ideas/test_service_venue_boundary.py`
- `var/agents/configuration/environment_variables.json`
- `var/agents/testing/*`

## Verification

- `uv run pytest tests/unit/gpt_trader/features/trade_ideas/test_service.py tests/unit/gpt_trader/features/trade_ideas/test_service_venue_boundary.py tests/unit/gpt_trader/cli/commands/test_ideas_manual_records.py -q` -> 26 passed
- `uv run black --check src/gpt_trader/features/trade_ideas/service.py tests/unit/gpt_trader/features/trade_ideas/test_service.py tests/unit/gpt_trader/features/trade_ideas/test_service_venue_boundary.py` -> passed
- `uv run ruff check src/gpt_trader/features/trade_ideas/service.py tests/unit/gpt_trader/features/trade_ideas/test_service.py tests/unit/gpt_trader/features/trade_ideas/test_service_venue_boundary.py` -> passed
- `uv run agent-regenerate --verify` -> passed
- `uv run local-ci --profile quick` -> passed, 7091 passed, 8 skipped

## Risk / Gate Notes

This tightens local product-runtime validation for audited trade-idea submission/fill records. It does not run or add broker/API checks, live trading commands, production preflight, canary operations, money movement, or order submission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for trade idea audit venues, allowing only supported venues and returning a clear error for invalid values.
  * Prevented invalid venue submissions and fills from changing trade idea state or writing audit events.
* **Tests**
  * Added coverage for supported and unsupported venue flows, including state transitions and error handling.
* **Chores**
  * Updated test inventory and related metadata to reflect the expanded test set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->