### PR TITLE
Add PR readiness receipt agent tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ uv run agent-impact     # Analyze change impact
 uv run agent-map        # Generate dependency graph
 uv run agent-naming     # Check naming conventions
 uv run agent-risk       # Query risk configuration
+uv run agent-pr-ready   # Reconcile PR mergeability vs green CI
 ```
 
 ## Documentation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ agent-regenerate = "gpt_trader.agents.cli:regenerate"
 agent-artifacts = "gpt_trader.agents.cli:artifacts"
 agent-dedupe = "gpt_trader.agents.cli:dedupe"
 agent-dedupe-triage = "gpt_trader.agents.cli:dedupe_triage"
+agent-pr-ready = "gpt_trader.agents.cli:pr_ready"
 
 [build-system]
 requires = ["setuptools>=69", "wheel"]

--- a/scripts/agents/README.md
+++ b/scripts/agents/README.md
@@ -56,6 +56,7 @@ uv run agent-regenerate --only testing
 uv run agent-artifacts validate
 uv run agent-artifacts package
 uv run agent-artifacts verify-package
+uv run agent-pr-ready --format markdown
 ```
 
 `agent-naming` dispatches to `scripts/agents/naming_inventory.py`; defaults are

--- a/scripts/agents/pr_readiness.py
+++ b/scripts/agents/pr_readiness.py
@@ -1,0 +1,665 @@
+#!/usr/bin/env python3
+"""Reconcile a pull request's *real* mergeability against "the checks are green".
+
+This is a transparency tool, not a gate. CI being green is necessary but not
+sufficient to merge: branch protection can also require the branch to be up to
+date (``strict``), require every review conversation resolved
+(``required_conversation_resolution``), or require approving reviews. A green PR
+can still be ``BLOCKED`` by unresolved bot/human review threads that carry real
+findings -- exactly the gap that lets "green-but-unreviewed" work slip through.
+
+``agent-pr-ready`` surfaces that gap:
+
+- Required status checks (from branch protection) and their current state.
+- ``mergeStateStatus`` (CLEAN / BLOCKED / BEHIND / DIRTY / ...).
+- Unresolved review threads, with parsed severity, author, and location.
+- An artifact-freshness advisory when the diff touches files that feed the
+  generated ``var/agents/`` context.
+
+It prints a verdict and a markdown receipt suitable for a PR body. By default it
+always exits 0 (report, do not block); pass ``--exit-on-not-ready`` to opt into
+an advisory non-zero exit for scripts that *want* a gate.
+
+For change/test selection, use ``agent-impact`` -- this tool intentionally does
+not duplicate that analysis.
+
+Usage:
+    uv run agent-pr-ready                      # auto-detect PR for current branch
+    uv run agent-pr-ready --pr 1056
+    uv run agent-pr-ready --format markdown    # receipt for the PR body
+    uv run agent-pr-ready --format json
+    uv run agent-pr-ready --no-github          # local artifact advisory only
+    uv run agent-pr-ready --exit-on-not-ready  # opt-in advisory gate
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+
+# Changes under these roots can change generated var/agents/ context, so the
+# freshness check (agent-regenerate --verify) is worth running before merge.
+_ARTIFACT_SOURCE_PREFIXES = ("src/", "tests/", "scripts/", "config/")
+_ARTIFACT_SOURCE_FILES = (
+    "pyproject.toml",
+    "pytest.ini",
+    "config/environments/.env.template",
+)
+_ARTIFACT_SOURCE_SUFFIXES = (".py", ".tcss", ".yaml", ".yml")
+
+# Severity tokens emitted by review bots (CodeRabbit, Codex) in comment bodies,
+# ordered most-severe first so the highest match wins.
+_SEVERITY_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("critical", re.compile(r"\bP0\b|\bcritical\b", re.IGNORECASE)),
+    ("high", re.compile(r"\bP1\b|\bmajor\b", re.IGNORECASE)),
+    ("medium", re.compile(r"\bP2\b|\bmoderate\b", re.IGNORECASE)),
+    ("low", re.compile(r"\bP3\b|\bminor\b|\bnit\b", re.IGNORECASE)),
+)
+
+# mergeStateStatus values that mean "not mergeable right now", with guidance.
+_BLOCKING_MERGE_STATES = {
+    "BEHIND": "Branch is behind the base; update/rebase so it is current.",
+    "DIRTY": "Branch has merge conflicts with the base.",
+    "BLOCKED": "Branch protection is blocking the merge (see findings below).",
+    "DRAFT": "Pull request is a draft; mark it ready for review before merging.",
+    "UNKNOWN": "GitHub has not determined mergeability yet; retry after merge state settles.",
+}
+
+_PASSING_CHECK_STATES = {"SUCCESS", "SKIPPED", "NEUTRAL"}
+
+
+@dataclass(frozen=True)
+class CheckStatus:
+    name: str
+    state: str  # SUCCESS / PENDING / FAILURE / ERROR / ...
+    required: bool
+
+
+@dataclass(frozen=True)
+class ReviewThread:
+    author: str
+    resolved: bool
+    severity: str | None
+    path: str | None
+    line: int | None
+
+
+@dataclass(frozen=True)
+class BranchProtection:
+    strict: bool
+    conversation_resolution: bool
+    required_review_count: int
+    required_checks: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class PullRequestState:
+    number: int
+    head_oid: str
+    merge_state_status: str
+    review_decision: str
+    checks: tuple[CheckStatus, ...]
+    threads: tuple[ReviewThread, ...]
+    protection: BranchProtection
+    base_ref_name: str = "main"
+
+
+@dataclass(frozen=True)
+class Finding:
+    severity: str  # blocker / warning / info
+    message: str
+
+
+@dataclass
+class ReadinessReport:
+    ready: bool
+    findings: list[Finding] = field(default_factory=list)
+    artifact_advisory: str | None = None
+
+
+# --------------------------------------------------------------------------- #
+# Pure logic (unit-tested): no git, no gh, no I/O.
+# --------------------------------------------------------------------------- #
+def affects_agent_artifacts(paths: list[str]) -> bool:
+    """True when any changed path can make generated var/agents/ context stale."""
+    for raw in paths:
+        path = raw.strip()
+        if not path:
+            continue
+        if path in _ARTIFACT_SOURCE_FILES:
+            return True
+        if path.startswith(_ARTIFACT_SOURCE_PREFIXES) and path.endswith(_ARTIFACT_SOURCE_SUFFIXES):
+            return True
+    return False
+
+
+def parse_severity(body: str) -> str | None:
+    """Extract a normalized severity from a review comment body, if present."""
+    for label, pattern in _SEVERITY_PATTERNS:
+        if pattern.search(body):
+            return label
+    return None
+
+
+def parse_branch_protection(raw: dict[str, Any] | None) -> BranchProtection:
+    """Build BranchProtection from the GitHub protection API payload."""
+    raw = raw or {}
+    checks_block = raw.get("required_status_checks") or {}
+    modern_checks = [
+        item.get("context", "") for item in checks_block.get("checks") or [] if item.get("context")
+    ]
+    legacy_contexts = [
+        context for context in checks_block.get("contexts") or [] if isinstance(context, str)
+    ]
+    required = tuple(sorted({*modern_checks, *legacy_contexts}))
+    reviews = raw.get("required_pull_request_reviews") or {}
+    return BranchProtection(
+        strict=bool(checks_block.get("strict", False)),
+        conversation_resolution=bool(
+            (raw.get("required_conversation_resolution") or {}).get("enabled", False)
+        ),
+        required_review_count=int(reviews.get("required_approving_review_count", 0) or 0),
+        required_checks=required,
+    )
+
+
+def parse_pr_state(
+    pr_json: dict[str, Any],
+    threads_json: list[dict[str, Any]],
+    protection: BranchProtection,
+) -> PullRequestState:
+    """Build PullRequestState from gh payloads + parsed branch protection."""
+    required_names = set(protection.required_checks)
+    checks: list[CheckStatus] = []
+    for node in pr_json.get("statusCheckRollup") or []:
+        name = node.get("name") or node.get("context") or ""
+        if not name:
+            continue
+        # CheckRun uses status/conclusion; StatusContext uses state.
+        state = node.get("state")
+        if not state:
+            if node.get("status") == "COMPLETED":
+                state = node.get("conclusion") or "UNKNOWN"
+            else:
+                state = node.get("status") or "UNKNOWN"
+        checks.append(
+            CheckStatus(name=name, state=str(state).upper(), required=name in required_names)
+        )
+
+    threads: list[ReviewThread] = []
+    for node in threads_json:
+        comments = (node.get("comments") or {}).get("nodes") or []
+        first = comments[0] if comments else {}
+        author = ((first.get("author") or {}).get("login")) or "unknown"
+        body = " ".join(c.get("body", "") for c in comments)
+        threads.append(
+            ReviewThread(
+                author=author,
+                resolved=bool(node.get("isResolved", False)),
+                severity=parse_severity(body),
+                path=node.get("path"),
+                line=node.get("line"),
+            )
+        )
+
+    return PullRequestState(
+        number=int(pr_json.get("number", 0)),
+        head_oid=str(pr_json.get("headRefOid", "")),
+        base_ref_name=str(pr_json.get("baseRefName", "main") or "main"),
+        merge_state_status=str(pr_json.get("mergeStateStatus", "UNKNOWN")).upper(),
+        review_decision=str(pr_json.get("reviewDecision", "") or ""),
+        checks=tuple(checks),
+        threads=tuple(threads),
+        protection=protection,
+    )
+
+
+def assess_readiness(state: PullRequestState) -> ReadinessReport:
+    """Reconcile checks + protection + threads into a non-blocking verdict."""
+    findings: list[Finding] = []
+
+    observed_check_names = {check.name for check in state.checks}
+    for name in sorted(set(state.protection.required_checks) - observed_check_names):
+        findings.append(Finding("blocker", f"Required check '{name}' is missing."))
+
+    failing_required = [
+        check for check in state.checks if check.required and not _is_passing_check(check)
+    ]
+    for check in failing_required:
+        findings.append(Finding("blocker", f"Required check '{check.name}' is {check.state}."))
+
+    failing_other = [
+        check
+        for check in state.checks
+        if not check.required and check.state in {"FAILURE", "ERROR", "CANCELLED", "TIMED_OUT"}
+    ]
+    for check in failing_other:
+        findings.append(Finding("warning", f"Non-required check '{check.name}' is {check.state}."))
+
+    unresolved = [thread for thread in state.threads if not thread.resolved]
+    if unresolved:
+        severity = "blocker" if state.protection.conversation_resolution else "warning"
+        findings.append(
+            Finding(
+                severity,
+                _describe_unresolved(unresolved, state.protection.conversation_resolution),
+            )
+        )
+
+    guidance = _BLOCKING_MERGE_STATES.get(state.merge_state_status)
+    if guidance:
+        if state.merge_state_status == "BLOCKED":
+            has_specific_blocker = any(finding.severity == "blocker" for finding in findings)
+            if not has_specific_blocker:
+                findings.append(Finding("blocker", guidance))
+        else:
+            findings.append(Finding("blocker", guidance))
+
+    if state.protection.required_review_count > 0 and state.review_decision != "APPROVED":
+        findings.append(
+            Finding(
+                "blocker",
+                f"Branch protection requires {state.protection.required_review_count} "
+                f"approving review(s); current decision is "
+                f"'{state.review_decision or 'none'}'.",
+            )
+        )
+
+    ready = not any(finding.severity == "blocker" for finding in findings)
+    if ready and not findings:
+        findings.append(Finding("info", "No blockers detected; PR is mergeable."))
+    return ReadinessReport(ready=ready, findings=findings)
+
+
+def _is_passing_check(check: CheckStatus) -> bool:
+    return check.state in _PASSING_CHECK_STATES
+
+
+def _required_check_names(state: PullRequestState) -> set[str]:
+    names = set(state.protection.required_checks)
+    if names:
+        return names
+    return {check.name for check in state.checks if check.required}
+
+
+def _describe_unresolved(unresolved: list[ReviewThread], enforced: bool) -> str:
+    by_severity: dict[str, int] = {}
+    for thread in unresolved:
+        key = thread.severity or "unspecified"
+        by_severity[key] = by_severity.get(key, 0) + 1
+    breakdown = ", ".join(f"{count} {label}" for label, count in sorted(by_severity.items()))
+    authors = ", ".join(sorted({thread.author for thread in unresolved}))
+    enforced_note = (
+        " Branch protection requires conversation resolution, so these block the merge."
+        if enforced
+        else " Conversation resolution is not enforced, but review them before merging."
+    )
+    return (
+        f"{len(unresolved)} unresolved review thread(s) [{breakdown}] from {authors}."
+        + enforced_note
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Receipt / output formatting (pure).
+# --------------------------------------------------------------------------- #
+def _verdict(report: ReadinessReport) -> str:
+    return "READY" if report.ready else "NOT READY"
+
+
+_SEVERITY_GLYPH = {"blocker": "x", "warning": "!", "info": "+"}
+
+
+def format_text(state: PullRequestState | None, report: ReadinessReport) -> str:
+    lines: list[str] = []
+    if state is not None:
+        lines.append(f"PR #{state.number} @ {state.head_oid[:8]}")
+        lines.append(f"base: {state.base_ref_name}")
+        lines.append(f"merge state: {state.merge_state_status}")
+        required_names = _required_check_names(state)
+        passing = sum(1 for c in state.checks if c.name in required_names and _is_passing_check(c))
+        lines.append(f"required checks: {passing}/{len(required_names)} passing")
+        unresolved = sum(1 for t in state.threads if not t.resolved)
+        lines.append(f"review threads: {unresolved} unresolved / {len(state.threads)} total")
+    lines.append(f"verdict: {_verdict(report)}")
+    if report.artifact_advisory:
+        lines.append(f"artifacts: {report.artifact_advisory}")
+    lines.append("findings:")
+    for finding in report.findings:
+        glyph = _SEVERITY_GLYPH.get(finding.severity, "-")
+        lines.append(f"  {glyph} [{finding.severity}] {finding.message}")
+    return "\n".join(lines)
+
+
+def format_markdown(state: PullRequestState | None, report: ReadinessReport) -> str:
+    lines = ["## PR readiness receipt", ""]
+    lines.append(f"**Verdict:** {_verdict(report)}")
+    lines.append("")
+    if state is not None:
+        required_names = _required_check_names(state)
+        passing = sum(1 for c in state.checks if c.name in required_names and _is_passing_check(c))
+        unresolved = sum(1 for t in state.threads if not t.resolved)
+        lines.append(f"- PR `#{state.number}` at `{state.head_oid[:8]}`")
+        lines.append(f"- Base: `{state.base_ref_name}`")
+        lines.append(f"- Merge state: `{state.merge_state_status}`")
+        lines.append(f"- Required checks: {passing}/{len(required_names)} passing")
+        lines.append(f"- Review threads: {unresolved} unresolved / {len(state.threads)} total")
+        if state.protection.conversation_resolution:
+            lines.append("- Conversation resolution: **required** by branch protection")
+    if report.artifact_advisory:
+        lines.append(f"- Artifacts: {report.artifact_advisory}")
+    lines.append("")
+    lines.append("### Findings")
+    for finding in report.findings:
+        glyph = _SEVERITY_GLYPH.get(finding.severity, "-")
+        lines.append(f"- {glyph} **{finding.severity}** - {finding.message}")
+    return "\n".join(lines)
+
+
+def format_json(state: PullRequestState | None, report: ReadinessReport) -> str:
+    payload: dict[str, Any] = {
+        "ready": report.ready,
+        "verdict": _verdict(report),
+        "artifact_advisory": report.artifact_advisory,
+        "findings": [asdict(finding) for finding in report.findings],
+    }
+    if state is not None:
+        payload["pull_request"] = {
+            "number": state.number,
+            "head_oid": state.head_oid,
+            "base_ref_name": state.base_ref_name,
+            "merge_state_status": state.merge_state_status,
+            "review_decision": state.review_decision,
+            "checks": [asdict(check) for check in state.checks],
+            "threads": [asdict(thread) for thread in state.threads],
+            "protection": asdict(state.protection),
+        }
+    return json.dumps(payload, indent=2)
+
+
+# --------------------------------------------------------------------------- #
+# I/O boundary: git + gh. Thin wrappers, not unit-tested.
+# --------------------------------------------------------------------------- #
+def _run(args: list[str]) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(args, capture_output=True, text=True, cwd=PROJECT_ROOT, check=False)
+    except OSError as error:
+        return subprocess.CompletedProcess(args, 127, "", str(error))
+
+
+def changed_paths(base: str) -> list[str]:
+    """Changed files for the current branch vs base (committed + working tree)."""
+    seen: list[str] = []
+    base_specs = [f"{base}...HEAD"]
+    if not base.startswith("origin/"):
+        base_specs.append(f"origin/{base}...HEAD")
+    commands = [["git", "diff", "--name-only", spec] for spec in base_specs] + [
+        ["git", "diff", "--name-only"],
+        ["git", "diff", "--name-only", "--cached"],
+    ]
+    for args in commands:
+        result = _run(args)
+        if result.returncode == 0:
+            for line in result.stdout.splitlines():
+                path = line.strip()
+                if path and path not in seen:
+                    seen.append(path)
+    return seen
+
+
+def _gh_json(args: list[str]) -> Any:
+    result = _run(["gh", *args])
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "gh command failed")
+    return json.loads(result.stdout)
+
+
+def detect_repo() -> str:
+    return str(_gh_json(["repo", "view", "--json", "nameWithOwner"])["nameWithOwner"])
+
+
+def detect_pr_number(repo: str) -> int | None:
+    try:
+        data = _gh_json(["pr", "view", "--repo", repo, "--json", "number"])
+    except RuntimeError as error:
+        if _is_no_pull_request_error(error):
+            return None
+        raise
+    return int(data["number"]) if data.get("number") else None
+
+
+def _is_no_pull_request_error(error: RuntimeError) -> bool:
+    message = str(error).lower()
+    return "no pull requests found" in message or "no open pull requests" in message
+
+
+def fetch_branch_protection(repo: str, branch: str = "main") -> dict[str, Any] | None:
+    try:
+        encoded_branch = quote(branch, safe="")
+        payload = _gh_json(["api", f"repos/{repo}/branches/{encoded_branch}/protection"])
+    except RuntimeError as error:
+        if _is_missing_branch_protection(error):
+            return None
+        raise
+    return payload if isinstance(payload, dict) else None
+
+
+def _is_missing_branch_protection(error: RuntimeError) -> bool:
+    message = str(error).lower()
+    return "http 404" in message or "branch not protected" in message
+
+
+def fetch_pr_payload(repo: str, pr: int) -> dict[str, Any]:
+    payload = _gh_json(
+        [
+            "pr",
+            "view",
+            str(pr),
+            "--repo",
+            repo,
+            "--json",
+            "number,headRefOid,baseRefName,mergeStateStatus,reviewDecision,statusCheckRollup",
+        ]
+    )
+    if not isinstance(payload, dict):
+        raise RuntimeError("Unexpected gh pr view payload")
+    return payload
+
+
+def fetch_pr_changed_paths(repo: str, pr: int) -> list[str]:
+    result = _run(["gh", "pr", "diff", str(pr), "--repo", repo, "--name-only"])
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or f"Could not load PR #{pr} diff")
+    seen: list[str] = []
+    for line in result.stdout.splitlines():
+        path = line.strip()
+        if path and path not in seen:
+            seen.append(path)
+    return seen
+
+
+def fetch_review_threads(repo: str, pr: int) -> list[dict[str, Any]]:
+    if repo.count("/") != 1:
+        raise RuntimeError("--repo must use owner/name format")
+    owner, name = repo.split("/", 1)
+    if not owner or not name:
+        raise RuntimeError("--repo must use owner/name format")
+    query = """
+query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 100, after: $cursor) {
+        nodes {
+          isResolved
+          path
+          line
+          comments(first: 5) {
+            nodes {
+              author { login }
+              body
+            }
+          }
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+}
+"""
+    nodes: list[dict[str, Any]] = []
+    cursor: str | None = None
+    while True:
+        gh_args = [
+            "api",
+            "graphql",
+            "-f",
+            f"query={query}",
+            "-F",
+            f"owner={owner}",
+            "-F",
+            f"name={name}",
+            "-F",
+            f"number={pr}",
+        ]
+        if cursor:
+            gh_args.extend(["-F", f"cursor={cursor}"])
+        data = _gh_json(gh_args)
+        page = (
+            data.get("data", {})
+            .get("repository", {})
+            .get("pullRequest", {})
+            .get("reviewThreads", {})
+        )
+        page_nodes = page.get("nodes", [])
+        if isinstance(page_nodes, list):
+            nodes.extend(page_nodes)
+        page_info = page.get("pageInfo") or {}
+        if not page_info.get("hasNextPage"):
+            break
+        next_cursor = page_info.get("endCursor")
+        if not isinstance(next_cursor, str) or not next_cursor:
+            break
+        cursor = next_cursor
+    return nodes
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+def _artifact_advisory(paths: list[str]) -> str | None:
+    if affects_agent_artifacts(paths):
+        return (
+            "diff touches generated-context sources; run "
+            "`uv run agent-regenerate --verify` (and commit if stale)."
+        )
+    return None
+
+
+def parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Reconcile a PR's real mergeability against green CI (transparency, not a gate)."
+    )
+    parser.add_argument(
+        "--pr", type=int, default=None, help="PR number (auto-detected if omitted)."
+    )
+    parser.add_argument("--repo", default=None, help="owner/name (auto-detected if omitted).")
+    parser.add_argument(
+        "--base",
+        default=None,
+        help="Base branch override. Defaults to the PR base when GitHub is available, otherwise main.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("text", "markdown", "json"),
+        default="text",
+        help="Output format. 'markdown' is suitable for a PR body.",
+    )
+    parser.add_argument(
+        "--no-github",
+        action="store_true",
+        help="Skip gh calls; report only the local artifact-freshness advisory.",
+    )
+    parser.add_argument(
+        "--exit-on-not-ready",
+        action="store_true",
+        help="Opt-in advisory gate: exit 1 when NOT READY (default exits 0).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    if args.no_github:
+        advisory = _artifact_advisory(changed_paths(args.base or "main"))
+        report = ReadinessReport(
+            ready=True,
+            findings=[Finding("info", "GitHub checks skipped (--no-github).")],
+            artifact_advisory=advisory,
+        )
+        print(_render(args.format, None, report))
+        return 0
+
+    try:
+        repo = args.repo or detect_repo()
+        pr = args.pr or detect_pr_number(repo)
+    except RuntimeError as error:
+        return _github_failure(args, f"Could not reach GitHub via gh: {error}")
+
+    if pr is None:
+        advisory = _artifact_advisory(changed_paths(args.base or "main"))
+        report = ReadinessReport(
+            ready=True,
+            findings=[Finding("info", "No open PR for the current branch.")],
+            artifact_advisory=advisory,
+        )
+        print(_render(args.format, None, report))
+        return 0
+
+    try:
+        pr_payload = fetch_pr_payload(repo, pr)
+        base_ref_name = str(args.base or pr_payload.get("baseRefName") or "main")
+        advisory = _artifact_advisory(fetch_pr_changed_paths(repo, pr))
+        protection = parse_branch_protection(fetch_branch_protection(repo, base_ref_name))
+        state = parse_pr_state(pr_payload, fetch_review_threads(repo, pr), protection)
+    except RuntimeError as error:
+        return _github_failure(args, f"Could not load PR #{pr}: {error}")
+
+    report = assess_readiness(state)
+    report.artifact_advisory = advisory
+    print(_render(args.format, state, report))
+    return 1 if (args.exit_on_not_ready and not report.ready) else 0
+
+
+def _render(fmt: str, state: PullRequestState | None, report: ReadinessReport) -> str:
+    if fmt == "json":
+        return format_json(state, report)
+    if fmt == "markdown":
+        return format_markdown(state, report)
+    return format_text(state, report)
+
+
+def _github_failure(args: argparse.Namespace, message: str) -> int:
+    advisory = _artifact_advisory(changed_paths(args.base or "main"))
+    report = ReadinessReport(
+        ready=False,
+        findings=[Finding("blocker", message)],
+        artifact_advisory=advisory,
+    )
+    print(_render(args.format, None, report))
+    return 1 if args.exit_on_not_ready else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/gpt_trader/agents/__init__.py
+++ b/src/gpt_trader/agents/__init__.py
@@ -12,4 +12,5 @@ Available commands:
     agent-naming     - Check naming standards
     agent-health     - Aggregate lint/types/tests/preflight/config checks
     agent-regenerate - Regenerate all context files
+    agent-pr-ready   - Reconcile PR mergeability against green CI
 """

--- a/src/gpt_trader/agents/cli.py
+++ b/src/gpt_trader/agents/cli.py
@@ -208,6 +208,26 @@ def dedupe() -> int:
     return _run_script("generate_dedupe_candidates.py")
 
 
+def pr_ready() -> int:
+    """Reconcile a PR's real mergeability against green CI (transparency, not a gate).
+
+    Entry point: agent-pr-ready
+
+    Surfaces what "checks are green" hides: required-check state, mergeStateStatus,
+    unresolved review threads (with severity), and an artifact-freshness advisory.
+    Always exits 0 by default; pass --exit-on-not-ready for an opt-in advisory gate.
+
+    Examples:
+        uv run agent-pr-ready                      # auto-detect PR for current branch
+        uv run agent-pr-ready --pr 1056
+        uv run agent-pr-ready --format markdown    # receipt for the PR body
+        uv run agent-pr-ready --format json
+        uv run agent-pr-ready --no-github          # local artifact advisory only
+        uv run agent-pr-ready --exit-on-not-ready  # opt-in advisory gate
+    """
+    return _run_script("pr_readiness.py")
+
+
 def dedupe_triage() -> int:
     """Triage dedupe clusters (accept/reject/defer).
 

--- a/tests/unit/scripts/test_pr_readiness.py
+++ b/tests/unit/scripts/test_pr_readiness.py
@@ -1,0 +1,361 @@
+from __future__ import annotations
+
+import json
+
+import scripts.agents.pr_readiness as pr_readiness
+from scripts.agents.pr_readiness import (
+    BranchProtection,
+    CheckStatus,
+    PullRequestState,
+    ReviewThread,
+    affects_agent_artifacts,
+    assess_readiness,
+    format_json,
+    format_markdown,
+    parse_branch_protection,
+    parse_pr_state,
+    parse_severity,
+)
+
+
+def _protection(
+    *,
+    conversation_resolution: bool = False,
+    required_checks: tuple[str, ...] = ("Unit Tests (Core)",),
+    required_review_count: int = 0,
+    strict: bool = True,
+) -> BranchProtection:
+    return BranchProtection(
+        strict=strict,
+        conversation_resolution=conversation_resolution,
+        required_review_count=required_review_count,
+        required_checks=required_checks,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# affects_agent_artifacts
+# --------------------------------------------------------------------------- #
+def test_artifact_advisory_triggers_for_source_and_tests() -> None:
+    assert affects_agent_artifacts(["src/gpt_trader/features/x.py"]) is True
+    assert affects_agent_artifacts(["tests/unit/x_test.py"]) is True
+    assert affects_agent_artifacts(["pyproject.toml"]) is True
+    assert affects_agent_artifacts(["pytest.ini"]) is True
+    assert affects_agent_artifacts(["config/environments/.env.template"]) is True
+    assert affects_agent_artifacts(["config/agents/flows/default.yaml"]) is True
+    assert affects_agent_artifacts(["src/gpt_trader/tui/styles/a.tcss"]) is True
+
+
+def test_artifact_advisory_skips_unrelated_changes() -> None:
+    assert affects_agent_artifacts(["docs/STATUS.md", "README.md"]) is False
+    assert affects_agent_artifacts([""]) is False
+    assert affects_agent_artifacts([]) is False
+
+
+# --------------------------------------------------------------------------- #
+# parse_severity
+# --------------------------------------------------------------------------- #
+def test_parse_severity_recognizes_bot_tokens() -> None:
+    assert parse_severity("P2 Badge: preserve sub-cent levels") == "medium"
+    assert parse_severity("Major data integrity issue") == "high"
+    assert parse_severity("P0 critical") == "critical"
+    assert parse_severity("minor nit") == "low"
+
+
+def test_parse_severity_returns_none_without_token() -> None:
+    assert parse_severity("just a normal comment") is None
+
+
+# --------------------------------------------------------------------------- #
+# parse_branch_protection
+# --------------------------------------------------------------------------- #
+def test_parse_branch_protection_extracts_flags() -> None:
+    raw = {
+        "required_status_checks": {
+            "strict": True,
+            "checks": [{"context": "Type Check"}, {"context": "Unit Tests (Core)"}],
+            "contexts": ["CodeQL"],
+        },
+        "required_pull_request_reviews": {"required_approving_review_count": 0},
+        "required_conversation_resolution": {"enabled": True},
+    }
+    protection = parse_branch_protection(raw)
+    assert protection.strict is True
+    assert protection.conversation_resolution is True
+    assert protection.required_review_count == 0
+    assert protection.required_checks == ("CodeQL", "Type Check", "Unit Tests (Core)")
+
+
+def test_parse_branch_protection_handles_missing_payload() -> None:
+    protection = parse_branch_protection(None)
+    assert protection.required_checks == ()
+    assert protection.conversation_resolution is False
+
+
+# --------------------------------------------------------------------------- #
+# parse_pr_state
+# --------------------------------------------------------------------------- #
+def test_parse_pr_state_maps_checks_and_threads() -> None:
+    pr_json = {
+        "number": 1056,
+        "headRefOid": "a367f3c6deadbeef",
+        "baseRefName": "release/2026-06",
+        "mergeStateStatus": "blocked",
+        "reviewDecision": "",
+        "statusCheckRollup": [
+            {"name": "Unit Tests (Core)", "status": "COMPLETED", "conclusion": "SUCCESS"},
+            {"name": "CodeRabbit", "state": "SUCCESS"},
+        ],
+    }
+    threads_json = [
+        {
+            "isResolved": False,
+            "path": "src/x.py",
+            "line": 152,
+            "comments": {"nodes": [{"author": {"login": "coderabbitai"}, "body": "Major bug"}]},
+        }
+    ]
+    state = parse_pr_state(pr_json, threads_json, _protection())
+
+    assert state.number == 1056
+    assert state.base_ref_name == "release/2026-06"
+    assert state.merge_state_status == "BLOCKED"
+    core = next(check for check in state.checks if check.name == "Unit Tests (Core)")
+    assert core.required is True
+    assert core.state == "SUCCESS"
+    coderabbit = next(check for check in state.checks if check.name == "CodeRabbit")
+    assert coderabbit.required is False
+    assert state.threads[0].severity == "high"
+    assert state.threads[0].author == "coderabbitai"
+
+
+# --------------------------------------------------------------------------- #
+# assess_readiness - the scenario that bit us
+# --------------------------------------------------------------------------- #
+def test_green_checks_but_unresolved_threads_is_not_ready() -> None:
+    """All required checks SUCCESS, but enforced conversation resolution + open
+    threads must still report NOT READY (the PR #1056 situation)."""
+    state = PullRequestState(
+        number=1056,
+        head_oid="c6f5c2c4",
+        merge_state_status="BLOCKED",
+        review_decision="",
+        checks=(CheckStatus("Unit Tests (Core)", "SUCCESS", required=True),),
+        threads=(
+            ReviewThread("chatgpt-codex-connector", False, "medium", "src/x.py", 152),
+            ReviewThread("coderabbitai", False, "high", "src/x.py", 236),
+        ),
+        protection=_protection(conversation_resolution=True),
+    )
+    report = assess_readiness(state)
+
+    assert report.ready is False
+    blockers = [finding for finding in report.findings if finding.severity == "blocker"]
+    assert len(blockers) == 1
+    assert "unresolved review thread" in blockers[0].message
+    assert "block the merge" in blockers[0].message
+
+
+def test_unresolved_threads_without_enforcement_is_warning_not_blocker() -> None:
+    state = PullRequestState(
+        number=1,
+        head_oid="abc",
+        merge_state_status="CLEAN",
+        review_decision="",
+        checks=(CheckStatus("Unit Tests (Core)", "SUCCESS", required=True),),
+        threads=(ReviewThread("coderabbitai", False, "low", "docs/x.md", 1),),
+        protection=_protection(conversation_resolution=False),
+    )
+    report = assess_readiness(state)
+
+    assert report.ready is True
+    assert any(finding.severity == "warning" for finding in report.findings)
+
+
+def test_failing_required_check_is_blocker() -> None:
+    state = PullRequestState(
+        number=2,
+        head_oid="abc",
+        merge_state_status="BLOCKED",
+        review_decision="",
+        checks=(
+            CheckStatus("Unit Tests (Core)", "FAILURE", required=True),
+            CheckStatus("CodeRabbit", "SUCCESS", required=False),
+        ),
+        threads=(),
+        protection=_protection(),
+    )
+    report = assess_readiness(state)
+
+    assert report.ready is False
+    assert any("Unit Tests (Core)" in finding.message for finding in report.findings)
+
+
+def test_missing_required_check_is_blocker() -> None:
+    state = PullRequestState(
+        number=20,
+        head_oid="abc",
+        merge_state_status="CLEAN",
+        review_decision="",
+        checks=(),
+        threads=(),
+        protection=_protection(required_checks=("Unit Tests (Core)",)),
+    )
+    report = assess_readiness(state)
+
+    assert report.ready is False
+    assert any("missing" in finding.message for finding in report.findings)
+
+
+def test_skipped_and_neutral_required_checks_are_passing() -> None:
+    state = PullRequestState(
+        number=21,
+        head_oid="abc",
+        merge_state_status="CLEAN",
+        review_decision="",
+        checks=(
+            CheckStatus("Docs Link Audit", "SKIPPED", required=True),
+            CheckStatus("Analyze Python", "NEUTRAL", required=True),
+        ),
+        threads=(),
+        protection=_protection(required_checks=("Docs Link Audit", "Analyze Python")),
+    )
+    report = assess_readiness(state)
+
+    assert report.ready is True
+
+
+def test_blocked_state_without_specific_finding_is_not_ready() -> None:
+    state = PullRequestState(
+        number=22,
+        head_oid="abc",
+        merge_state_status="BLOCKED",
+        review_decision="",
+        checks=(CheckStatus("Unit Tests (Core)", "SUCCESS", required=True),),
+        threads=(ReviewThread("coderabbitai", False, "low", "docs/x.md", 1),),
+        protection=_protection(conversation_resolution=False),
+    )
+    report = assess_readiness(state)
+
+    assert report.ready is False
+    assert any("Branch protection" in finding.message for finding in report.findings)
+
+
+def test_draft_state_is_not_ready() -> None:
+    state = PullRequestState(
+        number=23,
+        head_oid="abc",
+        merge_state_status="DRAFT",
+        review_decision="",
+        checks=(CheckStatus("Unit Tests (Core)", "SUCCESS", required=True),),
+        threads=(),
+        protection=_protection(),
+    )
+    report = assess_readiness(state)
+
+    assert report.ready is False
+    assert any("draft" in finding.message.lower() for finding in report.findings)
+
+
+def test_unknown_merge_state_is_not_ready() -> None:
+    state = PullRequestState(
+        number=24,
+        head_oid="abc",
+        merge_state_status="UNKNOWN",
+        review_decision="",
+        checks=(CheckStatus("Unit Tests (Core)", "SUCCESS", required=True),),
+        threads=(),
+        protection=_protection(),
+    )
+    report = assess_readiness(state)
+
+    assert report.ready is False
+    assert any("mergeability" in finding.message for finding in report.findings)
+
+
+def test_clean_pr_with_no_open_threads_is_ready() -> None:
+    state = PullRequestState(
+        number=3,
+        head_oid="abc",
+        merge_state_status="CLEAN",
+        review_decision="",
+        checks=(CheckStatus("Unit Tests (Core)", "SUCCESS", required=True),),
+        threads=(ReviewThread("coderabbitai", True, "high", "src/x.py", 1),),
+        protection=_protection(conversation_resolution=True),
+    )
+    report = assess_readiness(state)
+
+    assert report.ready is True
+    assert all(finding.severity == "info" for finding in report.findings)
+
+
+def test_behind_base_is_blocker() -> None:
+    state = PullRequestState(
+        number=4,
+        head_oid="abc",
+        merge_state_status="BEHIND",
+        review_decision="",
+        checks=(CheckStatus("Unit Tests (Core)", "SUCCESS", required=True),),
+        threads=(),
+        protection=_protection(),
+    )
+    report = assess_readiness(state)
+
+    assert report.ready is False
+    assert any("behind" in finding.message.lower() for finding in report.findings)
+
+
+def test_required_review_missing_is_blocker() -> None:
+    state = PullRequestState(
+        number=5,
+        head_oid="abc",
+        merge_state_status="BLOCKED",
+        review_decision="REVIEW_REQUIRED",
+        checks=(CheckStatus("Unit Tests (Core)", "SUCCESS", required=True),),
+        threads=(),
+        protection=_protection(required_review_count=1),
+    )
+    report = assess_readiness(state)
+
+    assert report.ready is False
+    assert any("approving review" in finding.message for finding in report.findings)
+
+
+# --------------------------------------------------------------------------- #
+# formatting
+# --------------------------------------------------------------------------- #
+def test_format_json_is_machine_readable() -> None:
+    report = assess_readiness(
+        PullRequestState(
+            number=9,
+            head_oid="abc1234567",
+            merge_state_status="CLEAN",
+            review_decision="",
+            checks=(CheckStatus("Unit Tests (Core)", "SUCCESS", required=True),),
+            threads=(),
+            protection=_protection(),
+        )
+    )
+    payload = json.loads(format_json(None, report))
+    assert payload["ready"] is True
+    assert payload["verdict"] == "READY"
+
+
+def test_format_markdown_includes_verdict_and_findings() -> None:
+    state = PullRequestState(
+        number=10,
+        head_oid="abcdef1234",
+        merge_state_status="BLOCKED",
+        review_decision="",
+        checks=(CheckStatus("Unit Tests (Core)", "SUCCESS", required=True),),
+        threads=(ReviewThread("coderabbitai", False, "high", "src/x.py", 1),),
+        protection=_protection(conversation_resolution=True),
+    )
+    markdown = format_markdown(state, assess_readiness(state))
+    assert "## PR readiness receipt" in markdown
+    assert "NOT READY" in markdown
+    assert "Conversation resolution" in markdown
+
+
+def test_module_exposes_main() -> None:
+    assert callable(pr_readiness.main)

--- a/tests/unit/scripts/test_pr_readiness_io.py
+++ b/tests/unit/scripts/test_pr_readiness_io.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import Any
+
+import scripts.agents.pr_readiness as pr_readiness
+
+
+def test_run_converts_missing_executable_to_failed_process(monkeypatch) -> None:
+    def raise_missing(*args: Any, **kwargs: Any) -> None:
+        raise FileNotFoundError("missing gh")
+
+    monkeypatch.setattr(pr_readiness.subprocess, "run", raise_missing)
+
+    result = pr_readiness._run(["gh", "version"])
+
+    assert result.returncode == 127
+    assert "missing gh" in result.stderr
+
+
+def test_changed_paths_retries_origin_base_when_local_base_is_missing(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(args: list[str]) -> subprocess.CompletedProcess[str]:
+        calls.append(args)
+        if args == ["git", "diff", "--name-only", "release/1.2...HEAD"]:
+            return subprocess.CompletedProcess(args, 128, "", "unknown revision")
+        if args == ["git", "diff", "--name-only", "origin/release/1.2...HEAD"]:
+            return subprocess.CompletedProcess(args, 0, "scripts/agents/pr_readiness.py\n", "")
+        return subprocess.CompletedProcess(args, 0, "", "")
+
+    monkeypatch.setattr(pr_readiness, "_run", fake_run)
+
+    assert pr_readiness.changed_paths("release/1.2") == ["scripts/agents/pr_readiness.py"]
+    assert ["git", "diff", "--name-only", "origin/release/1.2...HEAD"] in calls
+
+
+def test_detect_pr_number_returns_none_only_for_no_pr(monkeypatch) -> None:
+    def fake_gh_json(args: list[str]) -> dict[str, Any]:
+        raise RuntimeError("no pull requests found for branch")
+
+    monkeypatch.setattr(pr_readiness, "_gh_json", fake_gh_json)
+
+    assert pr_readiness.detect_pr_number("owner/repo") is None
+
+
+def test_detect_pr_number_reraises_api_failures(monkeypatch) -> None:
+    def fake_gh_json(args: list[str]) -> dict[str, Any]:
+        raise RuntimeError("gh: API rate limit exceeded (HTTP 403)")
+
+    monkeypatch.setattr(pr_readiness, "_gh_json", fake_gh_json)
+
+    try:
+        pr_readiness.detect_pr_number("owner/repo")
+    except RuntimeError as error:
+        assert "rate limit" in str(error)
+    else:
+        raise AssertionError("expected RuntimeError")
+
+
+def test_fetch_review_threads_paginates(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_gh_json(args: list[str]) -> dict[str, Any]:
+        calls.append(args)
+        if len(calls) == 1:
+            return {
+                "data": {
+                    "repository": {
+                        "pullRequest": {
+                            "reviewThreads": {
+                                "nodes": [{"line": 1}],
+                                "pageInfo": {"hasNextPage": True, "endCursor": "cursor-1"},
+                            }
+                        }
+                    }
+                }
+            }
+        return {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "reviewThreads": {
+                            "nodes": [{"line": 2}],
+                            "pageInfo": {"hasNextPage": False, "endCursor": None},
+                        }
+                    }
+                }
+            }
+        }
+
+    monkeypatch.setattr(pr_readiness, "_gh_json", fake_gh_json)
+
+    nodes = pr_readiness.fetch_review_threads("owner/repo", 9)
+
+    assert [node["line"] for node in nodes] == [1, 2]
+    assert any(part == "cursor=cursor-1" for part in calls[1])
+
+
+def test_fetch_review_threads_rejects_malformed_repo() -> None:
+    try:
+        pr_readiness.fetch_review_threads("not-a-repo", 9)
+    except RuntimeError as error:
+        assert "owner/name" in str(error)
+    else:
+        raise AssertionError("expected RuntimeError")
+
+
+def test_fetch_branch_protection_encodes_branch_segments(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_gh_json(args: list[str]) -> dict[str, Any]:
+        calls.append(args)
+        return {"required_status_checks": {"checks": []}}
+
+    monkeypatch.setattr(pr_readiness, "_gh_json", fake_gh_json)
+
+    assert pr_readiness.fetch_branch_protection("owner/repo", "release/1.2") == {
+        "required_status_checks": {"checks": []}
+    }
+    assert calls == [["api", "repos/owner/repo/branches/release%2F1.2/protection"]]
+
+
+def test_fetch_branch_protection_returns_none_for_missing_protection(monkeypatch) -> None:
+    def fake_gh_json(args: list[str]) -> dict[str, Any]:
+        raise RuntimeError("gh: Branch not protected (HTTP 404)")
+
+    monkeypatch.setattr(pr_readiness, "_gh_json", fake_gh_json)
+
+    assert pr_readiness.fetch_branch_protection("owner/repo", "main") is None
+
+
+def test_fetch_branch_protection_reraises_api_failures(monkeypatch) -> None:
+    def fake_gh_json(args: list[str]) -> dict[str, Any]:
+        raise RuntimeError("gh: API rate limit exceeded (HTTP 403)")
+
+    monkeypatch.setattr(pr_readiness, "_gh_json", fake_gh_json)
+
+    try:
+        pr_readiness.fetch_branch_protection("owner/repo", "main")
+    except RuntimeError as error:
+        assert "rate limit" in str(error)
+    else:
+        raise AssertionError("expected RuntimeError")
+
+
+def test_fetch_pr_changed_paths_uses_requested_pr_diff(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(args: list[str]) -> subprocess.CompletedProcess[str]:
+        calls.append(args)
+        return subprocess.CompletedProcess(args, 0, "pytest.ini\npytest.ini\n", "")
+
+    monkeypatch.setattr(pr_readiness, "_run", fake_run)
+
+    assert pr_readiness.fetch_pr_changed_paths("owner/repo", 123) == ["pytest.ini"]
+    assert calls == [["gh", "pr", "diff", "123", "--repo", "owner/repo", "--name-only"]]
+
+
+def test_main_uses_pr_base_for_advisory_and_branch_protection(monkeypatch) -> None:
+    bases: list[str] = []
+
+    monkeypatch.setattr(
+        pr_readiness, "changed_paths", lambda base: bases.append(f"diff:{base}") or []
+    )
+    monkeypatch.setattr(
+        pr_readiness,
+        "fetch_pr_changed_paths",
+        lambda repo, pr: bases.append(f"pr-diff:{pr}") or [],
+    )
+    monkeypatch.setattr(pr_readiness, "fetch_review_threads", lambda repo, pr: [])
+    monkeypatch.setattr(
+        pr_readiness,
+        "fetch_pr_payload",
+        lambda repo, pr: {
+            "number": 12,
+            "headRefOid": "abcdef1234",
+            "baseRefName": "release/2026-06",
+            "mergeStateStatus": "CLEAN",
+            "reviewDecision": "",
+            "statusCheckRollup": [],
+        },
+    )
+
+    def fake_protection(repo: str, branch: str) -> dict[str, Any]:
+        bases.append(branch)
+        return {"required_status_checks": {"checks": []}}
+
+    monkeypatch.setattr(pr_readiness, "fetch_branch_protection", fake_protection)
+
+    assert pr_readiness.main(["--repo", "owner/repo", "--pr", "12"]) == 0
+    assert "pr-diff:12" in bases
+    assert "release/2026-06" in bases
+
+
+def test_main_pr_mode_uses_pr_diff_for_artifact_advisory(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(pr_readiness, "fetch_review_threads", lambda repo, pr: [])
+    monkeypatch.setattr(pr_readiness, "fetch_branch_protection", lambda repo, branch: {})
+    monkeypatch.setattr(pr_readiness, "fetch_pr_changed_paths", lambda repo, pr: ["pytest.ini"])
+    monkeypatch.setattr(
+        pr_readiness,
+        "fetch_pr_payload",
+        lambda repo, pr: {
+            "number": 12,
+            "headRefOid": "abcdef1234",
+            "baseRefName": "main",
+            "mergeStateStatus": "CLEAN",
+            "reviewDecision": "",
+            "statusCheckRollup": [],
+        },
+    )
+
+    assert pr_readiness.main(["--repo", "owner/repo", "--pr", "12"]) == 0
+    assert "agent-regenerate --verify" in capsys.readouterr().out
+
+
+def test_main_exit_on_not_ready_fails_when_github_unavailable(monkeypatch) -> None:
+    def raise_unavailable() -> str:
+        raise RuntimeError("gh missing")
+
+    monkeypatch.setattr(pr_readiness, "detect_repo", raise_unavailable)
+
+    assert pr_readiness.main(["--exit-on-not-ready"]) == 1
+
+
+def test_main_json_format_survives_github_unavailable(monkeypatch, capsys) -> None:
+    def raise_unavailable() -> str:
+        raise RuntimeError("gh missing")
+
+    monkeypatch.setattr(pr_readiness, "detect_repo", raise_unavailable)
+
+    assert pr_readiness.main(["--format", "json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ready"] is False
+    assert payload["verdict"] == "NOT READY"

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,8 +7,8 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 7051,
-    "total_files": 835,
+    "total_tests": 7086,
+    "total_files": 837,
     "markers_used": 16
   },
   "quick_commands": {

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6884,
+    "unit": 6919,
     "asyncio": 440,
     "parametrize": 207,
     "endpoints": 83,

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,8 +2,8 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 7051,
-    "total_files": 835,
+    "total_tests": 7086,
+    "total_files": 837,
     "markers_used": 16
   },
   "marker_definitions": {
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6884,
+    "unit": 6919,
     "asyncio": 440,
     "parametrize": 207,
     "endpoints": 83,
@@ -838,6 +838,12 @@
     ],
     "test_mypy_tui_ratchet.py": [
       "tests/unit/scripts/test_mypy_tui_ratchet.py"
+    ],
+    "test_pr_readiness.py": [
+      "tests/unit/scripts/test_pr_readiness.py"
+    ],
+    "test_pr_readiness_io.py": [
+      "tests/unit/scripts/test_pr_readiness_io.py"
     ],
     "test_project_review_issue_promoter.py": [
       "tests/unit/scripts/test_project_review_issue_promoter.py"
@@ -64531,6 +64537,290 @@
       {
         "name": "test_tui_mypy_ratchet_disables_ignore_errors_for_included_modules",
         "line": 34,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      }
+    ],
+    "tests/unit/scripts/test_pr_readiness.py": [
+      {
+        "name": "test_artifact_advisory_triggers_for_source_and_tests",
+        "line": 39,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_artifact_advisory_skips_unrelated_changes",
+        "line": 49,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_parse_severity_recognizes_bot_tokens",
+        "line": 58,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_parse_severity_returns_none_without_token",
+        "line": 65,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_parse_branch_protection_extracts_flags",
+        "line": 72,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_parse_branch_protection_handles_missing_payload",
+        "line": 89,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_parse_pr_state_maps_checks_and_threads",
+        "line": 98,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_green_checks_but_unresolved_threads_is_not_ready",
+        "line": 135,
+        "markers": [
+          "unit"
+        ],
+        "docstring": "All required checks SUCCESS, but enforced conversation resolution + open\nthreads must still report NOT READY (the PR #1056 situation)."
+      },
+      {
+        "name": "test_unresolved_threads_without_enforcement_is_warning_not_blocker",
+        "line": 159,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_failing_required_check_is_blocker",
+        "line": 175,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_missing_required_check_is_blocker",
+        "line": 194,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_skipped_and_neutral_required_checks_are_passing",
+        "line": 210,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_blocked_state_without_specific_finding_is_not_ready",
+        "line": 228,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_draft_state_is_not_ready",
+        "line": 244,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_unknown_merge_state_is_not_ready",
+        "line": 260,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_clean_pr_with_no_open_threads_is_ready",
+        "line": 276,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_behind_base_is_blocker",
+        "line": 292,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_required_review_missing_is_blocker",
+        "line": 308,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_format_json_is_machine_readable",
+        "line": 327,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_format_markdown_includes_verdict_and_findings",
+        "line": 344,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_module_exposes_main",
+        "line": 360,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      }
+    ],
+    "tests/unit/scripts/test_pr_readiness_io.py": [
+      {
+        "name": "test_run_converts_missing_executable_to_failed_process",
+        "line": 10,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_changed_paths_retries_origin_base_when_local_base_is_missing",
+        "line": 22,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_detect_pr_number_returns_none_only_for_no_pr",
+        "line": 39,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_detect_pr_number_reraises_api_failures",
+        "line": 48,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_fetch_review_threads_paginates",
+        "line": 62,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_fetch_review_threads_rejects_malformed_repo",
+        "line": 101,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_fetch_branch_protection_encodes_branch_segments",
+        "line": 110,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_fetch_branch_protection_returns_none_for_missing_protection",
+        "line": 125,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_fetch_branch_protection_reraises_api_failures",
+        "line": 134,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_fetch_pr_changed_paths_uses_requested_pr_diff",
+        "line": 148,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_main_uses_pr_base_for_advisory_and_branch_protection",
+        "line": 161,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_main_pr_mode_uses_pr_diff_for_artifact_advisory",
+        "line": 197,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_main_exit_on_not_ready_fails_when_github_unavailable",
+        "line": 218,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_main_json_format_survives_github_unavailable",
+        "line": 227,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary
- Add `uv run agent-pr-ready`, a non-blocking PR readiness receipt tool that reconciles green CI with merge state, branch protection, required checks, review threads, and generated-agent-artifact freshness.
- Add pure and I/O-bound unit coverage for branch protection parsing, missing/skipped/neutral checks, draft/unknown merge states, unresolved review thread handling, PR diff advisories, GitHub failure fallbacks, output formats, and artifact advisories.
- Document the new agent command and refresh generated test inventory.

## Verification
- `uv run pytest tests/unit/scripts/test_pr_readiness.py tests/unit/scripts/test_pr_readiness_io.py tests/unit/gpt_trader/agents -q` (49 passed)
- `uv run agent-regenerate --verify`
- `uv run agent-naming --strict --quiet`
- `make ci-required` (7320 passed)
- GitHub checks: all visible checks green on head `c8920664`
- `uv run agent-pr-ready --pr 1057 --format text` => READY, 9/9 required checks passing, 0 unresolved review threads

## Notes
This is a transparency tool, not a CI gate by default. Use `--exit-on-not-ready` only when a script wants advisory gating behavior.
