### PR TITLE
docs: establish tracked convention for review spreadsheet artifacts (issue #968) [run:goal-pipeline-20260626-001-gpt-trader-clean-discovery-scout]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,8 @@ docs/_build/
 
 # Review artifacts convention (tracked review CSVs/XLSX only; see #968 and docs/agents/project_review_pipeline.md)
 !review_artifacts/
+!review_artifacts/*.csv
+!review_artifacts/*.xlsx
 review_artifacts/tmp/
 review_artifacts/*.tmp
 review_artifacts/*.log

--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,12 @@ archived/claudia_20250812_151036/
 *.csv
 docs/_build/
 
+# Review artifacts convention (tracked review CSVs/XLSX only; see #968 and docs/agents/project_review_pipeline.md)
+!review_artifacts/
+review_artifacts/tmp/
+review_artifacts/*.tmp
+review_artifacts/*.log
+
 # Data outputs (local caches / generated datasets)
 data/
 data_storage/

--- a/.gitignore
+++ b/.gitignore
@@ -61,10 +61,11 @@ archived/claudia_20250812_151036/
 docs/_build/
 
 # Review artifacts convention (tracked review CSVs/XLSX only; see #968 and docs/agents/project_review_pipeline.md)
-!review_artifacts/
+review_artifacts/**
+!review_artifacts/.gitkeep
 !review_artifacts/*.csv
 !review_artifacts/*.xlsx
-review_artifacts/tmp/
+review_artifacts/tmp/**
 review_artifacts/*.tmp
 review_artifacts/*.log
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,3 +211,9 @@ uv run pytest -m "integration" tests/      # Integration tests (opt-in)
 | `docs/naming.md` | Naming conventions |
 | `docs/TUI_STYLE_GUIDE.md` | TUI development guide |
 | `CONTRIBUTING.md` | Full contribution workflow |
+
+### Review Artifacts Convention (run goal-pipeline-20260626-001-gpt-trader-clean-discovery-scout)
+Review deliverables (CSVs, spreadsheets from agent review lanes) are tracked only in `review_artifacts/`.
+- `!review_artifacts/` exception in .gitignore (global *.csv still protects data/).
+- See docs/agents/project_review_pipeline.md for details and verification.
+- Keeps handoff data durable without broad un-ignores.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,6 +124,13 @@ After editing `.tcss` files, rebuild CSS:
 python scripts/build_tui_css.py
 ```
 
+### Agent Review Artifacts
+
+Review and analysis artifacts that should be durable project records belong in
+`review_artifacts/`. Commit only intended review CSV/XLSX deliverables there;
+keep temporary review outputs under `review_artifacts/tmp/`, and do not commit
+large datasets or secrets.
+
 ## Architecture
 
 ### Source Structure

--- a/docs/agents/project_review_pipeline.md
+++ b/docs/agents/project_review_pipeline.md
@@ -255,7 +255,7 @@ follow-up. New work gets a new finding packet.
 Review and analysis artifacts (spreadsheets, CSVs, reports) produced by agent review lanes:
 
 - Committed only under `review_artifacts/`
-- Use narrow exceptions in `.gitignore` (e.g. `!review_artifacts/`) so global `*.csv` and `data/` ignores do not swallow handoff deliverables.
+- Use narrow exceptions in `.gitignore` (for example, `!review_artifacts/*.csv`) so global `*.csv` and `data/` ignores do not swallow handoff deliverables.
 - Non-durable temps go in `review_artifacts/tmp/` (still ignored).
 - Document format/location in this file and AGENTS.md.
 - XLSX and targeted CSVs are allowed; avoid committing large datasets or secrets.

--- a/docs/agents/project_review_pipeline.md
+++ b/docs/agents/project_review_pipeline.md
@@ -250,6 +250,19 @@ gh pr merge --auto --squash --delete-branch
 After merge, confirm the issue is closed or comment with the merged PR and any
 follow-up. New work gets a new finding packet.
 
+## Review Artifacts Convention (from #968, run goal-pipeline-20260626-001-gpt-trader-clean-discovery-scout)
+
+Review and analysis artifacts (spreadsheets, CSVs, reports) produced by agent review lanes:
+
+- Committed only under `review_artifacts/`
+- Use narrow exceptions in `.gitignore` (e.g. `!review_artifacts/`) so global `*.csv` and `data/` ignores do not swallow handoff deliverables.
+- Non-durable temps go in `review_artifacts/tmp/` (still ignored).
+- Document format/location in this file and AGENTS.md.
+- XLSX and targeted CSVs are allowed; avoid committing large datasets or secrets.
+- Verification: after creating artifact, `git status` should show only the intended review files; broad generated CSVs outside remain ignored.
+
+This supports repeatable review workflow without polluting commits or losing handoff data.
+
 ## Cadence
 
 Start with an hourly Codex automation. Tighten the cadence only after the issue

--- a/src/gpt_trader/persistence/durability.py
+++ b/src/gpt_trader/persistence/durability.py
@@ -513,7 +513,9 @@ def repair_sqlite_database(database_path: Path, backup_path: Path | None = None)
         conn = sqlite3.connect(str(temp_db_path))
         recovered_count = 0
         try:
-            conn.execute("PRAGMA journal_mode=WAL")
+            # DELETE mode keeps the recovered temp database as a single file so
+            # Windows repair can swap it without fighting locked WAL sidecars.
+            conn.execute("PRAGMA journal_mode=DELETE")
             conn.execute("PRAGMA synchronous=NORMAL")
 
             # Initialize with known schemas to preserve them
@@ -550,9 +552,7 @@ def repair_sqlite_database(database_path: Path, backup_path: Path | None = None)
                         operation="database_repair",
                         table=table_name,
                     )
-            # Commit the copied data to the new database before closing
             conn.commit()
-            conn.execute("PRAGMA main.wal_checkpoint(TRUNCATE)")
         finally:
             try:
                 conn.execute("DETACH DATABASE corrupted")

--- a/tests/unit/gpt_trader/persistence/test_durability_repair.py
+++ b/tests/unit/gpt_trader/persistence/test_durability_repair.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sqlite3
+from contextlib import closing
 from pathlib import Path
 
 import pytest
@@ -18,9 +19,10 @@ def _sidecar_paths(database_path: Path) -> tuple[Path, Path]:
 
 
 def _create_repair_fixture_database(database_path: Path) -> None:
-    with sqlite3.connect(str(database_path)) as connection:
+    with closing(sqlite3.connect(str(database_path))) as connection:
         connection.execute("CREATE TABLE repair_items (id INTEGER PRIMARY KEY, name TEXT)")
         connection.execute("INSERT INTO repair_items VALUES (1, 'kept')")
+        connection.commit()
 
 
 def test_repair_sqlite_database_aborts_when_backup_copy_fails(
@@ -78,7 +80,7 @@ def test_repair_sqlite_database_copies_common_columns_from_stale_schema(
     tmp_path: Path,
 ) -> None:
     database_path = tmp_path / "events.db"
-    with sqlite3.connect(str(database_path)) as connection:
+    with closing(sqlite3.connect(str(database_path))) as connection:
         connection.execute(
             """
             CREATE TABLE events (
@@ -92,6 +94,7 @@ def test_repair_sqlite_database_copies_common_columns_from_stale_schema(
             "INSERT INTO events (event_type, payload) VALUES (?, ?)",
             ("order_submitted", '{"symbol": "BTC-USD"}'),
         )
+        connection.commit()
 
     assert durability.repair_sqlite_database(database_path) is True
 

--- a/var/agents/logging/event_catalog.json
+++ b/var/agents/logging/event_catalog.json
@@ -450,7 +450,7 @@
         "INFO",
         "WARNING"
       ],
-      "occurrence_count": 8,
+      "occurrence_count": 9,
       "source_files": [
         "persistence/durability.py"
       ],
@@ -2512,7 +2512,7 @@
     "consecutive_failures": 6,
     "details": 4,
     "environment": 12,
-    "error": 64,
+    "error": 65,
     "error_message": 89,
     "error_type": 87,
     "event_type": 5,
@@ -2539,7 +2539,7 @@
   "level_distribution": {
     "CRITICAL": 2,
     "DEBUG": 49,
-    "ERROR": 122,
+    "ERROR": 123,
     "INFO": 90,
     "WARNING": 101
   },

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -102,7 +102,7 @@
     "property": 82,
     "integration": 79,
     "usefixtures": 17,
-    "skipif": 8,
+    "skipif": 9,
     "slow": 4,
     "anyio": 3,
     "contract": 3,

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -39882,7 +39882,7 @@
     "tests/unit/gpt_trader/persistence/test_durability_repair.py": [
       {
         "name": "test_repair_sqlite_database_aborts_when_backup_copy_fails",
-        "line": 26,
+        "line": 28,
         "markers": [
           "unit"
         ],
@@ -39890,7 +39890,7 @@
       },
       {
         "name": "test_repair_sqlite_database_removes_stale_wal_sidecars",
-        "line": 44,
+        "line": 46,
         "markers": [
           "unit"
         ],
@@ -39898,7 +39898,7 @@
       },
       {
         "name": "test_repair_sqlite_database_preserves_uncheckpointed_wal_rows",
-        "line": 57,
+        "line": 59,
         "markers": [
           "unit"
         ],
@@ -39906,7 +39906,7 @@
       },
       {
         "name": "test_repair_sqlite_database_copies_common_columns_from_stale_schema",
-        "line": 77,
+        "line": 79,
         "markers": [
           "unit"
         ],

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -109,7 +109,7 @@
     "property": 82,
     "integration": 79,
     "usefixtures": 17,
-    "skipif": 8,
+    "skipif": 9,
     "slow": 4,
     "anyio": 3,
     "contract": 3,
@@ -35673,7 +35673,7 @@
     "tests/unit/gpt_trader/monitoring/notifications/test_notification_backends_core.py": [
       {
         "name": "TestConsoleNotificationBackend::test_name_property",
-        "line": 26,
+        "line": 27,
         "markers": [
           "unit"
         ],
@@ -35682,7 +35682,7 @@
       },
       {
         "name": "TestConsoleNotificationBackend::test_is_enabled_property",
-        "line": 30,
+        "line": 31,
         "markers": [
           "unit"
         ],
@@ -35691,7 +35691,7 @@
       },
       {
         "name": "TestConsoleNotificationBackend::test_send_writes_to_project_console_sink",
-        "line": 38,
+        "line": 39,
         "markers": [
           "asyncio",
           "unit"
@@ -35701,7 +35701,7 @@
       },
       {
         "name": "TestConsoleNotificationBackend::test_send_uses_default_console_sink_for_cli_fallback",
-        "line": 59,
+        "line": 60,
         "markers": [
           "asyncio",
           "unit"
@@ -35711,7 +35711,7 @@
       },
       {
         "name": "TestConsoleNotificationBackend::test_send_default_sink_does_not_reuse_cached_stdout",
-        "line": 80,
+        "line": 81,
         "markers": [
           "asyncio",
           "unit"
@@ -35721,7 +35721,7 @@
       },
       {
         "name": "TestConsoleNotificationBackend::test_send_filters_by_severity",
-        "line": 101,
+        "line": 102,
         "markers": [
           "asyncio",
           "unit"
@@ -35731,7 +35731,7 @@
       },
       {
         "name": "TestConsoleNotificationBackend::test_test_connection_always_true",
-        "line": 116,
+        "line": 117,
         "markers": [
           "asyncio",
           "unit"
@@ -35741,7 +35741,7 @@
       },
       {
         "name": "TestFileNotificationBackend::test_name_property",
-        "line": 125,
+        "line": 126,
         "markers": [
           "unit"
         ],
@@ -35750,7 +35750,7 @@
       },
       {
         "name": "TestFileNotificationBackend::test_send_writes_to_file",
-        "line": 130,
+        "line": 131,
         "markers": [
           "asyncio",
           "unit"
@@ -35760,7 +35760,7 @@
       },
       {
         "name": "TestFileNotificationBackend::test_test_connection_checks_writability",
-        "line": 152,
+        "line": 153,
         "markers": [
           "asyncio",
           "unit"
@@ -35770,7 +35770,7 @@
       },
       {
         "name": "TestFileNotificationBackend::test_test_connection_checks_existing_target_directly",
-        "line": 166,
+        "line": 167,
         "markers": [
           "asyncio",
           "unit"
@@ -35780,7 +35780,7 @@
       },
       {
         "name": "TestFileNotificationBackend::test_test_connection_rejects_trailing_separator_file_path",
-        "line": 177,
+        "line": 178,
         "markers": [
           "asyncio",
           "unit"
@@ -35790,7 +35790,7 @@
       },
       {
         "name": "TestFileNotificationBackend::test_test_connection_checks_broken_symlink_target_parent",
-        "line": 190,
+        "line": 191,
         "markers": [
           "asyncio",
           "unit"
@@ -35800,7 +35800,7 @@
       },
       {
         "name": "TestFileNotificationBackend::test_test_connection_checks_missing_symlink_target_without_creating_it",
-        "line": 205,
+        "line": 206,
         "markers": [
           "asyncio",
           "unit"
@@ -35810,7 +35810,7 @@
       },
       {
         "name": "TestFileNotificationBackend::test_test_connection_creates_parent_without_alert_file",
-        "line": 223,
+        "line": 224,
         "markers": [
           "asyncio",
           "unit"
@@ -35820,9 +35820,10 @@
       },
       {
         "name": "TestFileNotificationBackend::test_test_connection_handles_long_missing_file_name_without_alert_file",
-        "line": 235,
+        "line": 240,
         "markers": [
           "asyncio",
+          "skipif",
           "unit"
         ],
         "docstring": "",
@@ -35830,7 +35831,7 @@
       },
       {
         "name": "TestFileNotificationBackend::test_test_connection_offloads_file_check_to_thread",
-        "line": 250,
+        "line": 255,
         "markers": [
           "asyncio",
           "unit"
@@ -35840,7 +35841,7 @@
       },
       {
         "name": "TestFileNotificationBackend::test_test_connection_fails_for_invalid_path",
-        "line": 274,
+        "line": 279,
         "markers": [
           "asyncio",
           "unit"


### PR DESCRIPTION
Implements the tracked review artifact convention requested by #968 and carries the narrow required-check repairs needed after the new Windows portability job landed.

Run tag: `goal-pipeline-20260626-001-gpt-trader-clean-discovery-scout`
Focus: `clean-discovery-scout-968-or-scout`

Changes:
- Adds narrow `.gitignore` exceptions for top-level `review_artifacts/*.csv` and `review_artifacts/*.xlsx` while keeping broad generated CSVs, data outputs, temp files, logs, and `review_artifacts/tmp/` ignored.
- Adds `review_artifacts/.gitkeep` as the durable review-artifact location anchor.
- Documents the convention in `AGENTS.md` and `docs/agents/project_review_pipeline.md`.
- Refreshes generated agent context artifacts after the explicit freshness gate found stale inventory/catalog output from current `main`.
- Applies the missing Windows durability repair follow-up from the completed `#1003` branch: use SQLite `DELETE` journal mode for the recovered temp database so the Windows portability job can swap the repaired file without locked WAL sidecars.
- Closes SQLite repair test fixture connections explicitly so Windows can replace the database files under test.

Verification:
- `git check-ignore -v -n -- review_artifacts/sample.csv review_artifacts/sample.xlsx review_artifacts/sample.log review_artifacts/tmp/sample.csv other.csv data/sample.csv`
- `python scripts/maintenance/docs_link_audit.py`
- `python scripts/maintenance/docs_reachability_check.py`
- `uv run agent-regenerate --verify`
- `uv run pytest tests/unit/gpt_trader/persistence/test_durability_repair.py -q`
- `uv run local-ci --profile quick`
- `git diff --check`

No trading or execution behavior changes.

Closes #968


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQLite database recovery to produce more reliable single-file results across platforms.
* **Tests**
  * Updated durability repair tests to use explicit connection lifecycle management and commits.
* **Documentation**
  * Added a “Review Artifacts Convention” explaining where to store durable review CSV/XLSX outputs and how to keep temporary files out of version control.
* **Chores**
  * Refined ignore rules and updated internal test/event inventory tracking metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->