### PR TITLE
fix: remove shell from Windows clipboard copy

### DIFF
--- a/src/gpt_trader/tui/utilities/table_formatting.py
+++ b/src/gpt_trader/tui/utilities/table_formatting.py
@@ -396,7 +396,6 @@ def copy_to_clipboard(text: str) -> bool:
                 input=text.encode("utf-8"),
                 check=True,
                 capture_output=True,
-                shell=True,
             )
             return True
 

--- a/tests/unit/gpt_trader/tui/utilities/test_table_formatting.py
+++ b/tests/unit/gpt_trader/tui/utilities/test_table_formatting.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 import pytest
 from rich.text import Text
 
+import gpt_trader.tui.utilities.table_formatting as table_formatting
 from gpt_trader.tui.utilities.table_formatting import (
     copy_to_clipboard,
     create_numeric_cell,
@@ -105,6 +106,30 @@ class TestCopyToClipboard:
         """Copy empty string doesn't crash."""
         result = copy_to_clipboard("")
         assert isinstance(result, bool)
+
+    def test_windows_clipboard_copy_does_not_use_shell(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Windows clipboard copy invokes clip without a shell."""
+        calls: list[dict[str, object]] = []
+
+        def fake_run(command: list[str], **kwargs: object) -> None:
+            calls.append({"command": command, **kwargs})
+
+        monkeypatch.setattr(table_formatting.sys, "platform", "win32")
+        monkeypatch.setattr(table_formatting.subprocess, "run", fake_run)
+
+        result = copy_to_clipboard("test text")
+
+        assert result is True
+        assert calls == [
+            {
+                "command": ["clip"],
+                "input": b"test text",
+                "check": True,
+                "capture_output": True,
+            }
+        ]
 
 
 class TestTruncateId:

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6842,
+    "total_tests": 6843,
     "total_files": 806,
     "markers_used": 16
   },

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6677,
+    "unit": 6678,
     "asyncio": 411,
     "parametrize": 195,
     "endpoints": 83,

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6842,
+    "total_tests": 6843,
     "total_files": 806,
     "markers_used": 16
   },
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6677,
+    "unit": 6678,
     "asyncio": 411,
     "parametrize": 195,
     "endpoints": 83,
@@ -53463,7 +53463,7 @@
     "tests/unit/gpt_trader/tui/utilities/test_table_formatting.py": [
       {
         "name": "TestCreateNumericCell::test_basic_value",
-        "line": 21,
+        "line": 22,
         "markers": [
           "unit"
         ],
@@ -53472,7 +53472,7 @@
       },
       {
         "name": "TestCreateNumericCell::test_with_format_function",
-        "line": 28,
+        "line": 29,
         "markers": [
           "unit"
         ],
@@ -53481,7 +53481,7 @@
       },
       {
         "name": "TestCreateNumericCell::test_custom_justify",
-        "line": 33,
+        "line": 34,
         "markers": [
           "unit"
         ],
@@ -53490,7 +53490,7 @@
       },
       {
         "name": "TestCreateNumericCell::test_float_value",
-        "line": 38,
+        "line": 39,
         "markers": [
           "unit"
         ],
@@ -53499,7 +53499,7 @@
       },
       {
         "name": "TestCreateNumericCell::test_string_value",
-        "line": 43,
+        "line": 44,
         "markers": [
           "unit"
         ],
@@ -53508,7 +53508,7 @@
       },
       {
         "name": "TestFormatTableCell::test_format_text",
-        "line": 52,
+        "line": 53,
         "markers": [
           "unit"
         ],
@@ -53517,7 +53517,7 @@
       },
       {
         "name": "TestFormatTableCell::test_format_currency",
-        "line": 57,
+        "line": 58,
         "markers": [
           "unit"
         ],
@@ -53526,7 +53526,7 @@
       },
       {
         "name": "TestFormatTableCell::test_format_percentage",
-        "line": 63,
+        "line": 64,
         "markers": [
           "unit"
         ],
@@ -53535,7 +53535,7 @@
       },
       {
         "name": "TestFormatTableCell::test_format_number",
-        "line": 70,
+        "line": 71,
         "markers": [
           "unit"
         ],
@@ -53544,7 +53544,7 @@
       },
       {
         "name": "TestFormatTableCell::test_format_decimal",
-        "line": 75,
+        "line": 76,
         "markers": [
           "unit"
         ],
@@ -53553,7 +53553,7 @@
       },
       {
         "name": "TestFormatTableCell::test_format_with_max_length",
-        "line": 80,
+        "line": 81,
         "markers": [
           "unit"
         ],
@@ -53562,7 +53562,7 @@
       },
       {
         "name": "TestFormatTableCell::test_format_none",
-        "line": 85,
+        "line": 86,
         "markers": [
           "unit"
         ],
@@ -53571,7 +53571,7 @@
       },
       {
         "name": "TestCopyToClipboard::test_copy_on_macos",
-        "line": 94,
+        "line": 95,
         "markers": [
           "unit"
         ],
@@ -53580,7 +53580,7 @@
       },
       {
         "name": "TestCopyToClipboard::test_copy_empty_string",
-        "line": 104,
+        "line": 105,
         "markers": [
           "unit"
         ],
@@ -53588,8 +53588,17 @@
         "class": "TestCopyToClipboard"
       },
       {
+        "name": "TestCopyToClipboard::test_windows_clipboard_copy_does_not_use_shell",
+        "line": 110,
+        "markers": [
+          "unit"
+        ],
+        "docstring": "Windows clipboard copy invokes clip without a shell.",
+        "class": "TestCopyToClipboard"
+      },
+      {
         "name": "TestTruncateId::test_long_id_truncated",
-        "line": 113,
+        "line": 138,
         "markers": [
           "unit"
         ],
@@ -53598,7 +53607,7 @@
       },
       {
         "name": "TestTruncateId::test_short_id_unchanged",
-        "line": 118,
+        "line": 143,
         "markers": [
           "unit"
         ],
@@ -53607,7 +53616,7 @@
       },
       {
         "name": "TestTruncateId::test_exact_length_unchanged",
-        "line": 123,
+        "line": 148,
         "markers": [
           "unit"
         ],
@@ -53616,7 +53625,7 @@
       },
       {
         "name": "TestTruncateId::test_empty_string",
-        "line": 128,
+        "line": 153,
         "markers": [
           "unit"
         ],
@@ -53625,7 +53634,7 @@
       },
       {
         "name": "TestTruncateId::test_none_returns_empty",
-        "line": 133,
+        "line": 158,
         "markers": [
           "unit"
         ],
@@ -53634,7 +53643,7 @@
       },
       {
         "name": "TestTruncateId::test_default_length",
-        "line": 138,
+        "line": 163,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary
Remove the unnecessary Windows shell process from the TUI clipboard copy path.

Related issue / finding / RJ-routed package:
Closes #1007

## Type of change
- [ ] Refactor
- [ ] Feature
- [x] Bug fix
- [x] Tests only
- [ ] CI/Docs/Tooling

## Scope & Impact
- Affected areas / components: `src/gpt_trader/tui/utilities/table_formatting.py`, focused clipboard tests, generated testing inventory.
- Behavior changes: Windows clipboard copy now calls `clip` directly via `subprocess.run(["clip"], ...)` without `shell=True`. macOS, Linux, and `pyperclip` fallback behavior is unchanged.

## Test Plan
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Contract tests (if applicable)
- [x] Ran locally: `uv run pytest tests/unit/gpt_trader/tui/utilities/test_table_formatting.py -q`
- [x] Markers used appropriately (`unit`/`integration`/`slow`/`perf`)

## Complexity & Quality Gates
- [x] Mypy/type-check passed via `uv run local-ci --profile quick`
- [x] Xenon/radon complexity gate passed (CC <= 15 on live_trade execution): not applicable to this TUI utility change
- [x] No `sys.path` hacks in tests
- [x] No `MagicMock` on `async def` (use `AsyncMock`)
- [x] Import-lint rules respected (no "import up the stack") via `uv run local-ci --profile quick`

## Observability & Errors
- [x] Structured JSON logs for new/changed paths: not applicable; existing debug logging remains unchanged
- [x] Errors include diagnostic context (symbol, order_id, correlation_id): not applicable to clipboard utility path
- [x] Added/updated sampling examples in tests (if applicable): not applicable

## Configuration
- [ ] If config changed: `python -m gpt_trader.cli.config validate --profile <name>` passes
- [x] Env docs re-generated (if applicable) and committed: not applicable
- [x] No `ConfigLoader` usages introduced (ConfigManager-only)

## Breaking Changes
- [x] None
- [ ] Documented in PR body and release notes if any

## Verification
- `uv run pytest tests/unit/gpt_trader/tui/utilities/test_table_formatting.py -q` -> 21 passed
- `uv run ruff check src/gpt_trader/tui/utilities/table_formatting.py tests/unit/gpt_trader/tui/utilities/test_table_formatting.py` -> passed
- `uv run agent-regenerate --verify` -> all context files up to date
- `uv run local-ci --profile quick` -> passed; 7106 passed, 8 skipped
- `rg -n "shell=True" src/gpt_trader/tui/utilities/table_formatting.py tests/unit/gpt_trader/tui/utilities/test_table_formatting.py` -> no matches

## Checklist
- [x] Acceptance criteria in linked issue(s), finding packet, or routed package met
- [x] Affected paths listed in PR description
- [ ] Changelog entry (if repo uses one)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clipboard copying on Windows by avoiding shell-based subprocess execution.
  * Kept existing platform handling and fallback behavior intact.

* **Tests**
  * Added coverage to verify clipboard copying works without using a shell.
  * Updated test inventory counts to reflect the new test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->