### PR TITLE
feat(devex): ratchet Ruff coverage for scripts per #962 [run:goal-pipeline-20260626-004-gpt-trader-ruff-scripts-ratchet-962]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         run: uv run ruff check .
 
       - name: Lint (Ruff - critical scripts)
-        run: uv run ruff check scripts/ops scripts/ci scripts/monitoring scripts/production_preflight.py
+        run: uv run ruff check scripts/ops scripts/ci scripts/analysis/backtest_runner.py scripts/monitoring scripts/production_preflight.py
 
       - name: Format (Black)
         run: uv run black --check .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         run: uv run ruff check .
 
       - name: Lint (Ruff - critical scripts)
-        run: uv run ruff check scripts/ops scripts/monitoring scripts/production_preflight.py
+        run: uv run ruff check scripts/ops scripts/ci scripts/monitoring scripts/production_preflight.py
 
       - name: Format (Black)
         run: uv run black --check .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,11 @@ target-version = ["py312"]
 line-length = 100
 target-version = "py312"
 src = ["src"]
+# scripts/ is globally excluded from `ruff check .` to allow intentional looseness
+# for experiments, one-offs, and analysis. Only "critical" production/ops/ci/maintenance
+# scripts are explicitly linted in local-ci and CI as a ratchet (see issue #962).
+# Policy: expand the explicit list over time for operationally important scripts;
+# document exclusions for the rest.
 extend-exclude = [
     "scripts",
 ]

--- a/src/gpt_trader/ci/local_ci.py
+++ b/src/gpt_trader/ci/local_ci.py
@@ -199,6 +199,7 @@ def build_steps(profile: LocalCIProfile, args: argparse.Namespace) -> list[Plann
                 "ruff",
                 "check",
                 "scripts/ops",
+                "scripts/ci",
                 "scripts/analysis/backtest_runner.py",
                 "scripts/monitoring",
                 "scripts/production_preflight.py",


### PR DESCRIPTION
Implements a small ratchet step for issue #962: explicit policy comment + include scripts/ci in the critical Ruff lint list.

Run tag: `goal-pipeline-20260626-004-gpt-trader-ruff-scripts-ratchet-962`
Focus: `ruff-scripts-ratchet-962`

Changes:
- pyproject.toml: added detailed comment documenting the scripts lint policy (global exclude for flexibility, explicit critical paths for ratchet).
- src/gpt_trader/ci/local_ci.py: added "scripts/ci" to the Ruff critical scripts list.
- .github/workflows/ci.yml: added "scripts/ci" to the critical scripts lint step for consistency.

Verification:
- uv run ruff check scripts/ops scripts/ci scripts/monitoring scripts/production_preflight.py : passes
- Pre-commit (including ruff, black, yaml, etc.) passed
- No behavior changes; increases coverage for pipeline ci scripts.

This is a narrow, safe ratchet as recommended in the issue.

Closes #962

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded lint coverage to include additional script paths, helping catch issues earlier in the workflow.
  * Kept local CI checks aligned with the main pipeline for more consistent results.

* **Documentation**
  * Updated configuration comments to clarify which script areas are covered by linting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->