### PR TITLE
docs: align CI contract with live workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ gh pr create --fill
 gh pr merge --auto --squash --delete-branch
 ```
 
-If you touch `var/agents/**` or any agent-artifact inputs (notably `scripts/agents/**` or `config/environments/.env.template`), run `uv run agent-regenerate` and commit the updated artifacts (CI fails when they’re stale). To check quickly: `uv run agent-regenerate --verify`.
+If you touch `var/agents/**` or any agent-artifact inputs (notably `scripts/agents/**` or `config/environments/.env.template`), run `uv run agent-regenerate` and commit the updated artifacts. Local `make ci-required` and non-PR CI fail when they are stale; GitHub pull request CI reports stale artifacts as non-blocking. To check quickly: `uv run agent-regenerate --verify`.
 
 ### Quality Checks
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -335,15 +335,23 @@ pre-commit run --all-files
 
 ## CI Lanes
 
-The CI workflow (`.github/workflows/ci.yml`) runs checks in parallel lanes for faster feedback and isolated failures.
+The CI workflow (`.github/workflows/ci.yml`) runs checks in parallel lanes for
+faster feedback and isolated failures. The compact blocking/advisory contract
+lives in
+[`docs/DEVELOPMENT_GUIDELINES.md`](docs/DEVELOPMENT_GUIDELINES.md#continuous-integration);
+keep this section as a local command quick-reference, not a second source of
+truth for branch protection.
 
 ### Lane Overview
 
 | Lane | Job Name | Command | Purpose |
 |------|----------|---------|---------|
 | **Lint** | `lint` | `uv run ruff check . && uv run black --check .` | Code style |
+| **Docs Audit** | `docs-audit` | `uv run python scripts/maintenance/docs_link_audit.py && uv run python scripts/maintenance/docs_reachability_check.py` | Docs links and reachability |
 | **Type Check** | `typecheck` | `uv run mypy src` | Static typing |
+| **Agent Freshness** | `agent-freshness` | `uv run agent-regenerate --verify` | Generated agent inventories |
 | **TUI CSS** | `tui-css` | `python scripts/ci/check_tui_css_up_to_date.py` | Generated CSS in sync |
+| **Test Guardrails** | `test-guardrails` | `uv run python scripts/ci/check_test_hygiene.py` | Test hygiene and boundary checks |
 | **Unit (Core)** | `unit-tests` | `uv run pytest tests/unit -n auto -q --ignore-glob=tests/unit/gpt_trader/tui/test_snapshots_*.py` | Fast unit tests |
 | **TUI Snapshots** | `tui-snapshots` | `uv run pytest tests/unit/gpt_trader/tui/test_snapshots_*.py -v` | Visual regression |
 | **Property** | `property-tests` | `uv run pytest tests/property -v` | Property-based tests |

--- a/docs/DEVELOPMENT_GUIDELINES.md
+++ b/docs/DEVELOPMENT_GUIDELINES.md
@@ -94,14 +94,22 @@ bypass guards:
 
 ## Continuous Integration
 
-- `Python CI`: Default PR gate; runs selective tests on pull requests and full coverage on direct pushes.
-- `Targeted Suites`: Matrix guarding Coinbase, perps, and live-trade regressions when relevant paths change.
-- `Perps Validation`: Focused derivatives/perps health check; formerly the “phase6” workflow.
-- `Nightly Validation`: Coinbase websocket and harness smoke tests on a nightly cadence.
-- `Nightly Full Suite`: Scheduled full pytest run (slow markers included); manually triggerable for debugging.
-- `Security Audit`: Weekly pip-audit export to catch dependency vulnerabilities.
-- `GPT-Trader CI/CD Pipeline`: End-to-end build and deployment flow for staging/production releases; Docker publish is skipped on pull requests.
-- `Windows Portability`: Focused unit tests on windows-latest for persistence, monitoring, and scripts (see `windows-unit-tests` job in `.github/workflows/ci.yml`). Catches portability bugs for Windows development environment. Complements the default Ubuntu matrix. Added to address #955; currently runs on PRs (passes in recent merges) but not enforced as required check.
+This section is the compact contributor-facing CI contract. The executable
+source of truth remains `.github/workflows/*.yml` plus GitHub branch protection.
+Current `main` branch protection requires only the named `CI` contexts listed in
+the first row below, with strict up-to-date checks and conversation resolution
+enabled. There is no current path-filtered workflow; if a path-conditional lane
+is added later, add it to this table.
+
+| Check / workflow job | Tier | Trigger | Blocking status | Why it exists |
+| --- | --- | --- | --- | --- |
+| `CI` / `Lint & Format`, `Docs Link Audit`, `Type Check`, `TUI CSS Check`, `Test Guardrails`, `Unit Tests (Core)`, `TUI Snapshot Tests`, `Property Tests`, `Contract Tests` | Required merge safety | `pull_request`, `merge_group`, push to `main`/`develop`, manual | Required by `main` branch protection | Fast repo integrity, docs reachability, type checks, generated TUI CSS, and core test coverage |
+| `CI` / `Agent Health` | Advisory PR health | Same as `CI` | Not branch-protection required | Publishes an agent-health report without defining merge eligibility |
+| `CI` / `Agent Artifacts Freshness` | Generated artifact advisory on PR; blocking outside PR | Same as `CI` | Not branch-protection required; exits successfully with a warning on `pull_request`, fails on non-PR events when stale | Shows when `var/agents/**` needs regeneration without stalling ordinary PRs |
+| `CI` / `Windows Unit Tests (Portability)` and `Dependency Review` | Event/compatibility advisory | Windows follows `CI`; dependency review is `pull_request` only | Not branch-protection required | Covers Windows-sensitive units and high-severity dependency changes |
+| `CodeQL` / `Analyze Python` | Scheduled/security advisory | Push/PR to `main`/`develop`; weekly Monday 06:00 UTC | Not branch-protection required | GitHub code scanning |
+| `Agent Artifacts Refresh` / `Refresh, validate, and publish package`, `Verify uploaded package`; `UV Lock Upgrade` / `Upgrade uv.lock` | Scheduled/advisory maintenance | Scheduled and manual | Not branch-protection required; may publish a branch or PR | Keeps generated agent artifacts and dependency lock maintenance visible |
+| `Deploy` / `Build Docker Image`, `Deploy to Staging`, `Deploy to Production`, `Rollback Deployment`; `Integration Tests (Manual)` / `Coinbase Integration` | Release/readiness | Push to `main`/`staging`/tags or manual | Outside the PR merge gate; requires environment/secrets and project approval boundaries | Container/deploy and manual Coinbase checks; does not grant live trading, canary, or order authority |
 
 ### Local CI Command
 
@@ -147,7 +155,7 @@ checks were skipped and why.
 | Command | Intended use | Agent artifacts freshness | Readiness gate |
 | --- | --- | --- | --- |
 | `make ci-required` | Local PR-readiness validation surface | Blocking local step | Not run |
-| GitHub pull_request CI | GitHub PR validation in Actions | Non-blocking if stale on pull requests | Not run |
+| GitHub `pull_request` CI | GitHub PR validation in Actions | Non-blocking if stale on pull requests | Not run |
 | `uv run local-ci` / strict/full | Local PR-readiness validation plus local/live readiness evidence | Blocking local step | Runs `scripts/ci/check_readiness_gate.py --profile canary --strict` |
 | `uv run local-ci --profile quick` | Fast development loop | Skipped with an explicit banner reason | Skipped with an explicit banner reason |
 
@@ -197,9 +205,12 @@ Local CI (`make ci-required` / `uv run local-ci`) can report failures before the
 
 ### Agent Artifacts Freshness
 
-The required **Agent Artifacts Freshness** check verifies generated inventories
-under `var/agents/**` are up to date with their sources. If it fails, regenerate
-the artifacts and commit the results.
+The **Agent Artifacts Freshness** check verifies generated inventories under
+`var/agents/**` are up to date with their sources. It is blocking for
+`make ci-required`, strict/full `uv run local-ci`, and non-PR GitHub CI events.
+On GitHub pull requests it reports stale artifacts as a non-blocking warning so
+ordinary PRs are not stalled by the scheduled refresh lane. If a blocking local
+check fails, regenerate the artifacts and commit the results.
 
 ```bash
 make agent-regenerate        # or: uv run agent-regenerate


### PR DESCRIPTION
## Summary
Related issue / finding / routed package: delegated `/goal` from parent thread `019f1139-5b2a-7943-b921-b678bfce88cd`

Align the contributor-facing CI documentation with the current workflow files and live `main` branch protection, without adding a new standalone CI doctrine document.

What changed:
- Replaced stale `docs/DEVELOPMENT_GUIDELINES.md` CI lane prose with a compact contract table covering required merge safety, advisory/event checks, scheduled maintenance, and release/readiness lanes.
- Pointed `CONTRIBUTING.md` back to that compact contract and kept its CI lane section as a local command quick-reference.
- Corrected `AGENTS.md` artifact freshness wording so local/non-PR blocking behavior is distinct from non-blocking GitHub pull request warnings.

Drift found:
- `docs/DEVELOPMENT_GUIDELINES.md` still named old lanes/workflows such as `Targeted Suites`, `Perps Validation`, `Nightly Validation`, `Nightly Full Suite`, `Security Audit`, and `GPT-Trader CI/CD Pipeline` that do not exist as current workflow files.
- Live branch protection currently requires these `CI` contexts on `main`: `Test Guardrails`, `Lint & Format`, `Type Check`, `Unit Tests (Core)`, `Property Tests`, `Contract Tests`, `TUI CSS Check`, `Docs Link Audit`, and `TUI Snapshot Tests`.
- Current workflow files are `agent-artifacts-refresh.yml`, `ci.yml`, `codeql.yml`, `deploy.yml`, `integration.yml`, and `uv_lock_upgrade.yml`.

No workflow YAML changed. No live broker/API/canary/order commands were run.

## Type of change
- [ ] Refactor
- [ ] Feature
- [ ] Bug fix
- [ ] Tests only
- [x] CI/Docs/Tooling

## Scope & Impact
- Affected areas / components: `AGENTS.md`, `CONTRIBUTING.md`, `docs/DEVELOPMENT_GUIDELINES.md`
- Behavior changes: None. Documentation-only alignment with current workflows and branch protection.

## Test Plan
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Contract tests (if applicable)
- [x] Ran locally: `uv run python scripts/maintenance/docs_link_audit.py`
- [x] Ran locally: `uv run python scripts/maintenance/docs_reachability_check.py`
- [x] Ran locally: `uv run local-ci --profile quick`
- [x] Markers used appropriately (`unit`/`integration`/`slow`/`perf`)

Verification details:
- `uv run python scripts/maintenance/docs_link_audit.py` -> passed, 68 Markdown files scanned.
- `uv run python scripts/maintenance/docs_reachability_check.py` -> passed, 45 docs files reachable.
- First `uv run local-ci --profile quick` run exposed an unsynced worktree environment: missing `optuna` and a transient mypy error before full dev extras were installed.
- `uv sync --all-extras --dev` -> installed missing optional/dev extras.
- Rerun `uv run local-ci --profile quick` -> passed, including mypy and 7,268 unit tests. Quick profile intentionally skipped readiness gate and agent artifacts freshness, matching the updated docs.

## Complexity & Quality Gates
- [x] Mypy/type-check passed
- [ ] Xenon/radon complexity gate passed (CC <= 15 on live_trade execution)
- [x] No `sys.path` hacks in tests
- [x] No `MagicMock` on `async def` (use `AsyncMock`)
- [x] Import-lint rules respected (no "import up the stack")

## Observability & Errors
- [ ] Structured JSON logs for new/changed paths
- [ ] Errors include diagnostic context (symbol, order_id, correlation_id)
- [ ] Added/updated sampling examples in tests (if applicable)

## Configuration
- [ ] If config changed: `python -m gpt_trader.cli.config validate --profile <name>` passes
- [ ] Env docs re-generated (if applicable) and committed
- [x] No `ConfigLoader` usages introduced (ConfigManager-only)

## Breaking Changes
- [x] None
- [ ] Documented in PR body and release notes if any

## Follow-up
- If the project wants path-conditional targeted suites, nightly full validation, or a dedicated security audit lane again, add actual workflow YAML in a sibling implementation lane before documenting those names.
- Keep deploy/manual integration/readiness lanes outside normal PR CI unless a separate decision packet explicitly changes that boundary.

## Checklist
- [x] Acceptance criteria in linked issue(s), finding packet, or routed package met
- [x] Affected paths listed in PR description
- [ ] Changelog entry (if repo uses one)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified CI guidance and workflow expectations for contributors.
  * Expanded the CI command reference with additional lanes and clearer links between local checks and the main CI contract.
  * Updated guidance on stale generated artifacts so pull request CI is described more accurately, including when it blocks and when it does not.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->