### PR TITLE
[codex] Ratchet TUI mypy coverage

### DIFF
--- a/docs/DEVELOPMENT_GUIDELINES.md
+++ b/docs/DEVELOPMENT_GUIDELINES.md
@@ -126,8 +126,12 @@ uv run local-ci
 
 This covers the same core validation categories used around PRs: lint + format,
 docs audits, mypy, agent artifacts freshness, TUI CSS check, test guardrails,
-and core unit tests. Profile-specific local checks can still differ from GitHub
-pull_request enforcement, especially around readiness evidence.
+and core unit tests. The mypy pass includes the first TUI ratchet modules under
+`src/gpt_trader/tui/types.py`, `src/gpt_trader/tui/thresholds.py`, and
+`src/gpt_trader/tui/state_management/validators.py`; the broader dynamic
+Textual surface remains excluded until later ratchet steps. Profile-specific
+local checks can still differ from GitHub pull_request enforcement, especially
+around readiness evidence.
 
 The command accepts `--profile`/`-p` to select either the default strict/full
 profile or the quick/dev profile. Strict (the default and the `full` alias) runs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,10 +125,21 @@ strict_optional = true
 ignore_missing_imports = true
 explicit_package_bases = true
 mypy_path = "src"
-exclude = "(^|.*/)src/gpt_trader/tui/.*"
+# Keep most of the dynamic Textual surface out of the default mypy pass while
+# ratcheting small state/type modules into normal CI coverage.
+exclude = "(^|.*/)src/gpt_trader/tui/(?!(types|thresholds)\\.py$)(?!state_management/(?:__init__|validators)\\.py$).*"
 files = [
     "src/gpt_trader",
 ]
+
+[[tool.mypy.overrides]]
+module = [
+    "gpt_trader.tui.types",
+    "gpt_trader.tui.thresholds",
+    "gpt_trader.tui.state_management",
+    "gpt_trader.tui.state_management.validators",
+]
+ignore_errors = false
 
 [[tool.mypy.overrides]]
 module = "gpt_trader.tui.*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,7 @@ explicit_package_bases = true
 mypy_path = "src"
 # Keep most of the dynamic Textual surface out of the default mypy pass while
 # ratcheting small state/type modules into normal CI coverage.
-exclude = "(^|.*/)src/gpt_trader/tui/(?!(types|thresholds)\\.py$)(?!state_management/(?:__init__|validators)\\.py$).*"
+exclude = "(^|.*/)src/gpt_trader/tui/(?!(types|thresholds)\\.py$)(?!state_management/(?:__init__|validators)\\.py$).*\\.py$"
 files = [
     "src/gpt_trader",
 ]

--- a/tests/unit/scripts/test_mypy_tui_ratchet.py
+++ b/tests/unit/scripts/test_mypy_tui_ratchet.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+
+def _mypy_config() -> dict:
+    return tomllib.loads(Path("pyproject.toml").read_text())["tool"]["mypy"]
+
+
+def test_tui_mypy_ratchet_includes_initial_state_and_type_modules() -> None:
+    exclude = re.compile(_mypy_config()["exclude"])
+
+    included_paths = [
+        "src/gpt_trader/tui/types.py",
+        "src/gpt_trader/tui/thresholds.py",
+        "src/gpt_trader/tui/state_management/__init__.py",
+        "src/gpt_trader/tui/state_management/validators.py",
+    ]
+    excluded_paths = [
+        "src/gpt_trader/tui/app.py",
+        "src/gpt_trader/tui/screens/main_screen.py",
+        "src/gpt_trader/tui/services/mode_service.py",
+        "src/gpt_trader/tui/widgets/dashboard.py",
+    ]
+
+    assert all(exclude.search(path) is None for path in included_paths)
+    assert all(exclude.search(path) is not None for path in excluded_paths)
+
+
+def test_tui_mypy_ratchet_disables_ignore_errors_for_included_modules() -> None:
+    overrides = _mypy_config()["overrides"]
+
+    ratchet_override = next(
+        override
+        for override in overrides
+        if "gpt_trader.tui.state_management.validators" in override["module"]
+    )
+    broad_tui_override = next(
+        override for override in overrides if override["module"] == "gpt_trader.tui.*"
+    )
+
+    assert ratchet_override["ignore_errors"] is False
+    assert broad_tui_override["ignore_errors"] is True

--- a/tests/unit/scripts/test_mypy_tui_ratchet.py
+++ b/tests/unit/scripts/test_mypy_tui_ratchet.py
@@ -13,6 +13,8 @@ def test_tui_mypy_ratchet_includes_initial_state_and_type_modules() -> None:
     exclude = re.compile(_mypy_config()["exclude"])
 
     included_paths = [
+        "src/gpt_trader/tui/",
+        "src/gpt_trader/tui/state_management/",
         "src/gpt_trader/tui/types.py",
         "src/gpt_trader/tui/thresholds.py",
         "src/gpt_trader/tui/state_management/__init__.py",

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,8 +7,8 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6826,
-    "total_files": 805,
+    "total_tests": 6828,
+    "total_files": 806,
     "markers_used": 16
   },
   "quick_commands": {

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6661,
+    "unit": 6663,
     "asyncio": 411,
     "parametrize": 195,
     "endpoints": 83,

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,8 +2,8 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6826,
-    "total_files": 805,
+    "total_tests": 6828,
+    "total_files": 806,
     "markers_used": 16
   },
   "marker_definitions": {
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6661,
+    "unit": 6663,
     "asyncio": 411,
     "parametrize": 195,
     "endpoints": 83,
@@ -804,6 +804,9 @@
     ],
     "test_manage_logs.py": [
       "tests/unit/scripts/test_manage_logs.py"
+    ],
+    "test_mypy_tui_ratchet.py": [
+      "tests/unit/scripts/test_mypy_tui_ratchet.py"
     ],
     "test_project_review_issue_promoter.py": [
       "tests/unit/scripts/test_project_review_issue_promoter.py"
@@ -62554,6 +62557,24 @@
       {
         "name": "test_get_active_logs_reports_sizes",
         "line": 98,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      }
+    ],
+    "tests/unit/scripts/test_mypy_tui_ratchet.py": [
+      {
+        "name": "test_tui_mypy_ratchet_includes_initial_state_and_type_modules",
+        "line": 12,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_tui_mypy_ratchet_disables_ignore_errors_for_included_modules",
+        "line": 32,
         "markers": [
           "unit"
         ],

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -62574,7 +62574,7 @@
       },
       {
         "name": "test_tui_mypy_ratchet_disables_ignore_errors_for_included_modules",
-        "line": 32,
+        "line": 34,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary
- Reintroduces the first TUI mypy ratchet by including TUI type/state modules in the normal `uv run mypy src` path.
- Keeps the broader dynamic Textual surface excluded for later incremental ratchets.
- Adds a regression test that proves the included TUI files are not filtered by the pyproject exclude and are not covered by the broad `ignore_errors` override.

Closes #961

## Affected paths
- `pyproject.toml`
- `docs/DEVELOPMENT_GUIDELINES.md`
- `tests/unit/scripts/test_mypy_tui_ratchet.py`
- `var/agents/testing/index.json`
- `var/agents/testing/markers.json`
- `var/agents/testing/test_inventory.json`

## Verification
- `uv run mypy --no-incremental src` -> passed
- `uv run pytest tests/unit/scripts/test_mypy_tui_ratchet.py tests/unit/scripts/test_local_ci.py -q` -> 10 passed
- `uv run agent-regenerate --verify` -> passed
- `uv run local-ci --profile quick` -> passed, 7091 passed, 8 skipped

## Decision / safety notes
- This is config/test/docs-only and does not touch broker adapters, live trading, account capability, order submission, or execution policy.
- The first ratchet is intentionally narrow: `types.py`, `thresholds.py`, and `state_management/validators.py` are now covered while the remaining TUI modules stay excluded until follow-up ratchets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded local CI guidance for type checking, detailing which initial TUI modules are included in the first ratchet step.

* **Chores**
  * Refined the default type-checking exclusions for TUI code and enabled type checking for selected initial TUI modules.

* **Tests**
  * Added unit tests to verify the mypy “TUI ratchet” include/exclude behavior and override settings.

* **Chores**
  * Updated internal test index/count metadata to reflect the new tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->