### PR TITLE
Add baseline trade idea proposal intake

### DIFF
--- a/docs/specs/TRADE_IDEA_CLI_SPEC.md
+++ b/docs/specs/TRADE_IDEA_CLI_SPEC.md
@@ -44,6 +44,10 @@ Every mutating subcommand accepts:
 
 - `--actor ID` — actor identity (default: `GPT_TRADER_ACTOR` env, then OS user)
 
+Exception: `propose-baseline` defaults to the deterministic baseline proposer
+id so generated proposal audit events identify the proposer unless an operator
+explicitly overrides `--actor`.
+
 Current behavior is discoverable with:
 
 ```bash
@@ -55,6 +59,7 @@ uv run gpt-trader ideas --help
 ```
 gpt-trader ideas
 ├── propose          --file PATH | --stdin   [--actor-type {ai,human}] [--reason TEXT]
+├── propose-baseline --snapshot PATH         [--actor ID] [--reason TEXT]
 ├── resubmit         --file PATH | --stdin   [--actor-type {ai,human}] [--reason TEXT]
 ├── list             [--state STATE]
 ├── show             DECISION_ID [--events]
@@ -97,6 +102,76 @@ gpt-trader ideas
   still succeeds (rejection happens at review, per the framework).
 - Text: `✓ ideas propose OK (trade-20260612-001, state=proposed)` followed by
   `⚠ would fail approval: <reason>` lines if any.
+
+### `ideas propose-baseline`
+
+- Input: a local `MarketSnapshot` JSON fixture from `--snapshot PATH`.
+- Never calls broker, account, credential, preflight, canary, or live market
+  surfaces. The snapshot file is the complete data source for the command.
+- Parse the fixture into `MarketSnapshot` / `SymbolSeries`, run
+  `BaselineProposer`, preflight every emitted `TradeIdea` with
+  `service.validate_new_proposal`, preview approval policy with
+  `service.approval_violations`, then persist through
+  `service.propose(..., actor_type=ai)`.
+- The default actor id is the deterministic proposer id
+  (`baseline-ma-10-50` today); `--actor` overrides it when an operator needs a
+  different audit identity.
+- No-signal snapshots return success with `proposal_count=0` and
+  `was_noop=true`; they do not create trade-idea records.
+- Duplicate decision ids fail before any proposed record or audit event is
+  written for that invocation.
+- JSON `data` contains `proposer_id`, snapshot metadata, `proposal_count`, and
+  one entry per proposal:
+
+  ```json
+  {
+    "decision_id": "trade-20350612-btcusd-4c5a9e2d",
+    "state": "proposed",
+    "instrument": "BTC-USD",
+    "direction": "long",
+    "record_hash": "sha256...",
+    "approval_preview": {
+      "violations": [],
+      "warnings": []
+    }
+  }
+  ```
+
+  Approval-preview warnings are also mirrored into the top-level
+  `CliResponse.warnings` list for agent callers that already consume warning
+  envelopes.
+
+#### `propose-baseline` snapshot fixture shape
+
+The JSON file uses strings for timestamps and decimal fields so fixtures remain
+stable across languages and shells:
+
+```json
+{
+  "as_of": "2035-06-12T00:00:00+00:00",
+  "source": "local-fixture:coinbase-candles",
+  "series": [
+    {
+      "symbol": "BTC-USD",
+      "granularity": "1d",
+      "candles": [
+        {
+          "ts": "2035-04-20T00:00:00+00:00",
+          "open": "100",
+          "high": "100",
+          "low": "100",
+          "close": "100",
+          "volume": "1000"
+        }
+      ]
+    }
+  ]
+}
+```
+
+All candle timestamps must include a timezone, be strictly ascending within a
+series, and be strictly before `as_of`. The command rejects malformed fixtures
+as `INVALID_ARGUMENT`.
 
 ### `ideas resubmit`
 
@@ -296,6 +371,10 @@ Required cases:
 15. JSON mode for at least propose/approve/list/report asserting the
     `CliResponse` envelope per CLAUDE.md patterns
     (`result.errors[0].code == CliErrorCode.POLICY_VIOLATION.value`).
+14. `propose-baseline` success from a local snapshot fixture, no-signal
+    no-op behavior, duplicate decision handling, malformed snapshot input, and
+    JSON output with decision ids, record hashes, states, and approval-preview
+    warnings/violations.
 
 ## Acceptance criteria
 
@@ -306,6 +385,9 @@ Required cases:
 - [x] No import from `features/brokerages/` or `features/live_trade/` in
       `ideas.py` (enforce by review; this surface must stay execution-free).
 - [x] All policy violations reach the user; no first-error-only truncation.
+- [x] `propose-baseline` turns local candle fixtures into proposed records
+      without broker/API access, and reports approval-preview warnings per
+      proposal.
 - [x] The focused `tests/unit/gpt_trader/cli/commands/test_ideas_*.py` suite
       covers the implemented command group.
 - [ ] Re-run the repo-required quality bundle before merging any future change

--- a/src/gpt_trader/cli/commands/ideas.py
+++ b/src/gpt_trader/cli/commands/ideas.py
@@ -11,21 +11,28 @@ import argparse
 import json
 import sys
 from argparse import ArgumentParser, Namespace
+from collections.abc import Mapping
 from dataclasses import replace
+from datetime import datetime
 from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Any
 
 from gpt_trader.cli import options
 from gpt_trader.cli.response import CliError, CliErrorCode, CliResponse
+from gpt_trader.core import Candle
 from gpt_trader.errors import ValidationError
 from gpt_trader.features.trade_ideas import (
     ActorType,
     AuditIntegrityError,
+    BaselineProposer,
     BudgetIntegrityError,
     CloseoutResolution,
     InvalidTransitionError,
+    MarketSnapshot,
     PolicyViolationError,
+    SnapshotIntegrityError,
+    SymbolSeries,
     TradeIdea,
     TradeIdeaService,
     TradeIdeaState,
@@ -53,12 +60,20 @@ BUDGET_FIELDS = (
 )
 
 
-class IdeaInputError(ValueError):
-    """Raised when a JSON trade-idea payload cannot be parsed."""
+class InputPayloadError(ValueError):
+    """Raised when a JSON CLI payload cannot be parsed."""
 
     def __init__(self, message: str, *, field: str | None = None) -> None:
         super().__init__(message)
         self.field = field
+
+
+class IdeaInputError(InputPayloadError):
+    """Raised when a JSON trade-idea payload cannot be parsed."""
+
+
+class SnapshotInputError(InputPayloadError):
+    """Raised when a JSON market snapshot payload cannot be parsed."""
 
 
 def register(subparsers: Any) -> None:
@@ -85,6 +100,30 @@ def register(subparsers: Any) -> None:
     )
     propose.add_argument("--reason", default="New trade idea proposed", help="Audit reason")
     propose.set_defaults(handler=_handle_propose, subcommand="propose")
+
+    propose_baseline = ideas_subparsers.add_parser(
+        "propose-baseline",
+        help="Generate proposals from a local market snapshot fixture",
+        description=(
+            "Generate deterministic BaselineProposer trade ideas from a local JSON "
+            "market snapshot and persist them through the audited trade-idea service. "
+            "This command reads no broker, account, credential, canary, or preflight data."
+        ),
+    )
+    _add_common_options(propose_baseline)
+    _add_actor_options(propose_baseline, default_description="baseline proposer id")
+    propose_baseline.add_argument(
+        "--snapshot",
+        type=Path,
+        required=True,
+        help="Read a local MarketSnapshot JSON fixture",
+    )
+    propose_baseline.add_argument(
+        "--reason",
+        default="Baseline proposer generated idea from local snapshot",
+        help="Audit reason",
+    )
+    propose_baseline.set_defaults(handler=_handle_propose_baseline, subcommand="propose-baseline")
 
     resubmit = ideas_subparsers.add_parser(
         "resubmit", help="Submit a revised record after requested changes"
@@ -337,10 +376,14 @@ def _add_input_options(parser: ArgumentParser) -> None:
     source.add_argument("--stdin", action="store_true", help="Read TradeIdea JSON from stdin")
 
 
-def _add_actor_options(parser: ArgumentParser) -> None:
+def _add_actor_options(
+    parser: ArgumentParser,
+    *,
+    default_description: str = "GPT_TRADER_ACTOR, then OS user",
+) -> None:
     parser.add_argument(
         "--actor",
-        help="Actor id stamped into audit events (default: GPT_TRADER_ACTOR, then OS user)",
+        help=f"Actor id stamped into audit events (default: {default_description})",
     )
 
 
@@ -412,6 +455,136 @@ def _load_trade_idea(args: Namespace) -> TradeIdea:
         raise IdeaInputError(f"Invalid trade idea field: {error}") from error
 
 
+def _load_market_snapshot(path: Path) -> MarketSnapshot:
+    try:
+        raw_payload = path.read_text(encoding="utf-8")
+    except OSError as error:
+        raise SnapshotInputError(f"Could not read market snapshot input: {error}") from error
+
+    try:
+        payload = json.loads(raw_payload)
+    except json.JSONDecodeError as error:
+        raise SnapshotInputError(f"Malformed market snapshot JSON: {error.msg}") from error
+    if not isinstance(payload, Mapping):
+        raise SnapshotInputError("Market snapshot input must be a JSON object")
+
+    try:
+        return _market_snapshot_from_payload(payload)
+    except SnapshotInputError:
+        raise
+    except SnapshotIntegrityError as error:
+        context_field = _error_context(error).get("field")
+        raise SnapshotInputError(
+            f"Invalid market snapshot field: {error}",
+            field=context_field if isinstance(context_field, str) else None,
+        ) from error
+
+
+def _market_snapshot_from_payload(payload: Mapping[str, Any]) -> MarketSnapshot:
+    series_payloads = _required_payload_array(payload, "series", "series")
+    return MarketSnapshot(
+        as_of=_required_payload_datetime(payload, "as_of", "as_of"),
+        source=_required_payload_string(payload, "source", "source"),
+        series=tuple(
+            _symbol_series_from_payload(series_payload, index)
+            for index, series_payload in enumerate(series_payloads)
+        ),
+    )
+
+
+def _symbol_series_from_payload(payload: Any, index: int) -> SymbolSeries:
+    field_prefix = f"series[{index}]"
+    series_payload = _payload_object(payload, field_prefix)
+    candle_payloads = _required_payload_array(
+        series_payload,
+        "candles",
+        f"{field_prefix}.candles",
+    )
+    return SymbolSeries(
+        symbol=_required_payload_string(series_payload, "symbol", f"{field_prefix}.symbol"),
+        granularity=_required_payload_string(
+            series_payload,
+            "granularity",
+            f"{field_prefix}.granularity",
+        ),
+        candles=tuple(
+            _candle_from_payload(candle_payload, f"{field_prefix}.candles[{candle_index}]")
+            for candle_index, candle_payload in enumerate(candle_payloads)
+        ),
+    )
+
+
+def _candle_from_payload(payload: Any, field_prefix: str) -> Candle:
+    candle_payload = _payload_object(payload, field_prefix)
+    return Candle(
+        ts=_required_payload_datetime(candle_payload, "ts", f"{field_prefix}.ts"),
+        open=_required_payload_decimal(candle_payload, "open", f"{field_prefix}.open"),
+        high=_required_payload_decimal(candle_payload, "high", f"{field_prefix}.high"),
+        low=_required_payload_decimal(candle_payload, "low", f"{field_prefix}.low"),
+        close=_required_payload_decimal(candle_payload, "close", f"{field_prefix}.close"),
+        volume=_required_payload_decimal(candle_payload, "volume", f"{field_prefix}.volume"),
+    )
+
+
+def _payload_object(value: Any, field: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise SnapshotInputError(f"{field} must be a JSON object", field=field)
+    return value
+
+
+def _required_payload_value(payload: Mapping[str, Any], key: str, field: str) -> Any:
+    try:
+        return payload[key]
+    except KeyError as error:
+        raise SnapshotInputError(
+            f"Missing required market snapshot field: {field}",
+            field=field,
+        ) from error
+
+
+def _required_payload_array(
+    payload: Mapping[str, Any],
+    key: str,
+    field: str,
+) -> list[Any]:
+    value = _required_payload_value(payload, key, field)
+    if not isinstance(value, list):
+        raise SnapshotInputError(f"{field} must be a JSON array", field=field)
+    return value
+
+
+def _required_payload_string(payload: Mapping[str, Any], key: str, field: str) -> str:
+    value = _required_payload_value(payload, key, field)
+    if not isinstance(value, str) or not value.strip():
+        raise SnapshotInputError(f"{field} must be a non-empty string", field=field)
+    return value
+
+
+def _required_payload_decimal(payload: Mapping[str, Any], key: str, field: str) -> Decimal:
+    value = _required_payload_value(payload, key, field)
+    try:
+        parsed = Decimal(str(value))
+    except (InvalidOperation, ValueError) as error:
+        raise SnapshotInputError(f"{field} must be a decimal value", field=field) from error
+    if not parsed.is_finite():
+        raise SnapshotInputError(f"{field} must be finite", field=field)
+    return parsed
+
+
+def _required_payload_datetime(payload: Mapping[str, Any], key: str, field: str) -> datetime:
+    value = _required_payload_value(payload, key, field)
+    if not isinstance(value, str):
+        raise SnapshotInputError(f"{field} must be an ISO datetime string", field=field)
+    normalized = f"{value[:-1]}+00:00" if value.endswith("Z") else value
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as error:
+        raise SnapshotInputError(f"{field} must be an ISO datetime string", field=field) from error
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise SnapshotInputError(f"{field} must include a timezone", field=field)
+    return parsed
+
+
 def _handle_propose(args: Namespace) -> CliResponse:
     command = "ideas propose"
     try:
@@ -442,6 +615,49 @@ def _handle_propose(args: Namespace) -> CliResponse:
     return _success(command, args, payload, text, warnings=warning_messages)
 
 
+def _handle_propose_baseline(args: Namespace) -> CliResponse:
+    command = "ideas propose-baseline"
+    proposer = BaselineProposer()
+    try:
+        snapshot = _load_market_snapshot(args.snapshot)
+        ideas = proposer.propose(snapshot)
+        if not ideas:
+            payload = _baseline_payload(snapshot, proposer.proposer_id, [])
+            text = _status_line(command, "OK", "0 proposals")
+            return _success(command, args, payload, text, was_noop=True)
+
+        service = _service(args)
+        for idea in ideas:
+            service.validate_new_proposal(idea)
+        previews = [service.approval_violations(idea, actor_type=ActorType.HUMAN) for idea in ideas]
+        actor_id = _baseline_actor_id(args, proposer.proposer_id)
+        views = [
+            service.propose(
+                idea,
+                actor_id=actor_id,
+                actor_type=ActorType.AI,
+                reason=args.reason,
+                evidence=_baseline_evidence(args.snapshot, snapshot, proposer.proposer_id),
+            )
+            for idea in ideas
+        ]
+    except SnapshotInputError as error:
+        return _input_error(command, args, error)
+    except Exception as error:
+        return _mapped_error(command, args, error)
+
+    proposed = [
+        _baseline_proposed_summary(view, violations)
+        for view, violations in zip(views, previews, strict=True)
+    ]
+    payload = _baseline_payload(snapshot, proposer.proposer_id, proposed)
+    warnings = [
+        warning for proposal in proposed for warning in proposal["approval_preview"]["warnings"]
+    ]
+    text = _baseline_text(command, proposed)
+    return _success(command, args, payload, text, warnings=warnings)
+
+
 def _handle_resubmit(args: Namespace) -> CliResponse:
     command = "ideas resubmit"
     try:
@@ -470,6 +686,68 @@ def _handle_resubmit(args: Namespace) -> CliResponse:
     if violations:
         text += "\n" + "\n".join(f"⚠ would fail approval: {violation}" for violation in violations)
     return _success(command, args, payload, text, warnings=warning_messages)
+
+
+def _baseline_actor_id(args: Namespace, proposer_id: str) -> str:
+    explicit_actor = getattr(args, "actor", None)
+    return resolve_trade_idea_actor_id(explicit_actor or proposer_id)
+
+
+def _baseline_evidence(
+    snapshot_path: Path,
+    snapshot: MarketSnapshot,
+    proposer_id: str,
+) -> tuple[str, ...]:
+    return (
+        f"proposer_id={proposer_id}",
+        f"snapshot_path={snapshot_path}",
+        f"snapshot_source={snapshot.source}",
+        f"snapshot_as_of={snapshot.as_of.isoformat()}",
+    )
+
+
+def _baseline_proposed_summary(view: Any, violations: list[str]) -> dict[str, Any]:
+    warning_messages = [f"would fail approval: {violation}" for violation in violations]
+    return {
+        **_view_summary(view),
+        "record_hash": view.idea.record_hash(),
+        "approval_preview": {
+            "violations": violations,
+            "warnings": warning_messages,
+        },
+    }
+
+
+def _baseline_payload(
+    snapshot: MarketSnapshot,
+    proposer_id: str,
+    proposed: list[dict[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "proposer_id": proposer_id,
+        "snapshot": {
+            "as_of": snapshot.as_of.isoformat(),
+            "source": snapshot.source,
+            "symbols": list(snapshot.symbols()),
+        },
+        "proposal_count": len(proposed),
+        "proposed": proposed,
+    }
+
+
+def _baseline_text(command: str, proposed: list[dict[str, Any]]) -> str:
+    lines = [_status_line(command, "OK", f"{len(proposed)} proposals")]
+    for proposal in proposed:
+        lines.append(
+            "{decision_id}  state={state}  record_hash={record_hash}".format(
+                decision_id=proposal["decision_id"],
+                state=proposal["state"],
+                record_hash=proposal["record_hash"],
+            )
+        )
+        for warning in proposal["approval_preview"]["warnings"]:
+            lines.append(f"⚠ {proposal['decision_id']}: {warning}")
+    return "\n".join(lines)
 
 
 def _handle_list(args: Namespace) -> CliResponse:
@@ -874,7 +1152,7 @@ def _success(
     )
 
 
-def _input_error(command: str, args: Namespace, error: IdeaInputError) -> CliResponse:
+def _input_error(command: str, args: Namespace, error: InputPayloadError) -> CliResponse:
     details = {"field": error.field} if error.field else {}
     return _failure(
         command,

--- a/src/gpt_trader/cli/commands/ideas.py
+++ b/src/gpt_trader/cli/commands/ideas.py
@@ -627,20 +627,17 @@ def _handle_propose_baseline(args: Namespace) -> CliResponse:
             return _success(command, args, payload, text, was_noop=True)
 
         service = _service(args)
-        for idea in ideas:
-            service.validate_new_proposal(idea)
+        proposal_batch = tuple(ideas)
+        service.validate_new_proposals(proposal_batch)
         previews = [service.approval_violations(idea, actor_type=ActorType.HUMAN) for idea in ideas]
         actor_id = _baseline_actor_id(args, proposer.proposer_id)
-        views = [
-            service.propose(
-                idea,
-                actor_id=actor_id,
-                actor_type=ActorType.AI,
-                reason=args.reason,
-                evidence=_baseline_evidence(args.snapshot, snapshot, proposer.proposer_id),
-            )
-            for idea in ideas
-        ]
+        views = service.propose_batch(
+            proposal_batch,
+            actor_id=actor_id,
+            actor_type=ActorType.AI,
+            reason=args.reason,
+            evidence=_baseline_evidence(args.snapshot, snapshot, proposer.proposer_id),
+        )
     except SnapshotInputError as error:
         return _input_error(command, args, error)
     except Exception as error:

--- a/src/gpt_trader/features/trade_ideas/service.py
+++ b/src/gpt_trader/features/trade_ideas/service.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import getpass
 import os
+import shutil
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -187,6 +188,20 @@ class TradeIdeaService:
         self._require_default_preapproval_broker_ticket(idea)
         self._require_new_decision_id(idea.decision_id)
 
+    def validate_new_proposals(self, ideas: tuple[TradeIdea, ...]) -> None:
+        """Validate proposal batch preconditions without writing state."""
+        seen_decision_ids: set[str] = set()
+        for idea in ideas:
+            if idea.decision_id in seen_decision_ids:
+                raise DuplicateTradeIdeaError(
+                    f"Trade idea decision_id '{idea.decision_id}' appears more than once "
+                    "in the proposal batch",
+                    field="decision_id",
+                    value=idea.decision_id,
+                )
+            seen_decision_ids.add(idea.decision_id)
+            self.validate_new_proposal(idea)
+
     def validate_resubmission(self, idea: TradeIdea) -> None:
         """Validate resubmission lifecycle preconditions without writing state."""
         self._require_default_preapproval_broker_ticket(idea)
@@ -241,6 +256,46 @@ class TradeIdeaService:
             evidence=evidence,
         )
         return self.get(idea.decision_id)
+
+    def propose_batch(
+        self,
+        ideas: tuple[TradeIdea, ...],
+        *,
+        actor_id: str,
+        actor_type: ActorType = ActorType.AI,
+        reason: str = "New trade idea proposed",
+        evidence: tuple[str, ...] = (),
+    ) -> list[TradeIdeaView]:
+        """Persist a batch of new proposals as an all-or-nothing operation."""
+        self.validate_new_proposals(ideas)
+        if not ideas:
+            return []
+
+        audit_path = self._audit.path
+        original_audit = audit_path.read_bytes() if audit_path.exists() else None
+        created_decision_ids: list[str] = []
+        try:
+            views: list[TradeIdeaView] = []
+            for idea in ideas:
+                self._store.save(idea)
+                created_decision_ids.append(idea.decision_id)
+                self._append(
+                    idea,
+                    action=AuditAction.PROPOSED,
+                    after_state=TradeIdeaState.PROPOSED,
+                    actor_type=actor_type,
+                    actor_id=actor_id,
+                    reason=reason,
+                    evidence=evidence,
+                )
+                views.append(self.get(idea.decision_id))
+        except Exception:
+            self._restore_failed_proposal_batch(
+                created_decision_ids=tuple(created_decision_ids),
+                original_audit=original_audit,
+            )
+            raise
+        return views
 
     def request_changes(self, decision_id: str, actor_id: str, reason: str) -> TradeIdeaView:
         idea = self._require_idea(decision_id)
@@ -653,6 +708,22 @@ class TradeIdeaService:
                 field="decision_id",
                 value=decision_id,
             )
+
+    def _restore_failed_proposal_batch(
+        self,
+        *,
+        created_decision_ids: tuple[str, ...],
+        original_audit: bytes | None,
+    ) -> None:
+        for decision_id in created_decision_ids:
+            shutil.rmtree(self._store.root / decision_id, ignore_errors=True)
+
+        audit_path = self._audit.path
+        if original_audit is None:
+            audit_path.unlink(missing_ok=True)
+            return
+        audit_path.parent.mkdir(parents=True, exist_ok=True)
+        audit_path.write_bytes(original_audit)
 
     def _require_default_preapproval_broker_ticket(self, idea: TradeIdea) -> None:
         broker_ticket = idea.broker_ticket

--- a/src/gpt_trader/features/trade_ideas/service.py
+++ b/src/gpt_trader/features/trade_ideas/service.py
@@ -277,8 +277,8 @@ class TradeIdeaService:
         try:
             views: list[TradeIdeaView] = []
             for idea in ideas:
-                self._store.save(idea)
                 created_decision_ids.append(idea.decision_id)
+                self._store.save(idea)
                 self._append(
                     idea,
                     action=AuditAction.PROPOSED,
@@ -716,7 +716,10 @@ class TradeIdeaService:
         original_audit: bytes | None,
     ) -> None:
         for decision_id in created_decision_ids:
-            shutil.rmtree(self._store.root / decision_id, ignore_errors=True)
+            try:
+                shutil.rmtree(self._store.root / decision_id)
+            except FileNotFoundError:
+                pass
 
         audit_path = self._audit.path
         if original_audit is None:

--- a/tests/unit/gpt_trader/cli/commands/test_ideas_propose_baseline.py
+++ b/tests/unit/gpt_trader/cli/commands/test_ideas_propose_baseline.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from gpt_trader import cli
+from gpt_trader.cli.response import CliErrorCode
+
+AS_OF = datetime(2035, 6, 12, 0, 0, tzinfo=UTC)
+GOLDEN_CROSS = ["100"] * 50 + ["102", "104", "106"]
+FLAT = ["100"] * 53
+
+
+def _run_json(capsys: pytest.CaptureFixture[str], argv: list[str]) -> tuple[int, dict[str, Any]]:
+    exit_code = cli.main(argv)
+    output = capsys.readouterr().out
+    assert output
+    return exit_code, json.loads(output)
+
+
+def _root_args(root: Path) -> list[str]:
+    return ["--ideas-root", str(root), "--format", "json"]
+
+
+def _series_payload(
+    closes: list[str],
+    *,
+    symbol: str = "BTC-USD",
+    as_of: datetime = AS_OF,
+    last_volume: str = "5000",
+) -> dict[str, Any]:
+    candles: list[dict[str, str]] = []
+    for index, close in enumerate(closes):
+        timestamp = as_of - timedelta(days=len(closes) - index)
+        candles.append(
+            {
+                "ts": timestamp.isoformat(),
+                "open": close,
+                "high": close,
+                "low": close,
+                "close": close,
+                "volume": last_volume if index == len(closes) - 1 else "1000",
+            }
+        )
+    return {"symbol": symbol, "granularity": "1d", "candles": candles}
+
+
+def _snapshot_payload(
+    closes: list[str] = GOLDEN_CROSS,
+    *,
+    as_of: datetime = AS_OF,
+    source: str = "local-fixture:coinbase-candles",
+) -> dict[str, Any]:
+    return {
+        "as_of": as_of.isoformat(),
+        "source": source,
+        "series": [_series_payload(closes, as_of=as_of)],
+    }
+
+
+def _write_snapshot(path: Path, payload: dict[str, Any]) -> Path:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _propose_baseline(
+    capsys: pytest.CaptureFixture[str],
+    root: Path,
+    snapshot_path: Path,
+) -> tuple[int, dict[str, Any]]:
+    return _run_json(
+        capsys,
+        [
+            "ideas",
+            "propose-baseline",
+            *_root_args(root),
+            "--snapshot",
+            str(snapshot_path),
+        ],
+    )
+
+
+def test_propose_baseline_persists_generated_proposal(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = tmp_path / "ideas"
+    snapshot_path = _write_snapshot(tmp_path / "snapshot.json", _snapshot_payload())
+
+    exit_code, response = _propose_baseline(capsys, root, snapshot_path)
+
+    assert exit_code == 0
+    assert response["success"] is True
+    assert response["command"] == "ideas propose-baseline"
+    assert response["data"]["proposer_id"] == "baseline-ma-10-50"
+    assert response["data"]["proposal_count"] == 1
+    proposal = response["data"]["proposed"][0]
+    assert proposal["decision_id"].startswith("trade-20350612-btcusd-")
+    assert proposal["state"] == "proposed"
+    assert proposal["record_hash"]
+    assert proposal["approval_preview"] == {"violations": [], "warnings": []}
+    assert (root / "records" / proposal["decision_id"] / "latest.json").exists()
+    event = json.loads((root / "audit.jsonl").read_text(encoding="utf-8").splitlines()[0])
+    assert event["actor_type"] == "ai"
+    assert event["actor_id"] == "baseline-ma-10-50"
+    assert "proposer_id=baseline-ma-10-50" in event["evidence"]
+
+
+def test_propose_baseline_no_signal_is_noop(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = tmp_path / "ideas"
+    snapshot_path = _write_snapshot(tmp_path / "flat.json", _snapshot_payload(FLAT))
+
+    exit_code, response = _propose_baseline(capsys, root, snapshot_path)
+
+    assert exit_code == 0
+    assert response["data"]["proposal_count"] == 0
+    assert response["data"]["proposed"] == []
+    assert response["metadata"]["was_noop"] is True
+    assert not (root / "records").exists()
+    assert not (root / "audit.jsonl").exists()
+
+
+def test_propose_baseline_duplicate_decision_fails_without_extra_audit(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = tmp_path / "ideas"
+    snapshot_path = _write_snapshot(tmp_path / "snapshot.json", _snapshot_payload())
+    first_exit_code, first_response = _propose_baseline(capsys, root, snapshot_path)
+    assert first_exit_code == 0
+    original_audit = (root / "audit.jsonl").read_text(encoding="utf-8")
+
+    exit_code, response = _propose_baseline(capsys, root, snapshot_path)
+
+    assert exit_code == 1
+    assert response["errors"][0]["code"] == CliErrorCode.VALIDATION_ERROR.value
+    assert response["errors"][0]["details"]["field"] == "decision_id"
+    assert (root / "audit.jsonl").read_text(encoding="utf-8") == original_audit
+    decision_id = first_response["data"]["proposed"][0]["decision_id"]
+    latest = json.loads((root / "records" / decision_id / "latest.json").read_text())
+    assert latest["decision_id"] == decision_id
+
+
+def test_propose_baseline_malformed_snapshot_returns_invalid_argument(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = tmp_path / "ideas"
+    snapshot_path = _write_snapshot(
+        tmp_path / "malformed.json",
+        {"as_of": AS_OF.isoformat(), "source": "local-fixture:coinbase-candles"},
+    )
+
+    exit_code, response = _propose_baseline(capsys, root, snapshot_path)
+
+    assert exit_code == 1
+    assert response["errors"][0]["code"] == CliErrorCode.INVALID_ARGUMENT.value
+    assert response["errors"][0]["details"]["field"] == "series"
+    assert not (root / "records").exists()
+    assert not (root / "audit.jsonl").exists()
+
+
+def test_propose_baseline_json_output_includes_approval_preview_warnings(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = tmp_path / "ideas"
+    historical_as_of = datetime(2020, 6, 12, 0, 0, tzinfo=UTC)
+    snapshot_path = _write_snapshot(
+        tmp_path / "historical.json",
+        _snapshot_payload(as_of=historical_as_of),
+    )
+
+    exit_code, response = _propose_baseline(capsys, root, snapshot_path)
+
+    assert exit_code == 0
+    proposal = response["data"]["proposed"][0]
+    assert proposal["decision_id"].startswith("trade-20200612-btcusd-")
+    assert proposal["record_hash"]
+    assert proposal["state"] == "proposed"
+    assert any("expired" in item for item in proposal["approval_preview"]["violations"])
+    assert any("would fail approval" in item for item in proposal["approval_preview"]["warnings"])
+    assert response["warnings"] == proposal["approval_preview"]["warnings"]

--- a/tests/unit/gpt_trader/cli/commands/test_ideas_propose_baseline.py
+++ b/tests/unit/gpt_trader/cli/commands/test_ideas_propose_baseline.py
@@ -9,6 +9,12 @@ import pytest
 
 from gpt_trader import cli
 from gpt_trader.cli.response import CliErrorCode
+from gpt_trader.features.trade_ideas import (
+    BaselineProposer,
+    MarketSnapshot,
+    TradeIdea,
+    TradeIdeaAuditLog,
+)
 
 AS_OF = datetime(2035, 6, 12, 0, 0, tzinfo=UTC)
 GOLDEN_CROSS = ["100"] * 50 + ["102", "104", "106"]
@@ -143,6 +149,63 @@ def test_propose_baseline_duplicate_decision_fails_without_extra_audit(
     decision_id = first_response["data"]["proposed"][0]["decision_id"]
     latest = json.loads((root / "records" / decision_id / "latest.json").read_text())
     assert latest["decision_id"] == decision_id
+
+
+def test_propose_baseline_rejects_duplicate_generated_decisions_before_writes(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "ideas"
+    snapshot_path = _write_snapshot(tmp_path / "duplicates.json", _snapshot_payload())
+
+    original_propose = BaselineProposer.propose
+
+    def duplicate_proposal(self: BaselineProposer, snapshot: MarketSnapshot) -> list[TradeIdea]:
+        ideas = original_propose(self, snapshot)
+        return [ideas[0], ideas[0]]
+
+    monkeypatch.setattr(BaselineProposer, "propose", duplicate_proposal)
+
+    exit_code, response = _propose_baseline(capsys, root, snapshot_path)
+
+    assert exit_code == 1
+    assert response["errors"][0]["code"] == CliErrorCode.VALIDATION_ERROR.value
+    assert response["errors"][0]["details"]["field"] == "decision_id"
+    assert "appears more than once" in response["errors"][0]["message"]
+    assert not (root / "records").exists()
+    assert not (root / "audit.jsonl").exists()
+
+
+def test_propose_baseline_rolls_back_batch_when_later_write_fails(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "ideas"
+    payload = _snapshot_payload()
+    payload["series"].append(_series_payload(GOLDEN_CROSS, symbol="ETH-USD", as_of=AS_OF))
+    snapshot_path = _write_snapshot(tmp_path / "two-proposals.json", payload)
+    original_append = TradeIdeaAuditLog.append
+    append_calls = 0
+
+    def fail_second_append(*args: Any, **kwargs: Any) -> None:
+        nonlocal append_calls
+        append_calls += 1
+        if append_calls == 2:
+            raise RuntimeError("forced second append failure")
+        original_append(*args, **kwargs)
+
+    monkeypatch.setattr(TradeIdeaAuditLog, "append", fail_second_append)
+
+    exit_code, response = _propose_baseline(capsys, root, snapshot_path)
+
+    assert exit_code == 1
+    assert response["errors"][0]["code"] == CliErrorCode.OPERATION_FAILED.value
+    assert response["errors"][0]["message"] == "forced second append failure"
+    assert append_calls == 2
+    assert not list((root / "records").glob("*/latest.json"))
+    assert not (root / "audit.jsonl").exists()
 
 
 def test_propose_baseline_malformed_snapshot_returns_invalid_argument(

--- a/tests/unit/gpt_trader/features/trade_ideas/test_service_batch_rollback.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_service_batch_rollback.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from tests.unit.gpt_trader.features.trade_ideas.conftest import build_trade_idea
+
+import gpt_trader.features.trade_ideas.service as trade_idea_service_module
+from gpt_trader.features.trade_ideas import TradeIdea, TradeIdeaService
+
+
+def test_propose_batch_rolls_back_partial_record_when_save_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "trade_ideas"
+    service = TradeIdeaService(
+        root,
+        now_factory=lambda: datetime(2026, 6, 12, 10, 0, tzinfo=UTC),
+    )
+    first = build_trade_idea(decision_id="trade-20260612-batch-001")
+    second = build_trade_idea(decision_id="trade-20260612-batch-002")
+    original_save = service._store.save
+
+    def save_with_partial_failure(idea: TradeIdea) -> str:
+        if idea.decision_id == second.decision_id:
+            decision_dir = root / "records" / idea.decision_id
+            decision_dir.mkdir(parents=True)
+            (decision_dir / "latest.json").write_text(
+                json.dumps({"decision_id": idea.decision_id}),
+                encoding="utf-8",
+            )
+            raise RuntimeError("forced partial save failure")
+        return original_save(idea)
+
+    monkeypatch.setattr(service._store, "save", save_with_partial_failure)
+
+    with pytest.raises(RuntimeError, match="forced partial save failure"):
+        service.propose_batch(
+            (first, second),
+            actor_id="idea-generator-v1",
+        )
+
+    assert not (root / "records" / first.decision_id).exists()
+    assert not (root / "records" / second.decision_id).exists()
+    assert not (root / "audit.jsonl").exists()
+
+
+def test_propose_batch_surfaces_rollback_delete_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "trade_ideas"
+    service = TradeIdeaService(
+        root,
+        now_factory=lambda: datetime(2026, 6, 12, 10, 0, tzinfo=UTC),
+    )
+    first = build_trade_idea(decision_id="trade-20260612-batch-001")
+    second = build_trade_idea(decision_id="trade-20260612-batch-002")
+    original_append = trade_idea_service_module.TradeIdeaAuditLog.append
+    original_rmtree = trade_idea_service_module.shutil.rmtree
+    append_calls = 0
+
+    def fail_second_append(*args: object, **kwargs: object) -> None:
+        nonlocal append_calls
+        append_calls += 1
+        if append_calls == 2:
+            raise RuntimeError("forced second audit failure")
+        original_append(*args, **kwargs)
+
+    def fail_first_delete(path: Path) -> None:
+        if path.name == first.decision_id:
+            raise PermissionError("forced delete failure")
+        original_rmtree(path)
+
+    monkeypatch.setattr(trade_idea_service_module.TradeIdeaAuditLog, "append", fail_second_append)
+    monkeypatch.setattr(trade_idea_service_module.shutil, "rmtree", fail_first_delete)
+
+    with pytest.raises(PermissionError, match="forced delete failure"):
+        service.propose_batch(
+            (first, second),
+            actor_id="idea-generator-v1",
+        )
+
+    assert append_calls == 2
+    assert (root / "records" / first.decision_id).exists()

--- a/var/agents/configuration/environment_variables.json
+++ b/var/agents/configuration/environment_variables.json
@@ -835,7 +835,7 @@
       ],
       "code_references": [
         {
-          "line": 123,
+          "line": 124,
           "path": "src/gpt_trader/features/trade_ideas/service.py",
           "reader": "os.environ.get"
         }
@@ -1247,7 +1247,7 @@
       ],
       "code_references": [
         {
-          "line": 113,
+          "line": 114,
           "path": "src/gpt_trader/features/trade_ideas/service.py",
           "reader": "os.environ.get"
         }

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,8 +7,8 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6864,
-    "total_files": 809,
+    "total_tests": 6866,
+    "total_files": 810,
     "markers_used": 16
   },
   "quick_commands": {

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,8 +7,8 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6857,
-    "total_files": 808,
+    "total_tests": 6864,
+    "total_files": 809,
     "markers_used": 16
   },
   "quick_commands": {

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6699,
+    "unit": 6701,
     "asyncio": 411,
     "parametrize": 198,
     "endpoints": 83,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6692,
+    "unit": 6699,
     "asyncio": 411,
     "parametrize": 198,
     "endpoints": 83,

--- a/var/agents/testing/source_test_map.json
+++ b/var/agents/testing/source_test_map.json
@@ -1,8 +1,8 @@
 {
   "version": "1.0",
   "summary": {
-    "tests_scanned": 724,
-    "source_modules": 374,
+    "tests_scanned": 725,
+    "source_modules": 375,
     "unresolved_modules": 3
   },
   "source_to_tests": {
@@ -1314,6 +1314,7 @@
       "tests/unit/gpt_trader/features/trade_ideas/test_replay_runner.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_service.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_service_audit_integrity.py",
+      "tests/unit/gpt_trader/features/trade_ideas/test_service_batch_rollback.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_service_closeout.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_service_preapproval_broker_ticket.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_service_venue_boundary.py",
@@ -1322,6 +1323,9 @@
       "tests/unit/gpt_trader/features/trade_ideas/test_workflow.py",
       "tests/unit/gpt_trader/tui/test_ideas_review_screen.py",
       "tests/unit/gpt_trader/tui/test_snapshots_ideas_review.py"
+    ],
+    "gpt_trader.features.trade_ideas.service": [
+      "tests/unit/gpt_trader/features/trade_ideas/test_service_batch_rollback.py"
     ],
     "gpt_trader.logging.correlation": [
       "tests/unit/gpt_trader/features/live_trade/execution/test_order_submission_observability.py",
@@ -3988,6 +3992,10 @@
     "tests/unit/gpt_trader/features/trade_ideas/test_service_audit_integrity.py": [
       "gpt_trader.features.trade_ideas"
     ],
+    "tests/unit/gpt_trader/features/trade_ideas/test_service_batch_rollback.py": [
+      "gpt_trader.features.trade_ideas",
+      "gpt_trader.features.trade_ideas.service"
+    ],
     "tests/unit/gpt_trader/features/trade_ideas/test_service_closeout.py": [
       "gpt_trader.features.trade_ideas"
     ],
@@ -5269,6 +5277,7 @@
     "gpt_trader.features.strategy_tools.filters": "src/gpt_trader/features/strategy_tools/filters.py",
     "gpt_trader.features.strategy_tools.guards": "src/gpt_trader/features/strategy_tools/guards.py",
     "gpt_trader.features.trade_ideas": "src/gpt_trader/features/trade_ideas/__init__.py",
+    "gpt_trader.features.trade_ideas.service": "src/gpt_trader/features/trade_ideas/service.py",
     "gpt_trader.logging.correlation": "src/gpt_trader/logging/correlation.py",
     "gpt_trader.logging.json_formatter": "src/gpt_trader/logging/json_formatter.py",
     "gpt_trader.logging.runtime_helpers": "src/gpt_trader/logging/runtime_helpers.py",

--- a/var/agents/testing/source_test_map.json
+++ b/var/agents/testing/source_test_map.json
@@ -14,6 +14,7 @@
       "tests/unit/gpt_trader/cli/commands/test_ideas_lifecycle.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_manual_records.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_max_loss_validation.py",
+      "tests/unit/gpt_trader/cli/commands/test_ideas_propose_baseline.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_propose_integrity.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_queries.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_report.py",
@@ -346,6 +347,7 @@
       "tests/unit/gpt_trader/cli/commands/test_ideas_futures_budget.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_lifecycle.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_max_loss_validation.py",
+      "tests/unit/gpt_trader/cli/commands/test_ideas_propose_baseline.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_propose_integrity.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_queries.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_resubmit_integrity.py",
@@ -2715,6 +2717,10 @@
       "gpt_trader",
       "gpt_trader.cli.response",
       "gpt_trader.features.trade_ideas"
+    ],
+    "tests/unit/gpt_trader/cli/commands/test_ideas_propose_baseline.py": [
+      "gpt_trader",
+      "gpt_trader.cli.response"
     ],
     "tests/unit/gpt_trader/cli/commands/test_ideas_propose_integrity.py": [
       "gpt_trader",

--- a/var/agents/testing/source_test_map.json
+++ b/var/agents/testing/source_test_map.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "summary": {
-    "tests_scanned": 723,
+    "tests_scanned": 724,
     "source_modules": 374,
     "unresolved_modules": 3
   },
@@ -1296,6 +1296,7 @@
       "tests/unit/gpt_trader/cli/commands/test_ideas_lifecycle.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_manual_records.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_max_loss_validation.py",
+      "tests/unit/gpt_trader/cli/commands/test_ideas_propose_baseline.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_propose_integrity.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_queries.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_report.py",
@@ -2720,7 +2721,8 @@
     ],
     "tests/unit/gpt_trader/cli/commands/test_ideas_propose_baseline.py": [
       "gpt_trader",
-      "gpt_trader.cli.response"
+      "gpt_trader.cli.response",
+      "gpt_trader.features.trade_ideas"
     ],
     "tests/unit/gpt_trader/cli/commands/test_ideas_propose_integrity.py": [
       "gpt_trader",

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,8 +2,8 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6864,
-    "total_files": 809,
+    "total_tests": 6866,
+    "total_files": 810,
     "markers_used": 16
   },
   "marker_definitions": {
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6699,
+    "unit": 6701,
     "asyncio": 411,
     "parametrize": 198,
     "endpoints": 83,
@@ -549,6 +549,7 @@
       "tests/unit/gpt_trader/features/trade_ideas/test_replay_runner.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_service.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_service_audit_integrity.py",
+      "tests/unit/gpt_trader/features/trade_ideas/test_service_batch_rollback.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_service_closeout.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_service_preapproval_broker_ticket.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_service_venue_boundary.py",
@@ -33442,6 +33443,24 @@
       },
       {
         "name": "test_approval_count_ignores_unaudited_latest_for_nonapproved_records",
+        "line": 50,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      }
+    ],
+    "tests/unit/gpt_trader/features/trade_ideas/test_service_batch_rollback.py": [
+      {
+        "name": "test_propose_batch_rolls_back_partial_record_when_save_fails",
+        "line": 14,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_propose_batch_surfaces_rollback_delete_failure",
         "line": 50,
         "markers": [
           "unit"

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,8 +2,8 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6857,
-    "total_files": 808,
+    "total_tests": 6864,
+    "total_files": 809,
     "markers_used": 16
   },
   "marker_definitions": {
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6692,
+    "unit": 6699,
     "asyncio": 411,
     "parametrize": 198,
     "endpoints": 83,
@@ -9316,7 +9316,7 @@
     "tests/unit/gpt_trader/cli/commands/test_ideas_propose_baseline.py": [
       {
         "name": "test_propose_baseline_persists_generated_proposal",
-        "line": 87,
+        "line": 93,
         "markers": [
           "unit"
         ],
@@ -9324,7 +9324,7 @@
       },
       {
         "name": "test_propose_baseline_no_signal_is_noop",
-        "line": 112,
+        "line": 118,
         "markers": [
           "unit"
         ],
@@ -9332,7 +9332,23 @@
       },
       {
         "name": "test_propose_baseline_duplicate_decision_fails_without_extra_audit",
-        "line": 128,
+        "line": 134,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_propose_baseline_rejects_duplicate_generated_decisions_before_writes",
+        "line": 154,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_propose_baseline_rolls_back_batch_when_later_write_fails",
+        "line": 180,
         "markers": [
           "unit"
         ],
@@ -9340,7 +9356,7 @@
       },
       {
         "name": "test_propose_baseline_malformed_snapshot_returns_invalid_argument",
-        "line": 148,
+        "line": 211,
         "markers": [
           "unit"
         ],
@@ -9348,7 +9364,7 @@
       },
       {
         "name": "test_propose_baseline_json_output_includes_approval_preview_warnings",
-        "line": 166,
+        "line": 229,
         "markers": [
           "unit"
         ],

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -211,6 +211,7 @@
       "tests/unit/gpt_trader/cli/commands/test_ideas_lifecycle.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_manual_records.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_max_loss_validation.py",
+      "tests/unit/gpt_trader/cli/commands/test_ideas_propose_baseline.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_propose_integrity.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_queries.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_report.py",
@@ -9307,6 +9308,48 @@
         "line": 74,
         "markers": [
           "parametrize",
+          "unit"
+        ],
+        "docstring": ""
+      }
+    ],
+    "tests/unit/gpt_trader/cli/commands/test_ideas_propose_baseline.py": [
+      {
+        "name": "test_propose_baseline_persists_generated_proposal",
+        "line": 87,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_propose_baseline_no_signal_is_noop",
+        "line": 112,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_propose_baseline_duplicate_decision_fails_without_extra_audit",
+        "line": 128,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_propose_baseline_malformed_snapshot_returns_invalid_argument",
+        "line": 148,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_propose_baseline_json_output_includes_approval_preview_warnings",
+        "line": 166,
+        "markers": [
           "unit"
         ],
         "docstring": ""


### PR DESCRIPTION
## Summary
Adds the first Stage 1 proposal-intake operator path for deterministic baseline trade ideas.

Related issue / finding / RJ-routed package: RJ-routed package from goal delegation `019f0771-ffe2-79f0-bba4-385099861fe0`.

## Type of change
- [x] Feature
- [x] Tests only
- [x] CI/Docs/Tooling

## Scope & Impact
- Affected areas / components: `gpt-trader ideas` CLI, trade-idea CLI spec, focused CLI tests, generated test inventory.
- Behavior changes: adds `gpt-trader ideas propose-baseline --snapshot PATH`, which reads only a local JSON `MarketSnapshot` fixture, runs `BaselineProposer`, validates every emitted record before mutation, persists through `TradeIdeaService.propose`, and returns decision ids, record hashes, states, and approval-preview violations/warnings.
- Boundary: no broker API calls, live market/account access, credential reads, canary/preflight, order submission, replay scoring changes, closeout attribution changes, or broker-ticket payload generation.

## Test Plan
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Contract tests (if applicable)
- [x] Ran locally: `uv run pytest tests/unit/gpt_trader/cli/commands/test_ideas_propose_baseline.py tests/unit/gpt_trader/cli/commands/test_ideas_lifecycle.py tests/unit/gpt_trader/cli/commands/test_ideas_propose_integrity.py tests/unit/gpt_trader/cli/commands/test_ideas_max_loss_validation.py tests/unit/gpt_trader/cli/commands/test_ideas_approval_preview_integrity.py -q`
- [x] Markers used appropriately (`unit`/`integration`/`slow`/`perf`)

## Complexity & Quality Gates
- [x] Mypy/type-check passed
- [x] Xenon/radon complexity gate passed (CC <= 15 on live_trade execution)
- [x] No `sys.path` hacks in tests
- [x] No `MagicMock` on `async def` (use `AsyncMock`)
- [x] Import-lint rules respected (no "import up the stack")

## Observability & Errors
- [ ] Structured JSON logs for new/changed paths
- [x] Errors include diagnostic context (field-level `INVALID_ARGUMENT` for malformed snapshots; service errors retain existing context)
- [ ] Added/updated sampling examples in tests (if applicable)

## Configuration
- [ ] If config changed: `python -m gpt_trader.cli.config validate --profile <name>` passes
- [x] Env docs re-generated (not applicable; generated test inventory refreshed instead)
- [x] No `ConfigLoader` usages introduced (ConfigManager-only)

## Breaking Changes
- [x] None
- [ ] Documented in PR body and release notes if any

## Screenshots / Logs (optional)
Useful operator shape:

```bash
uv run gpt-trader ideas propose-baseline \
  --ideas-root var/data/trade_ideas/stage1-corpus \
  --snapshot fixtures/trade_ideas/btc_snapshot.json \
  --format json
```

Snapshot fixture shape:

```json
{
  "as_of": "2035-06-12T00:00:00+00:00",
  "source": "local-fixture:coinbase-candles",
  "series": [
    {
      "symbol": "BTC-USD",
      "granularity": "1d",
      "candles": [
        {
          "ts": "2035-04-20T00:00:00+00:00",
          "open": "100",
          "high": "100",
          "low": "100",
          "close": "100",
          "volume": "1000"
        }
      ]
    }
  ]
}
```

Additional verification run locally:
- `uv run gpt-trader ideas --help`
- `uv run gpt-trader ideas propose-baseline --help`
- `uv run agent-regenerate --verify`
- `uv run local-ci --profile quick` (7126 passed, 8 skipped)

## Checklist
- [x] Acceptance criteria in linked issue(s), finding packet, or routed package met
- [x] Affected paths listed in PR description
- [x] Changelog entry (repo does not appear to require one for this CLI feature)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `ideas propose-baseline` CLI command that generates deterministic trade-idea proposals from a local market snapshot fixture.
  * Returns structured JSON with snapshot metadata and an approval-preview section (including warnings).
* **Bug Fixes**
  * Validates snapshots more strictly and returns `INVALID_ARGUMENT` for malformed fixtures.
  * Prevents duplicate decision IDs/duplicate generated ideas and avoids extra records/audit entries.
  * Implements batch rollback to leave records/audit state consistent if persistence fails mid-run.
* **Tests**
  * Added unit tests for success, no-op, duplicates, rollback, malformed snapshots, and JSON warning output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->