### PR TITLE
[codex] Clarify local CI profile docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,20 @@ uv run pytest tests/property -q
 uv run pytest tests/unit/gpt_trader/tui/test_snapshots_*.py -q
 ```
 
+### Local Validation Profiles
+
+Use `uv run local-ci --profile quick` for fast development feedback; it skips
+readiness inputs and agent-artifact freshness with explicit banner messages.
+Use `make ci-required` for the local PR-readiness surface, including generated
+agent-artifact freshness. Use default `uv run local-ci` only when you also need
+strict/full local-live readiness evidence before a PR handoff.
+
+When strict/full fails on stale generated artifacts, run
+`uv run agent-regenerate` and then `uv run agent-regenerate --verify`. When it
+fails on readiness inputs, refresh the canary inputs with `make canary-daily`
+or follow the profile-specific commands in
+[`docs/DEVELOPMENT_GUIDELINES.md`](docs/DEVELOPMENT_GUIDELINES.md#local-ci-troubleshooting).
+
 ### Test Guardrails
 
 - Keep `test_*.py` modules <= 240 lines unless allowlisted.

--- a/docs/production.md
+++ b/docs/production.md
@@ -62,11 +62,14 @@ is ready.
 ## Validation Commands
 
 ```bash
-# Full local quality gate for PR-like confidence
+# Strict/full local gate: PR-readiness plus local/live readiness evidence
 uv run local-ci
 
-# Faster loop while editing
+# Fast development loop: skips readiness and agent-artifact freshness
 uv run local-ci --profile quick
+
+# Local PR-readiness surface without the canary readiness gate
+make ci-required
 
 # Profile and live-readiness diagnostics
 uv run python scripts/production_preflight.py --profile canary


### PR DESCRIPTION
Closes #969

## Summary
- add a short README local-validation profile guide that distinguishes quick feedback, local PR-readiness, and strict/full local-live readiness
- clarify the production validation command comments so `uv run local-ci`, `uv run local-ci --profile quick`, and `make ci-required` are not presented as interchangeable
- point stale artifact/readiness troubleshooting back to the detailed development guide

## Verification
- `python scripts/maintenance/docs_link_audit.py` - passed
- `python scripts/maintenance/docs_reachability_check.py` - passed
- `uv run agent-regenerate --verify` - passed, all context files up to date
- `uv run local-ci --profile quick` - passed, `7105 passed, 8 skipped`

## Notes
- Docs-only change.
- Quick profile remains documented as a feedback loop, not CI-equivalent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for local validation profiles in the testing/guardrails docs.
  * Clarified which local commands are best for fast development loops versus stricter PR-readiness checks.
  * Included troubleshooting tips for refreshing stale artifacts and verifying readiness inputs.
  * Updated the production validation commands section to better label strict and fast local checks, and added a PR-readiness command option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->