### PR TITLE
Add trade idea closeout CLI

### DIFF
--- a/docs/specs/TRADE_IDEA_CLI_SPEC.md
+++ b/docs/specs/TRADE_IDEA_CLI_SPEC.md
@@ -1,6 +1,6 @@
 ---
 status: current
-last-updated: 2026-06-24
+last-updated: 2026-06-27
 workstream: 1 (see TRADE_IDEA_INTERFACES_DESIGN_NOTES.md)
 depends-on: Workstream 0 (implemented service factory, error codes, actor resolution)
 ---
@@ -59,6 +59,13 @@ gpt-trader ideas
 ├── list             [--state STATE]
 ├── show             DECISION_ID [--events]
 ├── report
+├── closeout
+│   ├── record       DECISION_ID --resolution {thesis_target,invalidation,expiry}
+│   │                [--realized-profit-loss-amount DECIMAL]
+│   │                [--realized-profit-loss-percent DECIMAL]
+│   │                [--realized-profit-loss-unavailable-reason TEXT]
+│   │                [--evidence TEXT]... [--actor-type {human,system}]
+│   └── show         DECISION_ID
 ├── approve          DECISION_ID --reason TEXT
 ├── reject           DECISION_ID --reason TEXT
 ├── request-changes  DECISION_ID --reason TEXT
@@ -143,6 +150,36 @@ already exist (`IDEA_NOT_FOUND` otherwise). Service/audit layer enforces the
   compact `Monthly` section with one line per month showing idea count, approval
   rate, closeout coverage, and realized P/L amount. Empty stores and reports
   without monthly buckets omit the section while still returning success.
+
+### `ideas closeout record` / `ideas closeout show`
+
+- `record` wraps `service.record_closeout_attribution`; `show` wraps
+  `service.get_closeout_attribution`. Both use only local trade-idea storage.
+- `record` requires a terminal idea. The service enforces the terminal-state
+  precondition and pins the attribution to the latest terminal audit event and
+  record hash.
+- `record` accepts:
+  - `--resolution {thesis_target,invalidation,expiry}`
+  - `--realized-profit-loss-amount DECIMAL` and/or
+    `--realized-profit-loss-percent DECIMAL` (negative values represent losses)
+  - `--realized-profit-loss-unavailable-reason TEXT` when numeric realized P/L
+    is unavailable
+  - repeated `--evidence TEXT` strings
+  - `--actor-type {human,system}` with default `human`
+- At least one realized P/L value or unavailable reason is required.
+- JSON `data` for both successful commands is
+  `{decision_id, closeout_attribution}`. `closeout_attribution` is the
+  persisted closeout record dictionary, or `null` for `show` when the idea is
+  known but has no attribution (`was_noop=True`).
+- Text starts with:
+
+  ```text
+  ✓ ideas closeout record OK (trade-20260612-001, resolution=thesis_target)
+  ```
+
+- These commands never call broker, account, venue, preflight, canary, ticket
+  payload-generation, or live-trading surfaces. Evidence strings are operator
+  references only.
 
 ### `ideas approve DECISION_ID --reason TEXT`
 
@@ -236,21 +273,27 @@ Required cases:
 4. `show` unknown id → `IDEA_NOT_FOUND`. `show --events` includes history.
 5. `report` empty store, normal records, missing closeout coverage, JSON
    output, and read-only behavior that does not create `risk_budget.jsonl`.
-6. `approve` happy path → state `approved`, human actor in audit event.
-7. `approve` over-budget idea → exit 1, `POLICY_VIOLATION`, all violations in
+6. `closeout record` for a terminal filled idea with realized amount/percent
+   and repeated evidence; `closeout show` returns the persisted attribution.
+7. `closeout record` for an expired idea with unavailable P/L reason; proposed
+   ideas fail with `VALIDATION_ERROR`; missing realized P/L input fails with
+   `MISSING_ARGUMENT`; `closeout show` without attribution succeeds with
+   `was_noop=True`.
+8. `approve` happy path → state `approved`, human actor in audit event.
+9. `approve` over-budget idea → exit 1, `POLICY_VIOLATION`, all violations in
    `data["violations"]` (assert ≥2 violations both present).
-8. `request-changes` → `resubmit` (revised record) → `approve` full loop.
-9. `reject`, `cancel`, `expire` single, `expire --sweep` with explicit expiry
+10. `request-changes` → `resubmit` (revised record) → `approve` full loop.
+11. `reject`, `cancel`, `expire` single, `expire --sweep` with explicit expiry
    coverage (one stale + one fresh idea: only stale expires; `was_noop` when
    none) plus review-latency sweep coverage for a far-future idea whose review
    deadline exceeds `max_review_latency_hours`.
-10. `mark-submitted` then `mark-filled` with venue/external id recorded in
+12. `mark-submitted` then `mark-filled` with venue/external id recorded in
    audit events.
-11. `budget show` seeds defaults; `budget set --max-loss-per-idea-pct 2
+13. `budget show` seeds defaults; `budget set --max-loss-per-idea-pct 2
     --reason ...` bumps version; `budget set` with no field flags →
     `MISSING_ARGUMENT`.
-12. `audit verify` OK path; tampered line in `audit.jsonl` → failure.
-13. JSON mode for at least propose/approve/list/report asserting the
+14. `audit verify` OK path; tampered line in `audit.jsonl` → failure.
+15. JSON mode for at least propose/approve/list/report asserting the
     `CliResponse` envelope per CLAUDE.md patterns
     (`result.errors[0].code == CliErrorCode.POLICY_VIOLATION.value`).
 

--- a/src/gpt_trader/cli/commands/ideas.py
+++ b/src/gpt_trader/cli/commands/ideas.py
@@ -23,6 +23,7 @@ from gpt_trader.features.trade_ideas import (
     ActorType,
     AuditIntegrityError,
     BudgetIntegrityError,
+    CloseoutResolution,
     InvalidTransitionError,
     PolicyViolationError,
     TradeIdea,
@@ -127,6 +128,71 @@ def register(subparsers: Any) -> None:
     )
     _add_common_options(report)
     report.set_defaults(handler=_handle_report, subcommand="report")
+
+    closeout = ideas_subparsers.add_parser(
+        "closeout",
+        help="Record or inspect terminal closeout attribution",
+        description=(
+            "Record and inspect broker-neutral closeout attribution for terminal trade "
+            "ideas. This command never contacts a broker or account."
+        ),
+    )
+    closeout_subparsers = closeout.add_subparsers(dest="closeout_command", required=True)
+
+    closeout_record = closeout_subparsers.add_parser(
+        "record",
+        help="Record terminal closeout attribution; does not call a broker API",
+        description=(
+            "Append closeout attribution for a terminal trade idea. This records external "
+            "evidence only and never places, modifies, or cancels broker orders."
+        ),
+    )
+    _add_common_options(closeout_record)
+    _add_actor_options(closeout_record)
+    closeout_record.add_argument("decision_id", help="Trade idea decision identifier")
+    closeout_record.add_argument(
+        "--resolution",
+        required=True,
+        choices=[resolution.value for resolution in CloseoutResolution],
+        help="Why the terminal idea resolved",
+    )
+    closeout_record.add_argument(
+        "--realized-profit-loss-amount",
+        type=_decimal_value,
+        help="Realized profit/loss amount; negative values represent losses",
+    )
+    closeout_record.add_argument(
+        "--realized-profit-loss-percent",
+        type=_decimal_value,
+        help="Realized profit/loss percent; negative values represent losses",
+    )
+    closeout_record.add_argument(
+        "--realized-profit-loss-unavailable-reason",
+        default="",
+        help="Why realized profit/loss is unavailable",
+    )
+    closeout_record.add_argument(
+        "--evidence",
+        action="append",
+        default=None,
+        help="Evidence string to attach; repeat for multiple evidence entries",
+    )
+    closeout_record.add_argument(
+        "--actor-type",
+        choices=(ActorType.HUMAN.value, ActorType.SYSTEM.value),
+        default=ActorType.HUMAN.value,
+        help="Actor type stamped into the closeout attribution record",
+    )
+    closeout_record.set_defaults(handler=_handle_closeout_record, subcommand="closeout record")
+
+    closeout_show = closeout_subparsers.add_parser(
+        "show",
+        help="Show closeout attribution for one trade idea",
+        description="Read closeout attribution from local trade-idea records only.",
+    )
+    _add_common_options(closeout_show)
+    closeout_show.add_argument("decision_id", help="Trade idea decision identifier")
+    closeout_show.set_defaults(handler=_handle_closeout_show, subcommand="closeout show")
 
     approve = ideas_subparsers.add_parser("approve", help="Approve a proposed trade idea")
     _add_common_options(approve)
@@ -446,6 +512,58 @@ def _handle_report(args: Namespace) -> CliResponse:
     return _success(command, args, payload, text, was_noop=idea_count == 0)
 
 
+def _handle_closeout_record(args: Namespace) -> CliResponse:
+    command = "ideas closeout record"
+    decision_id_error = _decision_id_error(command, args, args.decision_id)
+    if decision_id_error is not None:
+        return decision_id_error
+    profit_loss_error = _closeout_profit_loss_error(command, args)
+    if profit_loss_error is not None:
+        return profit_loss_error
+    evidence_error = _evidence_error(command, args)
+    if evidence_error is not None:
+        return evidence_error
+
+    try:
+        record = _service(args).record_closeout_attribution(
+            args.decision_id,
+            actor_id=_actor_id(args),
+            actor_type=ActorType(args.actor_type),
+            resolution=args.resolution,
+            realized_profit_loss_amount=args.realized_profit_loss_amount,
+            realized_profit_loss_percent=args.realized_profit_loss_percent,
+            realized_profit_loss_unavailable_reason=(
+                args.realized_profit_loss_unavailable_reason.strip()
+            ),
+            evidence=_evidence(args),
+        )
+    except Exception as error:
+        return _mapped_error(command, args, error)
+    return _closeout_success(command, args, record)
+
+
+def _handle_closeout_show(args: Namespace) -> CliResponse:
+    command = "ideas closeout show"
+    decision_id_error = _decision_id_error(command, args, args.decision_id)
+    if decision_id_error is not None:
+        return decision_id_error
+    try:
+        record = _service(args).get_closeout_attribution(args.decision_id)
+    except Exception as error:
+        return _mapped_error(command, args, error)
+
+    payload = {
+        "decision_id": args.decision_id,
+        "closeout_attribution": record.to_dict() if record is not None else None,
+    }
+    if record is None:
+        text = _status_line(command, "OK", f"{args.decision_id}, no closeout attribution")
+        return _success(command, args, payload, text, was_noop=True)
+
+    text = _closeout_text(command, record.to_dict())
+    return _success(command, args, payload, text)
+
+
 def _handle_approve(args: Namespace) -> CliResponse:
     command = "ideas approve"
     reason_error = _reason_error(command, args)
@@ -663,10 +781,56 @@ def _budget_overrides(args: Namespace) -> dict[str, Any]:
     return overrides
 
 
+def _closeout_profit_loss_error(command: str, args: Namespace) -> CliResponse | None:
+    if (
+        args.realized_profit_loss_amount is not None
+        or args.realized_profit_loss_percent is not None
+        or args.realized_profit_loss_unavailable_reason.strip()
+    ):
+        return None
+    return _failure(
+        command,
+        args,
+        CliErrorCode.MISSING_ARGUMENT,
+        (
+            "Provide at least one of --realized-profit-loss-amount, "
+            "--realized-profit-loss-percent, or --realized-profit-loss-unavailable-reason"
+        ),
+        details={"field": "realized_profit_loss"},
+    )
+
+
+def _evidence(args: Namespace) -> tuple[str, ...]:
+    return tuple(item.strip() for item in (getattr(args, "evidence", None) or ()))
+
+
+def _evidence_error(command: str, args: Namespace) -> CliResponse | None:
+    for index, item in enumerate(getattr(args, "evidence", None) or ()):
+        if item.strip():
+            continue
+        return _failure(
+            command,
+            args,
+            CliErrorCode.INVALID_ARGUMENT,
+            "--evidence entries must be non-empty",
+            details={"field": "evidence", "index": index},
+        )
+    return None
+
+
 def _state_change_success(command: str, args: Namespace, view: Any) -> CliResponse:
     payload = _view_summary(view)
     text = _status_line(command, "OK", f"{view.idea.decision_id}, state={view.state.value}")
     return _success(command, args, payload, text)
+
+
+def _closeout_success(command: str, args: Namespace, record: Any) -> CliResponse:
+    record_payload = record.to_dict()
+    payload = {
+        "decision_id": record.decision_id,
+        "closeout_attribution": record_payload,
+    }
+    return _success(command, args, payload, _closeout_text(command, record_payload))
 
 
 def _view_summary(view: Any) -> dict[str, Any]:
@@ -901,3 +1065,23 @@ def _events_text(events: list[dict[str, Any]]) -> str:
 
 def _budget_text(payload: dict[str, Any]) -> str:
     return "\n".join(f"{key}: {value}" for key, value in payload.items())
+
+
+def _closeout_text(command: str, payload: dict[str, Any]) -> str:
+    lines = [
+        _status_line(
+            command, "OK", f"{payload['decision_id']}, resolution={payload['resolution']}"
+        ),
+        f"actor: {payload['actor_type']}/{payload['actor_id']}",
+        f"realized_profit_loss_amount: {payload['realized_profit_loss_amount']}",
+        f"realized_profit_loss_percent: {payload['realized_profit_loss_percent']}",
+        "realized_profit_loss_unavailable_reason: "
+        f"{payload['realized_profit_loss_unavailable_reason']}",
+        f"terminal_event_id: {payload['terminal_event_id']}",
+        f"record_hash: {payload['record_hash']}",
+    ]
+    evidence = payload.get("evidence", [])
+    if evidence:
+        lines.append("evidence:")
+        lines.extend(f"- {item}" for item in evidence)
+    return "\n".join(lines)

--- a/tests/unit/gpt_trader/cli/commands/test_ideas_closeout.py
+++ b/tests/unit/gpt_trader/cli/commands/test_ideas_closeout.py
@@ -1,0 +1,320 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from gpt_trader import cli
+from gpt_trader.cli.response import CliErrorCode
+from gpt_trader.features.trade_ideas import TimeHorizon
+from tests.unit.gpt_trader.features.trade_ideas.conftest import build_trade_idea
+
+
+def _future_horizon() -> TimeHorizon:
+    return TimeHorizon(
+        expected_hold="3-10 days",
+        expires_at=datetime(2035, 6, 19, 16, 0, tzinfo=UTC),
+    )
+
+
+def _idea_payload(**overrides: Any) -> dict[str, Any]:
+    return build_trade_idea(time_horizon=_future_horizon(), **overrides).to_dict()
+
+
+def _write_idea(path: Path, payload: dict[str, Any]) -> Path:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _run_json(capsys: pytest.CaptureFixture[str], argv: list[str]) -> tuple[int, dict[str, Any]]:
+    exit_code = cli.main(argv)
+    output = capsys.readouterr().out
+    assert output
+    return exit_code, json.loads(output)
+
+
+def _root_args(root: Path) -> list[str]:
+    return ["--ideas-root", str(root), "--format", "json"]
+
+
+def _propose(capsys: pytest.CaptureFixture[str], root: Path, payload: dict[str, Any]) -> None:
+    path = _write_idea(root.parent / f"{payload['decision_id']}.json", payload)
+    exit_code, response = _run_json(
+        capsys,
+        [
+            "ideas",
+            "propose",
+            *_root_args(root),
+            "--actor",
+            "idea-generator-v1",
+            "--file",
+            str(path),
+        ],
+    )
+    assert exit_code == 0
+    assert response["success"] is True
+
+
+def _approve(capsys: pytest.CaptureFixture[str], root: Path, decision_id: str) -> None:
+    exit_code, response = _run_json(
+        capsys,
+        [
+            "ideas",
+            "approve",
+            *_root_args(root),
+            "--actor",
+            "rj",
+            decision_id,
+            "--reason",
+            "Thesis and risk verified",
+        ],
+    )
+    assert exit_code == 0
+    assert response["data"]["state"] == "approved"
+
+
+def _expire(capsys: pytest.CaptureFixture[str], root: Path, decision_id: str) -> None:
+    exit_code, response = _run_json(
+        capsys,
+        [
+            "ideas",
+            "expire",
+            *_root_args(root),
+            "--actor",
+            "expiry-sweep",
+            decision_id,
+            "--reason",
+            "Idea passed review deadline",
+        ],
+    )
+    assert exit_code == 0
+    assert response["data"]["state"] == "expired"
+
+
+def _mark_filled(capsys: pytest.CaptureFixture[str], root: Path, decision_id: str) -> None:
+    exit_code, response = _run_json(
+        capsys,
+        [
+            "ideas",
+            "mark-submitted",
+            *_root_args(root),
+            "--actor",
+            "manual-recorder",
+            decision_id,
+            "--venue",
+            "manual",
+            "--external-order-id",
+            "order-123",
+        ],
+    )
+    assert exit_code == 0
+    assert response["data"]["state"] == "submitted"
+
+    exit_code, response = _run_json(
+        capsys,
+        [
+            "ideas",
+            "mark-filled",
+            *_root_args(root),
+            "--actor",
+            "manual-recorder",
+            decision_id,
+            "--venue",
+            "manual",
+            "--external-order-id",
+            "order-123",
+        ],
+    )
+    assert exit_code == 0
+    assert response["data"]["state"] == "filled"
+
+
+def test_closeout_record_and_show_for_filled_idea(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = tmp_path / "ideas"
+    payload = _idea_payload(decision_id="trade-closeout-filled")
+    _propose(capsys, root, payload)
+    _approve(capsys, root, payload["decision_id"])
+    _mark_filled(capsys, root, payload["decision_id"])
+
+    exit_code, response = _run_json(
+        capsys,
+        [
+            "ideas",
+            "closeout",
+            "record",
+            *_root_args(root),
+            "--actor",
+            "rj",
+            payload["decision_id"],
+            "--resolution",
+            "thesis_target",
+            "--realized-profit-loss-amount",
+            "125.50",
+            "--realized-profit-loss-percent",
+            "2.4",
+            "--evidence",
+            "statement:order-123",
+            "--evidence",
+            "chart:target-hit",
+        ],
+    )
+
+    assert exit_code == 0
+    assert response["command"] == "ideas closeout record"
+    closeout = response["data"]["closeout_attribution"]
+    assert closeout["decision_id"] == payload["decision_id"]
+    assert closeout["actor_type"] == "human"
+    assert closeout["actor_id"] == "rj"
+    assert closeout["resolution"] == "thesis_target"
+    assert closeout["realized_profit_loss_amount"] == "125.50"
+    assert closeout["realized_profit_loss_percent"] == "2.4"
+    assert closeout["realized_profit_loss_unavailable_reason"] == ""
+    assert closeout["max_loss"] == payload["max_loss"]
+    assert closeout["evidence"] == ["statement:order-123", "chart:target-hit"]
+    assert (root / "closeout_attributions.jsonl").exists()
+
+    exit_code, show_response = _run_json(
+        capsys,
+        [
+            "ideas",
+            "closeout",
+            "show",
+            *_root_args(root),
+            payload["decision_id"],
+        ],
+    )
+
+    assert exit_code == 0
+    assert show_response["command"] == "ideas closeout show"
+    assert show_response["data"]["closeout_attribution"] == closeout
+
+
+def test_closeout_record_accepts_unavailable_profit_loss_reason(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = tmp_path / "ideas"
+    payload = _idea_payload(decision_id="trade-closeout-expired")
+    _propose(capsys, root, payload)
+    _expire(capsys, root, payload["decision_id"])
+
+    exit_code, response = _run_json(
+        capsys,
+        [
+            "ideas",
+            "closeout",
+            "record",
+            *_root_args(root),
+            "--actor",
+            "expiry-sweep",
+            "--actor-type",
+            "system",
+            payload["decision_id"],
+            "--resolution",
+            "expiry",
+            "--realized-profit-loss-unavailable-reason",
+            "Expired before any entry fill",
+            "--evidence",
+            "expiry-sweep:2035-06-19",
+        ],
+    )
+
+    assert exit_code == 0
+    closeout = response["data"]["closeout_attribution"]
+    assert closeout["actor_type"] == "system"
+    assert closeout["resolution"] == "expiry"
+    assert closeout["realized_profit_loss_amount"] is None
+    assert closeout["realized_profit_loss_percent"] is None
+    assert closeout["realized_profit_loss_unavailable_reason"] == "Expired before any entry fill"
+    assert closeout["evidence"] == ["expiry-sweep:2035-06-19"]
+
+
+def test_closeout_record_rejects_non_terminal_idea(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = tmp_path / "ideas"
+    payload = _idea_payload(decision_id="trade-closeout-proposed")
+    _propose(capsys, root, payload)
+
+    exit_code, response = _run_json(
+        capsys,
+        [
+            "ideas",
+            "closeout",
+            "record",
+            *_root_args(root),
+            "--actor",
+            "rj",
+            payload["decision_id"],
+            "--resolution",
+            "invalidation",
+            "--realized-profit-loss-amount",
+            "-250",
+        ],
+    )
+
+    assert exit_code == 1
+    assert response["errors"][0]["code"] == CliErrorCode.VALIDATION_ERROR.value
+    assert "must be terminal" in response["errors"][0]["message"]
+    assert not (root / "closeout_attributions.jsonl").exists()
+
+
+def test_closeout_record_requires_profit_loss_or_unavailable_reason(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = tmp_path / "ideas"
+    payload = _idea_payload(decision_id="trade-closeout-missing-profit-loss")
+    _propose(capsys, root, payload)
+    _expire(capsys, root, payload["decision_id"])
+
+    exit_code, response = _run_json(
+        capsys,
+        [
+            "ideas",
+            "closeout",
+            "record",
+            *_root_args(root),
+            "--actor",
+            "rj",
+            payload["decision_id"],
+            "--resolution",
+            "expiry",
+        ],
+    )
+
+    assert exit_code == 1
+    assert response["errors"][0]["code"] == CliErrorCode.MISSING_ARGUMENT.value
+    assert response["errors"][0]["details"]["field"] == "realized_profit_loss"
+    assert not (root / "closeout_attributions.jsonl").exists()
+
+
+def test_closeout_show_without_attribution_is_successful_noop(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = tmp_path / "ideas"
+    payload = _idea_payload(decision_id="trade-closeout-missing")
+    _propose(capsys, root, payload)
+    _expire(capsys, root, payload["decision_id"])
+
+    exit_code, response = _run_json(
+        capsys,
+        [
+            "ideas",
+            "closeout",
+            "show",
+            *_root_args(root),
+            payload["decision_id"],
+        ],
+    )
+
+    assert exit_code == 0
+    assert response["success"] is True
+    assert response["metadata"]["was_noop"] is True
+    assert response["data"] == {
+        "decision_id": payload["decision_id"],
+        "closeout_attribution": None,
+    }

--- a/tests/unit/gpt_trader/cli/commands/test_ideas_queries.py
+++ b/tests/unit/gpt_trader/cli/commands/test_ideas_queries.py
@@ -227,6 +227,7 @@ def test_help_lists_ideas_subcommands(capsys: pytest.CaptureFixture[str]) -> Non
     assert "propose" in output
     assert "request-changes" in output
     assert "report" in output
+    assert "closeout" in output
     assert "mark-submitted" in output
     assert "budget" in output
     assert "audit" in output

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,8 +7,8 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6852,
-    "total_files": 807,
+    "total_tests": 6857,
+    "total_files": 808,
     "markers_used": 16
   },
   "quick_commands": {

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6687,
+    "unit": 6692,
     "asyncio": 411,
     "parametrize": 198,
     "endpoints": 83,

--- a/var/agents/testing/source_test_map.json
+++ b/var/agents/testing/source_test_map.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "summary": {
-    "tests_scanned": 722,
+    "tests_scanned": 723,
     "source_modules": 374,
     "unresolved_modules": 3
   },
@@ -9,6 +9,7 @@
     "gpt_trader": [
       "tests/unit/gpt_trader/cli/commands/test_ideas_approval_preview_integrity.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_budget.py",
+      "tests/unit/gpt_trader/cli/commands/test_ideas_closeout.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_futures_budget.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_lifecycle.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_manual_records.py",
@@ -341,6 +342,7 @@
     "gpt_trader.cli.response": [
       "tests/unit/gpt_trader/cli/commands/optimize/test_commands_execution.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_budget.py",
+      "tests/unit/gpt_trader/cli/commands/test_ideas_closeout.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_futures_budget.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_lifecycle.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_max_loss_validation.py",
@@ -1287,6 +1289,7 @@
     "gpt_trader.features.trade_ideas": [
       "tests/unit/gpt_trader/cli/commands/test_ideas_approval_preview_integrity.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_budget.py",
+      "tests/unit/gpt_trader/cli/commands/test_ideas_closeout.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_futures_budget.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_lifecycle.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_manual_records.py",
@@ -2684,6 +2687,11 @@
       "gpt_trader.features.trade_ideas"
     ],
     "tests/unit/gpt_trader/cli/commands/test_ideas_budget.py": [
+      "gpt_trader",
+      "gpt_trader.cli.response",
+      "gpt_trader.features.trade_ideas"
+    ],
+    "tests/unit/gpt_trader/cli/commands/test_ideas_closeout.py": [
       "gpt_trader",
       "gpt_trader.cli.response",
       "gpt_trader.features.trade_ideas"

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,8 +2,8 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6852,
-    "total_files": 807,
+    "total_tests": 6857,
+    "total_files": 808,
     "markers_used": 16
   },
   "marker_definitions": {
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6687,
+    "unit": 6692,
     "asyncio": 411,
     "parametrize": 198,
     "endpoints": 83,
@@ -206,6 +206,7 @@
       "tests/unit/gpt_trader/cli/commands/optimize/test_formatters.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_approval_preview_integrity.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_budget.py",
+      "tests/unit/gpt_trader/cli/commands/test_ideas_closeout.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_futures_budget.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_lifecycle.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_manual_records.py",
@@ -9149,6 +9150,48 @@
       {
         "name": "test_shared_root_and_actor_resolution_helpers",
         "line": 151,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      }
+    ],
+    "tests/unit/gpt_trader/cli/commands/test_ideas_closeout.py": [
+      {
+        "name": "test_closeout_record_and_show_for_filled_idea",
+        "line": 135,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_closeout_record_accepts_unavailable_profit_loss_reason",
+        "line": 197,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_closeout_record_rejects_non_terminal_idea",
+        "line": 236,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_closeout_record_requires_profit_loss_or_unavailable_reason",
+        "line": 266,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_closeout_show_without_attribution_is_successful_noop",
+        "line": 295,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary
Related issue / finding / RJ-routed package: RJ-routed package, Stage 1 trade-idea closeout CLI lane

- Add `gpt-trader ideas closeout record` and `gpt-trader ideas closeout show` as thin CLI adapters over existing closeout attribution service methods.
- Support terminal resolution, realized P/L amount and percent, unavailable P/L reason, repeated evidence strings, and human/system actor stamping.
- Document the implemented command shape and refresh generated testing inventory for the new focused test file.

## Type of change
- [x] Feature
- [x] Tests only
- [x] CI/Docs/Tooling

## Scope & Impact
- Affected areas / components: `src/gpt_trader/cli/commands/ideas.py`, trade-idea CLI spec, focused ideas CLI tests, generated test inventory.
- Behavior changes: adds local-only closeout record/show commands. No broker, account, venue, preflight, canary, ticket payload-generation, live trading, money movement, or order submission paths are called.

## Test Plan
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Contract tests (if applicable)
- [x] Ran locally: `uv run pytest tests/unit/gpt_trader/cli/commands/test_ideas_closeout.py tests/unit/gpt_trader/cli/commands/test_ideas_queries.py -q`
- [x] Ran locally: `uv run pytest tests/unit/gpt_trader/cli/commands/test_ideas_*.py -q`
- [x] Markers used appropriately (`unit`)

## Complexity & Quality Gates
- [x] Mypy/type-check passed (`uv run local-ci --profile quick`)
- [x] Xenon/radon complexity gate passed (not applicable to live_trade execution; local quick CI passed)
- [x] No `sys.path` hacks in tests
- [x] No `MagicMock` on `async def` (use `AsyncMock`)
- [x] Import-lint rules respected (no import-up-stack failures in local quick CI)

## Observability & Errors
- [ ] Structured JSON logs for new/changed paths
- [x] Errors include diagnostic context where applicable (`MISSING_ARGUMENT`, `INVALID_ARGUMENT`, service validation errors)
- [ ] Added/updated sampling examples in tests (if applicable)

## Configuration
- [ ] If config changed: `python -m gpt_trader.cli.config validate --profile <name>` passes
- [ ] Env docs re-generated (if applicable) and committed
- [x] No `ConfigLoader` usages introduced (ConfigManager-only)

## Breaking Changes
- [x] None
- [ ] Documented in PR body and release notes if any

## Screenshots / Logs (optional)
- `uv run gpt-trader ideas --help` -> passed; lists `closeout`.
- `uv run gpt-trader ideas closeout --help` -> passed; lists `record` and `show`.
- `uv run agent-regenerate --verify` -> passed after committing scoped testing inventory refresh.
- `uv run local-ci --profile quick` -> passed: 7126 passed, 8 skipped.

## Checklist
- [x] Acceptance criteria in linked issue(s), finding packet, or routed package met
- [x] Affected paths listed in PR description
- [ ] Changelog entry (if repo uses one)

## Known risks or follow-ups
- Quick CI intentionally skipped readiness gate, agent health, snapshots, property tests, and contract tests per the quick profile.
- Strict/full local CI was not run because the routed verification requested quick CI for this package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ideas closeout` commands to record and view trade idea closeouts.
  * Closeout entries can now include resolution details, realized P/L values, or a reason when P/L is unavailable.
  * Support added for attaching evidence and viewing closeout status in both text and JSON output.

* **Bug Fixes**
  * Improved validation for closeout submissions, including terminal-state checks and required input handling.
  * Viewing a closeout now cleanly reports when no attribution exists yet.

* **Tests**
  * Expanded CLI coverage for closeout recording, display, validation errors, and no-op behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->