### PR TITLE
ci: gate release image publishing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,34 +1,29 @@
-name: Deploy
+name: Release Image
 
 on:
   push:
-    branches: [main, staging]
-    tags: ['v*']
+    tags:
+      - 'v*'
   workflow_dispatch:
     inputs:
-      environment:
-        description: 'Environment to deploy to'
+      release_note:
+        description: 'Decision packet, runbook, or release note reference for this image publication'
         required: true
-        default: 'staging'
-        type: choice
-        options:
-          - staging
-          - production
-          - rollback
+        type: string
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}/gpt-trader
 
 concurrency:
-  group: deploy-${{ github.ref }}
-  cancel-in-progress: false  # Don't cancel in-progress deployments
+  group: release-image-${{ github.ref }}
+  cancel-in-progress: false
 
 permissions: {}
 
 jobs:
   build-image:
-    name: Build Docker Image
+    name: Build, Publish, and Scan Docker Image
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -40,6 +35,17 @@ jobs:
       image-tag: ${{ steps.scan-target.outputs.image }}
       image-digest: ${{ steps.build.outputs.digest }}
     steps:
+      - name: Confirm release boundary
+        env:
+          RELEASE_NOTE: ${{ github.event.inputs.release_note }}
+        run: |
+          set -euo pipefail
+          reference="${RELEASE_NOTE:-${GITHUB_REF_NAME:-unknown}}"
+          echo "Publishing and scanning a release image only."
+          echo "Reference: ${reference}"
+          echo "This workflow does not deploy staging or production."
+          echo "It does not run canary/prod preflight, broker/API commands, money movement, or order submission."
+
       - name: Checkout code
         # actions/checkout@v7
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
@@ -109,152 +115,3 @@ jobs:
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e
         with:
           sarif_file: 'trivy-results.sarif'
-
-  deploy-staging:
-    name: Deploy to Staging
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    needs: build-image
-    if: github.ref == 'refs/heads/staging' || github.event.inputs.environment == 'staging'
-    environment:
-      name: staging
-      url: https://staging.trading.example.com
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout code
-        # actions/checkout@v7
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
-        with:
-          persist-credentials: false
-
-      - name: Configure AWS credentials
-        # aws-actions/configure-aws-credentials@v6
-        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
-
-      - name: Update kubeconfig
-        run: aws eks update-kubeconfig --name trading-staging --region us-east-1
-
-      - name: Deploy to Kubernetes
-        run: |
-          kubectl set image deployment/trading-bot \
-            trading-bot=${{ needs.build-image.outputs.image-tag }} \
-            -n trading-system
-          kubectl rollout status deployment/trading-bot -n trading-system
-
-      - name: Run smoke tests
-        run: |
-          sleep 30
-          curl -f https://staging.trading.example.com/health || exit 1
-
-  deploy-production:
-    name: Deploy to Production
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    needs: [build-image, deploy-staging]
-    if: github.ref == 'refs/heads/main' || github.event.inputs.environment == 'production'
-    environment:
-      name: production
-      url: https://trading.example.com
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout code
-        # actions/checkout@v7
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
-        with:
-          persist-credentials: false
-
-      - name: Configure AWS credentials
-        # aws-actions/configure-aws-credentials@v6
-        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b
-        with:
-          aws-access-key-id: ${{ secrets.PROD_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.PROD_AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
-
-      - name: Update kubeconfig
-        run: aws eks update-kubeconfig --name trading-production --region us-east-1
-
-      - name: Blue-Green Deployment
-        run: |
-          # Create new deployment (green)
-          kubectl apply -f deploy/gpt_trader/kubernetes/deployment.yaml \
-            -n trading-system \
-            --dry-run=client -o yaml | \
-            sed 's/trading-bot/trading-bot-green/g' | \
-            kubectl apply -f -
-
-          # Update green deployment with new image
-          kubectl set image deployment/trading-bot-green \
-            trading-bot=${{ needs.build-image.outputs.image-tag }} \
-            -n trading-system
-
-          # Wait for green deployment to be ready
-          kubectl rollout status deployment/trading-bot-green -n trading-system
-
-          # Switch traffic to green
-          kubectl patch service trading-bot-service \
-            -p '{"spec":{"selector":{"deployment":"green"}}}' \
-            -n trading-system
-
-          # Wait and monitor
-          sleep 60
-
-          # If successful, remove blue deployment
-          kubectl delete deployment trading-bot -n trading-system || true
-          kubectl label deployment trading-bot-green deployment=blue -n trading-system
-
-      - name: Run production health checks
-        run: |
-          curl -f https://trading.example.com/health || exit 1
-          curl -f https://api.trading.example.com/ready || exit 1
-
-      - name: Send deployment notification
-        if: always()
-        # slackapi/slack-github-action@v3
-        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c
-        with:
-          payload: |
-            {
-              "text": "Production deployment ${{ job.status }} for version ${{ needs.build-image.outputs.image-tag }}"
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
-
-  rollback:
-    name: Rollback Deployment
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    if: github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'rollback'
-    permissions: {}
-    steps:
-      - name: Configure AWS credentials
-        # aws-actions/configure-aws-credentials@v6
-        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b
-        with:
-          aws-access-key-id: ${{ secrets.PROD_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.PROD_AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
-
-      - name: Rollback to previous version
-        run: |
-          aws eks update-kubeconfig --name trading-production --region us-east-1
-          kubectl rollout undo deployment/trading-bot -n trading-system
-          kubectl rollout status deployment/trading-bot -n trading-system
-
-      - name: Notify rollback
-        if: always()
-        # slackapi/slack-github-action@v3
-        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c
-        with:
-          payload: |
-            {
-              "text": "Rollback ${{ job.status }} for trading-bot deployment"
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,10 +37,19 @@ jobs:
     steps:
       - name: Confirm release boundary
         env:
+          EVENT_NAME: ${{ github.event_name }}
           RELEASE_NOTE: ${{ github.event.inputs.release_note }}
         run: |
           set -euo pipefail
-          reference="${RELEASE_NOTE:-${GITHUB_REF_NAME:-unknown}}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            reference="${RELEASE_NOTE:-}"
+            [ -n "${reference//[[:space:]]/}" ] || {
+              echo "release_note is required for manual release-image runs" >&2
+              exit 1
+            }
+          else
+            reference="${GITHUB_REF_NAME:-unknown}"
+          fi
           echo "Publishing and scanning a release image only."
           echo "Reference: ${reference}"
           echo "This workflow does not deploy staging or production."

--- a/deploy/gpt_trader/README.md
+++ b/deploy/gpt_trader/README.md
@@ -11,7 +11,7 @@ production, and optional security scanning. The base compose file
 (`docker/docker-compose.yaml`) now focuses on the essentials: the trading bot
 and opt-in Prometheus/Grafana metrics via the `observability` profile. The
 production reverse proxy (Nginx) lives in the optional
-`docker-compose.infrastructure.yaml` override.
+`docker/docker-compose.infrastructure.yaml` override.
 
 ## Image Targets
 The Dockerfile defines several stages selectable via the `BUILD_TARGET` build argument:

--- a/deploy/gpt_trader/README.md
+++ b/deploy/gpt_trader/README.md
@@ -1,11 +1,17 @@
 # gpt_trader Docker Deployment
 
-This directory hosts the active Docker assets for the gpt_trader trading system. The
-multi-stage Dockerfile builds uv-managed dependencies and exposes
-separate targets for development, testing, production, and optional security scanning. The base
-compose file (`docker/docker-compose.yaml`) now focuses on the essentials: the trading bot and
-opt-in Prometheus/Grafana metrics via the `observability` profile. The production reverse proxy
-(Nginx) lives in the optional `docker-compose.infrastructure.yaml` override.
+This directory hosts the Docker assets for the gpt_trader trading system. These
+assets are not an approval to run live automation or deploy production; live
+operations remain subject to the readiness gates in `docs/production.md` and
+the decision boundary in `docs/PRE_MIGRATION_DECISION_FRAMEWORK.md`. The
+GitHub release-image workflow only publishes and scans images for version tags
+or explicit manual runs. The multi-stage Dockerfile builds uv-managed
+dependencies and exposes separate targets for development, testing,
+production, and optional security scanning. The base compose file
+(`docker/docker-compose.yaml`) now focuses on the essentials: the trading bot
+and opt-in Prometheus/Grafana metrics via the `observability` profile. The
+production reverse proxy (Nginx) lives in the optional
+`docker-compose.infrastructure.yaml` override.
 
 ## Image Targets
 The Dockerfile defines several stages selectable via the `BUILD_TARGET` build argument:

--- a/docs/DEVELOPMENT_GUIDELINES.md
+++ b/docs/DEVELOPMENT_GUIDELINES.md
@@ -100,7 +100,9 @@ bypass guards:
 - `Nightly Validation`: Coinbase websocket and harness smoke tests on a nightly cadence.
 - `Nightly Full Suite`: Scheduled full pytest run (slow markers included); manually triggerable for debugging.
 - `Security Audit`: Weekly pip-audit export to catch dependency vulnerabilities.
-- `GPT-Trader CI/CD Pipeline`: End-to-end build and deployment flow for staging/production releases; Docker publish is skipped on pull requests.
+- `Release Image`: Version-tag or manual Docker image publication with Trivy
+  scanning; normal branch pushes do not publish images or deploy
+  staging/production.
 - `Windows Portability`: Focused unit tests on windows-latest for persistence, monitoring, and scripts (see `windows-unit-tests` job in `.github/workflows/ci.yml`). Catches portability bugs for Windows development environment. Complements the default Ubuntu matrix. Added to address #955; currently runs on PRs (passes in recent merges) but not enforced as required check.
 
 ### Local CI Command

--- a/docs/DEVELOPMENT_GUIDELINES.md
+++ b/docs/DEVELOPMENT_GUIDELINES.md
@@ -100,9 +100,9 @@ bypass guards:
 - `Nightly Validation`: Coinbase websocket and harness smoke tests on a nightly cadence.
 - `Nightly Full Suite`: Scheduled full pytest run (slow markers included); manually triggerable for debugging.
 - `Security Audit`: Weekly pip-audit export to catch dependency vulnerabilities.
-- `Release Image`: Version-tag or manual Docker image publication with Trivy
-  scanning; normal branch pushes do not publish images or deploy
-  staging/production.
+- `Release Image`: Version-tag or manual Docker image publication (manual runs
+  require a `release_note` reference) with Trivy scanning; normal branch pushes
+  do not publish images or deploy staging/production.
 - `Windows Portability`: Focused unit tests on windows-latest for persistence, monitoring, and scripts (see `windows-unit-tests` job in `.github/workflows/ci.yml`). Catches portability bugs for Windows development environment. Complements the default Ubuntu matrix. Added to address #955; currently runs on PRs (passes in recent merges) but not enforced as required check.
 
 ### Local CI Command


### PR DESCRIPTION
## Summary
Related issue / finding / routed package: delegated goal from source thread `019f1139-5b2a-7943-b921-b678bfce88cd`

Realigns `.github/workflows/deploy.yml` with the current `human_approved_execution` readiness boundary. The workflow was real enough to publish GHCR images and upload Trivy SARIF on ordinary `main` pushes, while staging/production jobs were skipped/placeholder-like. It now runs only for `v*` tags or explicit manual runs with a release note reference, publishes/scans the image, and contains no staging, production, rollback, AWS, Kubernetes, Slack, canary/prod preflight, broker/API, money movement, or order-submission steps.

## Type of change
- [x] CI/Docs/Tooling

## Scope & Impact
- Affected areas / components: `.github/workflows/deploy.yml`, `deploy/gpt_trader/README.md`, `docs/DEVELOPMENT_GUIDELINES.md`
- Behavior changes: normal branch pushes, including docs-only merges to `main`, no longer publish Docker images or imply deployment. Version tags and explicit manual release-image runs still build/publish/scan the Docker image.

## Evidence
- Recent read-only GitHub run evidence: deploy run `28326284715` for `docs: reground project status (#1050)` ran on a normal `main` push, built and pushed the Docker image, uploaded Trivy results, and skipped staging/production.
- Current repo docs keep Stage 1 in `human_approved_execution` / readiness-gated posture; production/live-operation docs do not authorize default production deploys.

## Test Plan
- [x] YAML parser/assertion validation for `.github/workflows/deploy.yml` passed. `actionlint` was not installed locally, so this is parser-based plus explicit checks that branch push triggers, deploy jobs, AWS/EKS/kubectl/Slack operations, and staging/production workflow inputs are absent.
- [x] `git diff --check`
- [x] `uv run python scripts/maintenance/docs_reachability_check.py`
- [x] Commit hook `check yaml` passed.

## External follow-up
- Consider removing or locking any obsolete GitHub Environment secrets/rules for the old staging/production/rollback workflow lanes if they are no longer intended.
- Consider reviewing GHCR tags/images that were published by prior docs-only `main` pushes, especially any misleading `latest` tag.

## Checklist
- [x] Acceptance criteria in linked issue(s), finding packet, or routed package met
- [x] Affected paths listed in PR description
- [ ] Changelog entry (if repo uses one)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Repurposed the release-image workflow to publish and security-scan Docker images on version tag pushes (`v*`) and approved manual runs that require a release note.
* **Bug Fixes**
  * Ensured the workflow stops after the security scan/upload, removing any follow-on deploy/rollback behavior.
  * Removed staging/production deployment and rollback from the release-image workflow so branch pushes won’t publish or deploy images.
* **Documentation**
  * Updated development guidelines and GPT-Trader README to clarify release-image readiness gates and optional compose/proxy/observability layering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->