### PR TITLE
[codex] Add default-off strategy signal trade idea adapter

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -23,7 +23,7 @@ the state per stage.
 | Stage | State |
 |-------|-------|
 | **0 — Rails** | **Complete** — all rubric evidence shipped and tested |
-| **1 — Human-approved loop** | **In progress (bridge remaining)** — reviewer tooling, attribution, real-data snapshot proposal (#1031), and paper-fill reconciliation (#1035) are operator-usable; the live strategy path is not yet routed through the approval workflow |
+| **1 — Human-approved loop** | **In progress (runtime bridge remaining)** — reviewer tooling, attribution, real-data snapshot proposal (#1031), paper-fill reconciliation (#1035), and the default-off strategy-signal adapter are operator-usable; the live strategy path is not yet routed through the approval workflow |
 | **2 — Bounded autonomy** | Not started |
 | **3 — Self-directed entity** | Not started |
 
@@ -42,23 +42,25 @@ the `gpt-trader ideas` CLI.
 The shipped surfaces turn the rails into most of a loop: reviewer tooling
 (CLI + TUI), outcome attribution, the track-record report, real-data
 `MarketSnapshot` proposal (`ideas snapshot build` → `ideas propose-baseline`,
-#1031 closed 2026-06-28), and paper-fill reconciliation onto the audit trail
-(`ideas reconcile-paper-fills`, #1035 closed 2026-06-28).
+#1031 closed 2026-06-28), paper-fill reconciliation onto the audit trail
+(`ideas reconcile-paper-fills`, #1035 closed 2026-06-28), and a default-off
+library adapter that maps supported strategy buy decisions into proposed trade
+ideas through `TradeIdeaService.propose()` only.
 
-The one remaining gap is the **strategy-signal bridge**: the existing TA/ensemble
-intelligence still does not emit trade ideas through `TradeIdeaService` (#1033,
-open and next). Build it through the existing spine, not a second proposer brain —
-see
+The remaining gap is **runtime strategy-signal routing**: the existing
+TA/ensemble intelligence still does not emit trade ideas from the live bot cycle
+through the approval workflow. Build that through the existing spine, not a
+second proposer brain — see
 [stabilize-before-closing-the-loop](decisions/stabilize-before-closing-the-loop.md).
 Track precise per-ticket status in the issue queue, not here.
 
 ## The structural fact
 
 The live TA bot (`features/live_trade/`) and the trade-idea workflow
-(`features/trade_ideas/`) still share **zero references in either direction**
-(verified 2026-06-28): the trading intelligence already built does not yet flow
-through the approval-gated rails. Bridging that seam (#1033) — not adding new
-feature surface — is the central remaining piece of Stage 1.
+(`features/trade_ideas/`) remain separated: strategy-to-idea mapping lives in
+`features/strategy_tools/trade_idea_adapter.py` as an explicit, default-off
+bridge, and the trading intelligence already built does not yet flow from the
+live bot cycle through the approval-gated rails.
 
 ## How to keep this doc honest
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -42,7 +42,7 @@ the `gpt-trader ideas` CLI.
 The shipped surfaces turn the rails into most of a loop: reviewer tooling
 (CLI + TUI), outcome attribution, the track-record report, real-data
 `MarketSnapshot` proposal (`ideas snapshot build` → `ideas propose-baseline`,
-#1031 closed 2026-06-28), paper-fill reconciliation onto the audit trail
+issue `#1031` closed 2026-06-28), paper-fill reconciliation onto the audit trail
 (`ideas reconcile-paper-fills`, #1035 closed 2026-06-28), and a default-off
 library adapter that maps supported strategy buy decisions into proposed trade
 ideas through `TradeIdeaService.propose()` only.

--- a/docs/architecture/SEAMS.md
+++ b/docs/architecture/SEAMS.md
@@ -30,6 +30,11 @@ The strategy seam is where market state becomes a **decision** (buy/sell/hold, s
 ### Notes
 - Prefer **returning domain-level actions** (from `gpt_trader.core`) over invoking broker APIs directly.
 - Avoid having strategies import concrete broker/persistence implementations.
+- The approval-path bridge for Stage 1 is
+  `src/gpt_trader/features/strategy_tools/trade_idea_adapter.py`: it maps
+  supported strategy decisions into proposed trade ideas through
+  `TradeIdeaService.propose()` only. It is default-off and does not wire the
+  live engine cycle or submit orders.
 
 ## 2) Execution seam
 

--- a/docs/specs/TRADE_IDEA_INTERFACES_DESIGN_NOTES.md
+++ b/docs/specs/TRADE_IDEA_INTERFACES_DESIGN_NOTES.md
@@ -23,6 +23,7 @@ already exists and is complete at the domain level:
 | `features/trade_ideas/audit.py` | Append-only `TradeIdeaAuditLog` (JSONL), `AuditEvent` |
 | `features/trade_ideas/store.py` | `TradeIdeaStore` — versioned records under record hash |
 | `features/trade_ideas/baseline.py`, `replay.py` | Baseline proposer and replay scoring |
+| `features/strategy_tools/trade_idea_adapter.py` | Default-off strategy decision → `TradeIdeaService.propose()` bridge |
 
 **Current interface state:** the CLI and TUI review surfaces now exist.
 `gpt-trader ideas` constructs `TradeIdeaService` through the trade-ideas factory
@@ -43,6 +44,14 @@ CLI, TUI, or MCP servers must stay thin adapters over these methods."*
 
 These notes preserve the interface decisions that shaped the implemented CLI and
 TUI surfaces. They are not a request to re-promote the TUI review workstream.
+
+The Stage 1 strategy-signal bridge starts as a library adapter, not runtime
+engine wiring. `StrategySignalToTradeIdeaAdapter` accepts an existing strategy
+decision shape plus explicit point-in-time context, maps supported buy signals
+to complete broker-neutral `TradeIdea` records, and submits them through
+`TradeIdeaService.propose()` only when explicitly enabled. Disabled, hold, sell,
+or close decisions produce no idea. It does not approve, preview, submit, modify,
+cancel, or reconcile orders, and it does not call broker/account APIs.
 
 ## Design Principles
 
@@ -69,6 +78,10 @@ TUI surfaces. They are not a request to re-promote the TUI review workstream.
 6. **Append-only mindset.** Interfaces never edit records in place. A change
    request produces a `needs_changes` event; the revised record is a new
    version saved via `resubmit`.
+7. **Default-off strategy bridges.** Strategy-signal bridges live outside the
+   broker-neutral `trade_ideas` core, require explicit enablement, and may only
+   call `TradeIdeaService.propose()` until a later decision/runbook scopes
+   runtime wiring.
 
 ## Shared Decisions (Workstream 0 — implemented)
 

--- a/src/gpt_trader/features/strategy_tools/__init__.py
+++ b/src/gpt_trader/features/strategy_tools/__init__.py
@@ -7,11 +7,21 @@ from gpt_trader.features.strategy_tools.filters import (
     create_conservative_filters,
 )
 from gpt_trader.features.strategy_tools.guards import RiskGuards, create_standard_risk_guards
+from gpt_trader.features.strategy_tools.trade_idea_adapter import (
+    StrategyDecisionSignal,
+    StrategySignalContext,
+    StrategySignalToTradeIdeaAdapter,
+    StrategySignalToTradeIdeaAdapterConfig,
+)
 
 __all__ = [
     "MarketConditionFilters",
     "RiskGuards",
+    "StrategyDecisionSignal",
     "StrategyEnhancements",
+    "StrategySignalContext",
+    "StrategySignalToTradeIdeaAdapter",
+    "StrategySignalToTradeIdeaAdapterConfig",
     "create_aggressive_filters",
     "create_conservative_filters",
     "create_standard_risk_guards",

--- a/src/gpt_trader/features/strategy_tools/trade_idea_adapter.py
+++ b/src/gpt_trader/features/strategy_tools/trade_idea_adapter.py
@@ -1,0 +1,291 @@
+"""Default-off bridge from strategy decisions to trade-idea proposals.
+
+The adapter is intentionally outside ``features.trade_ideas`` so the
+broker-neutral trade-idea slice does not import live strategy modules. It maps
+an existing strategy signal into a complete ``TradeIdea`` and, when requested,
+submits that idea through ``TradeIdeaService.propose`` only.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from typing import Any, Protocol, runtime_checkable
+
+from gpt_trader.errors import ValidationError
+from gpt_trader.features.trade_ideas import (
+    ActorType,
+    AutonomyMode,
+    Confidence,
+    ConfidenceLabel,
+    EntryZone,
+    MaxLoss,
+    ProductType,
+    SizingRecommendation,
+    TimeHorizon,
+    TradeDirection,
+    TradeIdea,
+    TradeIdeaService,
+    TradeIdeaView,
+    evaluate_eligibility,
+)
+
+_SAFE_SLUG = re.compile(r"[^a-z0-9._-]+")
+
+
+@runtime_checkable
+class StrategyDecisionSignal(Protocol):
+    """Structural strategy decision shape accepted by the adapter."""
+
+    action: Any
+    reason: str
+    confidence: float
+    indicators: Mapping[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class StrategySignalContext:
+    """Point-in-time context required to turn one strategy signal into an idea."""
+
+    symbol: str
+    current_mark: Decimal
+    as_of: datetime
+    strategy_name: str
+    data_source: str = "strategy:decision"
+    product_type: ProductType = ProductType.SPOT
+
+
+@dataclass(frozen=True, slots=True)
+class StrategySignalToTradeIdeaAdapterConfig:
+    """Configuration for the proposal-only strategy-signal adapter."""
+
+    enabled: bool = False
+    proposer_id_prefix: str = "strategy-signal"
+    risk_per_idea_pct: Decimal = Decimal("2")
+    entry_band_pct: Decimal = Decimal("1")
+    stop_loss_pct: Decimal = Decimal("2")
+    reward_multiple: Decimal = Decimal("2")
+    expiry_hours: int = 48
+    expected_hold: str = "1-5 days"
+    price_precision: Decimal = Decimal("0.01")
+
+
+class StrategySignalToTradeIdeaAdapter:
+    """Map strategy decisions to proposed trade ideas without execution side effects."""
+
+    def __init__(self, config: StrategySignalToTradeIdeaAdapterConfig | None = None) -> None:
+        self._config = config or StrategySignalToTradeIdeaAdapterConfig()
+
+    @property
+    def enabled(self) -> bool:
+        return self._config.enabled
+
+    def proposer_id(self, context: StrategySignalContext) -> str:
+        """Return the stable AI actor id recorded on proposal events."""
+        return f"{_safe_slug(self._config.proposer_id_prefix)}-{_safe_slug(context.strategy_name)}"
+
+    def map_decision(
+        self,
+        decision: StrategyDecisionSignal,
+        context: StrategySignalContext,
+    ) -> TradeIdea | None:
+        """Convert a strategy decision into a complete idea when enabled/actionable."""
+        if not self._config.enabled:
+            return None
+
+        self._validate_context(context)
+        action = _action_value(decision.action)
+        if action != "buy":
+            return None
+
+        confidence_value = _confidence_value(decision.confidence)
+        idea = self._build_long_idea(
+            decision=decision,
+            context=context,
+            confidence_value=confidence_value,
+        )
+        gaps = evaluate_eligibility(idea)
+        if gaps:
+            raise ValidationError(
+                "StrategySignalToTradeIdeaAdapter produced an ineligible idea: " + "; ".join(gaps)
+            )
+        return idea
+
+    def propose_decision(
+        self,
+        decision: StrategyDecisionSignal,
+        context: StrategySignalContext,
+        service: TradeIdeaService,
+    ) -> TradeIdeaView | None:
+        """Submit a mapped idea through ``TradeIdeaService.propose`` only."""
+        idea = self.map_decision(decision, context)
+        if idea is None:
+            return None
+
+        return service.propose(
+            idea,
+            actor_id=self.proposer_id(context),
+            actor_type=ActorType.AI,
+            reason="Strategy signal mapped to a human-review trade idea",
+            evidence=idea.data_used,
+        )
+
+    def _build_long_idea(
+        self,
+        *,
+        decision: StrategyDecisionSignal,
+        context: StrategySignalContext,
+        confidence_value: float,
+    ) -> TradeIdea:
+        config = self._config
+        as_of = _utc_aware(context.as_of)
+        mark = context.current_mark
+        stop_level = (mark * (1 - config.stop_loss_pct / 100)).quantize(config.price_precision)
+        entry_lower = (mark * (1 - config.entry_band_pct / 100)).quantize(config.price_precision)
+        entry_upper = (mark * (1 + config.entry_band_pct / 100)).quantize(config.price_precision)
+        target = (mark + config.reward_multiple * (mark - stop_level)).quantize(
+            config.price_precision
+        )
+        reason = decision.reason.strip() or f"{context.strategy_name} emitted a buy signal"
+
+        return TradeIdea(
+            decision_id=self._decision_id(decision, context, as_of),
+            autonomy_mode=AutonomyMode.HUMAN_APPROVED_EXECUTION,
+            thesis=(
+                f"{context.strategy_name} emitted a buy signal for {context.symbol}: " f"{reason}"
+            ),
+            instrument=context.symbol,
+            product_type=context.product_type,
+            direction=TradeDirection.LONG,
+            entry_zone=EntryZone(lower=entry_lower, upper=entry_upper),
+            invalidation=f"Close below the strategy stop level {stop_level}",
+            target_exit=f"Take profit near {target} or exit at expiry",
+            max_loss=MaxLoss(
+                percent_of_account=config.risk_per_idea_pct,
+                assumptions=(
+                    f"Strategy bridge uses a {config.stop_loss_pct}% stop from current mark {mark}",
+                    "Sizing remains advisory until a human approves the idea",
+                ),
+            ),
+            sizing_recommendation=SizingRecommendation(
+                rationale=(
+                    f"Size so a stop-out near {stop_level} risks no more than "
+                    f"{config.risk_per_idea_pct}% of account equity"
+                ),
+            ),
+            time_horizon=TimeHorizon(
+                expected_hold=config.expected_hold,
+                expires_at=as_of + timedelta(hours=config.expiry_hours),
+            ),
+            data_used=self._data_used(decision, context, as_of, confidence_value),
+            confidence=_confidence(confidence_value),
+            failure_mode=(
+                "Strategy signal fails if price rejects the entry zone and closes below "
+                "the mapped invalidation level"
+            ),
+            do_not_trade_if=(
+                f"Price has already moved above {entry_upper} before human review",
+                "The source strategy has reversed or emitted hold before approval",
+            ),
+        )
+
+    def _data_used(
+        self,
+        decision: StrategyDecisionSignal,
+        context: StrategySignalContext,
+        as_of: datetime,
+        confidence_value: float,
+    ) -> tuple[str, ...]:
+        action = _action_value(decision.action)
+        return (
+            (
+                f"{context.data_source}:{context.symbol}:mark={context.current_mark}:"
+                f"as_of={as_of.isoformat()}"
+            ),
+            (
+                f"strategy:{context.strategy_name}:action={action}:"
+                f"confidence={confidence_value:.4f}"
+            ),
+        )
+
+    def _decision_id(
+        self,
+        decision: StrategyDecisionSignal,
+        context: StrategySignalContext,
+        as_of: datetime,
+    ) -> str:
+        action = _action_value(decision.action)
+        strategy_slug = _safe_slug(context.strategy_name)
+        symbol_slug = _safe_slug(context.symbol)
+        digest = hashlib.sha256(
+            "|".join(
+                (
+                    self.proposer_id(context),
+                    context.symbol,
+                    str(context.current_mark),
+                    as_of.isoformat(),
+                    action,
+                    decision.reason,
+                )
+            ).encode()
+        ).hexdigest()[:8]
+        return f"trade-{as_of:%Y%m%d}-{strategy_slug}-{symbol_slug}-{digest}"
+
+    def _validate_context(self, context: StrategySignalContext) -> None:
+        if not context.symbol.strip():
+            raise ValidationError("symbol must be non-empty", field="symbol")
+        if not context.strategy_name.strip():
+            raise ValidationError("strategy_name must be non-empty", field="strategy_name")
+        if context.current_mark <= 0:
+            raise ValidationError(
+                "current_mark must be positive",
+                field="current_mark",
+                value=str(context.current_mark),
+            )
+        if context.product_type is not ProductType.SPOT:
+            raise ValidationError(
+                "StrategySignalToTradeIdeaAdapter currently supports spot ideas only",
+                field="product_type",
+                value=context.product_type.value,
+            )
+
+
+def _safe_slug(value: str) -> str:
+    slug = _SAFE_SLUG.sub("-", value.strip().lower()).strip("-")
+    return slug or "unknown"
+
+
+def _utc_aware(value: datetime) -> datetime:
+    if value.tzinfo is None or value.utcoffset() is None:
+        return value.replace(tzinfo=UTC)
+    return value
+
+
+def _action_value(action: Any) -> str:
+    value = getattr(action, "value", action)
+    return str(value).strip().lower()
+
+
+def _confidence_value(value: float) -> float:
+    confidence = float(value)
+    if not math.isfinite(confidence):
+        raise ValidationError("confidence must be finite", field="confidence", value=value)
+    return max(0.0, min(1.0, confidence))
+
+
+def _confidence(value: float) -> Confidence:
+    if value >= 0.75:
+        label = ConfidenceLabel.HIGH
+    elif value >= 0.5:
+        label = ConfidenceLabel.MEDIUM
+    else:
+        label = ConfidenceLabel.LOW
+    return Confidence(
+        label=label,
+        rationale=f"Mapped from strategy confidence {value:.4f}",
+    )

--- a/src/gpt_trader/features/strategy_tools/trade_idea_adapter.py
+++ b/src/gpt_trader/features/strategy_tools/trade_idea_adapter.py
@@ -151,7 +151,13 @@ class StrategySignalToTradeIdeaAdapter:
         target = (mark + config.reward_multiple * (mark - stop_level)).quantize(
             config.price_precision
         )
-        reason = decision.reason.strip() or f"{context.strategy_name} emitted a buy signal"
+        self._validate_price_levels(
+            stop_level=stop_level,
+            entry_lower=entry_lower,
+            entry_upper=entry_upper,
+            target=target,
+        )
+        reason = _idea_reason(decision, context)
 
         return TradeIdea(
             decision_id=self._decision_id(decision, context, as_of),
@@ -204,7 +210,8 @@ class StrategySignalToTradeIdeaAdapter:
         action = _action_value(decision.action)
         return (
             (
-                f"{context.data_source}:{context.symbol}:mark={context.current_mark}:"
+                f"{context.data_source}:{context.symbol}:"
+                f"mark={_canonical_decimal(context.current_mark)}:"
                 f"as_of={as_of.isoformat()}"
             ),
             (
@@ -227,14 +234,44 @@ class StrategySignalToTradeIdeaAdapter:
                 (
                     self.proposer_id(context),
                     context.symbol,
-                    str(context.current_mark),
+                    _canonical_decimal(context.current_mark),
                     as_of.isoformat(),
                     action,
-                    decision.reason,
+                    _idea_reason(decision, context),
                 )
             ).encode()
         ).hexdigest()[:8]
         return f"trade-{as_of:%Y%m%d}-{strategy_slug}-{symbol_slug}-{digest}"
+
+    def _validate_price_levels(
+        self,
+        *,
+        stop_level: Decimal,
+        entry_lower: Decimal,
+        entry_upper: Decimal,
+        target: Decimal,
+    ) -> None:
+        """Reject ideas where ``price_precision`` is too coarse for the mark.
+
+        For sub-cent symbols the default ``price_precision`` quantizes stop/entry/
+        target to ``0.00`` (or collapses them together), which ``evaluate_eligibility``
+        cannot detect because the bounds are still non-``None``. Reject here so a
+        degenerate, zero-priced idea is never proposed; callers can pass a finer
+        ``price_precision`` for low-priced symbols.
+        """
+        if any(level <= 0 for level in (stop_level, entry_lower, entry_upper, target)):
+            raise ValidationError(
+                "price_precision is too coarse for current_mark; "
+                "quantization erased a price level",
+                field="price_precision",
+                value=str(self._config.price_precision),
+            )
+        if not stop_level < entry_lower < entry_upper < target:
+            raise ValidationError(
+                "price_precision is too coarse to keep stop/entry/target levels distinct",
+                field="price_precision",
+                value=str(self._config.price_precision),
+            )
 
     def _validate_context(self, context: StrategySignalContext) -> None:
         if not context.symbol.strip():
@@ -262,8 +299,20 @@ def _safe_slug(value: str) -> str:
 
 def _utc_aware(value: datetime) -> datetime:
     if value.tzinfo is None or value.utcoffset() is None:
-        return value.replace(tzinfo=UTC)
-    return value
+        raise ValidationError("as_of must be timezone-aware", field="as_of")
+    return value.astimezone(UTC)
+
+
+def _idea_reason(decision: StrategyDecisionSignal, context: StrategySignalContext) -> str:
+    return decision.reason.strip() or f"{context.strategy_name} emitted a buy signal"
+
+
+def _canonical_decimal(value: Decimal) -> str:
+    """Render a decimal so equal values share one string (e.g. 60000 == 60000.00)."""
+    normalized = value.normalize()
+    # ``normalize`` can yield exponent form (6E+4); ``format(..., "f")`` keeps it plain
+    # while staying canonical, and preserves sub-cent precision (0.00001234).
+    return format(normalized, "f")
 
 
 def _action_value(action: Any) -> str:

--- a/tests/unit/gpt_trader/features/strategy_tools/test_trade_idea_adapter.py
+++ b/tests/unit/gpt_trader/features/strategy_tools/test_trade_idea_adapter.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from gpt_trader.errors import ValidationError
+from gpt_trader.features.live_trade.strategies.perps_baseline.strategy import (
+    Action,
+    Decision,
+)
+from gpt_trader.features.strategy_tools import (
+    StrategyDecisionSignal,
+    StrategySignalContext,
+    StrategySignalToTradeIdeaAdapter,
+    StrategySignalToTradeIdeaAdapterConfig,
+)
+from gpt_trader.features.trade_ideas import (
+    ActorType,
+    ProductType,
+    TradeDirection,
+    TradeIdeaService,
+    TradeIdeaState,
+    evaluate_eligibility,
+)
+
+
+def _context(**overrides) -> StrategySignalContext:
+    fields = {
+        "symbol": "BTC-USD",
+        "current_mark": Decimal("60000"),
+        "as_of": datetime(2026, 6, 29, 9, 0, tzinfo=UTC),
+        "strategy_name": "baseline-perps",
+        "data_source": "unit-test:strategy-decision",
+    }
+    fields.update(overrides)
+    return StrategySignalContext(**fields)
+
+
+def _buy_decision(**overrides) -> Decision:
+    fields = {
+        "action": Action.BUY,
+        "reason": "RSI recovered while price reclaimed the long moving average",
+        "confidence": 0.82,
+        "indicators": {"rsi": "44", "trend": "bullish"},
+    }
+    fields.update(overrides)
+    return Decision(**fields)
+
+
+def _enabled_adapter() -> StrategySignalToTradeIdeaAdapter:
+    return StrategySignalToTradeIdeaAdapter(StrategySignalToTradeIdeaAdapterConfig(enabled=True))
+
+
+def test_accepts_shipped_baseline_strategy_decision_shape() -> None:
+    assert isinstance(_buy_decision(), StrategyDecisionSignal)
+
+
+def test_default_off_adapter_does_not_map_or_propose(tmp_path: Path) -> None:
+    adapter = StrategySignalToTradeIdeaAdapter()
+    service = TradeIdeaService(tmp_path / "trade_ideas")
+
+    assert adapter.map_decision(_buy_decision(), _context()) is None
+    assert adapter.propose_decision(_buy_decision(), _context(), service) is None
+    assert service.list_views() == []
+
+
+def test_buy_decision_maps_to_eligible_broker_neutral_trade_idea() -> None:
+    idea = _enabled_adapter().map_decision(_buy_decision(), _context())
+
+    assert idea is not None
+    assert idea.decision_id.startswith("trade-20260629-baseline-perps-btc-usd-")
+    assert idea.autonomy_mode.value == "human_approved_execution"
+    assert idea.instrument == "BTC-USD"
+    assert idea.product_type is ProductType.SPOT
+    assert idea.direction is TradeDirection.LONG
+    assert idea.entry_zone.lower == Decimal("59400.00")
+    assert idea.entry_zone.upper == Decimal("60600.00")
+    assert idea.max_loss.percent_of_account == Decimal("2")
+    assert "unit-test:strategy-decision:BTC-USD" in idea.data_used[0]
+    assert evaluate_eligibility(idea) == []
+
+
+def test_propose_decision_enters_workflow_as_ai_proposed_only(tmp_path: Path) -> None:
+    adapter = _enabled_adapter()
+    service = TradeIdeaService(tmp_path / "trade_ideas")
+
+    view = adapter.propose_decision(_buy_decision(), _context(), service)
+
+    assert view is not None
+    assert view.state is TradeIdeaState.PROPOSED
+    assert [event.actor_type for event in view.events] == [ActorType.AI]
+    assert service.get(view.idea.decision_id).state is TradeIdeaState.PROPOSED
+
+
+@pytest.mark.parametrize("action", [Action.HOLD, Action.SELL, Action.CLOSE])
+def test_non_buy_decisions_are_not_mapped(action: Action, tmp_path: Path) -> None:
+    adapter = _enabled_adapter()
+    service = TradeIdeaService(tmp_path / "trade_ideas")
+    decision = _buy_decision(action=action)
+
+    assert adapter.map_decision(decision, _context()) is None
+    assert adapter.propose_decision(decision, _context(), service) is None
+    assert service.list_views() == []
+
+
+def test_non_spot_context_is_rejected_before_proposal(tmp_path: Path) -> None:
+    adapter = _enabled_adapter()
+    service = TradeIdeaService(tmp_path / "trade_ideas")
+    context = _context(product_type=ProductType.FUTURES)
+
+    with pytest.raises(ValidationError, match="supports spot ideas only"):
+        adapter.propose_decision(_buy_decision(), context, service)
+
+    assert service.list_views() == []

--- a/tests/unit/gpt_trader/features/strategy_tools/test_trade_idea_adapter.py
+++ b/tests/unit/gpt_trader/features/strategy_tools/test_trade_idea_adapter.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta, timezone
 from decimal import Decimal
 from pathlib import Path
 
@@ -104,6 +104,66 @@ def test_non_buy_decisions_are_not_mapped(action: Action, tmp_path: Path) -> Non
     assert adapter.map_decision(decision, _context()) is None
     assert adapter.propose_decision(decision, _context(), service) is None
     assert service.list_views() == []
+
+
+def test_subcent_mark_with_default_precision_is_rejected() -> None:
+    adapter = _enabled_adapter()
+    context = _context(symbol="SHIB-USD", current_mark=Decimal("0.00001234"))
+
+    with pytest.raises(ValidationError, match="price_precision is too coarse"):
+        adapter.map_decision(_buy_decision(), context)
+
+
+def test_subcent_mark_with_fine_precision_preserves_levels() -> None:
+    adapter = StrategySignalToTradeIdeaAdapter(
+        StrategySignalToTradeIdeaAdapterConfig(enabled=True, price_precision=Decimal("0.00000001"))
+    )
+    context = _context(symbol="SHIB-USD", current_mark=Decimal("0.00001234"))
+
+    idea = adapter.map_decision(_buy_decision(), context)
+
+    assert idea is not None
+    assert idea.entry_zone.lower > 0
+    assert idea.entry_zone.lower < idea.entry_zone.upper
+    assert evaluate_eligibility(idea) == []
+
+
+def test_decision_id_is_stable_across_equivalent_marks_and_reasons() -> None:
+    adapter = _enabled_adapter()
+
+    compact = adapter.map_decision(
+        _buy_decision(reason="breakout"), _context(current_mark=Decimal("60000"))
+    )
+    padded = adapter.map_decision(
+        _buy_decision(reason="  breakout  "), _context(current_mark=Decimal("60000.00"))
+    )
+
+    assert compact is not None and padded is not None
+    assert compact.decision_id == padded.decision_id
+
+
+def test_naive_as_of_is_rejected() -> None:
+    adapter = _enabled_adapter()
+    context = _context(as_of=datetime(2026, 6, 29, 9, 0))
+
+    with pytest.raises(ValidationError, match="as_of must be timezone-aware"):
+        adapter.map_decision(_buy_decision(), context)
+
+
+def test_decision_id_is_invariant_to_equivalent_utc_offsets() -> None:
+    adapter = _enabled_adapter()
+
+    utc = adapter.map_decision(
+        _buy_decision(), _context(as_of=datetime(2026, 6, 29, 9, 0, tzinfo=UTC))
+    )
+    eastern = adapter.map_decision(
+        _buy_decision(),
+        _context(as_of=datetime(2026, 6, 29, 5, 0, tzinfo=timezone(timedelta(hours=-4)))),
+    )
+
+    assert utc is not None and eastern is not None
+    assert utc.decision_id == eastern.decision_id
+    assert utc.time_horizon.expires_at == eastern.time_horizon.expires_at
 
 
 def test_non_spot_context_is_rejected_before_proposal(tmp_path: Path) -> None:

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 7046,
+    "total_tests": 7051,
     "total_files": 835,
     "markers_used": 16
   },

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,8 +7,8 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 7040,
-    "total_files": 834,
+    "total_tests": 7046,
+    "total_files": 835,
     "markers_used": 16
   },
   "quick_commands": {

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6879,
+    "unit": 6884,
     "asyncio": 440,
     "parametrize": 207,
     "endpoints": 83,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,9 +95,9 @@
     ]
   },
   "counts": {
-    "unit": 6873,
+    "unit": 6879,
     "asyncio": 440,
-    "parametrize": 206,
+    "parametrize": 207,
     "endpoints": 83,
     "property": 82,
     "integration": 81,

--- a/var/agents/testing/source_test_map.json
+++ b/var/agents/testing/source_test_map.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "summary": {
-    "tests_scanned": 745,
+    "tests_scanned": 746,
     "source_modules": 381,
     "unresolved_modules": 3
   },
@@ -524,6 +524,7 @@
       "tests/unit/gpt_trader/errors/test_handler.py",
       "tests/unit/gpt_trader/features/brokerages/coinbase/rest/test_base_build.py",
       "tests/unit/gpt_trader/features/brokerages/coinbase/rest/test_base_execute_order_payload.py",
+      "tests/unit/gpt_trader/features/strategy_tools/test_trade_idea_adapter.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_broker_payloads.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_service_venue_boundary.py",
       "tests/unit/gpt_trader/validation/test_base_validator.py",
@@ -1217,7 +1218,8 @@
       "tests/unit/gpt_trader/features/live_trade/strategies/test_perps_baseline_signals.py",
       "tests/unit/gpt_trader/features/live_trade/strategies/test_perps_baseline_strategies.py",
       "tests/unit/gpt_trader/features/live_trade/strategies/test_stateful_perps_baseline_edges.py",
-      "tests/unit/gpt_trader/features/optimize/runner/test_batch_runner.py"
+      "tests/unit/gpt_trader/features/optimize/runner/test_batch_runner.py",
+      "tests/unit/gpt_trader/features/strategy_tools/test_trade_idea_adapter.py"
     ],
     "gpt_trader.features.live_trade.strategies.regime_switcher": [
       "tests/unit/gpt_trader/features/live_trade/strategies/test_regime_switcher.py"
@@ -1316,7 +1318,8 @@
       "tests/unit/gpt_trader/features/strategy_dev/monitor/test_metrics_trade_record.py"
     ],
     "gpt_trader.features.strategy_tools": [
-      "tests/unit/gpt_trader/features/strategy_tools/test_strategy_tools_import.py"
+      "tests/unit/gpt_trader/features/strategy_tools/test_strategy_tools_import.py",
+      "tests/unit/gpt_trader/features/strategy_tools/test_trade_idea_adapter.py"
     ],
     "gpt_trader.features.strategy_tools.enhancements": [
       "tests/unit/gpt_trader/features/strategy_tools/test_strategy_enhancements_edges.py"
@@ -1349,6 +1352,7 @@
       "tests/unit/gpt_trader/cli/commands/test_ideas_review_latency.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_short_budget.py",
       "tests/unit/gpt_trader/cli/commands/test_ideas_snapshot_build.py",
+      "tests/unit/gpt_trader/features/strategy_tools/test_trade_idea_adapter.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_audit.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_baseline_proposer.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_broker_payloads.py",
@@ -4095,6 +4099,12 @@
     ],
     "tests/unit/gpt_trader/features/strategy_tools/test_strategy_tools_import.py": [
       "gpt_trader.features.strategy_tools"
+    ],
+    "tests/unit/gpt_trader/features/strategy_tools/test_trade_idea_adapter.py": [
+      "gpt_trader.errors",
+      "gpt_trader.features.live_trade.strategies.perps_baseline.strategy",
+      "gpt_trader.features.strategy_tools",
+      "gpt_trader.features.trade_ideas"
     ],
     "tests/unit/gpt_trader/features/trade_ideas/test_audit.py": [
       "gpt_trader.features.trade_ideas"

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 7046,
+    "total_tests": 7051,
     "total_files": 835,
     "markers_used": 16
   },
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6879,
+    "unit": 6884,
     "asyncio": 440,
     "parametrize": 207,
     "endpoints": 83,
@@ -33495,8 +33495,48 @@
         "docstring": ""
       },
       {
-        "name": "test_non_spot_context_is_rejected_before_proposal",
+        "name": "test_subcent_mark_with_default_precision_is_rejected",
         "line": 109,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_subcent_mark_with_fine_precision_preserves_levels",
+        "line": 117,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_decision_id_is_stable_across_equivalent_marks_and_reasons",
+        "line": 131,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_naive_as_of_is_rejected",
+        "line": 145,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_decision_id_is_invariant_to_equivalent_utc_offsets",
+        "line": 153,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_non_spot_context_is_rejected_before_proposal",
+        "line": 169,
         "markers": [
           "unit"
         ],

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,8 +2,8 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 7040,
-    "total_files": 834,
+    "total_tests": 7046,
+    "total_files": 835,
     "markers_used": 16
   },
   "marker_definitions": {
@@ -102,9 +102,9 @@
     ]
   },
   "marker_counts": {
-    "unit": 6873,
+    "unit": 6879,
     "asyncio": 440,
-    "parametrize": 206,
+    "parametrize": 207,
     "endpoints": 83,
     "property": 82,
     "integration": 81,
@@ -553,6 +553,7 @@
       "tests/unit/gpt_trader/features/strategy_tools/test_risk_guards_edges.py",
       "tests/unit/gpt_trader/features/strategy_tools/test_strategy_enhancements_edges.py",
       "tests/unit/gpt_trader/features/strategy_tools/test_strategy_tools_import.py",
+      "tests/unit/gpt_trader/features/strategy_tools/test_trade_idea_adapter.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_audit.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_baseline_proposer.py",
       "tests/unit/gpt_trader/features/trade_ideas/test_broker_payloads.py",
@@ -33449,6 +33450,57 @@
         ],
         "docstring": "Verify create_standard_risk_guards is callable.",
         "class": "TestFactoryFunctions"
+      }
+    ],
+    "tests/unit/gpt_trader/features/strategy_tools/test_trade_idea_adapter.py": [
+      {
+        "name": "test_accepts_shipped_baseline_strategy_decision_shape",
+        "line": 57,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_default_off_adapter_does_not_map_or_propose",
+        "line": 61,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_buy_decision_maps_to_eligible_broker_neutral_trade_idea",
+        "line": 70,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_propose_decision_enters_workflow_as_ai_proposed_only",
+        "line": 86,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_non_buy_decisions_are_not_mapped",
+        "line": 99,
+        "markers": [
+          "parametrize",
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_non_spot_context_is_rejected_before_proposal",
+        "line": 109,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
       }
     ],
     "tests/unit/gpt_trader/features/trade_ideas/test_audit.py": [


### PR DESCRIPTION
## Summary
Related issue / finding / routed package: Refs #1033

Adds a default-off `StrategySignalToTradeIdeaAdapter` in `features/strategy_tools` that maps supported strategy `BUY` decisions into broker-neutral `TradeIdea` records and submits them through `TradeIdeaService.propose()` only.

This intentionally does not wire the live `TradingEngine` cycle, approve ideas, preview orders, submit orders, reconcile fills, or call broker/account APIs. It establishes the proposal-only library bridge first so the runtime routing decision remains explicit.

## Type of change
- [ ] Refactor
- [x] Feature
- [ ] Bug fix
- [x] Tests only
- [x] CI/Docs/Tooling

## Scope & Impact
- Affected areas / components: `features/strategy_tools`, `features/trade_ideas` docs/status, generated testing inventories.
- Behavior changes: new default-off adapter API only. Existing runtime behavior is unchanged.

## Test Plan
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Contract tests (if applicable)
- [x] Ran locally: `uv run local-ci --profile quick`
- [x] Markers used appropriately (`unit`/`integration`/`slow`/`perf`)

## Complexity & Quality Gates
- [x] Mypy/type-check passed
- [x] Xenon/radon complexity gate passed (CC ≤ 15 on live_trade execution) — not applicable to live_trade execution; no live_trade execution code changed
- [x] No `sys.path` hacks in tests
- [x] No `MagicMock` on `async def` (use `AsyncMock`)
- [x] Import-lint rules respected (no “import up the stack”)

## Observability & Errors
- [ ] Structured JSON logs for new/changed paths — not applicable; no runtime logging added
- [x] Errors include diagnostic context (symbol, order_id, correlation_id) — validation errors include field context where relevant
- [ ] Added/updated sampling examples in tests (if applicable)

## Configuration
- [ ] If config changed: `python -m gpt_trader.cli.config validate --profile <name>` passes — no config changed
- [ ] Env docs re-generated (if applicable) and committed — not applicable
- [x] No `ConfigLoader` usages introduced (ConfigManager-only)

## Breaking Changes
- [x] None
- [ ] Documented in PR body and release notes if any

## Screenshots / Logs (optional)
Verification run locally:

- `uv run pytest tests/unit/gpt_trader/features/strategy_tools/test_trade_idea_adapter.py tests/unit/gpt_trader/features/strategy_tools/test_strategy_tools_import.py -q` → `15 passed`
- `uv run agent-regenerate --verify` → passed
- `uv run python scripts/maintenance/docs_reachability_check.py` → `49 files reachable`
- `uv run python scripts/maintenance/docs_link_audit.py` → `72 files scanned`
- `uv run mypy src` → passed
- `uv run local-ci --profile quick` → passed; `7315 passed`

## Checklist
- [x] Acceptance criteria in linked issue(s), finding packet, or routed package met for the adapter-only slice
- [x] Affected paths listed in PR description
- [ ] Changelog entry (if repo uses one)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a default-off strategy-signal bridge that converts supported buy decisions into broker-neutral proposed trade ideas.
  * Expanded strategy tooling exports to include the new adapter and related signal/context types.
* **Documentation**
  * Refined Stage 1 approval-path status and clarified the separation between live strategy signals and approval-gated trade-idea workflow.
  * Added design guidance for strategy-signal bridges, including default-off behavior and “propose-only” limits.
* **Tests**
  * Added unit tests covering enabled vs disabled behavior, supported vs non-supported actions, validation failures (e.g., precision, timezone, non-spot), and deterministic proposal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->