### PR TITLE
[codex] Reconcile docs status and generic agent routing

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent-review-finding.md
+++ b/.github/ISSUE_TEMPLATE/agent-review-finding.md
@@ -35,7 +35,7 @@ Touches trading execution: `false`
 
 ## Routing
 
-- Candidate for: claw
+- Candidate for: implementation
 - Decision needed: `false`
 - Blocked by: none
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ## Summary
 <!-- What and why. Keep it crisp. Link related issues. -->
-Related issue / finding / RJ-routed package:
+Related issue / finding / routed package:
 
 ## Type of change
 - [ ] Refactor

--- a/docs/GPT_TRADER_DECISION_LOG.md
+++ b/docs/GPT_TRADER_DECISION_LOG.md
@@ -11,7 +11,7 @@ decisions that should outlive chat, PR receipts, and local branch state.
 
 - **Status:** accepted direction; Stage 0 trade-idea rails implemented where
   noted below
-- **Owner:** RJ
+- **Owner:** Project owner
 - **Decision / direction:** Use the
   [Pre-Migration Decision Framework](PRE_MIGRATION_DECISION_FRAMEWORK.md) as
   the execution-migration gate. The accepted path is approval-gated execution
@@ -44,8 +44,8 @@ decisions that should outlive chat, PR receipts, and local branch state.
 ## 2026-06-22 — Continue Trade-Ideas CLI As The Active Discovery Lane
 
 - **Status:** accepted direction, implementation still WIP
-- **Owner:** Claw
-- **Reviewer:** Edison for decision quality; Hermes for explicit evidence receipts
+- **Owner:** Active implementation agent
+- **Reviewer:** Decision and evidence review agents
 - **Decision / direction:** Treat `codex/trade-ideas-cli` as the active viable
   GPT-Trader discovery lane. It is the CLI door into the existing
   human-approved trade-idea workflow, not an execution or broker-action lane.
@@ -73,7 +73,7 @@ decisions that should outlive chat, PR receipts, and local branch state.
 ## 2026-06-27 — Re-Orient On Actual State; Stabilize Before Closing The Loop
 
 - **Status:** accepted direction
-- **Owner:** RJ
+- **Owner:** Project owner
 - **Context:** An AI issue-generation run produced a large `feat(trade ideas):`
   backlog implied by the staged-autonomy docs. Review found the backlog reached
   for breadth (tournaments, MCP, reporting, filtering, exports) ahead of a

--- a/docs/GPT_TRADER_DECISION_LOG.md
+++ b/docs/GPT_TRADER_DECISION_LOG.md
@@ -69,3 +69,35 @@ decisions that should outlive chat, PR receipts, and local branch state.
 - **Rejected alternatives:** Do not publish stale local branches. Do not use
   OpenClaw's anchor as GPT-Trader's roadmap. Do not promote momentum receipts
   into product direction without a project-native decision entry.
+
+## 2026-06-27 — Re-Orient On Actual State; Stabilize Before Closing The Loop
+
+- **Status:** accepted direction
+- **Owner:** RJ
+- **Context:** An AI issue-generation run produced a large `feat(trade ideas):`
+  backlog implied by the staged-autonomy docs. Review found the backlog reached
+  for breadth (tournaments, MCP, reporting, filtering, exports) ahead of a
+  working loop. Ground-truth check established: Stage 0 rails are complete; Stage
+  1 is ~2/3 built but not a closed loop; and the live TA bot and the trade-idea
+  workflow are fully disconnected (zero references either direction). See
+  [Project Status](STATUS.md).
+- **Decision / direction:**
+  1. **Stabilize and reconcile before extending the loop.** Pause net-new
+     feature surface; reconcile docs to reality and keep rails/tests healthy
+     first. The loop-closing spine (#1031 → #1035 → #1033) is the planned next
+     build, not this stabilization pass.
+  2. **Bridge the existing bot; do not grow a second proposer brain.** When the
+     loop is built, trade ideas come from the existing TA/ensemble intelligence
+     routed through the approval gate (#1033), not from independent duplicate
+     proposers. Standalone proposers (e.g. #1034) are de-prioritized.
+  3. **Docs track reality.** Added the living [Project Status](STATUS.md);
+     corrected stale stage labels in the [Operating Rubric](OPERATING_RUBRIC.md).
+- **Safety boundary:** No change to the autonomy boundary. Still
+  `human_approved_execution`; no broker/API calls, credential reads, money
+  movement, or order submission authorized by this entry.
+- **Backlog action:** Open issues triaged with `triage:build-now`,
+  `triage:build-next`, `triage:blocked`, `triage:defer`; three export duplicates
+  (#1024, #1022, #1020) merged into #1044 and closed.
+- **Rejected alternatives:** Do not build the loop or jump toward Stage 2 before
+  stabilizing. Do not build trade-ideas as a second, independent proposer brain
+  parallel to the existing bot. Do not treat doc-implied stages as a backlog.

--- a/docs/OPERATING_RUBRIC.md
+++ b/docs/OPERATING_RUBRIC.md
@@ -39,7 +39,11 @@ creep.
 Each capability lists the evidence ("graduation evidence") that it works.
 A stage is complete when every capability in it has its evidence.
 
-### Stage 0 — Rails (in progress)
+This rubric defines the **target** for each stage. For the **current shipped
+state** — which capabilities are done, partial, or missing — see
+[Project Status](STATUS.md), the living "you are here" tracker.
+
+### Stage 0 — Rails (complete)
 
 These rails are the implemented evidence for the accepted pre-migration record,
 approval, audit, budget, eligibility, and operator-control triggers in the
@@ -57,7 +61,11 @@ submission policy.
 | Policy module that encodes the autonomy mode | `src/gpt_trader/features/trade_ideas/policy.py` refuses non-human approval in `human_approved_execution` mode |
 | Operator can reject, expire, and amend tickets before execution | `src/gpt_trader/features/trade_ideas/service.py` exposes audited request-changes/resubmit, reject, cancel, expire, and expire-due paths before submission |
 
-### Stage 1 — Human-approved loop
+### Stage 1 — Human-approved loop (in progress)
+
+Reviewer tooling, outcome attribution, and the track-record report are shipped;
+a proposer fed by real market data and automatic paper-fill reconciliation are
+the open gaps. See [Project Status](STATUS.md) for the per-capability state.
 
 | Capability | Evidence |
 |------------|----------|

--- a/docs/OPERATING_RUBRIC_V2.md
+++ b/docs/OPERATING_RUBRIC_V2.md
@@ -1,0 +1,221 @@
+# Operating Rubric — v2 (draft)
+
+---
+status: draft
+supersedes: OPERATING_RUBRIC.md (on acceptance)
+---
+
+> **Draft for owner review.** This restructures the v1 rubric without discarding
+> its content. Every number marked **(tune)** is a proposed starting value, not a
+> decision — they encode risk appetite and are yours to set. On acceptance this
+> replaces `OPERATING_RUBRIC.md` and inherits its index entry. Nothing here
+> authorizes live execution; the autonomy boundary stays `human_approved_execution`.
+
+## Why v2 has this shape
+
+The v1 rubric did three jobs at once — stated a philosophy, listed capabilities,
+and tried to gate scope creep — and the three tangled. Its "evidence" column
+meant three incompatible things (a file exists / a metric / demonstrated once),
+so "Stage 0 complete" could be claimed because code existed, even though the
+capability wasn't wired into a working loop. It also modelled features, not the
+operating loop, so "the loop isn't connected to real data or real intelligence"
+could not surface as a failed criterion.
+
+v2 separates the three jobs and fixes the evidence problem:
+
+- **Part 1 — Charter:** the north star. Philosophy + invariants. Rarely changes.
+- **Part 2 — The operating loop:** the *object* the gates measure. Cadence and
+  health, so "is the loop actually closed and fed" is checkable.
+- **Part 3 — Graduation gates:** one consistent evidence type, with numeric
+  promotion gates **and** demotion triggers per stage transition.
+
+What is *built* (which file exists, which command works) is no longer "evidence"
+here — that belongs in [Project Status](STATUS.md). Evidence in this rubric is
+always a **measured outcome over a window**, never a code pointer.
+
+---
+
+# Part 1 — Charter
+
+## Risk Philosophy (owner-accepted, 2026-06-11 — unchanged)
+
+1. **Principal is fully at risk.** The owner funds the bot with a lump sum he
+   is prepared to lose entirely. Loss of principal is an acceptable outcome;
+   timidity that prevents the system from ever demonstrating skill is the
+   bigger failure. Seeded budgets are therefore aggressive.
+2. **Realized gains are not principal.** Tripling the portfolio and then
+   riding it back to zero is explicitly the *worst* outcome — worse than
+   losing the original stake outright. Drawdown-from-peak matters more than
+   drawdown-from-principal. High-water-mark tracking, profit-taking, and
+   rebalancing are first-class capabilities, not enhancements.
+3. **Limits exist to bound system failure, not to second-guess the agent.**
+   Budget levers cap the blast radius of bugs, bad data, venue outages, and
+   compromised credentials. They are designed to be *renegotiated by the
+   agents themselves* through the audited budget workflow — handed over
+   progressively as track record accumulates, never silently removed.
+4. **Every grant of autonomy is earned, recorded, and reversible.** Autonomy
+   expansions ride the same append-only audit trail as trades.
+
+## Non-negotiables (invariants — true at every stage)
+
+- Append-only audit trail for every state change, budget change, and autonomy grant.
+- A reachable kill switch once anything can submit orders.
+- No secrets or credentials in records, logs, or reports.
+- Blast-radius caps always exist — they may be wide, but never absent.
+- **Autonomy ratchets down automatically and up only by re-earning.** A breach
+  suspends the current grant via an audited event (down-ladder is automatic, not
+  silent); restoring it requires re-meeting the gate plus a recorded human decision.
+
+*Architecture invariant (not a capability):* every operator action is a library
+call with identity stamping; CLI / TUI / MCP are thin adapters over it. Tooling
+serves owner, developing agents, and operating agents equally.
+
+---
+
+# Part 2 — The operating loop
+
+The thing the gates grade is a loop, not a feature set. One turn of the loop:
+
+```
+market snapshot → propose → eligibility/policy filter → review (human or auto)
+   → approve → execute (paper/live) → record fill → attribute at closeout
+   → refresh track record → (feeds the next turn)
+```
+
+**Cadence (proposed — tune):**
+
+| Step | Cadence / SLA |
+|------|---------------|
+| Propose | On schedule each session, or every 4h (tune) — from real market data, not fixtures |
+| Review | Proposed ideas reviewed or auto-expired within the review-latency budget |
+| Execute | Approved → submitted within one execution window |
+| Closeout | Resolved ideas attributed within one reporting period |
+| Track-record refresh | Regenerated each reporting period |
+
+**Loop health (checkable every run — a red here blocks promotion):**
+
+- Proposals flowing when the market is open (volume > 0).
+- Review-latency p95 within the budgeted SLA (no silent backlog).
+- Attribution coverage = 100% of closed ideas.
+- Audit integrity verification passes.
+- No step starved or backlogged.
+
+A stage's autonomy is only valid while loop health is green.
+
+---
+
+# Part 3 — Graduation gates
+
+## Evidence — one type only
+
+> **Evidence = a demonstrated, measured outcome over a defined observation
+> window, recorded in the audit/closeout trail.**
+
+Not a file. Not "exercised once" hand-wave. Not "code compiles." If a criterion
+can't be expressed as a measured outcome over a window, it isn't a gate — it's
+either an invariant (Part 1) or a build task (STATUS + the issue tracker).
+
+**Observation window (proposed — tune):** rolling 60 days *and* ≥ 200 closed
+ideas, whichever is larger. Gates are evaluated over this window.
+
+## Metric vocabulary (defined once, referenced by gates)
+
+| Metric | Definition |
+|--------|------------|
+| Eligibility pass rate | Proposed ideas passing eligibility without human edit ÷ proposed |
+| Attribution coverage | Closed ideas with recorded resolution + realized PnL ÷ closed |
+| Risk calibration | Losing ideas whose realized loss ≤ recorded max-loss estimate ÷ losing ideas |
+| Expectancy (avg R) | Mean realized return in R-multiples (realized PnL ÷ estimated max loss) |
+| Benchmark edge | Expectancy(system) − Expectancy(deterministic baseline) on identical windows |
+| Max drawdown-from-peak | Largest peak-to-trough equity decline over the window, % of peak |
+| Track-record depth | (count of closed ideas, calendar days observed) |
+
+## The ladder
+
+Each transition lists **promotion gates** (all required, all measured over the
+window) and inherits the **demotion triggers** below. Numbers are **(tune)**.
+
+### Stage 0 — Rails · *complete*
+
+Foundation, not a performance stage. Holds as long as the Part 1 non-negotiables
+hold. (Per [STATUS.md](STATUS.md), the rails are shipped.)
+
+### Stage 1 — Human-approved loop
+
+**Entry (capability prerequisites — the loop is closed, no performance bar yet):**
+
+- A proposer emits eligible ideas from **real market data**, not fixtures (#1031).
+- Approved tickets execute in paper and fills **reconcile onto the audit trail
+  automatically** (#1035).
+- Every closed idea gets resolution + realized-PnL attribution.
+- The expiry sweep runs on schedule.
+
+Operate here, human-approving every idea, until the Stage 2 gate is met.
+
+**Stage 1 → Stage 2 promotion gates** (earn auto-approval within budget):
+
+| Gate | Threshold (tune) |
+|------|------------------|
+| Track-record depth | ≥ 200 closed paper ideas over ≥ 60 days |
+| Eligibility pass rate | ≥ 90% |
+| Attribution coverage | = 100% |
+| Risk calibration | ≥ 95% (the system's loss estimates are trustworthy) |
+| Skill | Expectancy > 0 **and** benchmark edge > 0 (beats the deterministic baseline, not just "doesn't lose") |
+| Max drawdown-from-peak | ≤ the budget's configured peak-drawdown limit across the whole window |
+| Kill-switch drill | Verified halt of propose/approve/submit (not assumed) |
+| Daily-loss breaker | Demonstrated to halt submission in paper |
+
+### Stage 2 — Bounded autonomy
+
+Ideas inside the budget envelope auto-approve; outside it they queue for human
+review; both paths audited. High-water-mark protection active. Profit-taking /
+rebalancing per recorded policy. Daily-loss breaker enforced at runtime.
+
+**Stage 2 → Stage 3 promotion gates** (earn self-direction):
+
+| Gate | Threshold (tune) |
+|------|------------------|
+| Sustained bounded autonomy | ≥ 90 days with zero budget breaches that needed human rescue |
+| HWM protection proven | De-risked on ≥ 1 real peak-drawdown event (paper or canary), not just configured |
+| Budget renegotiation exercised | Agent proposed a budget change with rationale; human approved; new version took effect ≥ once |
+| Profit-taking exercised | Skim/rebalance executed per policy, visible in audit ≥ 3 times |
+| Calibration + skill sustained | At or above Stage-2-entry thresholds across the window |
+
+### Stage 3 — Self-directed entity
+
+Capital allocation across concurrent strategies (recorded with trade-idea rigor),
+self-adjusted budgets inside an owner-set meta-envelope, scheduled self-review
+leaving auditable notes, and a periodic plain-language owner report (positions,
+PnL vs high-water mark, budget changes, notable decisions).
+
+## De-escalation — the down-ladder (every stage with autonomy)
+
+The current autonomy grant is **automatically suspended via an audited event**
+when any trips over the rolling window:
+
+| Trigger | Action |
+|---------|--------|
+| Drawdown-from-peak exceeds the configured peak-drawdown limit | De-risk + suspend auto-approval → back to human approval |
+| Risk calibration falls below floor (realized loss exceeded estimate on > 10% of recent losers — tune) | Suspend auto-approval |
+| Audit integrity check fails, or kill-switch drill fails | Immediate drop to Stage 0 (manual only) |
+| Data staleness / venue degradation beyond threshold | Pause proposing + auto-approval until cleared |
+
+Restoration is **not** automatic: re-meet the relevant promotion gate over a
+fresh window, with a recorded human decision. This is the concrete form of
+"earned, recorded, reversible" — and the operational expression of the
+"triple-then-zero is the worst outcome" philosophy.
+
+---
+
+## Appendix — v1 → v2 mapping (nothing dropped)
+
+| v1 element | Lands in v2 as |
+|------------|----------------|
+| Risk Philosophy (4 points) | Part 1 Charter, verbatim |
+| Non-negotiables | Part 1 invariants (+ down-ladder made explicit) |
+| Stage 0 evidence (file pointers) | Moved to [STATUS.md](STATUS.md); Stage 0 is "complete" there, not "evidence" here |
+| Stage 1 capabilities (proposer, reviewer tooling, paper fills, attribution, expiry, report) | Stage 1 **entry prerequisites** + the operating loop (Part 2) |
+| Stage 1 "≥90% eligibility" | A Stage 1→2 promotion gate |
+| Stage 2 capabilities (auto-approval, HWM, profit-taking, kill switch, budget renegotiation, daily-loss breaker) | Split: Stage 2 description + Stage 1→2 and 2→3 promotion gates + down-ladder triggers |
+| Stage 3 capabilities | Stage 3 description |
+| "grade work against this before adding surface" intent | Realized structurally: capabilities are no longer phrased as a build-backlog |

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ cannot provide. The metadata block is enforced by
 
 ## Start Here
 
+0. **[Project Status](STATUS.md)** - Where we actually are: shipped reality vs the staged-autonomy target
 1. **[Architecture](ARCHITECTURE.md)** - Understand vertical slices before touching code
 2. **[Development Guidelines](DEVELOPMENT_GUIDELINES.md)** - Where to change things + guardrails
 3. **[Readiness Checklist](READINESS.md)** - Gates to move from paper to live trading
@@ -34,6 +35,7 @@ cannot provide. The metadata block is enforced by
 
 | Document | Purpose |
 |----------|---------|
+| [Project Status](STATUS.md) | Living "you are here": shipped state per stage vs the target |
 | [Architecture](ARCHITECTURE.md) | System design and capabilities |
 | [Architecture Boundaries](architecture/BOUNDARIES.md) | Layer ownership and dependency direction |
 | [Ownership Map](architecture/OWNERSHIP.md) | Module ownership map and boundaries |
@@ -45,6 +47,7 @@ cannot provide. The metadata block is enforced by
 | [Pre-Migration Decision Framework](PRE_MIGRATION_DECISION_FRAMEWORK.md) | AI-assisted trading autonomy, product, venue, approval, and audit gates |
 | [Trade-Idea Interface Design Notes](specs/TRADE_IDEA_INTERFACES_DESIGN_NOTES.md) | Implemented CLI and future TUI workstreams for human-approved trade ideas |
 | [Operating Rubric](OPERATING_RUBRIC.md) | Staged capabilities and graduation evidence for the autonomous entity |
+| [Operating Rubric v2 Draft](OPERATING_RUBRIC_V2.md) | Draft measured-outcome rubric for owner review |
 | [Reliability Guide](RELIABILITY.md) | Guard stack, degradation responses, chaos testing |
 | [TUI Guide](TUI_GUIDE.md) | Launching and operating the terminal UI |
 | [TUI Style Guide](TUI_STYLE_GUIDE.md) | Visual standards for TUI components |

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,0 +1,101 @@
+# Project Status — Where We Actually Are
+
+---
+status: current
+---
+
+This is the **factual current-state tracker**: what is actually shipped and
+working, as distinct from what the direction docs describe as the destination.
+
+- The [Operating Rubric](OPERATING_RUBRIC.md) and
+  [Pre-Migration Decision Framework](PRE_MIGRATION_DECISION_FRAMEWORK.md) define
+  **where we are going** and the evidence each capability needs.
+- This doc records **where we are** — updated whenever the shipped reality
+  changes, so planning and backlog work start from reality, not from
+  aspirational stage descriptions.
+
+If a stage description in another doc disagrees with observed code, this doc
+wins until the other doc is reconciled. Verify file/function references here
+before relying on them — they reflect the dated snapshot below.
+
+## Snapshot (2026-06-27)
+
+| Stage | Capability | State |
+|-------|------------|-------|
+| **Stage 0 — Rails** | Record, workflow, audit, eligibility, budget, policy, operator controls | **Complete** — all rubric evidence shipped and tested |
+| **Stage 1 — Human-approved loop** | Propose → review → paper-execute → attribute → report | **In progress (~2/3)** — workflow and review tooling exist; the loop is not closed end-to-end |
+| **Stage 2 — Bounded autonomy** | Auto-approval, high-water-mark, kill switch, runtime circuit breaker | **Not started** |
+| **Stage 3 — Self-directed entity** | Capital allocation, self-adjusted budgets, self-review | **Not started** |
+
+## Stage 0 — Rails (complete)
+
+Every capability the rubric lists for Stage 0 has shipped, tested evidence in
+`src/gpt_trader/features/trade_ideas/`: broker-neutral record + hashing
+(`models.py`), approval-gated state machine (`workflow.py`), append-only audit
+log (`audit.py`), eligibility + approval policy (`eligibility.py`, `policy.py`),
+versioned risk budget (`budget.py`), and operator lifecycle controls —
+reject / request-changes / resubmit / cancel / expire (`service.py`). The full
+human lifecycle is exposed through the `gpt-trader ideas` CLI.
+
+The rails are done.
+
+## Stage 1 — Human-approved loop (in progress)
+
+| Capability | State | Notes |
+|------------|-------|-------|
+| Reviewer tooling (CLI + TUI) | **Done** | `ideas list/show/approve/reject/...` plus the TUI review screen |
+| Outcome attribution | **Done** | `closeout.py` records resolution + realized PnL vs max-loss |
+| Track-record report | **Done** | `ideas report` |
+| Expiry sweep | **Partial** | `service.expire_due_ideas()` exists; not yet wired to a scheduler |
+| Proposer from **real market data** | **Missing** | `BaselineProposer` runs only on hand-authored JSON fixtures — issue #1031 |
+| Paper fills onto audit trail | **Manual only** | Only via `ideas mark-filled`; no reconciliation from the paper engine — issue #1035 |
+
+The two gaps (real-data proposer + automatic paper-fill reconciliation) are the
+ends that turn the scaffolding into an actual loop.
+
+## The structural fact: two disconnected worlds
+
+The live TA bot (`features/live_trade/`, the ensemble/intelligence strategies,
+the broker) and the trade-idea workflow (`features/trade_ideas/`) share **zero
+references in either direction** (verified 2026-06-27). The trade-idea system
+never touches a broker; the live engine never touches the approval workflow.
+
+Consequence: the trading intelligence already built does **not** flow through
+the approval-gated rails. Bridging that gap — not adding new feature surface —
+is the central piece of work. See the recorded direction below.
+
+## Current stance (2026-06-27 owner alignment)
+
+1. **Stabilize and reconcile before extending the loop.** Pause net-new feature
+   surface. Reconcile docs to reality (this doc + rubric labels), keep the rails
+   and tests healthy, and only then plan the loop-closing work.
+2. **Bridge the existing bot; do not grow a second proposer brain.** When the
+   loop is built, trade ideas should come from the existing TA/ensemble
+   intelligence routed through the gate (issue #1033), not from independent,
+   duplicate proposers. Independent/standalone proposers (e.g. #1034) are
+   de-prioritized accordingly.
+3. **Docs track reality.** The rubric/framework remain the destination; this
+   STATUS doc is the living "you are here" and is updated as state changes.
+
+Recorded in the [Decision Log](GPT_TRADER_DECISION_LOG.md) (2026-06-27 entry).
+
+## Loop-closing spine (when stabilization is done)
+
+The work that actually closes the Stage 1 loop, in order:
+
+1. **#1031** — Coinbase `MarketSnapshot` builder (real data in) — keystone.
+2. **#1035** — reconcile paper fills onto the audit trail (execution end).
+3. **#1033** — strategy-signal → trade-idea adapter (bridge the two worlds).
+
+Then: budget gates (#1036), preflight readiness (#1037), pending-approval
+notifications (#1038). Proposer-enrichment, tournaments, MCP, reporting polish,
+futures, and auto-approval are all post-loop and were triaged accordingly on the
+GitHub issue tracker (`triage:*` labels).
+
+## How to keep this doc honest
+
+- Update it when a capability moves between Missing / Partial / Done — ideally in
+  the same PR that changes the state.
+- Prefer concrete pointers (file, function, issue number) over prose claims.
+- When this doc and a direction doc disagree, fix the direction doc or open a
+  decision-log entry; don't let the gap persist silently.

--- a/docs/agents/project_review_pipeline.md
+++ b/docs/agents/project_review_pipeline.md
@@ -6,14 +6,14 @@ status: draft
 
 This document defines the recurring project-review pipeline for GPT-Trader. The
 pipeline is intentionally staged: frequent scouts produce candidate findings,
-and only validated, deduped findings are promoted to GitHub issues for Claw,
-Hermes, and Codex review loops.
+and only validated, deduped findings are promoted to GitHub issues for
+implementation or review loops.
 
 ## Goals
 
 - Keep a frequent agent scout close to current repo truth.
 - Promote only actionable, evidence-backed findings.
-- Use GitHub issues as the durable queue for Claw/Hermes implementation.
+- Use GitHub issues as the durable project queue for implementation agents.
 - Preserve GPT-Trader safety boundaries around broker access, trading
   execution, account capability, and explicit decision records.
 - Feed PR review feedback back into implementation agents without broadening
@@ -124,7 +124,7 @@ Required fields:
     "uv run agent-regenerate --verify"
   ],
   "routing": {
-    "candidate_for": ["claw"],
+    "candidate_for": ["implementation"],
     "decision_needed": false,
     "blocked_by": []
   }
@@ -150,7 +150,8 @@ recommend the next policy and implementation route.
 ## Stage 3: Promote
 
 Promotion creates or updates a GitHub issue from a validated packet. Promote at
-most one finding per scout run unless RJ explicitly requests a bulk pass.
+most one finding per scout run unless the project owner explicitly requests a
+bulk pass.
 
 Dry-run first:
 
@@ -180,8 +181,6 @@ GitHub issues are the durable queue. These labels are routing signals:
 | --- | --- |
 | `agent-review` | Finding came from the recurring GPT-Trader review lane |
 | `agent-ready` | Finding passed promotion gates, has no decision/blocker gate, and is ready for implementation |
-| `claw-candidate` | Candidate for Claw implementation |
-| `hermes-candidate` | Candidate for Hermes implementation |
 | `decision-needed` | Requires an explicit decision packet and agent recommendation before implementation or execution |
 | `codex-review-feedback` | Follow-up from Codex review comments or checks |
 
@@ -191,7 +190,8 @@ unknown labels from the GitHub call.
 
 ## Stage 5: Implement
 
-Claw and Hermes should treat each promoted issue as the implementation contract:
+Implementation agents should treat each promoted issue as the implementation
+contract:
 
 - work only the acceptance criteria in the issue
 - preserve out-of-scope boundaries
@@ -204,14 +204,14 @@ issue-backed work, include `Closes #<issue>`.
 
 ### Direct Package Cycles
 
-When RJ or the active agent workspace explicitly routes a build/package cycle,
-a promoted GitHub issue is useful but not required. In that path, the direct
-request, the observed repo evidence, and the PR body form the implementation
-contract.
+When the project owner or the active agent workspace explicitly routes a
+build/package cycle, a promoted GitHub issue is useful but not required. In that
+path, the direct request, the observed repo evidence, and the PR body form the
+implementation contract.
 
 Use this path only when the work is already bounded and safe to verify locally:
 
-- name the package source in the PR body, such as `RJ-routed package`,
+- name the package source in the PR body, such as `owner-routed package`,
   `agent-review finding`, or a specific doc/receipt
 - preserve the same trading boundaries as issue-backed work
 - run the smallest meaningful verification plus repo-required checks
@@ -265,5 +265,5 @@ This supports repeatable review workflow without polluting commits or losing han
 ## Cadence
 
 Start with an hourly Codex automation. Tighten the cadence only after the issue
-promotion rate is low, dedupe is reliable, and Claw/Hermes are not receiving
-stale or duplicate work.
+promotion rate is low, dedupe is reliable, and implementation agents are not
+receiving stale or duplicate work.

--- a/docs/specs/TRADE_IDEA_TUI_REVIEW_SPEC.md
+++ b/docs/specs/TRADE_IDEA_TUI_REVIEW_SPEC.md
@@ -60,7 +60,7 @@ the bot runtime.
 ## Layout
 
 ```
-┌─ Ideas Review ── reviewer: rj ───────────────────────────────────────┐
+┌─ Ideas Review ── reviewer: operator ─────────────────────────────────┐
 │ ┌─ Queue (DataTable) ──────────────┐ ┌─ Detail (VerticalScroll) ───┐ │
 │ │ ID  STATE  INSTR  DIR  LOSS% EXP │ │ thesis, instrument, entry,  │ │
 │ │ ...                              │ │ invalidation, target, loss, │ │

--- a/scripts/agents/dedupe_triage.py
+++ b/scripts/agents/dedupe_triage.py
@@ -12,7 +12,7 @@ Files:
 Usage:
   uv run python scripts/agents/dedupe_triage.py --list
   uv run python scripts/agents/dedupe_triage.py --show 678535a285b3
-  uv run python scripts/agents/dedupe_triage.py --set 72948f9bf0a3 rejected --owner rj --reason "Fanout cluster; not redundant."
+  uv run python scripts/agents/dedupe_triage.py --set 72948f9bf0a3 rejected --owner operator --reason "Fanout cluster; not redundant."
   uv run python scripts/agents/dedupe_triage.py --clear 72948f9bf0a3
 """
 

--- a/scripts/maintenance/project_review_issue_promoter.py
+++ b/scripts/maintenance/project_review_issue_promoter.py
@@ -26,7 +26,7 @@ CATEGORIES = {
     "tooling",
     "trading-readiness",
 }
-CANDIDATES = {"claw", "hermes", "codex-review", "decision"}
+CANDIDATES = {"implementation", "codex-review", "decision"}
 EVIDENCE_ANCHOR_FIELDS = ("command", "path", "url")
 
 CUSTOM_LABELS = {
@@ -37,14 +37,6 @@ CUSTOM_LABELS = {
     "agent-ready": {
         "color": "0e8a16",
         "description": "Validated and ready for agent implementation",
-    },
-    "claw-candidate": {
-        "color": "1d76db",
-        "description": "Candidate for Claw implementation",
-    },
-    "hermes-candidate": {
-        "color": "006b75",
-        "description": "Candidate for Hermes implementation",
     },
     "decision-needed": {
         "color": "d876e3",
@@ -131,7 +123,7 @@ def example_packet() -> dict[str, Any]:
         "acceptance_criteria": ["`uv run agent-regenerate --verify` passes."],
         "suggested_verification": ["uv run agent-regenerate --verify"],
         "routing": {
-            "candidate_for": ["claw"],
+            "candidate_for": ["implementation"],
             "decision_needed": False,
             "blocked_by": [],
         },
@@ -274,10 +266,6 @@ def packet_labels(packet: dict[str, Any]) -> list[str]:
         if not routing.get("decision_needed") and not blocked_by and not decision_candidate:
             labels.add("agent-ready")
         if isinstance(candidates, list):
-            if "claw" in candidates:
-                labels.add("claw-candidate")
-            if "hermes" in candidates:
-                labels.add("hermes-candidate")
             if "codex-review" in candidates:
                 labels.add("codex-review-feedback")
         if routing.get("decision_needed") or decision_candidate:

--- a/src/gpt_trader/agents/cli.py
+++ b/src/gpt_trader/agents/cli.py
@@ -216,6 +216,6 @@ def dedupe_triage() -> int:
     Examples:
         uv run agent-dedupe-triage --list
         uv run agent-dedupe-triage --show 72948f9bf0a3
-        uv run agent-dedupe-triage --set 72948f9bf0a3 rejected --owner rj --reason "Not redundant"
+        uv run agent-dedupe-triage --set 72948f9bf0a3 rejected --owner operator --reason "Not redundant"
     """
     return _run_script("dedupe_triage.py")

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6980,
+    "total_tests": 6981,
     "total_files": 829,
     "markers_used": 16
   },

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,9 +95,9 @@
     ]
   },
   "counts": {
-    "unit": 6814,
+    "unit": 6815,
     "asyncio": 440,
-    "parametrize": 203,
+    "parametrize": 204,
     "endpoints": 83,
     "property": 82,
     "integration": 80,

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6980,
+    "total_tests": 6981,
     "total_files": 829,
     "markers_used": 16
   },
@@ -102,9 +102,9 @@
     ]
   },
   "marker_counts": {
-    "unit": 6814,
+    "unit": 6815,
     "asyncio": 440,
-    "parametrize": 203,
+    "parametrize": 204,
     "endpoints": 83,
     "property": 82,
     "integration": 80,
@@ -63590,6 +63590,15 @@
       {
         "name": "test_suggest_sections_for_representative_paths",
         "line": 74,
+        "markers": [
+          "parametrize",
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_has_required_metadata",
+        "line": 112,
         "markers": [
           "parametrize",
           "unit"


### PR DESCRIPTION
## Summary
- Add a factual project status tracker and draft measured-outcome operating rubric v2.
- Update docs index, operating rubric, and decision log so current-state docs match shipped trade-idea reality.
- Replace project-facing personal-agent routing terms with generic implementation/review routing language.
- Refresh generated agent test inventory after touching agent scripts.

## Scope & Impact
- Docs and agent-review workflow language only.
- No broker/API calls, credential handling, live trading, order submission, or execution enablement.
- Removes stale local worktree residue by recovering the useful patch into this branch.

## Test Plan
- `uv run python scripts/maintenance/docs_reachability_check.py`
- `uv run pytest tests/unit/scripts/test_project_review_issue_promoter.py tests/unit/scripts/test_docs_maintenance.py -q`
- `uv run ruff check scripts/agents/dedupe_triage.py scripts/maintenance/project_review_issue_promoter.py src/gpt_trader/agents/cli.py`
- `uv run agent-regenerate --verify`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated project review and routing terminology to use a more general “implementation” path.
  * Added a new operating rubric draft and a current project status page for clearer progress tracking.

* **Documentation**
  * Improved the docs index and several templates to better match the latest workflow language.
  * Updated review and decision logs with current status and guidance.

* **Tests**
  * Refreshed test inventory and metadata counts to reflect the latest test suite state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->