### PR TITLE
Fix AttributeError in order-event recording monitoring logger

### DIFF
--- a/scripts/agents/generate_event_catalog.py
+++ b/scripts/agents/generate_event_catalog.py
@@ -276,7 +276,7 @@ def generate_event_catalog(scan_results: dict[str, Any]) -> dict[str, Any]:
             "components": sorted(components) if components else None,
             "statuses": sorted(statuses) if statuses else None,
             "levels": sorted(levels),
-            "common_fields": sorted(all_fields)[:15],
+            "common_fields": sorted(all_fields),
             "source_files": sorted(files)[:5],  # Limit to 5 example files
         }
 

--- a/src/gpt_trader/utilities/logging_patterns.py
+++ b/src/gpt_trader/utilities/logging_patterns.py
@@ -72,6 +72,90 @@ class StructuredLogger:
         extracted_kwargs["exc_info"] = True
         self.logger.error(msg, *args, extra=extra_kwargs, **extracted_kwargs)
 
+    # ------------------------------------------------------------------
+    # Monitoring event helpers
+    #
+    # The monitoring logger returned by ``gpt_trader.monitoring.system.get_logger``
+    # is a ``StructuredLogger``. Order-event and metrics code emit semantic
+    # events through these helpers; they record structured INFO log records so
+    # the kwargs survive as record attributes for downstream log processors.
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _coerce_level(level: Any) -> int:
+        """Resolve a logging level from an int, level name, or LogLevel enum."""
+        if isinstance(level, bool):
+            return logging.INFO
+        if isinstance(level, int):
+            return level
+        # ``LogLevel`` (gpt_trader.monitoring.system) exposes ``.value`` as the
+        # level name, e.g. "INFO"; bare strings such as "WARNING" also work.
+        name = getattr(level, "value", level)
+        if isinstance(name, str):
+            resolved = logging.getLevelName(name.upper())
+            if isinstance(resolved, int):
+                return resolved
+        return logging.INFO
+
+    def log_event(
+        self,
+        *,
+        event_type: str,
+        message: str,
+        level: Any = logging.INFO,
+        component: str | None = None,
+        **fields: Any,
+    ) -> None:
+        """Emit a structured monitoring event."""
+        context: dict[str, Any] = {"event_type": event_type}
+        if component is not None:
+            context["component"] = component
+        context.update(fields)
+        self.log(self._coerce_level(level), message, **context)
+
+    def log_order_submission(
+        self,
+        *,
+        client_order_id: str,
+        symbol: str,
+        side: str,
+        order_type: str,
+        quantity: float,
+        price: float | None,
+    ) -> None:
+        """Record an order submission attempt as a structured event."""
+        self.log_event(
+            event_type="order_submission",
+            message="Order submission attempt",
+            operation="order_submit",
+            client_order_id=client_order_id,
+            symbol=symbol,
+            side=side,
+            order_type=order_type,
+            quantity=quantity,
+            price=price,
+        )
+
+    def log_order_status_change(
+        self,
+        *,
+        order_id: str,
+        client_order_id: str,
+        from_status: str | None,
+        to_status: str,
+        reason: str | None = None,
+    ) -> None:
+        """Record an order status transition as a structured event."""
+        self.log_event(
+            event_type="order_status_change",
+            message="Order status change",
+            operation="order_status",
+            order_id=order_id,
+            client_order_id=client_order_id,
+            from_status=from_status,
+            to_status=to_status,
+            reason=reason,
+        )
+
 
 def get_logger(name: str, component: str | None = None, **kwargs: Any) -> StructuredLogger:
     return StructuredLogger(name, component=component)

--- a/src/gpt_trader/utilities/logging_patterns.py
+++ b/src/gpt_trader/utilities/logging_patterns.py
@@ -38,7 +38,7 @@ class StructuredLogger:
             else:
                 extra_kwargs[key] = value
 
-        if self.component:
+        if self.component and "component" not in extra_kwargs:
             extra_kwargs["component"] = self.component
 
         return extracted_kwargs, extra_kwargs

--- a/tests/unit/gpt_trader/features/live_trade/execution/test_order_event_recorder_real_logger.py
+++ b/tests/unit/gpt_trader/features/live_trade/execution/test_order_event_recorder_real_logger.py
@@ -1,0 +1,129 @@
+"""Integration tests exercising OrderEventRecorder against the real monitoring logger.
+
+The recorder records order events through ``get_monitoring_logger()`` (a
+``StructuredLogger``). These tests deliberately do **not** mock that logger so
+the real ``log_event`` / ``log_order_submission`` / ``log_order_status_change``
+methods are exercised. They guard against the regression where those methods did
+not exist on ``StructuredLogger``, raising ``AttributeError`` at runtime (which
+the best-effort wrappers swallowed into noisy exception tracebacks).
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+import pytest
+
+import gpt_trader.features.live_trade.execution.order_event_recorder as recorder_module
+from gpt_trader.core import OrderSide, OrderType
+from gpt_trader.features.live_trade.execution.order_event_recorder import OrderEventRecorder
+from tests.unit.gpt_trader.utilities.logging_patterns_test_helpers import captured_logger
+
+
+@pytest.fixture
+def recorder_logger_spy(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    """Spy on the recorder's own module logger.
+
+    On a monitoring-logger failure the recorder swallows the exception and
+    records it via ``logger.exception("Failed to log ...")``. Asserting that was
+    never called proves the real monitoring path ran without ``AttributeError``.
+    """
+    spy = MagicMock()
+    monkeypatch.setattr(recorder_module, "logger", spy)
+    return spy
+
+
+def _assert_no_logging_failures(spy: MagicMock) -> None:
+    assert spy.exception.call_count == 0, (
+        "Recorder fell back to logger.exception, indicating the monitoring "
+        "logger call failed (e.g. AttributeError)"
+    )
+
+
+def test_record_submission_attempt_uses_real_logger(
+    order_event_recorder: OrderEventRecorder,
+    recorder_logger_spy: MagicMock,
+) -> None:
+    with captured_logger("system") as (_, handler):
+        order_event_recorder.record_submission_attempt(
+            submit_id="client-123",
+            symbol="BTC-USD",
+            side=OrderSide.BUY,
+            order_type=OrderType.LIMIT,
+            quantity=Decimal("1.5"),
+            price=Decimal("50000"),
+        )
+
+    _assert_no_logging_failures(recorder_logger_spy)
+    record = next(r for r in handler.records if getattr(r, "event_type", None) == "order_submission")
+    assert record.client_order_id == "client-123"  # type: ignore[attr-defined]
+    assert record.symbol == "BTC-USD"  # type: ignore[attr-defined]
+    assert record.side == "BUY"  # type: ignore[attr-defined]
+    assert record.order_type == "LIMIT"  # type: ignore[attr-defined]
+
+
+def test_record_rejection_uses_real_logger(
+    order_event_recorder: OrderEventRecorder,
+    recorder_logger_spy: MagicMock,
+) -> None:
+    with captured_logger("system") as (_, handler):
+        order_event_recorder.record_rejection(
+            symbol="BTC-USD",
+            side="BUY",
+            quantity=Decimal("1.0"),
+            price=Decimal("50000"),
+            reason="insufficient_margin",
+            client_order_id="client-123",
+        )
+
+    _assert_no_logging_failures(recorder_logger_spy)
+    record = next(
+        r for r in handler.records if getattr(r, "event_type", None) == "order_status_change"
+    )
+    assert record.to_status == "REJECTED"  # type: ignore[attr-defined]
+    assert record.client_order_id == "client-123"  # type: ignore[attr-defined]
+
+
+def test_record_trade_event_uses_real_logger(
+    order_event_recorder: OrderEventRecorder,
+    order_event_mock_order: MagicMock,
+    recorder_logger_spy: MagicMock,
+) -> None:
+    with captured_logger("system") as (_, handler):
+        order_event_recorder.record_trade_event(
+            order=order_event_mock_order,
+            symbol="BTC-USD",
+            side=OrderSide.BUY,
+            quantity=Decimal("1.0"),
+            price=Decimal("50000"),
+            effective_price=Decimal("50000"),
+            submit_id="client-123",
+        )
+
+    _assert_no_logging_failures(recorder_logger_spy)
+    record = next(
+        r for r in handler.records if getattr(r, "event_type", None) == "order_status_change"
+    )
+    assert record.order_id == "order-123"  # type: ignore[attr-defined]
+
+
+def test_record_preview_uses_real_logger(
+    order_event_recorder: OrderEventRecorder,
+    recorder_logger_spy: MagicMock,
+) -> None:
+    with captured_logger("system") as (_, handler):
+        order_event_recorder.record_preview(
+            symbol="ETH-USD",
+            side=OrderSide.SELL,
+            order_type=OrderType.MARKET,
+            quantity=Decimal("2.0"),
+            price=None,
+            preview={"estimated_fee": "0.1"},
+        )
+
+    _assert_no_logging_failures(recorder_logger_spy)
+    record = next(r for r in handler.records if getattr(r, "event_type", None) == "order_preview")
+    assert record.component == "TradingEngine"  # type: ignore[attr-defined]
+    assert record.symbol == "ETH-USD"  # type: ignore[attr-defined]
+    assert record.side == "SELL"  # type: ignore[attr-defined]

--- a/tests/unit/gpt_trader/features/live_trade/execution/test_order_event_recorder_real_logger.py
+++ b/tests/unit/gpt_trader/features/live_trade/execution/test_order_event_recorder_real_logger.py
@@ -56,7 +56,9 @@ def test_record_submission_attempt_uses_real_logger(
         )
 
     _assert_no_logging_failures(recorder_logger_spy)
-    record = next(r for r in handler.records if getattr(r, "event_type", None) == "order_submission")
+    record = next(
+        r for r in handler.records if getattr(r, "event_type", None) == "order_submission"
+    )
     assert record.client_order_id == "client-123"  # type: ignore[attr-defined]
     assert record.symbol == "BTC-USD"  # type: ignore[attr-defined]
     assert record.side == "BUY"  # type: ignore[attr-defined]

--- a/tests/unit/gpt_trader/utilities/test_logging_patterns_domain.py
+++ b/tests/unit/gpt_trader/utilities/test_logging_patterns_domain.py
@@ -218,3 +218,119 @@ def test_log_system_health_defaults_to_structured_logger():
     record = handler.records[0]
     assert record.levelno == logging.INFO
     assert has_attr(record, "status", "healthy")
+
+
+class _Level:
+    """Stand-in for monitoring.system.LogLevel (``.value`` is the level name)."""
+
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+
+def test_log_event_emits_structured_record_with_fields():
+    with captured_logger("monitoring") as (_, handler):
+        slog = lp.StructuredLogger("monitoring")
+        slog.log_event(
+            level=_Level("INFO"),
+            event_type="order_preview",
+            message="Order preview generated",
+            component="TradingEngine",
+            symbol="BTC-USD",
+            side="BUY",
+        )
+
+    record = handler.records[0]
+    assert record.levelno == logging.INFO
+    assert record.getMessage() == "Order preview generated"
+    assert has_attr(record, "event_type", "order_preview")
+    assert has_attr(record, "component", "TradingEngine")
+    assert has_attr(record, "symbol", "BTC-USD")
+    assert has_attr(record, "side", "BUY")
+
+
+def test_log_event_coerces_string_and_int_levels():
+    with captured_logger("monitoring") as (_, handler):
+        slog = lp.StructuredLogger("monitoring")
+        slog.log_event(level="WARNING", event_type="warn", message="warn")
+        slog.log_event(level=logging.ERROR, event_type="err", message="err")
+        slog.log_event(event_type="default", message="default")
+
+    assert handler.records[0].levelno == logging.WARNING
+    assert handler.records[1].levelno == logging.ERROR
+    assert handler.records[2].levelno == logging.INFO
+
+
+def test_log_order_submission_records_event():
+    with captured_logger("monitoring") as (_, handler):
+        slog = lp.StructuredLogger("monitoring")
+        slog.log_order_submission(
+            client_order_id="client-123",
+            symbol="BTC-USD",
+            side="BUY",
+            order_type="LIMIT",
+            quantity=1.5,
+            price=50000.0,
+        )
+
+    record = handler.records[0]
+    assert record.levelno == logging.INFO
+    assert has_attr(record, "event_type", "order_submission")
+    assert has_attr(record, "operation", "order_submit")
+    assert has_attr(record, "client_order_id", "client-123")
+    assert has_attr(record, "symbol", "BTC-USD")
+    assert has_attr(record, "side", "BUY")
+    assert has_attr(record, "order_type", "LIMIT")
+    assert has_attr(record, "quantity", 1.5)
+    assert has_attr(record, "price", 50000.0)
+
+
+def test_log_order_submission_accepts_none_price():
+    with captured_logger("monitoring") as (_, handler):
+        slog = lp.StructuredLogger("monitoring")
+        slog.log_order_submission(
+            client_order_id="client-123",
+            symbol="BTC-USD",
+            side="BUY",
+            order_type="MARKET",
+            quantity=1.0,
+            price=None,
+        )
+
+    record = handler.records[0]
+    assert has_attr(record, "price")
+    assert record.price is None  # type: ignore[attr-defined]
+
+
+def test_log_order_status_change_records_event():
+    with captured_logger("monitoring") as (_, handler):
+        slog = lp.StructuredLogger("monitoring")
+        slog.log_order_status_change(
+            order_id="order-123",
+            client_order_id="client-123",
+            from_status=None,
+            to_status="open",
+        )
+
+    record = handler.records[0]
+    assert record.levelno == logging.INFO
+    assert has_attr(record, "event_type", "order_status_change")
+    assert has_attr(record, "operation", "order_status")
+    assert has_attr(record, "order_id", "order-123")
+    assert has_attr(record, "client_order_id", "client-123")
+    assert has_attr(record, "to_status", "open")
+
+
+def test_log_order_status_change_includes_optional_reason():
+    with captured_logger("monitoring") as (_, handler):
+        slog = lp.StructuredLogger("monitoring")
+        slog.log_order_status_change(
+            order_id="",
+            client_order_id="",
+            from_status=None,
+            to_status="REJECTED",
+            reason="paused",
+        )
+
+    record = handler.records[0]
+    assert has_attr(record, "to_status", "REJECTED")
+    assert has_attr(record, "reason", "paused")

--- a/tests/unit/gpt_trader/utilities/test_logging_patterns_domain.py
+++ b/tests/unit/gpt_trader/utilities/test_logging_patterns_domain.py
@@ -248,6 +248,19 @@ def test_log_event_emits_structured_record_with_fields():
     assert has_attr(record, "side", "BUY")
 
 
+def test_log_event_preserves_explicit_component_over_default_component():
+    with captured_logger("monitoring") as (_, handler):
+        slog = lp.StructuredLogger("monitoring", component="default-component")
+        slog.log_event(
+            event_type="order_preview",
+            message="Order preview generated",
+            component="TradingEngine",
+        )
+
+    record = handler.records[0]
+    assert has_attr(record, "component", "TradingEngine")
+
+
 def test_log_event_coerces_string_and_int_levels():
     with captured_logger("monitoring") as (_, handler):
         slog = lp.StructuredLogger("monitoring")

--- a/tests/unit/scripts/test_generate_event_catalog.py
+++ b/tests/unit/scripts/test_generate_event_catalog.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from scripts.agents.generate_event_catalog import scan_logging_calls
+from scripts.agents.generate_event_catalog import generate_event_catalog, scan_logging_calls
 
 
 def test_exception_logging_counts_as_error_level(tmp_path):
@@ -52,3 +52,46 @@ def record_close(logger, pos, quantity):
         "reduce_only",
         "symbol",
     ]
+
+
+def test_event_catalog_common_fields_are_not_truncated():
+    scan_results = {
+        "operations": {
+            "order_submit": [
+                {
+                    "file": "sample.py",
+                    "component": None,
+                    "status": None,
+                    "level": "INFO",
+                    "fields": [
+                        "attempt",
+                        "client_order_id",
+                        "delay_seconds",
+                        "error_message",
+                        "error_type",
+                        "event_type",
+                        "max_attempts",
+                        "message",
+                        "order_id",
+                        "order_type",
+                        "price",
+                        "quantity",
+                        "reason",
+                        "reason_detail",
+                        "reduce_only",
+                        "side",
+                        "symbol",
+                    ],
+                }
+            ]
+        },
+        "components": {},
+        "fields": {},
+        "levels": {"INFO": 1},
+    }
+
+    catalog = generate_event_catalog(scan_results)
+
+    common_fields = catalog["events"]["order_submit"]["common_fields"]
+    assert "side" in common_fields
+    assert "symbol" in common_fields

--- a/var/agents/logging/event_catalog.json
+++ b/var/agents/logging/event_catalog.json
@@ -1530,7 +1530,10 @@
         "quantity",
         "reason",
         "reason_detail",
-        "reduce_only"
+        "reduce_only",
+        "side",
+        "stage",
+        "symbol"
       ],
       "components": null,
       "levels": [

--- a/var/agents/logging/event_catalog.json
+++ b/var/agents/logging/event_catalog.json
@@ -136,6 +136,7 @@
       "order_recovery",
       "order_rejected",
       "order_route",
+      "order_status",
       "order_submit",
       "order_suppressed",
       "order_update_persist",
@@ -1493,6 +1494,26 @@
       ],
       "statuses": null
     },
+    "order_status": {
+      "common_fields": [
+        "client_order_id",
+        "event_type",
+        "from_status",
+        "message",
+        "order_id",
+        "reason",
+        "to_status"
+      ],
+      "components": null,
+      "levels": [
+        "INFO"
+      ],
+      "occurrence_count": 1,
+      "source_files": [
+        "utilities/logging_patterns.py"
+      ],
+      "statuses": null
+    },
     "order_submit": {
       "common_fields": [
         "attempt",
@@ -1500,16 +1521,16 @@
         "delay_seconds",
         "error_message",
         "error_type",
+        "event_type",
         "max_attempts",
+        "message",
         "order_id",
         "order_type",
         "price",
         "quantity",
         "reason",
         "reason_detail",
-        "reduce_only",
-        "side",
-        "stage"
+        "reduce_only"
       ],
       "components": null,
       "levels": [
@@ -1517,11 +1538,12 @@
         "INFO",
         "WARNING"
       ],
-      "occurrence_count": 13,
+      "occurrence_count": 14,
       "source_files": [
         "features/live_trade/engines/strategy.py",
         "features/live_trade/execution/order_event_recorder.py",
-        "features/live_trade/execution/order_submission.py"
+        "features/live_trade/execution/order_submission.py",
+        "utilities/logging_patterns.py"
       ],
       "statuses": null
     },
@@ -2537,14 +2559,14 @@
     "action": 10,
     "attempt": 4,
     "client_ip": 4,
-    "client_order_id": 20,
+    "client_order_id": 22,
     "consecutive_failures": 6,
     "details": 5,
     "environment": 12,
     "error": 66,
     "error_message": 93,
     "error_type": 91,
-    "event_type": 5,
+    "event_type": 7,
     "flatten_operation_id": 9,
     "granularity": 6,
     "guard_name": 9,
@@ -2552,26 +2574,26 @@
     "latency_seconds": 5,
     "max_attempts": 4,
     "mode": 4,
-    "order_id": 29,
+    "order_id": 30,
+    "order_type": 4,
     "outcome": 5,
     "path": 12,
-    "portfolio_id": 4,
-    "price": 4,
-    "quantity": 10,
-    "reason": 27,
+    "price": 5,
+    "quantity": 11,
+    "reason": 28,
     "secret_ref": 6,
     "service": 9,
-    "side": 26,
+    "side": 27,
     "stage": 174,
-    "symbol": 84
+    "symbol": 85
   },
   "level_distribution": {
     "CRITICAL": 2,
     "DEBUG": 50,
     "ERROR": 124,
-    "INFO": 93,
+    "INFO": 95,
     "WARNING": 105
   },
-  "total_event_types": 137,
+  "total_event_types": 138,
   "version": "1.0"
 }

--- a/var/agents/logging/index.json
+++ b/var/agents/logging/index.json
@@ -27,7 +27,7 @@
       "cleanup_orders",
       "collateral_update"
     ],
-    "total_events": 137
+    "total_events": 138
   },
   "usage": {
     "correlation": "Use correlation_id field to trace requests across logs",

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,8 +7,8 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 7004,
-    "total_files": 831,
+    "total_tests": 7015,
+    "total_files": 833,
     "markers_used": 16
   },
   "quick_commands": {

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 7015,
+    "total_tests": 7017,
     "total_files": 833,
     "markers_used": 16
   },

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6837,
+    "unit": 6848,
     "asyncio": 440,
     "parametrize": 205,
     "endpoints": 83,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6848,
+    "unit": 6850,
     "asyncio": 440,
     "parametrize": 205,
     "endpoints": 83,

--- a/var/agents/testing/source_test_map.json
+++ b/var/agents/testing/source_test_map.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "summary": {
-    "tests_scanned": 743,
+    "tests_scanned": 744,
     "source_modules": 380,
     "unresolved_modules": 3
   },
@@ -475,6 +475,7 @@
       "tests/unit/gpt_trader/features/live_trade/execution/test_broker_executor_retry_flows.py",
       "tests/unit/gpt_trader/features/live_trade/execution/test_order_event_recorder.py",
       "tests/unit/gpt_trader/features/live_trade/execution/test_order_event_recorder_preview.py",
+      "tests/unit/gpt_trader/features/live_trade/execution/test_order_event_recorder_real_logger.py",
       "tests/unit/gpt_trader/features/live_trade/execution/test_order_event_recorder_rejection.py",
       "tests/unit/gpt_trader/features/live_trade/execution/test_order_event_recorder_submission.py",
       "tests/unit/gpt_trader/features/live_trade/execution/test_order_submission_core.py",
@@ -960,6 +961,7 @@
     "gpt_trader.features.live_trade.execution.order_event_recorder": [
       "tests/unit/gpt_trader/features/live_trade/execution/test_order_event_recorder.py",
       "tests/unit/gpt_trader/features/live_trade/execution/test_order_event_recorder_preview.py",
+      "tests/unit/gpt_trader/features/live_trade/execution/test_order_event_recorder_real_logger.py",
       "tests/unit/gpt_trader/features/live_trade/execution/test_order_event_recorder_rejection.py",
       "tests/unit/gpt_trader/features/live_trade/execution/test_order_event_recorder_submission.py",
       "tests/unit/gpt_trader/features/live_trade/execution/test_order_submission_observability_metrics.py"
@@ -3554,6 +3556,10 @@
       "gpt_trader.features.live_trade.execution.order_event_recorder"
     ],
     "tests/unit/gpt_trader/features/live_trade/execution/test_order_event_recorder_preview.py": [
+      "gpt_trader.core",
+      "gpt_trader.features.live_trade.execution.order_event_recorder"
+    ],
+    "tests/unit/gpt_trader/features/live_trade/execution/test_order_event_recorder_real_logger.py": [
       "gpt_trader.core",
       "gpt_trader.features.live_trade.execution.order_event_recorder"
     ],

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 7015,
+    "total_tests": 7017,
     "total_files": 833,
     "markers_used": 16
   },
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6848,
+    "unit": 6850,
     "asyncio": 440,
     "parametrize": 205,
     "endpoints": 83,
@@ -59369,7 +59369,7 @@
         "docstring": ""
       },
       {
-        "name": "test_log_event_coerces_string_and_int_levels",
+        "name": "test_log_event_preserves_explicit_component_over_default_component",
         "line": 251,
         "markers": [
           "unit"
@@ -59377,8 +59377,16 @@
         "docstring": ""
       },
       {
+        "name": "test_log_event_coerces_string_and_int_levels",
+        "line": 264,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
         "name": "test_log_order_submission_records_event",
-        "line": 263,
+        "line": 276,
         "markers": [
           "unit"
         ],
@@ -59386,7 +59394,7 @@
       },
       {
         "name": "test_log_order_submission_accepts_none_price",
-        "line": 287,
+        "line": 300,
         "markers": [
           "unit"
         ],
@@ -59394,7 +59402,7 @@
       },
       {
         "name": "test_log_order_status_change_records_event",
-        "line": 304,
+        "line": 317,
         "markers": [
           "unit"
         ],
@@ -59402,7 +59410,7 @@
       },
       {
         "name": "test_log_order_status_change_includes_optional_reason",
-        "line": 323,
+        "line": 336,
         "markers": [
           "unit"
         ],
@@ -64029,6 +64037,14 @@
       {
         "name": "test_structured_logging_fields_do_not_depend_on_operation_position",
         "line": 28,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_event_catalog_common_fields_are_not_truncated",
+        "line": 57,
         "markers": [
           "unit"
         ],

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,8 +2,8 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 7004,
-    "total_files": 831,
+    "total_tests": 7015,
+    "total_files": 833,
     "markers_used": 16
   },
   "marker_definitions": {
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6837,
+    "unit": 6848,
     "asyncio": 440,
     "parametrize": 205,
     "endpoints": 83,
@@ -423,6 +423,7 @@
       "tests/unit/gpt_trader/features/live_trade/execution/test_mark_staleness_and_risk_metrics_guard.py",
       "tests/unit/gpt_trader/features/live_trade/execution/test_order_event_recorder.py",
       "tests/unit/gpt_trader/features/live_trade/execution/test_order_event_recorder_preview.py",
+      "tests/unit/gpt_trader/features/live_trade/execution/test_order_event_recorder_real_logger.py",
       "tests/unit/gpt_trader/features/live_trade/execution/test_order_event_recorder_rejection.py",
       "tests/unit/gpt_trader/features/live_trade/execution/test_order_event_recorder_submission.py",
       "tests/unit/gpt_trader/features/live_trade/execution/test_order_event_schema.py",
@@ -806,6 +807,9 @@
     "test_docs_currency_scan.py": [
       "tests/integration/scripts/test_docs_currency_scan.py",
       "tests/unit/scripts/test_docs_currency_scan.py"
+    ],
+    "test_docs_link_audit.py": [
+      "tests/unit/scripts/test_docs_link_audit.py"
     ],
     "test_docs_maintenance.py": [
       "tests/unit/scripts/test_docs_maintenance.py"
@@ -23467,6 +23471,40 @@
         ],
         "docstring": "Test that 'market' as display_price is handled.",
         "class": "TestRecordSuccess"
+      }
+    ],
+    "tests/unit/gpt_trader/features/live_trade/execution/test_order_event_recorder_real_logger.py": [
+      {
+        "name": "test_record_submission_attempt_uses_real_logger",
+        "line": 44,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_record_rejection_uses_real_logger",
+        "line": 68,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_record_trade_event_uses_real_logger",
+        "line": 90,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_record_preview_uses_real_logger",
+        "line": 113,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
       }
     ],
     "tests/unit/gpt_trader/features/live_trade/execution/test_order_event_recorder_rejection.py": [
@@ -59321,6 +59359,54 @@
           "unit"
         ],
         "docstring": ""
+      },
+      {
+        "name": "test_log_event_emits_structured_record_with_fields",
+        "line": 230,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_log_event_coerces_string_and_int_levels",
+        "line": 251,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_log_order_submission_records_event",
+        "line": 263,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_log_order_submission_accepts_none_price",
+        "line": 287,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_log_order_status_change_records_event",
+        "line": 304,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_log_order_status_change_includes_optional_reason",
+        "line": 323,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
       }
     ],
     "tests/unit/gpt_trader/utilities/test_parsing.py": [
@@ -63754,6 +63840,16 @@
       {
         "name": "test_render_report_collapses_newlines_in_notes",
         "line": 126,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      }
+    ],
+    "tests/unit/scripts/test_docs_link_audit.py": [
+      {
+        "name": "test_iter_markdown_files_ignores_review_artifacts_tmp",
+        "line": 6,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary
The order-event recording path called `log_order_submission`, `log_order_status_change`, and `log_event` on the monitoring logger, but those methods were never defined on `StructuredLogger`.

`get_monitoring_logger()` (`gpt_trader.monitoring.system.get_logger`) returns a `StructuredLogger` from `gpt_trader/utilities/logging_patterns.py`, which only defined the standard `info`/`warning`/`error`/`debug`/`critical`/`log`/`exception` methods. So at runtime every order submission, status change, and preview raised `AttributeError` (as seen in `var/logs/coinbase_trader.log`). The best-effort `try/except` wrappers in `order_event_recorder.py` swallowed the error into a noisy `logger.exception("Failed to log ...")` traceback instead of recording the event.

This was masked in tests because the existing recorder tests mock the monitoring logger with `MagicMock`, which auto-creates the missing methods — the real `StructuredLogger` never gained them.

Fix implements the intended contract (option **a**) on `StructuredLogger`, matching the kwargs used at the call sites and asserted by the existing mocked tests, rather than rewriting every call site/test.

Related issue / finding / routed package: order-event recorder `AttributeError` on monitoring logger (spot/CFM execution path)

## Type of change
- [ ] Refactor
- [ ] Feature
- [x] Bug fix
- [ ] Tests only
- [ ] CI/Docs/Tooling

## Scope & Impact
- Affected areas / components:
  - `src/gpt_trader/utilities/logging_patterns.py` — added `log_event`, `log_order_submission`, `log_order_status_change` (plus a `_coerce_level` helper) to `StructuredLogger`.
  - Consumers fixed without code changes: `features/live_trade/execution/order_event_recorder.py` (lines 91, 179, 248, 313) and `monitoring/system/metrics.py:77` (same latent `log_event` failure).
- Any behavior changes? Yes — these calls now emit structured INFO log records (with the kwargs preserved as record attributes) instead of raising `AttributeError` and logging a swallowed traceback. This affects the **shared spot/CFM execution path** via `OrderSubmitter` → `OrderEventRecorder` (not INTX-only). No change to order flow control: the calls were already best-effort.

## Test Plan
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Contract tests (if applicable)
- [x] Ran locally: `uv run pytest tests/unit/.../execution tests/unit/.../utilities tests/unit/.../monitoring/system` (686 passed)
- [x] Markers used appropriately

Details:
- Added direct unit tests for the three new `StructuredLogger` methods in `tests/unit/gpt_trader/utilities/test_logging_patterns_domain.py` (field propagation, level coercion from `LogLevel` enum / string / int, optional `reason`, `None` price).
- Added `tests/unit/gpt_trader/features/live_trade/execution/test_order_event_recorder_real_logger.py`, which exercises `OrderEventRecorder` against the **real, unmocked** monitoring logger and asserts the recorder never falls back to `logger.exception` (i.e. no `AttributeError`), while verifying the structured records are emitted.

## Complexity & Quality Gates
- [x] Mypy/type-check passed (`uv run mypy` on touched src files: clean)
- [ ] Xenon/radon complexity gate passed (CC ≤ 15 on live_trade execution)
- [x] No `sys.path` hacks in tests
- [x] No `MagicMock` on `async def` (use `AsyncMock`)
- [x] Import-lint rules respected (no “import up the stack”)

## Observability & Errors
- [x] Structured JSON logs for new/changed paths — the new helpers emit structured records carrying `event_type`, `operation`, and the order context (`order_id`, `client_order_id`, `symbol`, etc.)
- [x] Errors include diagnostic context (symbol, order_id, correlation_id)
- [x] Added/updated sampling examples in tests (if applicable)

## Configuration
- [ ] If config changed: `python -m gpt_trader.cli.config validate --profile <name>` passes
- [ ] Env docs re-generated (if applicable) and committed
- [x] No `ConfigLoader` usages introduced (ConfigManager-only)

## Breaking Changes
- [x] None
- [ ] Documented in PR body and release notes if any

## Checklist
- [x] Acceptance criteria in linked issue(s), finding packet, or routed package met
- [x] Affected paths listed in PR description
- [ ] Changelog entry (if repo uses one)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYkXhWx2oTpXP861qWEMkX

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYkXhWx2oTpXP861qWEMkX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added monitoring-style structured logging helpers for emitting order submission and order status change events with consistent event types and key attributes.
  * Improved level coercion for more consistent structured event output.
  * Updated the event catalog to include a new `order_status` event and enrich `order_submit` common fields.

* **Bug Fixes**
  * Improved reliability around order event recording, ensuring structured logging paths are used without triggering fallback logging.

* **Tests**
  * Added unit and real-logger integration coverage for structured fields, level coercion, and optional reason handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->