### PR TITLE
Tighten derivatives cleanup and workspace artifact handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ experiments/
 *.swo
 backups/
 tmp_ws_root/
+work/
 results/
 _tmp_status.txt
 
@@ -117,6 +118,7 @@ pip-audit-report.json
 .hypothesis/
 # var/ directory - ignore all except agents/
 var/*
+!var/README.md
 !var/agents/
 .mypy_cache/
 .pytest_cache/

--- a/scripts/maintenance/cleanup_workspace.py
+++ b/scripts/maintenance/cleanup_workspace.py
@@ -201,6 +201,7 @@ def rotate_large_file(
     threshold_mb: int,
     stale_minutes: int,
     category: str,
+    require_stale: bool = True,
 ) -> None:
     if not path.exists():
         return
@@ -210,19 +211,20 @@ def rotate_large_file(
     if size_mb < threshold_mb:
         return
 
-    stale_cutoff = utcnow() - timedelta(minutes=stale_minutes)
-    if datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc) > stale_cutoff:
-        session.record_action(
-            "rotate-skip",
-            path,
-            "active",
-            details={
-                "category": category,
-                "size_mb": round(size_mb, 2),
-                "reason": "recently_modified",
-            },
-        )
-        return
+    if require_stale:
+        stale_cutoff = utcnow() - timedelta(minutes=stale_minutes)
+        if datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc) > stale_cutoff:
+            session.record_action(
+                "rotate-skip",
+                path,
+                "active",
+                details={
+                    "category": category,
+                    "size_mb": round(size_mb, 2),
+                    "reason": "recently_modified",
+                },
+            )
+            return
 
     archive_dir.mkdir(parents=True, exist_ok=True)
     suffix = "".join(path.suffixes)
@@ -257,6 +259,24 @@ def rotate_large_file(
         session.record_error("rotate", path, exc)
 
 
+def clean_root_logs(
+    session: CleanupSession,
+    *,
+    threshold_mb: int,
+    stale_minutes: int,
+) -> None:
+    """Rotate the cleanup audit log itself when it grows too large."""
+    rotate_large_file(
+        session,
+        session.audit_path,
+        session.audit_path.parent / "archive",
+        threshold_mb=threshold_mb,
+        stale_minutes=stale_minutes,
+        category="cleanup_audit_log",
+        require_stale=False,
+    )
+
+
 def parse_rotation(file_path: Path) -> tuple[str, int] | None:
     parts = file_path.name.split(".")
     if len(parts) < 3:
@@ -285,19 +305,30 @@ def clean_tool_caches(session: CleanupSession, *, preserve_hypothesis: bool = Fa
 
 
 def clean_pycache_directories(session: CleanupSession) -> None:
-    """Remove __pycache__ directories from source and test trees."""
+    """Remove __pycache__ directories from maintained Python trees."""
     # Remove root-level __pycache__
     root_pycache = REPO_ROOT / "__pycache__"
     if root_pycache.exists():
         remove_path(session, root_pycache, category="python_cache", reason="bytecode_cache")
 
-    # Remove __pycache__ from source and test trees
-    search_roots = [REPO_ROOT / "src", REPO_ROOT / "tests"]
+    search_roots = [REPO_ROOT / "src", REPO_ROOT / "tests", REPO_ROOT / "scripts"]
     for root in search_roots:
         if not root.exists():
             continue
         for pycache in root.rglob("__pycache__"):
             remove_path(session, pycache, category="python_cache", reason="bytecode_cache")
+
+
+def clean_build_artifacts(session: CleanupSession) -> None:
+    targets = [
+        "build",
+        "dist",
+        "src/gpt_trader.egg-info",
+    ]
+    for rel in targets:
+        remove_path(
+            session, REPO_ROOT / rel, category="build_artifact", reason="regenerated_by_build"
+        )
 
 
 def clean_coverage_artifacts(session: CleanupSession) -> None:
@@ -312,6 +343,33 @@ def clean_coverage_artifacts(session: CleanupSession) -> None:
         remove_path(
             session, REPO_ROOT / rel, category="coverage_artifact", reason="regenerated_by_tests"
         )
+
+
+def clean_macos_artifacts(session: CleanupSession) -> None:
+    remove_path(
+        session,
+        REPO_ROOT / ".DS_Store",
+        category="macos_artifact",
+        reason="finder_metadata",
+    )
+    search_roots = [
+        REPO_ROOT / ".claude",
+        REPO_ROOT / ".github",
+        REPO_ROOT / "config",
+        REPO_ROOT / "deploy",
+        REPO_ROOT / "docs",
+        REPO_ROOT / "review_artifacts",
+        REPO_ROOT / "runtime_data",
+        REPO_ROOT / "scripts",
+        REPO_ROOT / "src",
+        REPO_ROOT / "tests",
+        REPO_ROOT / "var",
+    ]
+    for root in search_roots:
+        if not root.exists():
+            continue
+        for ds_store in root.rglob(".DS_Store"):
+            remove_path(session, ds_store, category="macos_artifact", reason="finder_metadata")
 
 
 def clean_var_logs(
@@ -414,9 +472,16 @@ def main() -> None:
     args = parse_args()
     session = CleanupSession(apply=args.apply, quiet=args.quiet)
 
+    clean_root_logs(
+        session,
+        threshold_mb=args.log_threshold_mb,
+        stale_minutes=args.stale_minutes,
+    )
     clean_tool_caches(session, preserve_hypothesis=args.preserve_hypothesis)
     clean_pycache_directories(session)
+    clean_build_artifacts(session)
     clean_coverage_artifacts(session)
+    clean_macos_artifacts(session)
     clean_var_logs(
         session,
         keep_rotations=args.keep_rotations,

--- a/scripts/maintenance/docs_link_audit.py
+++ b/scripts/maintenance/docs_link_audit.py
@@ -24,6 +24,7 @@ EXCLUDED_DIRS = {
     "data",
     "experiments",
     "logs",
+    "review_artifacts/tmp",
     "runtime_data",
     "var",
 }
@@ -44,7 +45,9 @@ def parse_args() -> argparse.Namespace:
 def iter_markdown_files(root: Path) -> list[Path]:
     markdown_files: list[Path] = []
     for path in root.rglob("*.md"):
-        if any(part in EXCLUDED_DIRS for part in path.parts):
+        rel_parts = path.relative_to(root).parts
+        rel_dirs = {"/".join(rel_parts[:index]) for index in range(1, len(rel_parts))}
+        if any(part in EXCLUDED_DIRS for part in rel_parts) or rel_dirs & EXCLUDED_DIRS:
             continue
         markdown_files.append(path)
     return markdown_files

--- a/src/gpt_trader/app/config/validation.py
+++ b/src/gpt_trader/app/config/validation.py
@@ -16,6 +16,8 @@ from pydantic import BaseModel, Field, ValidationError
 if TYPE_CHECKING:
     from gpt_trader.app.config.bot_config import BotConfig
 
+ALLOWED_COINBASE_DERIVATIVES_TYPES = frozenset({"intx_perps", "perpetuals", "us_futures"})
+
 
 class ConfigValidationError(Exception):
     """Raised when configuration values fail validation."""
@@ -97,6 +99,24 @@ def validate_config(config: BotConfig) -> list[str]:
     # Validate Symbols
     if not config.symbols:
         errors.append("symbols list cannot be empty")
+
+    raw_derivatives_type = config.coinbase_derivatives_type
+    if not isinstance(raw_derivatives_type, str):
+        errors.append(
+            "coinbase_derivatives_type must be one of: "
+            f"{', '.join(sorted(ALLOWED_COINBASE_DERIVATIVES_TYPES))}"
+        )
+        derivatives_type = ""
+    else:
+        derivatives_type = raw_derivatives_type.strip().lower()
+        if derivatives_type and derivatives_type not in ALLOWED_COINBASE_DERIVATIVES_TYPES:
+            errors.append(
+                f"coinbase_derivatives_type must be one of: "
+                f"{', '.join(sorted(ALLOWED_COINBASE_DERIVATIVES_TYPES))}; "
+                f"got {raw_derivatives_type!r}"
+            )
+    if config.derivatives_enabled and not derivatives_type:
+        errors.append("coinbase_derivatives_type must be set when derivatives_enabled is true")
 
     raw_trading_modes = config.trading_modes
     if not isinstance(raw_trading_modes, list):

--- a/src/gpt_trader/features/live_trade/symbols.py
+++ b/src/gpt_trader/features/live_trade/symbols.py
@@ -73,7 +73,7 @@ def us_futures_enabled(profile: Profile, *, config: BotConfig) -> bool:
         return True
 
     # Check derivatives type
-    if config.coinbase_derivatives_type == "us_futures":
+    if config.coinbase_derivatives_type.strip().lower() == "us_futures":
         return True
 
     return False
@@ -90,11 +90,11 @@ def intx_perpetuals_enabled(profile: Profile, *, config: BotConfig) -> bool:
     if config.coinbase_intx_perpetuals_enabled:
         return True
 
-    # Check derivatives type (default to INTX)
-    if config.coinbase_derivatives_type in ("intx_perps", "perpetuals"):
+    # INTX is frozen; only an explicit INTX derivatives type enables this helper.
+    if config.coinbase_derivatives_type.strip().lower() in ("intx_perps", "perpetuals"):
         return True
 
-    return True
+    return False
 
 
 def normalize_symbol_list(

--- a/tests/unit/gpt_trader/app/config/test_validation.py
+++ b/tests/unit/gpt_trader/app/config/test_validation.py
@@ -166,3 +166,38 @@ class TestValidateConfigCFMConsistency:
         errors = validate_config(BotConfig(cfm_enabled=True, trading_modes=["spot", "cfm"]))
 
         assert errors == []
+
+
+class TestValidateConfigCoinbaseDerivativesType:
+    """Tests for Coinbase derivatives venue type validation."""
+
+    def test_known_derivatives_types_are_valid(self) -> None:
+        for derivatives_type in ("intx_perps", "perpetuals", "us_futures"):
+            errors = validate_config(BotConfig(coinbase_derivatives_type=derivatives_type))
+
+            assert errors == []
+
+    def test_derivatives_type_is_case_and_whitespace_tolerant(self) -> None:
+        errors = validate_config(BotConfig(coinbase_derivatives_type=" US_FUTURES "))
+
+        assert errors == []
+
+    def test_unknown_derivatives_type_is_invalid(self) -> None:
+        errors = validate_config(BotConfig(coinbase_derivatives_type="options"))
+
+        assert (
+            "coinbase_derivatives_type must be one of: intx_perps, perpetuals, us_futures; "
+            "got 'options'"
+        ) in errors
+
+    def test_derivatives_enabled_requires_nonempty_derivatives_type(self) -> None:
+        errors = validate_config(BotConfig(derivatives_enabled=True, coinbase_derivatives_type=""))
+
+        assert "coinbase_derivatives_type must be set when derivatives_enabled is true" in errors
+
+    def test_derivatives_type_must_be_a_string(self) -> None:
+        errors = validate_config(BotConfig(coinbase_derivatives_type=None))  # type: ignore[arg-type]
+
+        assert (
+            "coinbase_derivatives_type must be one of: intx_perps, perpetuals, us_futures" in errors
+        )

--- a/tests/unit/gpt_trader/features/live_trade/test_symbols_derivatives.py
+++ b/tests/unit/gpt_trader/features/live_trade/test_symbols_derivatives.py
@@ -136,6 +136,14 @@ class TestIntxPerpetualsEnabled:
         result = symbols.intx_perpetuals_enabled(Profile.PROD, config=config)
         assert result is True
 
+    def test_returns_false_when_derivatives_type_is_us_futures(self) -> None:
+        config = make_bot_config_extended(
+            derivatives_enabled=True,
+            coinbase_derivatives_type="us_futures",
+        )
+        result = symbols.intx_perpetuals_enabled(Profile.PROD, config=config)
+        assert result is False
+
     def test_returns_true_when_derivatives_type_is_perpetuals(self) -> None:
         config = make_bot_config_extended(
             derivatives_enabled=True,
@@ -144,7 +152,7 @@ class TestIntxPerpetualsEnabled:
         result = symbols.intx_perpetuals_enabled(Profile.PROD, config=config)
         assert result is True
 
-    def test_returns_true_by_default(self) -> None:
+    def test_returns_false_without_explicit_intx_type(self) -> None:
         config = make_bot_config_extended(derivatives_enabled=True)
         result = symbols.intx_perpetuals_enabled(Profile.PROD, config=config)
-        assert result is True
+        assert result is False

--- a/tests/unit/scripts/test_cleanup_workspace.py
+++ b/tests/unit/scripts/test_cleanup_workspace.py
@@ -5,7 +5,6 @@ from datetime import timedelta
 from pathlib import Path
 
 import pytest
-
 from scripts.maintenance import cleanup_workspace
 
 
@@ -101,3 +100,55 @@ def test_rotate_large_file_archives_stale(
     assert log_path.exists()
     assert log_path.stat().st_size == 0
     assert list(archive_dir.glob("runtime_*.log.gz"))
+
+
+def test_clean_root_logs_rotates_recent_large_audit_log(
+    cleanup_session: cleanup_workspace.CleanupSession,
+) -> None:
+    audit_path = cleanup_session.audit_path
+    audit_path.write_bytes(b"x" * 2048)
+
+    cleanup_workspace.clean_root_logs(
+        cleanup_session,
+        threshold_mb=0,
+        stale_minutes=60,
+    )
+
+    assert audit_path.exists()
+    assert audit_path.stat().st_size > 0
+    assert list((audit_path.parent / "archive").glob("cleanup_audit_*.log.gz"))
+
+
+def test_clean_pycache_directories_includes_scripts(
+    cleanup_session: cleanup_workspace.CleanupSession, tmp_path: Path
+) -> None:
+    scripts_pycache = tmp_path / "scripts" / "maintenance" / "__pycache__"
+    scripts_pycache.mkdir(parents=True)
+
+    cleanup_workspace.clean_pycache_directories(cleanup_session)
+
+    assert scripts_pycache.exists() is False
+
+
+def test_clean_build_artifacts_removes_egg_info(
+    cleanup_session: cleanup_workspace.CleanupSession, tmp_path: Path
+) -> None:
+    egg_info = tmp_path / "src" / "gpt_trader.egg-info"
+    egg_info.mkdir(parents=True)
+    (egg_info / "PKG-INFO").write_text("metadata")
+
+    cleanup_workspace.clean_build_artifacts(cleanup_session)
+
+    assert egg_info.exists() is False
+
+
+def test_clean_macos_artifacts_removes_ds_store(
+    cleanup_session: cleanup_workspace.CleanupSession, tmp_path: Path
+) -> None:
+    ds_store = tmp_path / "docs" / ".DS_Store"
+    ds_store.parent.mkdir(parents=True)
+    ds_store.write_bytes(b"metadata")
+
+    cleanup_workspace.clean_macos_artifacts(cleanup_session)
+
+    assert ds_store.exists() is False

--- a/tests/unit/scripts/test_docs_link_audit.py
+++ b/tests/unit/scripts/test_docs_link_audit.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+from scripts.maintenance import docs_link_audit
+
+
+def test_iter_markdown_files_ignores_review_artifacts_tmp(tmp_path: Path) -> None:
+    docs_file = tmp_path / "docs" / "README.md"
+    scratch_file = tmp_path / "review_artifacts" / "tmp" / "scratch.md"
+    durable_artifact_file = tmp_path / "review_artifacts" / "summary.md"
+
+    docs_file.parent.mkdir()
+    docs_file.write_text("# docs\n")
+    scratch_file.parent.mkdir(parents=True)
+    scratch_file.write_text("[broken](missing.md)\n")
+    durable_artifact_file.write_text("# review\n")
+
+    markdown_files = {
+        path.relative_to(tmp_path) for path in docs_link_audit.iter_markdown_files(tmp_path)
+    }
+
+    assert Path("docs/README.md") in markdown_files
+    assert Path("review_artifacts/summary.md") in markdown_files
+    assert Path("review_artifacts/tmp/scratch.md") not in markdown_files

--- a/var/README.md
+++ b/var/README.md
@@ -1,0 +1,12 @@
+# Runtime Workspace
+
+Most of this directory is local runtime state created by development, test, and
+operator commands. Keep generated logs, databases, status files, dashboards, and
+temporary outputs out of commits.
+
+`var/agents/` is the tracked exception: it contains generated agent handoff
+artifacts and must be refreshed with `uv run agent-regenerate` when its inputs
+change.
+
+Use `make clean-dry-run` to inspect safe local cleanup actions and `make clean`
+to apply them.

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6994,
+    "total_tests": 7004,
     "total_files": 831,
     "markers_used": 16
   },

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6827,
+    "unit": 6837,
     "asyncio": 440,
     "parametrize": 205,
     "endpoints": 83,

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 6994,
+    "total_tests": 7004,
     "total_files": 831,
     "markers_used": 16
   },
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6827,
+    "unit": 6837,
     "asyncio": 440,
     "parametrize": 205,
     "endpoints": 83,
@@ -3593,6 +3593,51 @@
         ],
         "docstring": "",
         "class": "TestValidateConfigCFMConsistency"
+      },
+      {
+        "name": "TestValidateConfigCoinbaseDerivativesType::test_known_derivatives_types_are_valid",
+        "line": 174,
+        "markers": [
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestValidateConfigCoinbaseDerivativesType"
+      },
+      {
+        "name": "TestValidateConfigCoinbaseDerivativesType::test_derivatives_type_is_case_and_whitespace_tolerant",
+        "line": 180,
+        "markers": [
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestValidateConfigCoinbaseDerivativesType"
+      },
+      {
+        "name": "TestValidateConfigCoinbaseDerivativesType::test_unknown_derivatives_type_is_invalid",
+        "line": 185,
+        "markers": [
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestValidateConfigCoinbaseDerivativesType"
+      },
+      {
+        "name": "TestValidateConfigCoinbaseDerivativesType::test_derivatives_enabled_requires_nonempty_derivatives_type",
+        "line": 193,
+        "markers": [
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestValidateConfigCoinbaseDerivativesType"
+      },
+      {
+        "name": "TestValidateConfigCoinbaseDerivativesType::test_derivatives_type_must_be_a_string",
+        "line": 198,
+        "markers": [
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestValidateConfigCoinbaseDerivativesType"
       }
     ],
     "tests/unit/gpt_trader/app/config/test_validation_rules.py": [
@@ -30601,7 +30646,7 @@
         "class": "TestIntxPerpetualsEnabled"
       },
       {
-        "name": "TestIntxPerpetualsEnabled::test_returns_true_when_derivatives_type_is_perpetuals",
+        "name": "TestIntxPerpetualsEnabled::test_returns_false_when_derivatives_type_is_us_futures",
         "line": 139,
         "markers": [
           "unit"
@@ -30610,8 +30655,17 @@
         "class": "TestIntxPerpetualsEnabled"
       },
       {
-        "name": "TestIntxPerpetualsEnabled::test_returns_true_by_default",
+        "name": "TestIntxPerpetualsEnabled::test_returns_true_when_derivatives_type_is_perpetuals",
         "line": 147,
+        "markers": [
+          "unit"
+        ],
+        "docstring": "",
+        "class": "TestIntxPerpetualsEnabled"
+      },
+      {
+        "name": "TestIntxPerpetualsEnabled::test_returns_false_without_explicit_intx_type",
+        "line": 155,
         "markers": [
           "unit"
         ],
@@ -63369,7 +63423,7 @@
     "tests/unit/scripts/test_cleanup_workspace.py": [
       {
         "name": "test_clean_tool_caches_preserve_hypothesis",
-        "line": 25,
+        "line": 24,
         "markers": [
           "unit"
         ],
@@ -63377,7 +63431,7 @@
       },
       {
         "name": "test_clean_coverage_artifacts_removes_files",
-        "line": 37,
+        "line": 36,
         "markers": [
           "unit"
         ],
@@ -63385,7 +63439,7 @@
       },
       {
         "name": "test_clean_var_logs_prunes_archived_gz",
-        "line": 55,
+        "line": 54,
         "markers": [
           "unit"
         ],
@@ -63393,7 +63447,39 @@
       },
       {
         "name": "test_rotate_large_file_archives_stale",
-        "line": 80,
+        "line": 79,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_clean_root_logs_rotates_recent_large_audit_log",
+        "line": 105,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_clean_pycache_directories_includes_scripts",
+        "line": 122,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_clean_build_artifacts_removes_egg_info",
+        "line": 133,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_clean_macos_artifacts_removes_ds_store",
+        "line": 145,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary
- tighten derivatives configuration validation and derivative symbol handling
- improve workspace cleanup handling for ignored review/runtime artifacts
- make docs link audit ignore `review_artifacts/tmp/` scratch markdown while preserving durable artifact scanning
- refresh generated test inventory artifacts

## Validation
- `uv run pytest tests/unit/scripts/test_cleanup_workspace.py tests/unit/gpt_trader/app/config/test_validation.py tests/unit/gpt_trader/features/live_trade/test_symbols_derivatives.py -q` -> 56 passed
- `uv run pytest tests/unit/scripts/test_docs_link_audit.py -q` -> 1 passed
- `python scripts/maintenance/docs_link_audit.py` -> passed
- `uv run agent-regenerate --verify` -> passed
- `uv run local-ci --profile quick` -> passed, including 7,274 core unit tests

## Notes
- No broker execution or live trading path is enabled by this change.
