### PR TITLE
docs: add Windows Portability CI policy section per #955 [run:goal-pipeline-20260626-008-gpt-trader-windows-policy-955]

### DIFF
--- a/docs/DEVELOPMENT_GUIDELINES.md
+++ b/docs/DEVELOPMENT_GUIDELINES.md
@@ -102,6 +102,7 @@ bypass guards:
 - `Nightly Full Suite`: Scheduled full pytest run (slow markers included); manually triggerable for debugging.
 - `Security Audit`: Weekly pip-audit export to catch dependency vulnerabilities.
 - `GPT-Trader CI/CD Pipeline`: End-to-end build and deployment flow for staging/production releases; Docker publish is skipped on pull requests.
+- `Windows Portability`: Focused unit tests on windows-latest for persistence, monitoring, and scripts (see `windows-unit-tests` job in `.github/workflows/ci.yml`). Catches portability bugs for Windows development environment. Complements the default Ubuntu matrix. Added to address #955; currently runs on PRs (passes in recent merges) but not enforced as required check.
 
 ### Local CI Command
 


### PR DESCRIPTION
Documents the existing `windows-unit-tests` job (added previously) and its scope as the portability policy.

- Addresses #955 policy requirement.
- Bounded to docs update (job already exists and passes in CI).
- Closes #955

Verification: local docs check, agent-regenerate ok.

Run tag in title.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development guidelines with a new note about Windows portability testing in continuous integration.
  * Clarified that a dedicated Windows unit-test job runs on pull requests to help catch platform-specific issues alongside the default Ubuntu checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->