### PR TITLE
[codex] Validate profile session times

### DIFF
--- a/src/gpt_trader/app/config/profile_loader.py
+++ b/src/gpt_trader/app/config/profile_loader.py
@@ -32,6 +32,7 @@ Schema Structure:
 from __future__ import annotations
 
 import os
+import re
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from datetime import time
@@ -53,6 +54,8 @@ if TYPE_CHECKING:
     from gpt_trader.app.config.bot_config import BotConfig
 
 logger = get_logger(__name__, component="profile_loader")
+
+_SESSION_TIME_PATTERN = re.compile(r"\d{2}:\d{2}(?::\d{2})?\Z")
 
 
 class ProfileValidationError(ValueError):
@@ -128,6 +131,11 @@ def _parse_session_time(
         return None
     if isinstance(value, time):
         return value
+    if not isinstance(value, str) or not _SESSION_TIME_PATTERN.fullmatch(value):
+        raise ProfileValidationError(
+            f"session.{field_name} for profile '{profile_name}' must be a valid "
+            f"HH:MM or HH:MM:SS time string; got {value!r}"
+        )
     try:
         return time.fromisoformat(value)
     except (TypeError, ValueError) as exc:

--- a/src/gpt_trader/app/config/profile_loader.py
+++ b/src/gpt_trader/app/config/profile_loader.py
@@ -119,10 +119,13 @@ class SessionConfig:
 def _parse_session_time(
     session_data: Mapping[str, Any], field_name: str, profile_name: str
 ) -> time | None:
+    """Parse an optional session time while preserving explicit YAML nulls."""
     if field_name not in session_data:
         return None
 
     value = session_data[field_name]
+    if value is None:
+        return None
     if isinstance(value, time):
         return value
     try:

--- a/src/gpt_trader/app/config/profile_loader.py
+++ b/src/gpt_trader/app/config/profile_loader.py
@@ -55,6 +55,10 @@ if TYPE_CHECKING:
 logger = get_logger(__name__, component="profile_loader")
 
 
+class ProfileValidationError(ValueError):
+    """Raised when profile YAML contains invalid configuration values."""
+
+
 @dataclass
 class TradingConfig:
     """Trading section of profile configuration."""
@@ -110,6 +114,24 @@ class SessionConfig:
     trading_days: list[str] = field(
         default_factory=lambda: ["monday", "tuesday", "wednesday", "thursday", "friday"]
     )
+
+
+def _parse_session_time(
+    session_data: Mapping[str, Any], field_name: str, profile_name: str
+) -> time | None:
+    if field_name not in session_data:
+        return None
+
+    value = session_data[field_name]
+    if isinstance(value, time):
+        return value
+    try:
+        return time.fromisoformat(value)
+    except (TypeError, ValueError) as exc:
+        raise ProfileValidationError(
+            f"session.{field_name} for profile '{profile_name}' must be a valid "
+            f"HH:MM or HH:MM:SS time string; got {value!r}"
+        ) from exc
 
 
 @dataclass
@@ -193,18 +215,8 @@ class ProfileSchema:
         )
 
         # Parse session config
-        start_time = None
-        end_time = None
-        if "start_time" in session_data:
-            try:
-                start_time = time.fromisoformat(session_data["start_time"])
-            except (ValueError, TypeError):
-                pass
-        if "end_time" in session_data:
-            try:
-                end_time = time.fromisoformat(session_data["end_time"])
-            except (ValueError, TypeError):
-                pass
+        start_time = _parse_session_time(session_data, "start_time", profile_name)
+        end_time = _parse_session_time(session_data, "end_time", profile_name)
 
         session = SessionConfig(
             start_time=start_time,
@@ -598,6 +610,21 @@ class ProfileLoader:
                 )
 
                 return schema
+            except ProfileValidationError as exc:
+                payload = profile_yaml_parse_error_payload(
+                    profile=profile.value,
+                    path=yaml_path,
+                    exception=exc,
+                )
+                logger.warning(
+                    "Failed to validate profile YAML",
+                    operation="profile_load",
+                    profile=profile.value,
+                    path=str(yaml_path),
+                    error=payload["reason"],
+                    details=payload,
+                )
+                raise
             except Exception as exc:
                 payload = profile_yaml_parse_error_payload(
                     profile=profile.value,
@@ -809,6 +836,7 @@ __all__ = [
     "ProfileLoader",
     "ProfileOverrideDecision",
     "ProfileOverrideSource",
+    "ProfileValidationError",
     "ProfileSchema",
     "ProfileRegistryEntry",
     "PROFILE_REGISTRY",

--- a/tests/unit/gpt_trader/app/config/test_profile_loader.py
+++ b/tests/unit/gpt_trader/app/config/test_profile_loader.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import time
 from decimal import Decimal
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -13,6 +14,7 @@ from gpt_trader.app.config.profile_loader import (
     ProfileLoader,
     ProfileOverrideSource,
     ProfileSchema,
+    ProfileValidationError,
     get_env_defaults_for_profile,
     get_env_profile_override,
     get_profile_registry_entry_by_name,
@@ -149,6 +151,32 @@ monitoring:
         assert details["severity"] == "warning"
         assert details["reason"].startswith("Profile YAML not found")
 
+    def test_invalid_session_time_re_raises_with_field_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mock_logger = MagicMock()
+        monkeypatch.setattr("gpt_trader.app.config.profile_loader.logger", mock_logger)
+
+        yaml_path = tmp_path / "dev.yaml"
+        yaml_path.write_text(
+            """
+profile_name: "dev"
+session:
+  start_time: "09:00"
+  end_time: "2026-06-27 15:00"
+"""
+        )
+
+        loader = ProfileLoader(profiles_dir=tmp_path)
+        with pytest.raises(ProfileValidationError, match=r"session\.end_time"):
+            loader.load(Profile.DEV)
+
+        assert mock_logger.warning.call_count == 1
+        logged_kwargs = mock_logger.warning.call_args.kwargs
+        details = logged_kwargs.get("details", {})
+        assert "session.end_time" in details["reason"]
+        assert details["path"].endswith("dev.yaml")
+
 
 class TestProfileSchema:
     """Tests for ProfileSchema dataclass."""
@@ -215,6 +243,8 @@ class TestProfileSchema:
         assert schema.risk.max_leverage == 5
         assert schema.risk.daily_loss_limit_pct == 0.1
         assert schema.execution.time_in_force == "FOK"
+        assert schema.session.start_time == time(9, 0)
+        assert schema.session.end_time == time(17, 0)
         assert schema.session.trading_days == ["monday", "wednesday", "friday"]
         assert schema.monitoring.update_interval == 120
 
@@ -240,6 +270,29 @@ class TestProfileSchema:
         assert schema.execution.mock_broker is True
         assert schema.execution.use_limit_orders is True
         assert schema.execution.market_order_fallback is False
+
+    @pytest.mark.parametrize(
+        ("field_name", "value"),
+        [
+            ("start_time", "not-a-time"),
+            ("end_time", "2026-06-27 15:00"),
+        ],
+    )
+    def test_from_yaml_rejects_invalid_session_times(self, field_name: str, value: str) -> None:
+        data = {
+            "profile_name": "invalid-session",
+            "session": {
+                "start_time": "09:00",
+                "end_time": "17:00",
+                field_name: value,
+            },
+        }
+
+        with pytest.raises(
+            ProfileValidationError,
+            match=rf"session\.{field_name}.*HH:MM",
+        ):
+            ProfileSchema.from_yaml(data, "invalid-session")
 
 
 class TestProfileRegistryHelpers:

--- a/tests/unit/gpt_trader/app/config/test_profile_loader.py
+++ b/tests/unit/gpt_trader/app/config/test_profile_loader.py
@@ -14,7 +14,6 @@ from gpt_trader.app.config.profile_loader import (
     ProfileLoader,
     ProfileOverrideSource,
     ProfileSchema,
-    ProfileValidationError,
     get_env_defaults_for_profile,
     get_env_profile_override,
     get_profile_registry_entry_by_name,
@@ -151,32 +150,6 @@ monitoring:
         assert details["severity"] == "warning"
         assert details["reason"].startswith("Profile YAML not found")
 
-    def test_invalid_session_time_re_raises_with_field_path(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        mock_logger = MagicMock()
-        monkeypatch.setattr("gpt_trader.app.config.profile_loader.logger", mock_logger)
-
-        yaml_path = tmp_path / "dev.yaml"
-        yaml_path.write_text(
-            """
-profile_name: "dev"
-session:
-  start_time: "09:00"
-  end_time: "2026-06-27 15:00"
-"""
-        )
-
-        loader = ProfileLoader(profiles_dir=tmp_path)
-        with pytest.raises(ProfileValidationError, match=r"session\.end_time"):
-            loader.load(Profile.DEV)
-
-        assert mock_logger.warning.call_count == 1
-        logged_kwargs = mock_logger.warning.call_args.kwargs
-        details = logged_kwargs.get("details", {})
-        assert "session.end_time" in details["reason"]
-        assert details["path"].endswith("dev.yaml")
-
 
 class TestProfileSchema:
     """Tests for ProfileSchema dataclass."""
@@ -270,29 +243,6 @@ class TestProfileSchema:
         assert schema.execution.mock_broker is True
         assert schema.execution.use_limit_orders is True
         assert schema.execution.market_order_fallback is False
-
-    @pytest.mark.parametrize(
-        ("field_name", "value"),
-        [
-            ("start_time", "not-a-time"),
-            ("end_time", "2026-06-27 15:00"),
-        ],
-    )
-    def test_from_yaml_rejects_invalid_session_times(self, field_name: str, value: str) -> None:
-        data = {
-            "profile_name": "invalid-session",
-            "session": {
-                "start_time": "09:00",
-                "end_time": "17:00",
-                field_name: value,
-            },
-        }
-
-        with pytest.raises(
-            ProfileValidationError,
-            match=rf"session\.{field_name}.*HH:MM",
-        ):
-            ProfileSchema.from_yaml(data, "invalid-session")
 
 
 class TestProfileRegistryHelpers:

--- a/tests/unit/gpt_trader/app/config/test_profile_loader_session_times.py
+++ b/tests/unit/gpt_trader/app/config/test_profile_loader_session_times.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import time
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -79,3 +80,52 @@ def test_from_yaml_preserves_explicit_null_session_times() -> None:
 
     assert schema.session.start_time is None
     assert schema.session.end_time is None
+
+
+@pytest.mark.parametrize(
+    ("start_time", "expected"),
+    [
+        ("09:00", time(9, 0)),
+        ("09:00:30", time(9, 0, 30)),
+    ],
+)
+def test_from_yaml_accepts_documented_session_time_shapes(start_time: str, expected: time) -> None:
+    data = {
+        "profile_name": "valid-session",
+        "session": {
+            "start_time": start_time,
+            "end_time": "17:00",
+        },
+    }
+
+    schema = ProfileSchema.from_yaml(data, "valid-session")
+
+    assert schema.session.start_time == expected
+
+
+@pytest.mark.parametrize(
+    "start_time",
+    [
+        "09",
+        "0900",
+        "T09:00",
+        "09:00Z",
+        "9:00",
+    ],
+)
+def test_from_yaml_rejects_non_contract_session_time_shapes(
+    start_time: str,
+) -> None:
+    data = {
+        "profile_name": "invalid-shape",
+        "session": {
+            "start_time": start_time,
+            "end_time": "17:00",
+        },
+    }
+
+    with pytest.raises(
+        ProfileValidationError,
+        match=r"session\.start_time.*HH:MM",
+    ):
+        ProfileSchema.from_yaml(data, "invalid-shape")

--- a/tests/unit/gpt_trader/app/config/test_profile_loader_session_times.py
+++ b/tests/unit/gpt_trader/app/config/test_profile_loader_session_times.py
@@ -1,0 +1,81 @@
+"""Session-time validation tests for profile loading."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from gpt_trader.app.config.profile_loader import (
+    ProfileLoader,
+    ProfileSchema,
+    ProfileValidationError,
+)
+from gpt_trader.config.types import Profile
+
+
+def test_loader_invalid_session_time_re_raises_with_field_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    mock_logger = MagicMock()
+    monkeypatch.setattr("gpt_trader.app.config.profile_loader.logger", mock_logger)
+
+    yaml_path = tmp_path / "dev.yaml"
+    yaml_path.write_text(
+        """
+profile_name: "dev"
+session:
+  start_time: "09:00"
+  end_time: "2026-06-27 15:00"
+"""
+    )
+
+    loader = ProfileLoader(profiles_dir=tmp_path)
+    with pytest.raises(ProfileValidationError, match=r"session\.end_time"):
+        loader.load(Profile.DEV)
+
+    assert mock_logger.warning.call_count == 1
+    logged_kwargs = mock_logger.warning.call_args.kwargs
+    details = logged_kwargs.get("details", {})
+    assert "session.end_time" in details["reason"]
+    assert details["path"].endswith("dev.yaml")
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    [
+        ("start_time", "not-a-time"),
+        ("end_time", "2026-06-27 15:00"),
+    ],
+)
+def test_from_yaml_rejects_invalid_session_times(field_name: str, value: str) -> None:
+    data = {
+        "profile_name": "invalid-session",
+        "session": {
+            "start_time": "09:00",
+            "end_time": "17:00",
+            field_name: value,
+        },
+    }
+
+    with pytest.raises(
+        ProfileValidationError,
+        match=rf"session\.{field_name}.*HH:MM",
+    ):
+        ProfileSchema.from_yaml(data, "invalid-session")
+
+
+def test_from_yaml_preserves_explicit_null_session_times() -> None:
+    data = {
+        "profile_name": "null-session",
+        "session": {
+            "start_time": None,
+            "end_time": None,
+        },
+    }
+
+    schema = ProfileSchema.from_yaml(data, "null-session")
+
+    assert schema.session.start_time is None
+    assert schema.session.end_time is None

--- a/var/agents/configuration/environment_variables.json
+++ b/var/agents/configuration/environment_variables.json
@@ -12,7 +12,7 @@
       ],
       "code_references": [
         {
-          "line": 306,
+          "line": 309,
           "path": "src/gpt_trader/app/config/profile_loader.py",
           "reader": "os.getenv"
         }
@@ -1497,7 +1497,7 @@
       ],
       "code_references": [
         {
-          "line": 303,
+          "line": 306,
           "path": "src/gpt_trader/app/config/profile_loader.py",
           "reader": "os.getenv"
         }

--- a/var/agents/configuration/environment_variables.json
+++ b/var/agents/configuration/environment_variables.json
@@ -12,7 +12,7 @@
       ],
       "code_references": [
         {
-          "line": 294,
+          "line": 306,
           "path": "src/gpt_trader/app/config/profile_loader.py",
           "reader": "os.getenv"
         }
@@ -1497,7 +1497,7 @@
       ],
       "code_references": [
         {
-          "line": 291,
+          "line": 303,
           "path": "src/gpt_trader/app/config/profile_loader.py",
           "reader": "os.getenv"
         }

--- a/var/agents/configuration/environment_variables.json
+++ b/var/agents/configuration/environment_variables.json
@@ -12,7 +12,7 @@
       ],
       "code_references": [
         {
-          "line": 309,
+          "line": 317,
           "path": "src/gpt_trader/app/config/profile_loader.py",
           "reader": "os.getenv"
         }
@@ -1497,7 +1497,7 @@
       ],
       "code_references": [
         {
-          "line": 306,
+          "line": 314,
           "path": "src/gpt_trader/app/config/profile_loader.py",
           "reader": "os.getenv"
         }

--- a/var/agents/logging/event_catalog.json
+++ b/var/agents/logging/event_catalog.json
@@ -1663,7 +1663,7 @@
         "INFO",
         "WARNING"
       ],
-      "occurrence_count": 3,
+      "occurrence_count": 4,
       "source_files": [
         "app/config/profile_loader.py"
       ],
@@ -2510,9 +2510,9 @@
     "client_ip": 4,
     "client_order_id": 20,
     "consecutive_failures": 6,
-    "details": 4,
+    "details": 5,
     "environment": 12,
-    "error": 65,
+    "error": 66,
     "error_message": 89,
     "error_type": 87,
     "event_type": 5,
@@ -2525,7 +2525,7 @@
     "mode": 4,
     "order_id": 29,
     "outcome": 5,
-    "path": 11,
+    "path": 12,
     "portfolio_id": 4,
     "price": 4,
     "quantity": 10,
@@ -2541,7 +2541,7 @@
     "DEBUG": 49,
     "ERROR": 123,
     "INFO": 90,
-    "WARNING": 101
+    "WARNING": 102
   },
   "total_event_types": 136,
   "version": "1.0"

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6843,
+    "total_tests": 6845,
     "total_files": 806,
     "markers_used": 16
   },

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6846,
+    "total_tests": 6848,
     "total_files": 807,
     "markers_used": 16
   },

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,8 +7,8 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6845,
-    "total_files": 806,
+    "total_tests": 6846,
+    "total_files": 807,
     "markers_used": 16
   },
   "quick_commands": {

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,9 +95,9 @@
     ]
   },
   "counts": {
-    "unit": 6681,
+    "unit": 6683,
     "asyncio": 411,
-    "parametrize": 196,
+    "parametrize": 198,
     "endpoints": 83,
     "property": 82,
     "integration": 79,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,9 +95,9 @@
     ]
   },
   "counts": {
-    "unit": 6678,
+    "unit": 6680,
     "asyncio": 411,
-    "parametrize": 195,
+    "parametrize": 196,
     "endpoints": 83,
     "property": 82,
     "integration": 79,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6680,
+    "unit": 6681,
     "asyncio": 411,
     "parametrize": 196,
     "endpoints": 83,

--- a/var/agents/testing/source_test_map.json
+++ b/var/agents/testing/source_test_map.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "summary": {
-    "tests_scanned": 721,
+    "tests_scanned": 722,
     "source_modules": 374,
     "unresolved_modules": 3
   },
@@ -84,6 +84,7 @@
       "tests/integration/test_container_lifecycle_runtime.py",
       "tests/unit/gpt_trader/app/config/test_profile_loader.py",
       "tests/unit/gpt_trader/app/config/test_profile_loader_container_api.py",
+      "tests/unit/gpt_trader/app/config/test_profile_loader_session_times.py",
       "tests/unit/gpt_trader/app/test_application_container.py",
       "tests/unit/gpt_trader/cli/test_options.py",
       "tests/unit/gpt_trader/cli/test_services_build_config.py",
@@ -380,6 +381,7 @@
     "gpt_trader.config.types": [
       "tests/unit/gpt_trader/app/config/test_profile_loader.py",
       "tests/unit/gpt_trader/app/config/test_profile_loader_container_api.py",
+      "tests/unit/gpt_trader/app/config/test_profile_loader_session_times.py",
       "tests/unit/gpt_trader/app/containers/test_risk_validation.py",
       "tests/unit/gpt_trader/app/test_bootstrap.py",
       "tests/unit/gpt_trader/app/test_bootstrap_profile_loading.py",
@@ -2398,6 +2400,10 @@
       "gpt_trader.app.config",
       "gpt_trader.app.config.profile_loader",
       "gpt_trader.app.container",
+      "gpt_trader.config.types"
+    ],
+    "tests/unit/gpt_trader/app/config/test_profile_loader_session_times.py": [
+      "gpt_trader.app.config.profile_loader",
       "gpt_trader.config.types"
     ],
     "tests/unit/gpt_trader/app/config/test_validation.py": [

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6846,
+    "total_tests": 6848,
     "total_files": 807,
     "markers_used": 16
   },
@@ -102,9 +102,9 @@
     ]
   },
   "marker_counts": {
-    "unit": 6681,
+    "unit": 6683,
     "asyncio": 411,
-    "parametrize": 196,
+    "parametrize": 198,
     "endpoints": 83,
     "property": 82,
     "integration": 79,
@@ -3271,7 +3271,7 @@
     "tests/unit/gpt_trader/app/config/test_profile_loader_session_times.py": [
       {
         "name": "test_loader_invalid_session_time_re_raises_with_field_path",
-        "line": 18,
+        "line": 19,
         "markers": [
           "unit"
         ],
@@ -3279,7 +3279,7 @@
       },
       {
         "name": "test_from_yaml_rejects_invalid_session_times",
-        "line": 52,
+        "line": 53,
         "markers": [
           "parametrize",
           "unit"
@@ -3288,8 +3288,26 @@
       },
       {
         "name": "test_from_yaml_preserves_explicit_null_session_times",
-        "line": 69,
+        "line": 70,
         "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_from_yaml_accepts_documented_session_time_shapes",
+        "line": 92,
+        "markers": [
+          "parametrize",
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_from_yaml_rejects_non_contract_session_time_shapes",
+        "line": 116,
+        "markers": [
+          "parametrize",
           "unit"
         ],
         "docstring": ""

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,8 +2,8 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6845,
-    "total_files": 806,
+    "total_tests": 6846,
+    "total_files": 807,
     "markers_used": 16
   },
   "marker_definitions": {
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6680,
+    "unit": 6681,
     "asyncio": 411,
     "parametrize": 196,
     "endpoints": 83,
@@ -131,6 +131,7 @@
       "tests/unit/gpt_trader/app/config/test_defaults.py",
       "tests/unit/gpt_trader/app/config/test_profile_loader.py",
       "tests/unit/gpt_trader/app/config/test_profile_loader_container_api.py",
+      "tests/unit/gpt_trader/app/config/test_profile_loader_session_times.py",
       "tests/unit/gpt_trader/app/config/test_validation.py",
       "tests/unit/gpt_trader/app/config/test_validation_rules.py",
       "tests/unit/gpt_trader/app/containers/test_risk_validation.py",
@@ -3020,7 +3021,7 @@
     "tests/unit/gpt_trader/app/config/test_profile_loader.py": [
       {
         "name": "TestProfileLoader::test_load_from_yaml_file",
-        "line": 30,
+        "line": 29,
         "markers": [
           "unit"
         ],
@@ -3029,7 +3030,7 @@
       },
       {
         "name": "TestProfileLoader::test_fallback_to_hardcoded_defaults",
-        "line": 70,
+        "line": 69,
         "markers": [
           "unit"
         ],
@@ -3038,7 +3039,7 @@
       },
       {
         "name": "TestProfileLoader::test_hardcoded_defaults_exist_for_all_profiles",
-        "line": 83,
+        "line": 82,
         "markers": [
           "unit"
         ],
@@ -3047,7 +3048,7 @@
       },
       {
         "name": "TestProfileLoader::test_profile_yaml_files_are_registered_profiles",
-        "line": 94,
+        "line": 93,
         "markers": [
           "unit"
         ],
@@ -3056,7 +3057,7 @@
       },
       {
         "name": "TestProfileLoader::test_observe_profile_is_read_only_live_data_shape",
-        "line": 101,
+        "line": 100,
         "markers": [
           "unit"
         ],
@@ -3065,7 +3066,7 @@
       },
       {
         "name": "TestProfileLoader::test_logs_payload_on_yaml_parse_error",
-        "line": 110,
+        "line": 109,
         "markers": [
           "unit"
         ],
@@ -3074,7 +3075,7 @@
       },
       {
         "name": "TestProfileLoader::test_logs_payload_when_profile_missing",
-        "line": 136,
+        "line": 135,
         "markers": [
           "unit"
         ],
@@ -3082,17 +3083,8 @@
         "class": "TestProfileLoader"
       },
       {
-        "name": "TestProfileLoader::test_invalid_session_time_re_raises_with_field_path",
-        "line": 154,
-        "markers": [
-          "unit"
-        ],
-        "docstring": "",
-        "class": "TestProfileLoader"
-      },
-      {
         "name": "TestProfileSchema::test_from_yaml_minimal",
-        "line": 184,
+        "line": 157,
         "markers": [
           "unit"
         ],
@@ -3101,7 +3093,7 @@
       },
       {
         "name": "TestProfileSchema::test_from_yaml_full",
-        "line": 196,
+        "line": 169,
         "markers": [
           "unit"
         ],
@@ -3110,7 +3102,7 @@
       },
       {
         "name": "TestProfileSchema::test_from_yaml_uses_trading_execution_when_top_level_execution_missing",
-        "line": 251,
+        "line": 224,
         "markers": [
           "unit"
         ],
@@ -3118,18 +3110,8 @@
         "class": "TestProfileSchema"
       },
       {
-        "name": "TestProfileSchema::test_from_yaml_rejects_invalid_session_times",
-        "line": 281,
-        "markers": [
-          "parametrize",
-          "unit"
-        ],
-        "docstring": "",
-        "class": "TestProfileSchema"
-      },
-      {
         "name": "TestProfileRegistryHelpers::test_get_env_defaults_for_unknown_profile_uses_prod_defaults",
-        "line": 301,
+        "line": 251,
         "markers": [
           "unit"
         ],
@@ -3138,7 +3120,7 @@
       },
       {
         "name": "TestProfileRegistryHelpers::test_is_dev_profile",
-        "line": 321,
+        "line": 271,
         "markers": [
           "parametrize",
           "unit"
@@ -3148,7 +3130,7 @@
       },
       {
         "name": "TestProfileRegistryHelpers::test_registry_lookup_is_case_insensitive",
-        "line": 324,
+        "line": 274,
         "markers": [
           "unit"
         ],
@@ -3157,7 +3139,7 @@
       },
       {
         "name": "TestProfileOverridePrecedence::test_cli_profile_wins",
-        "line": 333,
+        "line": 283,
         "markers": [
           "unit"
         ],
@@ -3166,7 +3148,7 @@
       },
       {
         "name": "TestProfileOverridePrecedence::test_file_profile_overrides_env",
-        "line": 344,
+        "line": 294,
         "markers": [
           "unit"
         ],
@@ -3175,7 +3157,7 @@
       },
       {
         "name": "TestProfileOverridePrecedence::test_env_profile_overrides_default",
-        "line": 355,
+        "line": 305,
         "markers": [
           "unit"
         ],
@@ -3184,7 +3166,7 @@
       },
       {
         "name": "TestProfileOverridePrecedence::test_falls_back_to_default",
-        "line": 366,
+        "line": 316,
         "markers": [
           "unit"
         ],
@@ -3193,7 +3175,7 @@
       },
       {
         "name": "TestProfileOverridePrecedence::test_blank_values_are_ignored",
-        "line": 377,
+        "line": 327,
         "markers": [
           "unit"
         ],
@@ -3202,7 +3184,7 @@
       },
       {
         "name": "TestProfileOverridePrecedence::test_env_helper_uses_bot_profile_when_primary_is_whitespace",
-        "line": 388,
+        "line": 338,
         "markers": [
           "unit"
         ],
@@ -3284,6 +3266,33 @@
         ],
         "docstring": "Test that all profiles can be loaded.",
         "class": "TestLoadProfile"
+      }
+    ],
+    "tests/unit/gpt_trader/app/config/test_profile_loader_session_times.py": [
+      {
+        "name": "test_loader_invalid_session_time_re_raises_with_field_path",
+        "line": 18,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_from_yaml_rejects_invalid_session_times",
+        "line": 52,
+        "markers": [
+          "parametrize",
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_from_yaml_preserves_explicit_null_session_times",
+        "line": 69,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
       }
     ],
     "tests/unit/gpt_trader/app/config/test_validation.py": [

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6843,
+    "total_tests": 6845,
     "total_files": 806,
     "markers_used": 16
   },
@@ -102,9 +102,9 @@
     ]
   },
   "marker_counts": {
-    "unit": 6678,
+    "unit": 6680,
     "asyncio": 411,
-    "parametrize": 195,
+    "parametrize": 196,
     "endpoints": 83,
     "property": 82,
     "integration": 79,
@@ -3020,7 +3020,7 @@
     "tests/unit/gpt_trader/app/config/test_profile_loader.py": [
       {
         "name": "TestProfileLoader::test_load_from_yaml_file",
-        "line": 28,
+        "line": 30,
         "markers": [
           "unit"
         ],
@@ -3029,7 +3029,7 @@
       },
       {
         "name": "TestProfileLoader::test_fallback_to_hardcoded_defaults",
-        "line": 68,
+        "line": 70,
         "markers": [
           "unit"
         ],
@@ -3038,7 +3038,7 @@
       },
       {
         "name": "TestProfileLoader::test_hardcoded_defaults_exist_for_all_profiles",
-        "line": 81,
+        "line": 83,
         "markers": [
           "unit"
         ],
@@ -3047,7 +3047,7 @@
       },
       {
         "name": "TestProfileLoader::test_profile_yaml_files_are_registered_profiles",
-        "line": 92,
+        "line": 94,
         "markers": [
           "unit"
         ],
@@ -3056,7 +3056,7 @@
       },
       {
         "name": "TestProfileLoader::test_observe_profile_is_read_only_live_data_shape",
-        "line": 99,
+        "line": 101,
         "markers": [
           "unit"
         ],
@@ -3065,7 +3065,7 @@
       },
       {
         "name": "TestProfileLoader::test_logs_payload_on_yaml_parse_error",
-        "line": 108,
+        "line": 110,
         "markers": [
           "unit"
         ],
@@ -3074,7 +3074,7 @@
       },
       {
         "name": "TestProfileLoader::test_logs_payload_when_profile_missing",
-        "line": 134,
+        "line": 136,
         "markers": [
           "unit"
         ],
@@ -3082,8 +3082,17 @@
         "class": "TestProfileLoader"
       },
       {
+        "name": "TestProfileLoader::test_invalid_session_time_re_raises_with_field_path",
+        "line": 154,
+        "markers": [
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestProfileLoader"
+      },
+      {
         "name": "TestProfileSchema::test_from_yaml_minimal",
-        "line": 156,
+        "line": 184,
         "markers": [
           "unit"
         ],
@@ -3092,7 +3101,7 @@
       },
       {
         "name": "TestProfileSchema::test_from_yaml_full",
-        "line": 168,
+        "line": 196,
         "markers": [
           "unit"
         ],
@@ -3101,7 +3110,7 @@
       },
       {
         "name": "TestProfileSchema::test_from_yaml_uses_trading_execution_when_top_level_execution_missing",
-        "line": 221,
+        "line": 251,
         "markers": [
           "unit"
         ],
@@ -3109,8 +3118,18 @@
         "class": "TestProfileSchema"
       },
       {
+        "name": "TestProfileSchema::test_from_yaml_rejects_invalid_session_times",
+        "line": 281,
+        "markers": [
+          "parametrize",
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestProfileSchema"
+      },
+      {
         "name": "TestProfileRegistryHelpers::test_get_env_defaults_for_unknown_profile_uses_prod_defaults",
-        "line": 248,
+        "line": 301,
         "markers": [
           "unit"
         ],
@@ -3119,7 +3138,7 @@
       },
       {
         "name": "TestProfileRegistryHelpers::test_is_dev_profile",
-        "line": 268,
+        "line": 321,
         "markers": [
           "parametrize",
           "unit"
@@ -3129,7 +3148,7 @@
       },
       {
         "name": "TestProfileRegistryHelpers::test_registry_lookup_is_case_insensitive",
-        "line": 271,
+        "line": 324,
         "markers": [
           "unit"
         ],
@@ -3138,7 +3157,7 @@
       },
       {
         "name": "TestProfileOverridePrecedence::test_cli_profile_wins",
-        "line": 280,
+        "line": 333,
         "markers": [
           "unit"
         ],
@@ -3147,7 +3166,7 @@
       },
       {
         "name": "TestProfileOverridePrecedence::test_file_profile_overrides_env",
-        "line": 291,
+        "line": 344,
         "markers": [
           "unit"
         ],
@@ -3156,7 +3175,7 @@
       },
       {
         "name": "TestProfileOverridePrecedence::test_env_profile_overrides_default",
-        "line": 302,
+        "line": 355,
         "markers": [
           "unit"
         ],
@@ -3165,7 +3184,7 @@
       },
       {
         "name": "TestProfileOverridePrecedence::test_falls_back_to_default",
-        "line": 313,
+        "line": 366,
         "markers": [
           "unit"
         ],
@@ -3174,7 +3193,7 @@
       },
       {
         "name": "TestProfileOverridePrecedence::test_blank_values_are_ignored",
-        "line": 324,
+        "line": 377,
         "markers": [
           "unit"
         ],
@@ -3183,7 +3202,7 @@
       },
       {
         "name": "TestProfileOverridePrecedence::test_env_helper_uses_bot_profile_when_primary_is_whitespace",
-        "line": 335,
+        "line": 388,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary
Treat malformed profile `session.start_time` / `session.end_time` values as validation errors instead of silently dropping them to `None`.

Related issue / finding / RJ-routed package:
Closes #1008

Pipeline id: `goal-pipeline-20260626-gpt-trader-issue1008-session-time-validation`

## Type of change
- [ ] Refactor
- [ ] Feature
- [x] Bug fix
- [ ] Tests only
- [x] CI/Docs/Tooling

## Scope & Impact
- Affected areas / components: profile YAML loading, profile-loader tests, generated agent context files.
- Behavior change: invalid profile session time values now raise `ProfileValidationError` with a `session.<field>` path. `ProfileLoader.load()` logs the normalized profile-load error payload with the YAML path and re-raises that validation error; existing YAML parse/missing-file fallback behavior is unchanged.

## Test Plan
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Contract tests (if applicable)
- [ ] Ran locally: `pytest -m "unit and not slow"`
- [x] Markers used appropriately (`unit`/`integration`/`slow`/`perf`)

Verification:
- `uv run pytest tests/unit/gpt_trader/app/config/test_profile_loader.py` -> 30 passed
- `uv run agent-regenerate --verify` -> all context files up to date
- `git diff --check` -> passed
- `uv run local-ci --profile quick` -> passed

## Complexity & Quality Gates
- [x] Mypy/type-check passed
- [ ] Xenon/radon complexity gate passed (CC <= 15 on live_trade execution)
- [x] No `sys.path` hacks in tests
- [x] No `MagicMock` on `async def` (use `AsyncMock`)
- [x] Import-lint rules respected (no "import up the stack")

## Observability & Errors
- [x] Structured JSON logs for new/changed paths
- [ ] Errors include diagnostic context (symbol, order_id, correlation_id)
- [ ] Added/updated sampling examples in tests (if applicable)

The changed error path includes profile, YAML path, and `session.<field>` context; no symbol/order/correlation context applies to profile parsing.

## Configuration
- [ ] If config changed: `python -m gpt_trader.cli.config validate --profile <name>` passes
- [x] Env docs re-generated (if applicable) and committed
- [x] No `ConfigLoader` usages introduced (ConfigManager-only)

## Breaking Changes
- [ ] None
- [x] Documented in PR body and release notes if any

Invalid session time strings that were previously ignored now fail profile loading.

## Screenshots / Logs (optional)
Not applicable.

## Checklist
- [x] Acceptance criteria in linked issue(s), finding packet, or routed package met
- [x] Affected paths listed in PR description
- [ ] Changelog entry (if repo uses one)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Profile YAML now strictly validates `session.start_time` and `session.end_time`; invalid time strings no longer get ignored.
  * Explicit `null` session times are preserved as empty values (`None`) after parsing.
  * Profile validation warnings now include more specific field and YAML path details.
* **Tests**
  * Added a new unit test module covering loader/schema behavior for valid times, invalid formats (with field-specific errors), and `null` handling.
  * Updated existing schema tests to assert parsed `datetime.time` values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->