### PR TITLE
Add trade idea baseline replay CLI

### DIFF
--- a/docs/specs/TRADE_IDEA_CLI_SPEC.md
+++ b/docs/specs/TRADE_IDEA_CLI_SPEC.md
@@ -1,6 +1,6 @@
 ---
 status: current
-last-updated: 2026-06-24
+last-updated: 2026-06-27
 workstream: 1 (see TRADE_IDEA_INTERFACES_DESIGN_NOTES.md)
 depends-on: Workstream 0 (implemented service factory, error codes, actor resolution)
 ---
@@ -34,11 +34,14 @@ The implementation follows the structure of `cli/commands/controls.py`: a
 
 ## Common options
 
-Every subcommand accepts:
+Every storage-backed workflow subcommand accepts:
 
 - `--format {text,json}` (via `options.add_output_options`)
 - `--ideas-root PATH` — override storage root (default: `GPT_TRADER_IDEAS_ROOT`
   env, then `var/data/trade_ideas/`)
+
+Read-only replay commands accept `--format {text,json}` but do not read or
+write `--ideas-root`; they operate only on the local fixture named by `--file`.
 
 Every mutating subcommand accepts:
 
@@ -59,6 +62,14 @@ gpt-trader ideas
 ├── list             [--state STATE]
 ├── show             DECISION_ID [--events]
 ├── report
+├── replay
+│   └── baseline     --file PATH --symbol SYMBOL --granularity GRANULARITY
+│                    [--short-window N] [--long-window N]
+│                    [--crossover-lookback N] [--min-history N]
+│                    [--risk-per-idea-pct DECIMAL] [--entry-band-pct DECIMAL]
+│                    [--reward-multiple DECIMAL] [--expiry-hours N]
+│                    [--expected-hold TEXT] [--price-precision DECIMAL]
+│                    [--source LABEL]
 ├── approve          DECISION_ID --reason TEXT
 ├── reject           DECISION_ID --reason TEXT
 ├── request-changes  DECISION_ID --reason TEXT
@@ -143,6 +154,67 @@ already exist (`IDEA_NOT_FOUND` otherwise). Service/audit layer enforces the
   compact `Monthly` section with one line per month showing idea count, approval
   rate, closeout coverage, and realized P/L amount. Empty stores and reports
   without monthly buckets omit the section while still returning success.
+
+### `ideas replay baseline`
+
+- Read-only Stage 1 calibration command over local candle fixtures. It
+  constructs `BaselineProposer(BaselineProposerConfig(...))`, feeds it through
+  `TradeIdeaReplayRunner`, and formats the returned `ReplayReport`.
+- It never reads credentials, contacts brokers/accounts/live market data, writes
+  trade-idea records, creates tickets, or touches closeout attribution.
+- Required options:
+  - `--file PATH`
+  - `--symbol SYMBOL`
+  - `--granularity GRANULARITY`
+- Supported baseline/replay options:
+  - `--source LABEL` (default `fixture:candles`)
+  - `--min-history N` (default `long-window + crossover-lookback`)
+  - `--short-window N` (default `10`)
+  - `--long-window N` (default `50`)
+  - `--crossover-lookback N` (default `3`)
+  - `--risk-per-idea-pct DECIMAL` (default `2`)
+  - `--entry-band-pct DECIMAL` (default `1`)
+  - `--reward-multiple DECIMAL` (default `2`)
+  - `--expiry-hours N` (default `48`)
+  - `--expected-hold TEXT` (default `5-15 days`)
+  - `--price-precision DECIMAL` (default `0.01`)
+- Candle fixture shape:
+
+  ```json
+  {
+    "candles": [
+      {
+        "ts": "2026-06-12T12:00:00+00:00",
+        "open": "100",
+        "high": "102",
+        "low": "99",
+        "close": "101",
+        "volume": "1000"
+      }
+    ]
+  }
+  ```
+
+  Timestamps are ISO-8601; naive timestamps are treated as UTC. Decimal values
+  may be strings or JSON numbers. Malformed JSON, a missing `candles` array,
+  missing candle fields, invalid timestamps, and non-finite decimals return
+  `INVALID_ARGUMENT` with the offending field when available.
+- JSON `data` is `ReplayReport.to_dict()` and includes `proposer_id`,
+  `symbol`, `granularity`, `source`, `snapshots_evaluated`, `ideas_proposed`,
+  `target_hits`, `stop_hits`, `timed_out`, `not_filled`, `no_future_data`,
+  `resolved_ideas`, `target_hit_rate`, `stop_hit_rate`, `average_return_r`, and
+  per-idea replay outcomes.
+- Text starts with:
+
+  ```text
+  ✓ ideas replay baseline OK (BTC-USD ONE_HOUR, snapshots=2, ideas=1)
+  proposer_id: baseline-ma-2-4
+  outcomes: target_hits=1, stop_hits=0, timed_out=0, not_filled=0, no_future_data=0
+  hit_rates: target=100.00%, stop=0.00%
+  average_return_r: 2
+  ```
+
+  A replay with zero proposed ideas succeeds with `was_noop=True`.
 
 ### `ideas approve DECISION_ID --reason TEXT`
 
@@ -236,27 +308,32 @@ Required cases:
 4. `show` unknown id → `IDEA_NOT_FOUND`. `show --events` includes history.
 5. `report` empty store, normal records, missing closeout coverage, JSON
    output, and read-only behavior that does not create `risk_budget.jsonl`.
-6. `approve` happy path → state `approved`, human actor in audit event.
-7. `approve` over-budget idea → exit 1, `POLICY_VIOLATION`, all violations in
+6. `replay baseline` text success, malformed fixture input, empty/no-idea
+   replay success with `was_noop=True`, and JSON output exposing
+   `ReplayReport` aggregate fields.
+7. `approve` happy path → state `approved`, human actor in audit event.
+8. `approve` over-budget idea → exit 1, `POLICY_VIOLATION`, all violations in
    `data["violations"]` (assert ≥2 violations both present).
-8. `request-changes` → `resubmit` (revised record) → `approve` full loop.
-9. `reject`, `cancel`, `expire` single, `expire --sweep` with explicit expiry
+9. `request-changes` → `resubmit` (revised record) → `approve` full loop.
+10. `reject`, `cancel`, `expire` single, `expire --sweep` with explicit expiry
    coverage (one stale + one fresh idea: only stale expires; `was_noop` when
    none) plus review-latency sweep coverage for a far-future idea whose review
    deadline exceeds `max_review_latency_hours`.
-10. `mark-submitted` then `mark-filled` with venue/external id recorded in
+11. `mark-submitted` then `mark-filled` with venue/external id recorded in
    audit events.
-11. `budget show` seeds defaults; `budget set --max-loss-per-idea-pct 2
+12. `budget show` seeds defaults; `budget set --max-loss-per-idea-pct 2
     --reason ...` bumps version; `budget set` with no field flags →
     `MISSING_ARGUMENT`.
-12. `audit verify` OK path; tampered line in `audit.jsonl` → failure.
-13. JSON mode for at least propose/approve/list/report asserting the
+13. `audit verify` OK path; tampered line in `audit.jsonl` → failure.
+14. JSON mode for at least propose/approve/list/report/replay baseline asserting the
     `CliResponse` envelope per CLAUDE.md patterns
     (`result.errors[0].code == CliErrorCode.POLICY_VIOLATION.value`).
 
 ## Acceptance criteria
 
 - [x] `gpt-trader ideas --help` lists all subcommands with accurate help text.
+- [x] `gpt-trader ideas replay baseline --help` documents the local fixture
+      replay surface and its broker-free boundary.
 - [x] Full loop works on a clean checkout with no env vars:
       propose → list → show → approve → mark-submitted → mark-filled,
       and the audit log verifies afterward.

--- a/docs/specs/TRADE_IDEA_INTERFACES_DESIGN_NOTES.md
+++ b/docs/specs/TRADE_IDEA_INTERFACES_DESIGN_NOTES.md
@@ -1,6 +1,6 @@
 ---
 status: current
-last-updated: 2026-06-25
+last-updated: 2026-06-27
 scope: Operator and agent interfaces over the trade_ideas slice
 audience: Implementation agents (Codex) and reviewers
 ---
@@ -29,12 +29,15 @@ already exists and is complete at the domain level:
 `gpt-trader ideas` constructs `TradeIdeaService` through the trade-ideas factory
 and exposes the agent-facing approval workflow: propose, list, show, approve,
 reject, request-changes, expire, resubmit, mark-submitted, mark-filled, budget,
-and audit. The TUI `IdeasReviewScreen` is the implemented human review surface:
-it lists proposed ideas, renders record details, previews policy violations, and
-records approve, reject, request-changes, and expire decisions through
-`TradeIdeaService`. MCP or other remote surfaces remain future work. The service
-docstring still states the adapter boundary explicitly: *"interfaces such as CLI,
-TUI, or MCP servers must stay thin adapters over these methods."*
+audit, and report. It also exposes the read-only Stage 1 baseline calibration
+surface, `gpt-trader ideas replay baseline`, which parses a local candle fixture
+and formats `TradeIdeaReplayRunner` / `ReplayReport` output without using
+`TradeIdeaService` storage. The TUI `IdeasReviewScreen` is the implemented human
+review surface: it lists proposed ideas, renders record details, previews policy
+violations, and records approve, reject, request-changes, and expire decisions
+through `TradeIdeaService`. MCP or other remote surfaces remain future work. The
+service docstring still states the adapter boundary explicitly: *"interfaces such
+as CLI, TUI, or MCP servers must stay thin adapters over these methods."*
 
 These notes preserve the interface decisions that shaped the implemented CLI and
 TUI surfaces. They are not a request to re-promote the TUI review workstream.

--- a/src/gpt_trader/cli/commands/ideas.py
+++ b/src/gpt_trader/cli/commands/ideas.py
@@ -41,6 +41,7 @@ from gpt_trader.features.trade_ideas import (
     is_safe_decision_id,
     resolve_trade_idea_actor_id,
 )
+from gpt_trader.features.trade_ideas.replay import _granularity_duration
 from gpt_trader.features.trade_ideas.report import (
     build_trade_idea_track_record_report,
     format_trade_idea_track_record_report,
@@ -624,6 +625,14 @@ def _default_replay_min_history(config: BaselineProposerConfig) -> int:
     return max(config.short_window, config.long_window) + config.crossover_lookback
 
 
+def _validate_replay_granularity(granularity: str) -> None:
+    if _granularity_duration(granularity) is None:
+        raise CandleInputError(
+            f"Unsupported replay granularity: {granularity}",
+            field="granularity",
+        )
+
+
 def _handle_propose(args: Namespace) -> CliResponse:
     command = "ideas propose"
     try:
@@ -727,6 +736,7 @@ def _handle_report(args: Namespace) -> CliResponse:
 def _handle_replay_baseline(args: Namespace) -> CliResponse:
     command = "ideas replay baseline"
     try:
+        _validate_replay_granularity(args.granularity)
         candles = _load_candle_fixture(args.file)
         proposer_config = BaselineProposerConfig(
             short_window=args.short_window,

--- a/src/gpt_trader/cli/commands/ideas.py
+++ b/src/gpt_trader/cli/commands/ideas.py
@@ -592,6 +592,12 @@ def _parse_candle_decimal(value: Any, index: int, field_name: str) -> Decimal:
 
 
 def _validate_candle_semantics(candle: Candle, index: int) -> None:
+    for field_name in ("open", "high", "low", "close"):
+        if getattr(candle, field_name) <= 0:
+            raise CandleInputError(
+                f"candle at index {index} has non-positive {field_name}",
+                field=f"candles[{index}].{field_name}",
+            )
     if candle.high < candle.low:
         raise CandleInputError(
             f"candle at index {index} has high below low",

--- a/src/gpt_trader/cli/commands/ideas.py
+++ b/src/gpt_trader/cli/commands/ideas.py
@@ -12,20 +12,27 @@ import json
 import sys
 from argparse import ArgumentParser, Namespace
 from dataclasses import replace
+from datetime import UTC, datetime
 from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Any
 
 from gpt_trader.cli import options
 from gpt_trader.cli.response import CliError, CliErrorCode, CliResponse
+from gpt_trader.core import Candle
 from gpt_trader.errors import ValidationError
 from gpt_trader.features.trade_ideas import (
     ActorType,
     AuditIntegrityError,
+    BaselineProposer,
+    BaselineProposerConfig,
     BudgetIntegrityError,
     InvalidTransitionError,
     PolicyViolationError,
+    ReplayReport,
+    ReplayRunnerConfig,
     TradeIdea,
+    TradeIdeaReplayRunner,
     TradeIdeaService,
     TradeIdeaState,
     UnknownTradeIdeaError,
@@ -54,6 +61,14 @@ BUDGET_FIELDS = (
 
 class IdeaInputError(ValueError):
     """Raised when a JSON trade-idea payload cannot be parsed."""
+
+    def __init__(self, message: str, *, field: str | None = None) -> None:
+        super().__init__(message)
+        self.field = field
+
+
+class CandleInputError(ValueError):
+    """Raised when a replay candle fixture cannot be parsed."""
 
     def __init__(self, message: str, *, field: str | None = None) -> None:
         super().__init__(message)
@@ -127,6 +142,76 @@ def register(subparsers: Any) -> None:
     )
     _add_common_options(report)
     report.set_defaults(handler=_handle_report, subcommand="report")
+
+    replay = ideas_subparsers.add_parser(
+        "replay",
+        help="Replay proposer calibration against local candle fixtures",
+        description=(
+            "Read-only calibration commands over local candle fixtures. "
+            "Replay commands never contact brokers, accounts, or live market data."
+        ),
+    )
+    replay_subparsers = replay.add_subparsers(dest="replay_command", required=True)
+    baseline = replay_subparsers.add_parser(
+        "baseline",
+        help="Replay the deterministic baseline proposer over candle history",
+        description=(
+            "Feed a local OHLCV candle fixture to the deterministic baseline proposer "
+            "and summarize replay scoring. This command is broker-free and read-only."
+        ),
+    )
+    options.add_output_options(baseline, include_quiet=False)
+    baseline.add_argument(
+        "--file",
+        type=Path,
+        required=True,
+        help="JSON fixture with a top-level candles array of OHLCV bars",
+    )
+    baseline.add_argument("--symbol", required=True, help="Symbol represented by the candles")
+    baseline.add_argument(
+        "--granularity",
+        required=True,
+        help="Candle granularity, for example ONE_HOUR, 1H, or 1D",
+    )
+    baseline.add_argument(
+        "--source",
+        default="fixture:candles",
+        help="Source label stamped into point-in-time replay snapshots",
+    )
+    baseline.add_argument(
+        "--min-history",
+        type=_positive_int_value,
+        help=(
+            "Minimum historical candles before evaluating snapshots "
+            "(default: long-window + crossover-lookback)"
+        ),
+    )
+    baseline.add_argument("--short-window", type=_positive_int_value, default=10)
+    baseline.add_argument("--long-window", type=_positive_int_value, default=50)
+    baseline.add_argument("--crossover-lookback", type=_positive_int_value, default=3)
+    baseline.add_argument(
+        "--risk-per-idea-pct",
+        type=_non_negative_decimal_value,
+        default=Decimal("2"),
+    )
+    baseline.add_argument(
+        "--entry-band-pct",
+        type=_positive_decimal_value,
+        default=Decimal("1"),
+    )
+    baseline.add_argument(
+        "--reward-multiple",
+        type=_positive_decimal_value,
+        default=Decimal("2"),
+    )
+    baseline.add_argument("--expiry-hours", type=_positive_int_value, default=48)
+    baseline.add_argument("--expected-hold", default="5-15 days")
+    baseline.add_argument(
+        "--price-precision",
+        type=_positive_decimal_value,
+        default=Decimal("0.01"),
+    )
+    baseline.set_defaults(handler=_handle_replay_baseline, subcommand="replay baseline")
 
     approve = ideas_subparsers.add_parser("approve", help="Approve a proposed trade idea")
     _add_common_options(approve)
@@ -305,6 +390,23 @@ def _non_negative_int_value(value: str) -> int:
     return parsed
 
 
+def _positive_decimal_value(value: str) -> Decimal:
+    parsed = _decimal_value(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError(f"decimal value must be positive: {value}")
+    return parsed
+
+
+def _positive_int_value(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError(f"invalid integer value: {value}") from error
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError(f"integer value must be positive: {value}")
+    return parsed
+
+
 def _bool_value(value: str) -> bool:
     return value.lower() == "true"
 
@@ -344,6 +446,81 @@ def _load_trade_idea(args: Namespace) -> TradeIdea:
         raise IdeaInputError(f"Missing required trade idea field: {field}", field=field) from error
     except (InvalidOperation, TypeError, ValueError) as error:
         raise IdeaInputError(f"Invalid trade idea field: {error}") from error
+
+
+def _load_candle_fixture(path: Path) -> tuple[Candle, ...]:
+    try:
+        raw_payload = path.read_text(encoding="utf-8")
+    except OSError as error:
+        raise CandleInputError(f"Could not read candle fixture: {error}") from error
+
+    try:
+        payload = json.loads(raw_payload)
+    except json.JSONDecodeError as error:
+        raise CandleInputError(f"Malformed candle fixture JSON: {error.msg}") from error
+    if not isinstance(payload, dict):
+        raise CandleInputError("Candle fixture must be a JSON object", field="candles")
+
+    raw_candles = payload.get("candles")
+    if not isinstance(raw_candles, list):
+        raise CandleInputError("Candle fixture must contain a candles array", field="candles")
+
+    return tuple(_parse_candle(row, index) for index, row in enumerate(raw_candles))
+
+
+def _parse_candle(row: Any, index: int) -> Candle:
+    if not isinstance(row, dict):
+        raise CandleInputError(
+            f"candle at index {index} must be a JSON object",
+            field=f"candles[{index}]",
+        )
+    return Candle(
+        ts=_parse_candle_timestamp(_required_candle_field(row, "ts", index), index),
+        open=_parse_candle_decimal(_required_candle_field(row, "open", index), index, "open"),
+        high=_parse_candle_decimal(_required_candle_field(row, "high", index), index, "high"),
+        low=_parse_candle_decimal(_required_candle_field(row, "low", index), index, "low"),
+        close=_parse_candle_decimal(_required_candle_field(row, "close", index), index, "close"),
+        volume=_parse_candle_decimal(_required_candle_field(row, "volume", index), index, "volume"),
+    )
+
+
+def _required_candle_field(row: dict[str, Any], field_name: str, index: int) -> Any:
+    if field_name not in row:
+        raise CandleInputError(
+            f"candle at index {index} is missing required field '{field_name}'",
+            field=f"candles[{index}].{field_name}",
+        )
+    return row[field_name]
+
+
+def _parse_candle_timestamp(value: Any, index: int) -> datetime:
+    field = f"candles[{index}].ts"
+    if not isinstance(value, str):
+        raise CandleInputError("candle ts must be an ISO-8601 string", field=field)
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise CandleInputError(f"Invalid candle timestamp: {value}", field=field) from error
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _parse_candle_decimal(value: Any, index: int, field_name: str) -> Decimal:
+    field = f"candles[{index}].{field_name}"
+    try:
+        parsed = Decimal(str(value))
+    except InvalidOperation as error:
+        raise CandleInputError(
+            f"Invalid decimal candle value for {field_name}: {value}",
+            field=field,
+        ) from error
+    if not parsed.is_finite():
+        raise CandleInputError(
+            f"Candle decimal value must be finite for {field_name}: {value}",
+            field=field,
+        )
+    return parsed
 
 
 def _handle_propose(args: Namespace) -> CliResponse:
@@ -444,6 +621,40 @@ def _handle_report(args: Namespace) -> CliResponse:
     text = format_trade_idea_track_record_report(payload)
     idea_count = payload["proposal_volume"]["idea_count"]
     return _success(command, args, payload, text, was_noop=idea_count == 0)
+
+
+def _handle_replay_baseline(args: Namespace) -> CliResponse:
+    command = "ideas replay baseline"
+    try:
+        candles = _load_candle_fixture(args.file)
+        proposer_config = BaselineProposerConfig(
+            short_window=args.short_window,
+            long_window=args.long_window,
+            crossover_lookback=args.crossover_lookback,
+            risk_per_idea_pct=args.risk_per_idea_pct,
+            entry_band_pct=args.entry_band_pct,
+            reward_multiple=args.reward_multiple,
+            expiry_hours=args.expiry_hours,
+            expected_hold=args.expected_hold,
+            price_precision=args.price_precision,
+        )
+        min_history = (
+            args.min_history
+            if args.min_history is not None
+            else proposer_config.long_window + proposer_config.crossover_lookback
+        )
+        report = TradeIdeaReplayRunner(
+            BaselineProposer(proposer_config),
+            config=ReplayRunnerConfig(source=args.source, min_history=min_history),
+        ).run_series(symbol=args.symbol, granularity=args.granularity, candles=candles)
+    except CandleInputError as error:
+        return _input_error(command, args, error)
+    except Exception as error:
+        return _mapped_error(command, args, error)
+
+    payload = report.to_dict()
+    text = _replay_report_text(report)
+    return _success(command, args, payload, text, was_noop=report.ideas_proposed == 0)
 
 
 def _handle_approve(args: Namespace) -> CliResponse:
@@ -710,7 +921,9 @@ def _success(
     )
 
 
-def _input_error(command: str, args: Namespace, error: IdeaInputError) -> CliResponse:
+def _input_error(
+    command: str, args: Namespace, error: IdeaInputError | CandleInputError
+) -> CliResponse:
     details = {"field": error.field} if error.field else {}
     return _failure(
         command,
@@ -901,3 +1114,42 @@ def _events_text(events: list[dict[str, Any]]) -> str:
 
 def _budget_text(payload: dict[str, Any]) -> str:
     return "\n".join(f"{key}: {value}" for key, value in payload.items())
+
+
+def _replay_report_text(report: ReplayReport) -> str:
+    average_return_r = report.average_return_r
+    return "\n".join(
+        [
+            _status_line(
+                "ideas replay baseline",
+                "OK",
+                (
+                    f"{report.symbol} {report.granularity}, "
+                    f"snapshots={report.snapshots_evaluated}, "
+                    f"ideas={report.ideas_proposed}"
+                ),
+            ),
+            f"proposer_id: {report.proposer_id}",
+            (
+                "outcomes: "
+                f"target_hits={report.target_hits}, "
+                f"stop_hits={report.stop_hits}, "
+                f"timed_out={report.timed_out}, "
+                f"not_filled={report.not_filled}, "
+                f"no_future_data={report.no_future_data}"
+            ),
+            (
+                "hit_rates: "
+                f"target={_decimal_pct(report.target_hit_rate)}, "
+                f"stop={_decimal_pct(report.stop_hit_rate)}"
+            ),
+            (
+                "average_return_r: "
+                f"{average_return_r.normalize() if average_return_r is not None else 'n/a'}"
+            ),
+        ]
+    )
+
+
+def _decimal_pct(value: Decimal) -> str:
+    return f"{(value * Decimal('100')).quantize(Decimal('0.01'))}%"

--- a/src/gpt_trader/cli/commands/ideas.py
+++ b/src/gpt_trader/cli/commands/ideas.py
@@ -16,7 +16,7 @@ from dataclasses import replace
 from datetime import UTC, datetime
 from decimal import Decimal, InvalidOperation
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from gpt_trader.cli import options
 from gpt_trader.cli.response import CliError, CliErrorCode, CliResponse
@@ -791,6 +791,24 @@ def _default_replay_min_history(config: BaselineProposerConfig) -> int:
     return max(config.short_window, config.long_window) + config.crossover_lookback
 
 
+def _resolve_replay_min_history(args: Namespace, config: BaselineProposerConfig) -> int:
+    minimum_history = _default_replay_min_history(config)
+    requested_min_history = cast(int | None, args.min_history)
+    if requested_min_history is None:
+        return minimum_history
+    if requested_min_history < minimum_history:
+        raise CandleInputError(
+            (
+                "--min-history must be at least "
+                f"{minimum_history} for short-window={config.short_window}, "
+                f"long-window={config.long_window}, "
+                f"crossover-lookback={config.crossover_lookback}"
+            ),
+            field="min_history",
+        )
+    return requested_min_history
+
+
 def _validate_replay_granularity(granularity: str) -> None:
     if _granularity_duration(granularity) is None:
         raise CandleInputError(
@@ -1017,11 +1035,7 @@ def _handle_replay_baseline(args: Namespace) -> CliResponse:
             expected_hold=args.expected_hold,
             price_precision=args.price_precision,
         )
-        min_history = (
-            args.min_history
-            if args.min_history is not None
-            else _default_replay_min_history(proposer_config)
-        )
+        min_history = _resolve_replay_min_history(args, proposer_config)
         report = TradeIdeaReplayRunner(
             BaselineProposer(proposer_config),
             config=ReplayRunnerConfig(source=args.source, min_history=min_history),

--- a/tests/unit/gpt_trader/cli/commands/test_ideas_queries.py
+++ b/tests/unit/gpt_trader/cli/commands/test_ideas_queries.py
@@ -227,6 +227,7 @@ def test_help_lists_ideas_subcommands(capsys: pytest.CaptureFixture[str]) -> Non
     assert "propose" in output
     assert "request-changes" in output
     assert "report" in output
+    assert "replay" in output
     assert "mark-submitted" in output
     assert "budget" in output
     assert "audit" in output

--- a/tests/unit/gpt_trader/cli/commands/test_ideas_replay_baseline.py
+++ b/tests/unit/gpt_trader/cli/commands/test_ideas_replay_baseline.py
@@ -130,6 +130,23 @@ def test_replay_baseline_malformed_input_returns_invalid_argument(
     assert response["errors"][0]["details"]["field"] == "candles[0].open"
 
 
+def test_replay_baseline_rejects_unsupported_granularity(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    fixture = _write_fixture(tmp_path / "candles.json", _baseline_hit_fixture())
+    argv = _baseline_args(fixture)
+    granularity_index = argv.index("--granularity") + 1
+    argv[granularity_index] = "BAD"
+
+    exit_code, response = _run_json(capsys, argv)
+
+    assert exit_code == 1
+    assert response["errors"][0]["code"] == CliErrorCode.INVALID_ARGUMENT.value
+    assert response["errors"][0]["details"]["field"] == "granularity"
+    assert "Unsupported replay granularity: BAD" in response["errors"][0]["message"]
+
+
 def test_replay_baseline_preserves_json_number_precision(tmp_path: Path) -> None:
     fixture = tmp_path / "precise-candles.json"
     fixture.write_text(

--- a/tests/unit/gpt_trader/cli/commands/test_ideas_replay_baseline.py
+++ b/tests/unit/gpt_trader/cli/commands/test_ideas_replay_baseline.py
@@ -249,6 +249,24 @@ def test_replay_baseline_default_history_uses_largest_window(
     assert response["data"]["snapshots_evaluated"] == 1
 
 
+def test_replay_baseline_rejects_custom_min_history_below_largest_window(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    fixture = _write_fixture(tmp_path / "flat-candles.json", _flat_fixture())
+    argv = _baseline_args(fixture)
+    argv[argv.index("--short-window") + 1] = "5"
+    argv[argv.index("--long-window") + 1] = "2"
+    argv.extend(["--min-history", "5"])
+
+    exit_code, response = _run_json(capsys, argv)
+
+    assert exit_code == 1
+    assert response["errors"][0]["code"] == CliErrorCode.INVALID_ARGUMENT.value
+    assert response["errors"][0]["details"]["field"] == "min_history"
+    assert "--min-history must be at least 6" in response["errors"][0]["message"]
+
+
 def test_replay_baseline_help_documents_required_flags_and_read_only_contract(
     capsys: pytest.CaptureFixture[str],
 ) -> None:

--- a/tests/unit/gpt_trader/cli/commands/test_ideas_replay_baseline.py
+++ b/tests/unit/gpt_trader/cli/commands/test_ideas_replay_baseline.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from gpt_trader import cli
+from gpt_trader.cli.response import CliErrorCode
+
+AS_OF = datetime(2026, 6, 12, 12, 0, tzinfo=UTC)
+
+
+def _candle(
+    offset_hours: int,
+    *,
+    open_: str = "101",
+    high: str = "102",
+    low: str = "100",
+    close: str = "101",
+    volume: str = "1000",
+) -> dict[str, str]:
+    return {
+        "ts": (AS_OF + timedelta(hours=offset_hours)).isoformat(),
+        "open": open_,
+        "high": high,
+        "low": low,
+        "close": close,
+        "volume": volume,
+    }
+
+
+def _baseline_hit_fixture() -> dict[str, list[dict[str, str]]]:
+    return {
+        "candles": [
+            _candle(-5, open_="100", high="100", low="100", close="100"),
+            _candle(-4, open_="100", high="100", low="100", close="100"),
+            _candle(-3, open_="100", high="100", low="100", close="100"),
+            _candle(-2, open_="100", high="100", low="100", close="100"),
+            _candle(-1, open_="110", high="110", low="110", close="110"),
+            _candle(0, open_="110", high="112", low="109", close="111"),
+            _candle(1, open_="111", high="126", low="111", close="126"),
+        ]
+    }
+
+
+def _flat_fixture() -> dict[str, list[dict[str, str]]]:
+    return {
+        "candles": [
+            _candle(offset, open_="100", high="100", low="100", close="100")
+            for offset in range(-5, 2)
+        ]
+    }
+
+
+def _write_fixture(path: Path, payload: dict[str, Any]) -> Path:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _baseline_args(path: Path, *, output_format: str = "json") -> list[str]:
+    return [
+        "ideas",
+        "replay",
+        "baseline",
+        "--file",
+        str(path),
+        "--symbol",
+        "BTC-USD",
+        "--granularity",
+        "ONE_HOUR",
+        "--short-window",
+        "2",
+        "--long-window",
+        "4",
+        "--crossover-lookback",
+        "1",
+        "--expiry-hours",
+        "3",
+        "--format",
+        output_format,
+    ]
+
+
+def _run_json(capsys: pytest.CaptureFixture[str], argv: list[str]) -> tuple[int, dict[str, Any]]:
+    exit_code = cli.main(argv)
+    output = capsys.readouterr().out
+    assert output
+    return exit_code, json.loads(output)
+
+
+def _run_text(capsys: pytest.CaptureFixture[str], argv: list[str]) -> tuple[int, str]:
+    exit_code = cli.main(argv)
+    output = capsys.readouterr().out
+    assert output
+    return exit_code, output
+
+
+def test_replay_baseline_text_success_reports_replay_summary(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    fixture = _write_fixture(tmp_path / "candles.json", _baseline_hit_fixture())
+
+    exit_code, output = _run_text(capsys, _baseline_args(fixture, output_format="text"))
+
+    assert exit_code == 0
+    assert "ideas replay baseline OK (BTC-USD ONE_HOUR, snapshots=2, ideas=1)" in output
+    assert "proposer_id: baseline-ma-2-4" in output
+    assert "target_hits=1" in output
+    assert "average_return_r: 2" in output
+
+
+def test_replay_baseline_malformed_input_returns_invalid_argument(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    payload = _baseline_hit_fixture()
+    payload["candles"][0]["open"] = "not-a-decimal"
+    fixture = _write_fixture(tmp_path / "bad-candles.json", payload)
+
+    exit_code, response = _run_json(capsys, _baseline_args(fixture))
+
+    assert exit_code == 1
+    assert response["errors"][0]["code"] == CliErrorCode.INVALID_ARGUMENT.value
+    assert response["errors"][0]["details"]["field"] == "candles[0].open"
+
+
+def test_replay_baseline_no_idea_replay_is_successful_noop(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    fixture = _write_fixture(tmp_path / "flat-candles.json", _flat_fixture())
+
+    exit_code, response = _run_json(capsys, _baseline_args(fixture))
+
+    assert exit_code == 0
+    assert response["success"] is True
+    assert response["metadata"]["was_noop"] is True
+    assert response["data"]["snapshots_evaluated"] == 2
+    assert response["data"]["ideas_proposed"] == 0
+    assert response["data"]["target_hits"] == 0
+    assert response["data"]["average_return_r"] is None
+
+
+def test_replay_baseline_json_output_returns_replay_report(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    fixture = _write_fixture(tmp_path / "candles.json", _baseline_hit_fixture())
+
+    exit_code, response = _run_json(capsys, _baseline_args(fixture))
+
+    assert exit_code == 0
+    assert response["command"] == "ideas replay baseline"
+    data = response["data"]
+    assert data["proposer_id"] == "baseline-ma-2-4"
+    assert data["snapshots_evaluated"] == 2
+    assert data["ideas_proposed"] == 1
+    assert data["target_hits"] == 1
+    assert data["stop_hits"] == 0
+    assert data["timed_out"] == 0
+    assert data["not_filled"] == 0
+    assert data["no_future_data"] == 0
+    assert data["target_hit_rate"] == "1"
+    assert data["average_return_r"] == "2"
+    assert data["ideas"][0]["outcome"] == "target_hit"

--- a/tests/unit/gpt_trader/cli/commands/test_ideas_replay_baseline.py
+++ b/tests/unit/gpt_trader/cli/commands/test_ideas_replay_baseline.py
@@ -183,6 +183,24 @@ def test_replay_baseline_rejects_semantically_invalid_ohlcv_rows(
     assert response["errors"][0]["details"]["field"] == expected_field
 
 
+@pytest.mark.parametrize("field", ["open", "high", "low", "close"])
+def test_replay_baseline_rejects_non_positive_ohlc_prices(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    field: str,
+) -> None:
+    payload = _baseline_hit_fixture()
+    payload["candles"][0][field] = "0"
+    fixture = _write_fixture(tmp_path / "non-positive-ohlc.json", payload)
+
+    exit_code, response = _run_json(capsys, _baseline_args(fixture))
+
+    assert exit_code == 1
+    assert response["errors"][0]["code"] == CliErrorCode.INVALID_ARGUMENT.value
+    assert response["errors"][0]["details"]["field"] == f"candles[0].{field}"
+    assert f"non-positive {field}" in response["errors"][0]["message"]
+
+
 def test_replay_baseline_default_history_uses_largest_window(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
@@ -199,9 +217,9 @@ def test_replay_baseline_default_history_uses_largest_window(
         "--granularity",
         "ONE_HOUR",
         "--short-window",
-        "5",
-        "--long-window",
         "2",
+        "--long-window",
+        "5",
         "--crossover-lookback",
         "1",
         "--format",

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6865,
+    "total_tests": 6866,
     "total_files": 809,
     "markers_used": 16
   },

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6876,
+    "total_tests": 6877,
     "total_files": 811,
     "markers_used": 16
   },

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6866,
+    "total_tests": 6867,
     "total_files": 809,
     "markers_used": 16
   },

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,9 +95,9 @@
     ]
   },
   "counts": {
-    "unit": 6700,
+    "unit": 6701,
     "asyncio": 411,
-    "parametrize": 199,
+    "parametrize": 200,
     "endpoints": 83,
     "property": 82,
     "integration": 79,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6711,
+    "unit": 6712,
     "asyncio": 411,
     "parametrize": 200,
     "endpoints": 83,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6701,
+    "unit": 6702,
     "asyncio": 411,
     "parametrize": 200,
     "endpoints": 83,

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6876,
+    "total_tests": 6877,
     "total_files": 811,
     "markers_used": 16
   },
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6711,
+    "unit": 6712,
     "asyncio": 411,
     "parametrize": 200,
     "endpoints": 83,
@@ -9559,7 +9559,7 @@
         "docstring": ""
       },
       {
-        "name": "test_replay_baseline_help_documents_required_flags_and_read_only_contract",
+        "name": "test_replay_baseline_rejects_custom_min_history_below_largest_window",
         "line": 252,
         "markers": [
           "unit"
@@ -9567,8 +9567,16 @@
         "docstring": ""
       },
       {
+        "name": "test_replay_baseline_help_documents_required_flags_and_read_only_contract",
+        "line": 270,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
         "name": "test_replay_baseline_no_idea_replay_is_successful_noop",
-        "line": 265,
+        "line": 283,
         "markers": [
           "unit"
         ],
@@ -9576,7 +9584,7 @@
       },
       {
         "name": "test_replay_baseline_json_output_returns_replay_report",
-        "line": 282,
+        "line": 300,
         "markers": [
           "unit"
         ],

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6866,
+    "total_tests": 6867,
     "total_files": 809,
     "markers_used": 16
   },
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6701,
+    "unit": 6702,
     "asyncio": 411,
     "parametrize": 200,
     "endpoints": 83,
@@ -9457,7 +9457,7 @@
         "docstring": ""
       },
       {
-        "name": "test_replay_baseline_preserves_json_number_precision",
+        "name": "test_replay_baseline_rejects_unsupported_granularity",
         "line": 133,
         "markers": [
           "unit"
@@ -9465,8 +9465,16 @@
         "docstring": ""
       },
       {
+        "name": "test_replay_baseline_preserves_json_number_precision",
+        "line": 150,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
         "name": "test_replay_baseline_rejects_semantically_invalid_ohlcv_rows",
-        "line": 168,
+        "line": 185,
         "markers": [
           "parametrize",
           "unit"
@@ -9475,7 +9483,7 @@
       },
       {
         "name": "test_replay_baseline_rejects_non_positive_ohlc_prices",
-        "line": 187,
+        "line": 204,
         "markers": [
           "parametrize",
           "unit"
@@ -9484,7 +9492,7 @@
       },
       {
         "name": "test_replay_baseline_default_history_uses_largest_window",
-        "line": 204,
+        "line": 221,
         "markers": [
           "unit"
         ],
@@ -9492,7 +9500,7 @@
       },
       {
         "name": "test_replay_baseline_help_documents_required_flags_and_read_only_contract",
-        "line": 235,
+        "line": 252,
         "markers": [
           "unit"
         ],
@@ -9500,7 +9508,7 @@
       },
       {
         "name": "test_replay_baseline_no_idea_replay_is_successful_noop",
-        "line": 248,
+        "line": 265,
         "markers": [
           "unit"
         ],
@@ -9508,7 +9516,7 @@
       },
       {
         "name": "test_replay_baseline_json_output_returns_replay_report",
-        "line": 265,
+        "line": 282,
         "markers": [
           "unit"
         ],

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6865,
+    "total_tests": 6866,
     "total_files": 809,
     "markers_used": 16
   },
@@ -102,9 +102,9 @@
     ]
   },
   "marker_counts": {
-    "unit": 6700,
+    "unit": 6701,
     "asyncio": 411,
-    "parametrize": 199,
+    "parametrize": 200,
     "endpoints": 83,
     "property": 82,
     "integration": 79,
@@ -9474,8 +9474,17 @@
         "docstring": ""
       },
       {
+        "name": "test_replay_baseline_rejects_non_positive_ohlc_prices",
+        "line": 187,
+        "markers": [
+          "parametrize",
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
         "name": "test_replay_baseline_default_history_uses_largest_window",
-        "line": 186,
+        "line": 204,
         "markers": [
           "unit"
         ],
@@ -9483,7 +9492,7 @@
       },
       {
         "name": "test_replay_baseline_help_documents_required_flags_and_read_only_contract",
-        "line": 217,
+        "line": 235,
         "markers": [
           "unit"
         ],
@@ -9491,7 +9500,7 @@
       },
       {
         "name": "test_replay_baseline_no_idea_replay_is_successful_noop",
-        "line": 230,
+        "line": 248,
         "markers": [
           "unit"
         ],
@@ -9499,7 +9508,7 @@
       },
       {
         "name": "test_replay_baseline_json_output_returns_replay_report",
-        "line": 247,
+        "line": 265,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary
Related issue / finding / RJ-routed package: RJ-routed package, Stage 1 baseline replay/calibration operator surface for trade ideas.

Adds `gpt-trader ideas replay baseline`, a broker-free read-only calibration command that loads local OHLCV candle fixtures, runs the deterministic `BaselineProposer` through `TradeIdeaReplayRunner`, and renders `ReplayReport` summaries in text or JSON.

## Type of change
- [ ] Refactor
- [x] Feature
- [ ] Bug fix
- [x] Tests only
- [x] CI/Docs/Tooling

## Scope & Impact
- Affected areas / components: `src/gpt_trader/cli/commands/ideas.py`, trade-idea CLI tests, trade-idea interface specs.
- Behavior changes: `gpt-trader ideas` now includes `replay baseline`; the command only reads a local fixture and formats replay results. It does not call broker APIs, read credentials, create tickets, write idea storage, or change closeout attribution behavior.

## Test Plan
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Contract tests (if applicable)
- [x] Ran locally: `uv run pytest tests/unit/gpt_trader/cli/commands/test_ideas_replay_baseline.py tests/unit/gpt_trader/features/trade_ideas/test_replay.py tests/unit/gpt_trader/features/trade_ideas/test_replay_runner.py -q`
- [x] Ran locally: `uv run pytest tests/unit/gpt_trader/cli/commands/test_ideas_*.py -q`
- [x] Markers used appropriately (`unit`/`integration`/`slow`/`perf`)

## Complexity & Quality Gates
- [x] Mypy/type-check passed (`uv run local-ci --profile quick`)
- [x] Xenon/radon complexity gate passed (not applicable; no live_trade execution path touched)
- [x] No `sys.path` hacks in tests
- [x] No `MagicMock` on `async def` (use `AsyncMock`)
- [x] Import-lint rules respected (no “import up the stack”)

## Observability & Errors
- [ ] Structured JSON logs for new/changed paths
- [x] Errors include diagnostic context (malformed fixture responses include the offending field when available)
- [ ] Added/updated sampling examples in tests (if applicable)

## Configuration
- [ ] If config changed: `python -m gpt_trader.cli.config validate --profile <name>` passes
- [ ] Env docs re-generated (if applicable) and committed
- [x] No `ConfigLoader` usages introduced (ConfigManager-only)

## Breaking Changes
- [x] None
- [ ] Documented in PR body and release notes if any

## Screenshots / Logs (optional)
Verification:
- `uv run ruff check src/gpt_trader/cli/commands/ideas.py tests/unit/gpt_trader/cli/commands/test_ideas_replay_baseline.py tests/unit/gpt_trader/cli/commands/test_ideas_queries.py` -> passed
- `uv run pytest tests/unit/gpt_trader/cli/commands/test_ideas_replay_baseline.py tests/unit/gpt_trader/features/trade_ideas/test_replay.py tests/unit/gpt_trader/features/trade_ideas/test_replay_runner.py -q` -> 26 passed
- `uv run pytest tests/unit/gpt_trader/cli/commands/test_ideas_*.py -q` -> 90 passed
- `uv run gpt-trader ideas --help` -> passed; lists `replay`
- `uv run gpt-trader ideas replay baseline --help` -> passed; documents fixture/options
- `uv run local-ci --profile quick` -> passed; 7,125 core unit tests passed, 8 skipped; quick profile skipped readiness, agent artifacts freshness, TUI snapshots, property tests, and contract tests as designed

## Checklist
- [x] Acceptance criteria in linked issue(s), finding packet, or routed package met
- [x] Affected paths listed in PR description
- [x] Changelog entry (if repo uses one) not required for this scoped CLI/spec addition


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `ideas replay baseline` to replay deterministic baseline ideas from a local candle JSON fixture, with both text and JSON report output.
* **Bug Fixes**
  * Strengthened fixture input validation (UTC timestamp handling, finite/precision-preserving decimals, required fields, positive-only numeric checks, OHLCV constraint enforcement) with field-specific `INVALID_ARGUMENT` errors and correct noop reporting.
* **Tests**
  * Added unit coverage for success, noop behavior, malformed/precision-critical inputs, invalid OHLCV rows, unsupported granularity, default history selection, and `--help` read-only boundaries.
* **Documentation**
  * Updated the CLI contract/spec and interface design notes, including the replay read-only requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->