### PR TITLE
[codex] Fail closed on credentialed time sync checks

### DIFF
--- a/src/gpt_trader/preflight/checks/system.py
+++ b/src/gpt_trader/preflight/checks/system.py
@@ -3,10 +3,25 @@ from __future__ import annotations
 import shutil
 import sys
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from gpt_trader.preflight.core import PreflightCheck
+
+
+def _build_coinbase_time_client(api_key: str, private_key: str) -> Any:
+    from gpt_trader.features.brokerages.coinbase.auth import create_cdp_jwt_auth
+    from gpt_trader.features.brokerages.coinbase.client import CoinbaseClient
+
+    auth = create_cdp_jwt_auth(
+        api_key=api_key,
+        private_key=private_key,
+    )
+    return CoinbaseClient(
+        base_url="https://api.coinbase.com",
+        auth=auth,
+        api_mode="advanced",
+    )
 
 
 def check_python_version(checker: PreflightCheck) -> bool:
@@ -34,44 +49,36 @@ def check_system_time(checker: PreflightCheck) -> bool:
 
         api_key, private_key = ctx.resolve_cdp_credentials()
         if api_key and private_key:
-            try:
-                from gpt_trader.features.brokerages.coinbase.auth import (
-                    create_cdp_jwt_auth,
-                )
-                from gpt_trader.features.brokerages.coinbase.client import CoinbaseClient
-
-                auth = create_cdp_jwt_auth(
-                    api_key=api_key,
-                    private_key=private_key,
-                )
-                client = CoinbaseClient(
-                    base_url="https://api.coinbase.com",
-                    auth=auth,
-                    api_mode="advanced",
-                )
-
+            if ctx.should_skip_remote_checks():
+                checker.log_warning("Skipping Coinbase server time verification by policy")
+            else:
                 try:
+                    client = _build_coinbase_time_client(
+                        api_key=api_key,
+                        private_key=private_key,
+                    )
                     server_time_resp = client.get_time()
-                    if server_time_resp and "iso" in server_time_resp:
-                        server_time = datetime.fromisoformat(
-                            server_time_resp["iso"].replace("Z", "+00:00")
-                        )
-                        diff = abs((system_time - server_time).total_seconds())
+                    if not server_time_resp or "iso" not in server_time_resp:
+                        raise ValueError("Coinbase time response missing 'iso'")
 
-                        if diff < 1:
-                            checker.log_success(f"System clock synchronized (drift: {diff:.2f}s)")
-                            return True
-                        if diff < 5:
-                            checker.log_warning(f"System clock drift: {diff:.2f}s (acceptable)")
-                            return True
+                    server_time = datetime.fromisoformat(
+                        server_time_resp["iso"].replace("Z", "+00:00")
+                    )
+                    diff = abs((system_time - server_time).total_seconds())
 
-                        checker.log_error(f"System clock drift: {diff:.2f}s - SYNC REQUIRED")
-                        checker.log_info("Run: sudo ntpdate -s time.nist.gov")
-                        return False
-                except Exception:
-                    pass
-            except Exception:  # pragma: no cover - optional dependency path
-                pass
+                    if diff < 1:
+                        checker.log_success(f"System clock synchronized (drift: {diff:.2f}s)")
+                        return True
+                    if diff < 5:
+                        checker.log_warning(f"System clock drift: {diff:.2f}s (acceptable)")
+                        return True
+
+                    checker.log_error(f"System clock drift: {diff:.2f}s - SYNC REQUIRED")
+                    checker.log_info("Run: sudo ntpdate -s time.nist.gov")
+                    return False
+                except Exception as exc:
+                    checker.log_error(f"Cannot verify Coinbase server time: {exc}")
+                    return False
 
         if 2024 <= system_time.year <= 2030:
             checker.log_warning("Cannot verify time sync, but system time seems reasonable")

--- a/tests/unit/gpt_trader/preflight/test_checks_system.py
+++ b/tests/unit/gpt_trader/preflight/test_checks_system.py
@@ -16,6 +16,8 @@ from gpt_trader.preflight.checks.system import (
 )
 from gpt_trader.preflight.core import PreflightCheck
 
+FAKE_COINBASE_PRIVATE_KEY = "test-private-key"
+
 
 class TestCheckPythonVersion:
     """Test Python version check."""
@@ -190,11 +192,9 @@ class TestCheckSystemTime:
         cleared_env: None,
     ) -> None:
         checker = PreflightCheck(profile="dev")
+        monkeypatch.setenv("COINBASE_PREFLIGHT_FORCE_REMOTE", "1")
         monkeypatch.setenv("COINBASE_CDP_API_KEY", "organizations/abc/apiKeys/xyz")
-        monkeypatch.setenv(
-            "COINBASE_CDP_PRIVATE_KEY",
-            "-----BEGIN EC PRIVATE KEY-----\ntest\n-----END EC PRIVATE KEY-----",
-        )
+        monkeypatch.setenv("COINBASE_CDP_PRIVATE_KEY", FAKE_COINBASE_PRIVATE_KEY)
         mock_now = datetime(2025, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
         mock_datetime.now.return_value = mock_now
         client = MagicMock()
@@ -213,11 +213,9 @@ class TestCheckSystemTime:
         cleared_env: None,
     ) -> None:
         checker = PreflightCheck(profile="dev")
+        monkeypatch.setenv("COINBASE_PREFLIGHT_FORCE_REMOTE", "1")
         monkeypatch.setenv("COINBASE_CDP_API_KEY", "organizations/abc/apiKeys/xyz")
-        monkeypatch.setenv(
-            "COINBASE_CDP_PRIVATE_KEY",
-            "-----BEGIN EC PRIVATE KEY-----\ntest\n-----END EC PRIVATE KEY-----",
-        )
+        monkeypatch.setenv("COINBASE_CDP_PRIVATE_KEY", FAKE_COINBASE_PRIVATE_KEY)
         mock_datetime.now.return_value = datetime(2025, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
 
         def raise_client_error(**_: str) -> object:
@@ -238,11 +236,9 @@ class TestCheckSystemTime:
         cleared_env: None,
     ) -> None:
         checker = PreflightCheck(profile="dev")
+        monkeypatch.setenv("COINBASE_PREFLIGHT_FORCE_REMOTE", "1")
         monkeypatch.setenv("COINBASE_CDP_API_KEY", "organizations/abc/apiKeys/xyz")
-        monkeypatch.setenv(
-            "COINBASE_CDP_PRIVATE_KEY",
-            "-----BEGIN EC PRIVATE KEY-----\ntest\n-----END EC PRIVATE KEY-----",
-        )
+        monkeypatch.setenv("COINBASE_CDP_PRIVATE_KEY", FAKE_COINBASE_PRIVATE_KEY)
         mock_datetime.now.return_value = datetime(2025, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
         client = MagicMock()
         client.get_time.return_value = {"epoch": 1_750_000_000}
@@ -262,10 +258,7 @@ class TestCheckSystemTime:
         checker = PreflightCheck(profile="dev")
         monkeypatch.setenv("COINBASE_PREFLIGHT_SKIP_REMOTE", "1")
         monkeypatch.setenv("COINBASE_CDP_API_KEY", "organizations/abc/apiKeys/xyz")
-        monkeypatch.setenv(
-            "COINBASE_CDP_PRIVATE_KEY",
-            "-----BEGIN EC PRIVATE KEY-----\ntest\n-----END EC PRIVATE KEY-----",
-        )
+        monkeypatch.setenv("COINBASE_CDP_PRIVATE_KEY", FAKE_COINBASE_PRIVATE_KEY)
         mock_datetime.now.return_value = datetime(2025, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
         client_factory = MagicMock()
         monkeypatch.setattr(system_checks, "_build_coinbase_time_client", client_factory)

--- a/tests/unit/gpt_trader/preflight/test_checks_system.py
+++ b/tests/unit/gpt_trader/preflight/test_checks_system.py
@@ -155,6 +155,8 @@ class TestCheckSystemTime:
     @pytest.fixture
     def cleared_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
         for key in (
+            "COINBASE_PREFLIGHT_FORCE_REMOTE",
+            "COINBASE_PREFLIGHT_SKIP_REMOTE",
             "COINBASE_CREDENTIALS_FILE",
             "COINBASE_PROD_CDP_API_KEY",
             "COINBASE_CDP_API_KEY",
@@ -179,6 +181,100 @@ class TestCheckSystemTime:
         result = check_system_time(checker)
 
         assert result is True
+        assert any("seems reasonable" in w for w in checker.warnings)
+
+    def test_passes_with_credentialed_server_time(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        mock_datetime: MagicMock,
+        cleared_env: None,
+    ) -> None:
+        checker = PreflightCheck(profile="dev")
+        monkeypatch.setenv("COINBASE_CDP_API_KEY", "organizations/abc/apiKeys/xyz")
+        monkeypatch.setenv(
+            "COINBASE_CDP_PRIVATE_KEY",
+            "-----BEGIN EC PRIVATE KEY-----\ntest\n-----END EC PRIVATE KEY-----",
+        )
+        mock_now = datetime(2025, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+        mock_datetime.now.return_value = mock_now
+        client = MagicMock()
+        client.get_time.return_value = {"iso": "2025-06-15T12:00:00Z"}
+        monkeypatch.setattr(system_checks, "_build_coinbase_time_client", lambda **_: client)
+
+        result = check_system_time(checker)
+
+        assert result is True
+        assert any("synchronized" in s for s in checker.successes)
+
+    def test_fails_closed_when_credentialed_time_client_raises(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        mock_datetime: MagicMock,
+        cleared_env: None,
+    ) -> None:
+        checker = PreflightCheck(profile="dev")
+        monkeypatch.setenv("COINBASE_CDP_API_KEY", "organizations/abc/apiKeys/xyz")
+        monkeypatch.setenv(
+            "COINBASE_CDP_PRIVATE_KEY",
+            "-----BEGIN EC PRIVATE KEY-----\ntest\n-----END EC PRIVATE KEY-----",
+        )
+        mock_datetime.now.return_value = datetime(2025, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+
+        def raise_client_error(**_: str) -> object:
+            raise RuntimeError("network unavailable")
+
+        monkeypatch.setattr(system_checks, "_build_coinbase_time_client", raise_client_error)
+
+        result = check_system_time(checker)
+
+        assert result is False
+        assert any("Cannot verify Coinbase server time" in e for e in checker.errors)
+        assert not any("seems reasonable" in w for w in checker.warnings)
+
+    def test_fails_closed_when_credentialed_time_response_missing_iso(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        mock_datetime: MagicMock,
+        cleared_env: None,
+    ) -> None:
+        checker = PreflightCheck(profile="dev")
+        monkeypatch.setenv("COINBASE_CDP_API_KEY", "organizations/abc/apiKeys/xyz")
+        monkeypatch.setenv(
+            "COINBASE_CDP_PRIVATE_KEY",
+            "-----BEGIN EC PRIVATE KEY-----\ntest\n-----END EC PRIVATE KEY-----",
+        )
+        mock_datetime.now.return_value = datetime(2025, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+        client = MagicMock()
+        client.get_time.return_value = {"epoch": 1_750_000_000}
+        monkeypatch.setattr(system_checks, "_build_coinbase_time_client", lambda **_: client)
+
+        result = check_system_time(checker)
+
+        assert result is False
+        assert any("missing 'iso'" in e for e in checker.errors)
+
+    def test_explicit_remote_skip_preserves_local_time_sanity_path(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        mock_datetime: MagicMock,
+        cleared_env: None,
+    ) -> None:
+        checker = PreflightCheck(profile="dev")
+        monkeypatch.setenv("COINBASE_PREFLIGHT_SKIP_REMOTE", "1")
+        monkeypatch.setenv("COINBASE_CDP_API_KEY", "organizations/abc/apiKeys/xyz")
+        monkeypatch.setenv(
+            "COINBASE_CDP_PRIVATE_KEY",
+            "-----BEGIN EC PRIVATE KEY-----\ntest\n-----END EC PRIVATE KEY-----",
+        )
+        mock_datetime.now.return_value = datetime(2025, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+        client_factory = MagicMock()
+        monkeypatch.setattr(system_checks, "_build_coinbase_time_client", client_factory)
+
+        result = check_system_time(checker)
+
+        assert result is True
+        client_factory.assert_not_called()
+        assert any("Skipping Coinbase server time verification" in w for w in checker.warnings)
         assert any("seems reasonable" in w for w in checker.warnings)
 
     def test_fails_with_unreasonable_time(

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6848,
+    "total_tests": 6852,
     "total_files": 807,
     "markers_used": 16
   },

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6683,
+    "unit": 6687,
     "asyncio": 411,
     "parametrize": 198,
     "endpoints": 83,

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6848,
+    "total_tests": 6852,
     "total_files": 807,
     "markers_used": 16
   },
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6683,
+    "unit": 6687,
     "asyncio": 411,
     "parametrize": 198,
     "endpoints": 83,
@@ -41437,7 +41437,7 @@
       },
       {
         "name": "TestCheckSystemTime::test_passes_with_reasonable_time_no_credentials",
-        "line": 168,
+        "line": 170,
         "markers": [
           "unit"
         ],
@@ -41445,8 +41445,44 @@
         "class": "TestCheckSystemTime"
       },
       {
+        "name": "TestCheckSystemTime::test_passes_with_credentialed_server_time",
+        "line": 186,
+        "markers": [
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestCheckSystemTime"
+      },
+      {
+        "name": "TestCheckSystemTime::test_fails_closed_when_credentialed_time_client_raises",
+        "line": 209,
+        "markers": [
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestCheckSystemTime"
+      },
+      {
+        "name": "TestCheckSystemTime::test_fails_closed_when_credentialed_time_response_missing_iso",
+        "line": 234,
+        "markers": [
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestCheckSystemTime"
+      },
+      {
+        "name": "TestCheckSystemTime::test_explicit_remote_skip_preserves_local_time_sanity_path",
+        "line": 256,
+        "markers": [
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestCheckSystemTime"
+      },
+      {
         "name": "TestCheckSystemTime::test_fails_with_unreasonable_time",
-        "line": 184,
+        "line": 280,
         "markers": [
           "unit"
         ],
@@ -41455,7 +41491,7 @@
       },
       {
         "name": "TestCheckSystemTime::test_handles_exception",
-        "line": 201,
+        "line": 297,
         "markers": [
           "unit"
         ],
@@ -41464,7 +41500,7 @@
       },
       {
         "name": "TestCheckSystemTime::test_prints_section_header",
-        "line": 213,
+        "line": 309,
         "markers": [
           "unit"
         ],

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -41356,7 +41356,7 @@
     "tests/unit/gpt_trader/preflight/test_checks_system.py": [
       {
         "name": "TestCheckPythonVersion::test_passes_on_python_312_or_higher",
-        "line": 23,
+        "line": 25,
         "markers": [
           "unit"
         ],
@@ -41365,7 +41365,7 @@
       },
       {
         "name": "TestCheckPythonVersion::test_passes_on_current_python",
-        "line": 35,
+        "line": 37,
         "markers": [
           "unit"
         ],
@@ -41374,7 +41374,7 @@
       },
       {
         "name": "TestCheckPythonVersion::test_logs_python_version",
-        "line": 43,
+        "line": 45,
         "markers": [
           "unit"
         ],
@@ -41383,7 +41383,7 @@
       },
       {
         "name": "TestCheckPythonVersion::test_version_check_logic",
-        "line": 51,
+        "line": 53,
         "markers": [
           "unit"
         ],
@@ -41392,7 +41392,7 @@
       },
       {
         "name": "TestCheckPythonVersion::test_prints_section_header",
-        "line": 57,
+        "line": 59,
         "markers": [
           "unit"
         ],
@@ -41401,7 +41401,7 @@
       },
       {
         "name": "TestCheckDiskSpace::test_passes_with_plenty_of_space",
-        "line": 75,
+        "line": 77,
         "markers": [
           "unit"
         ],
@@ -41410,7 +41410,7 @@
       },
       {
         "name": "TestCheckDiskSpace::test_warns_with_low_space",
-        "line": 94,
+        "line": 96,
         "markers": [
           "unit"
         ],
@@ -41419,7 +41419,7 @@
       },
       {
         "name": "TestCheckDiskSpace::test_fails_with_critical_space",
-        "line": 113,
+        "line": 115,
         "markers": [
           "unit"
         ],
@@ -41428,7 +41428,7 @@
       },
       {
         "name": "TestCheckDiskSpace::test_handles_exception",
-        "line": 132,
+        "line": 134,
         "markers": [
           "unit"
         ],
@@ -41437,7 +41437,7 @@
       },
       {
         "name": "TestCheckSystemTime::test_passes_with_reasonable_time_no_credentials",
-        "line": 170,
+        "line": 172,
         "markers": [
           "unit"
         ],
@@ -41446,7 +41446,7 @@
       },
       {
         "name": "TestCheckSystemTime::test_passes_with_credentialed_server_time",
-        "line": 186,
+        "line": 188,
         "markers": [
           "unit"
         ],
@@ -41464,7 +41464,7 @@
       },
       {
         "name": "TestCheckSystemTime::test_fails_closed_when_credentialed_time_response_missing_iso",
-        "line": 234,
+        "line": 232,
         "markers": [
           "unit"
         ],
@@ -41473,7 +41473,7 @@
       },
       {
         "name": "TestCheckSystemTime::test_explicit_remote_skip_preserves_local_time_sanity_path",
-        "line": 256,
+        "line": 252,
         "markers": [
           "unit"
         ],
@@ -41482,7 +41482,7 @@
       },
       {
         "name": "TestCheckSystemTime::test_fails_with_unreasonable_time",
-        "line": 280,
+        "line": 273,
         "markers": [
           "unit"
         ],
@@ -41491,7 +41491,7 @@
       },
       {
         "name": "TestCheckSystemTime::test_handles_exception",
-        "line": 297,
+        "line": 290,
         "markers": [
           "unit"
         ],
@@ -41500,7 +41500,7 @@
       },
       {
         "name": "TestCheckSystemTime::test_prints_section_header",
-        "line": 309,
+        "line": 302,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary
- fail closed when credentialed Coinbase server-time verification cannot be completed
- keep explicit remote-skip policy on the local sanity fallback path
- add focused unit coverage for success, verification failure, malformed response, and explicit skip behavior
- refresh generated testing metadata after adding tests

## Verification
- uv run pytest tests/unit/gpt_trader/preflight/test_checks_system.py -q
- uv run ruff check src/gpt_trader/preflight/checks/system.py tests/unit/gpt_trader/preflight/test_checks_system.py
- uv run black --check src/gpt_trader/preflight/checks/system.py tests/unit/gpt_trader/preflight/test_checks_system.py
- uv run mypy src/gpt_trader/preflight/checks/system.py
- uv run agent-regenerate --verify
- uv run local-ci --profile quick

Closes #1009

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Coinbase server-time verification behavior: remote checks can be explicitly skipped with clear warnings and a local sanity fallback.
  * Server-time responses are now strictly validated for an expected `iso` timestamp; missing/invalid data fails the check instead of being ignored.
  * Remote verification failures now report the underlying error and fail closed when verification can’t be performed.
* **Tests**
  * Added unit test coverage for forced remote verification, skip-remote behavior, and failure-closed scenarios.
* **Chores**
  * Updated test inventory metadata and summary counts to match the expanded test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->