### PR TITLE
docs: add AI issue-labeling routing standard + fix template drift

### DIFF
--- a/.github/ISSUE_TEMPLATE/spot-filter-refactor.md
+++ b/.github/ISSUE_TEMPLATE/spot-filter-refactor.md
@@ -1,7 +1,7 @@
 ---
 name: Refactor spot filter pipeline into composable filter strategies
 about: Extract filter logic into testable, composable strategies
-labels: refactoring, code-quality, strategy, enhancement
+labels: architecture, live-trade
 ---
 
 ## Objective

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,12 +106,11 @@ Issue labels drive repository issue routing for agents and humans. Keep them con
 - **Type label (required):** one of `bug`, `enhancement`, `architecture`, `chore`, `documentation`, `tests`, `ci`, or `security`.
 - **Area label(s) (required, 1–2):** one or two labels from the domain set, e.g. `trade-ideas`, `live-trade`, `cli`, `tui`, `mcp`, `reporting`, `runtime`, `monitoring`, `audit`, `closeout`.
 - **Optional detail labels:** use tags like `persistence`, `broker-neutral`, `reliability`, `packaging`, `deploy`, etc. as needed.
-- **`codex` label:** routing signal for Codex-workflow issues (agent-review lane marker).
+- **`codex` label:** routing signal for the agent-review / Codex workflow. Issues in this lane (e.g. the `agent-review-finding` template) are **exempt** from the Type/Area requirements above — `codex` alone is sufficient.
 
 For this repository, status/priority labels are intentionally deferred until they solve a real need. The default issue templates should already include the intended label shape so no extra manual steps are needed at issue creation.
 
 ## Quality Standards
-
 
 ### Code Quality
 - Clean, readable code with meaningful variable names

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,19 @@ Before branching, make sure to:
 7. **Push to your fork** (`git push origin feature/amazing-feature`)
 8. **Open a Pull Request**
 
+## Issue Labeling for AI Routing
+
+Issue labels drive repository issue routing for agents and humans. Keep them consistent and machine-friendly:
+
+- **Type label (required):** one of `bug`, `enhancement`, `architecture`, `chore`, `documentation`, `tests`, `ci`, or `security`.
+- **Area label(s) (required, 1–2):** one or two labels from the domain set, e.g. `trade-ideas`, `live-trade`, `cli`, `tui`, `mcp`, `reporting`, `runtime`, `monitoring`, `audit`, `closeout`.
+- **Optional detail labels:** use tags like `persistence`, `broker-neutral`, `reliability`, `packaging`, `deploy`, etc. as needed.
+- **`codex` label:** routing signal for Codex-workflow issues (agent-review lane marker).
+
+For this repository, status/priority labels are intentionally deferred until they solve a real need. The default issue templates should already include the intended label shape so no extra manual steps are needed at issue creation.
+
 ## Quality Standards
+
 
 ### Code Quality
 - Clean, readable code with meaningful variable names


### PR DESCRIPTION
## Summary

Establishes a lightweight, machine-friendly issue-labeling standard for AI/human routing and fixes a concrete template-drift bug.

- **Fix template drift:** `.github/ISSUE_TEMPLATE/spot-filter-refactor.md` referenced three labels that don't exist in the repo (`refactoring`, `code-quality`, `strategy`). Replaced with `architecture, live-trade` — `architecture` is the correct type for a refactor (its label description is literally "Architecture / cohesion / refactors") and `live-trade` is the area.
- **Add `CONTRIBUTING.md` labeling policy:** a small fixed combo — **1 Type label** + **1–2 Area labels** + optional detail tags. Status/priority labels are intentionally deferred until they solve a real need, and the intended label shape lives in the issue templates (defaults, not gates).
- **Document & exempt the `codex` lane:** `codex` is the agent-review/Codex routing signal. The `agent-review-finding` template carries `codex` alone, so the policy now marks that lane as **explicitly exempt** from the Type/Area requirements rather than leaving it as an undocumented omission.
- **Tidy:** removed a stray double blank line introduced before the Code Quality heading.

## Design rationale

This repo is effectively one human + AI agents, so labels exist for **machine routing**, not multi-contributor human triage. The standard is therefore deliberately minimal: it mirrors the shape already used by recent baseline issues (e.g. #1019–#1024: one type + 1–2 area + optional detail) instead of importing P0/P1 tiers or `status/*` taxonomies from large OSS repos. Good labels are made automatic via templates rather than enforced as a creation-time gate.

## Verification

- Confirmed every `labels:` entry across `.github/ISSUE_TEMPLATE/*.md` resolves to an existing GitHub label (`architecture`, `live-trade`, `codex`).
- `pre-commit run --files .github/ISSUE_TEMPLATE/spot-filter-refactor.md CONTRIBUTING.md` → all applicable hooks pass.
- Docs/template-only change set; no functional test run required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clearer guidance for issue labeling, including required and optional label types plus when to use status and priority labels.
* **Chores**
  * Updated an issue template’s labels to better route it to the appropriate workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->