### PR TITLE
Define canonical source selection model

### DIFF
--- a/docs/INFORMATION_ARCHITECTURE.md
+++ b/docs/INFORMATION_ARCHITECTURE.md
@@ -22,18 +22,61 @@ expensive "where are we actually?" audits. If you catch yourself summarizing
 the current state, the backlog, or a decision that already has a home, **link
 instead of copy**.
 
-## Three tiers, by how often a fact changes
+## Source classes
 
-| Tier | What it holds | Home | Kept honest by |
+| Class | What it holds | Home | Kept honest by |
 |------|---------------|------|----------------|
 | **Durable** | Things that change rarely and must be authored: direction, decisions, architecture invariants, naming/policy, standards | `docs/` (and root `AGENTS.md`/`CLAUDE.md`) | Human review + the doc scanners |
-| **Living** | Things that track reality and change often: current state, the backlog | `docs/STATUS.md` (pointers only) + **GitHub Issues** | The scanners + `agent-regenerate --verify` |
-| **Ephemeral** | Per-task working artifacts: plans, regrounding audits, scout findings, scratch packets | `work/` (gitignored) and `review_artifacts/` | Discarded; never promoted into `docs/` |
+| **Living** | Things that track reality and change often: current state pointers and the work queue | `docs/STATUS.md` (pointers only) + **GitHub Issues** | The scanners + live issue/PR state |
+| **Generated** | Inventories, schemas, maps, and catalogs derived from source/config | `var/agents/**` | `uv run agent-regenerate --verify` |
+| **Review deliverable** | Human-reviewable CSV/XLSX exports intentionally kept as handoff artifacts | root-level `review_artifacts/*.csv` and `review_artifacts/*.xlsx` | `.gitignore` exceptions + `git status` scope review |
+| **Runtime** | Per-run local state, readiness inputs, metrics, reports, SQLite stores, JSONL fallbacks | `runtime_data/` and ignored runtime paths | Runtime/readiness commands; not committed |
+| **Ephemeral** | Per-task plans, regrounding audits, scratch packets, temporary exports | `work/` and `review_artifacts/tmp/` | Discarded or promoted only as a decision, issue, or review deliverable |
 
 The failure mode this repo kept hitting: ephemeral planning artifacts and
 living-state summaries leaked into `docs/`, where they became durable-looking
-but went stale. Ephemeral work goes in `work/`. Living state stays small and
-points at the source.
+but went stale. Ephemeral work goes in `work/` or `review_artifacts/tmp/`.
+Living state stays small and points at the source.
+
+## Canonical Source Matrix
+
+Use this table before creating a file, converting a file to another format, or
+copying a fact into a second home.
+
+| Artifact family | Canonical source | Allowed derived/display formats | Validation command | Update trigger | Forbidden alternate homes |
+|-----------------|------------------|---------------------------------|--------------------|----------------|---------------------------|
+| Project direction, autonomy boundary, execution gates | `docs/DIRECTION.md` plus accepted/proposed records in `docs/decisions/` | Markdown links from README, status, readiness, and operations docs | `uv run python scripts/maintenance/docs_link_audit.py`; `uv run python scripts/maintenance/generate_decision_index.py --check` | Destination, gate, or execution-boundary policy changes | STATUS prose, README summaries, readiness docs as policy owners, GitHub-only decisions |
+| Current shipped state | Code/tests/generated inventories, with a small pointer snapshot in `docs/STATUS.md` | Markdown pointers only; issue and PR links for volatile details | `uv run python scripts/maintenance/docs_currency_scan.py`; `uv run python scripts/maintenance/docs_link_audit.py`; `uv run python scripts/maintenance/docs_reachability_check.py` | A capability moves between missing, partial, and done | Architecture prose, roadmap tables, README status lists, durable scratch logs |
+| Backlog and implementation queue | GitHub issues and labels | PR links, issue comments, and labels; docs link to the tracker instead of copying it | `gh issue list --state open --limit 50`; promoter dry-run for agent findings | A bounded build/fix/review item is accepted for work | Markdown roadmap queues, STATUS "next work" lists, review spreadsheets as planning truth |
+| Decisions and open questions | One Markdown ADR per file in `docs/decisions/*.md`, with lifecycle in frontmatter | Generated decision index in `docs/decisions/README.md` | `uv run python scripts/maintenance/generate_decision_index.py --check`; docs link/reachability checks | A durable choice is opened, accepted, rejected, superseded, or deprecated | Separate open-question tables, GitHub issue body as the only durable packet, duplicated "accepted direction" sections |
+| Architecture and standards | Authored docs for invariants (`docs/ARCHITECTURE.md`, `docs/DI_POLICY.md`, `docs/naming.md`, `docs/testing.md`) plus source code | Markdown prose for invariants; generated maps under `var/agents/**` for inventories | Docs scanners; `uv run agent-regenerate --verify` when generated maps are involved | A durable invariant or standard changes | Hand-maintained module inventories, generated maps copied into prose |
+| Agent scout finding before promotion | A JSON object with `schema_version: "gpt-trader.agent-finding.v1"` | The promoter's rendered dry-run body for review | `uv run python scripts/maintenance/project_review_issue_promoter.py --packet <packet>` | A scout has one evidence-backed finding worth promoting | Markdown backlog tables, review artifacts, ad hoc JSON shapes |
+| Promoted agent finding and implementation work | GitHub issue created or updated from the validated packet | Issue labels/comments and linked PRs | `gh issue view <number>`; PR checks and review state | The finding enters implementation, decision, or review routing | Local packet files as the ongoing queue, STATUS next-work lists |
+| PR readiness and review feedback | GitHub PR, checks, review threads, and explicit repair/request comments | Bounded review-feedback packets copied into issue/PR comments when needed | `gh pr view <number> --json ...`; repo PR checks | A check or review produces actionable feedback | Durable docs, broad scratch plans, unlinked local notes |
+| Generated inventories and machine schemas | Source code, generator scripts, and config inputs | Generated JSON/Markdown/DOT under `var/agents/**` | `uv run agent-regenerate --verify` | Code/config/generator inputs change | Hand-maintained reference tables, edited generated files without changing the source |
+| Config profiles and templates | Tracked YAML/JSON config under `config/**`, `.env.template`, and typed config code | Generated env/config inventories in `var/agents/**`; docs pointers | Config tests plus `uv run agent-regenerate --verify` when inventories change | Profile, env var, or schema behavior changes | Untracked `.env`, docs tables as canonical config, runtime profile dumps |
+| Runtime state and operational evidence | Per-profile runtime stores under `runtime_data/<profile>/`, including SQLite databases and generated reports | JSONL fallback/import streams and text/JSON reports for the same run | Readiness/preflight/report commands named by the operational doc | A local run, readiness check, or diagnostic command executes | Committed docs, review artifacts, issue bodies as raw runtime stores |
+| Review CSV/XLSX deliverables | Intentional root-level `review_artifacts/*.csv` or `review_artifacts/*.xlsx` handoff files | CSV/XLSX only; PR body summarizes purpose and provenance | `git status --short review_artifacts .gitignore`; human review for size/secrets | A review lane produces a durable handoff artifact | `data/`, `runtime_data/`, `review_artifacts/tmp/`, broad CSV unignore rules, hidden planning truth |
+| Temporary worksheets, scratch packets, and local exports | `work/` or `review_artifacts/tmp/` | Any local format that remains ignored | `git status --short --ignored work review_artifacts/tmp` when auditing | A task needs temporary state | `docs/`, GitHub issues unless promoted, committed review artifacts unless intentionally curated |
+
+### Format selection rules
+
+- **Markdown** is for durable prose, decision records, status pointers, and
+  human-readable indexes. Do not convert stable prose to JSON just because it can
+  be structured.
+- **JSON** is for machine contracts: agent packets, generated schemas,
+  inventories, and API-style exports that need validation or repeat routing.
+- **YAML** is for tracked configuration/profile inputs and decision frontmatter,
+  not for backlog or status mirrors.
+- **CSV/XLSX** is for bounded human review deliverables under
+  `review_artifacts/`. It is not a hidden planning database.
+- **SQLite** is for runtime persistence such as event/order stores. Keep it in
+  ignored runtime paths.
+- **JSONL** is acceptable for append-only runtime logs, imports, and legacy
+  fallbacks; when a SQLite store is documented as canonical, JSONL stays a
+  fallback/display path.
+- **GitHub issues/PRs** own the living queue and implementation review state.
+  Docs may point to them; docs should not copy their changing contents.
 
 ## Where does X go?
 
@@ -47,6 +90,8 @@ points at the source.
 | API / CLI / env-var / metric inventories | Generated `var/agents/**` (run `agent-regenerate`) | Hand-written reference tables that must be kept in sync |
 | How agents work / repo rules | `AGENTS.md` (canonical); `.claude/CLAUDE.md` points at it | Duplicated process prose across several docs |
 | A per-task plan, audit, or scout finding | `work/` (gitignored); promote only the **decision or issue** it produces | Anywhere under `docs/` |
+| A validated scout finding packet | JSON packet using `gpt-trader.agent-finding.v1`, then a GitHub issue after promotion | STATUS, roadmap docs, review spreadsheets |
+| A review CSV/XLSX handoff | Root-level `review_artifacts/*.csv` or `review_artifacts/*.xlsx` | `review_artifacts/tmp/`, `data/`, `runtime_data/`, broad CSV unignore rules |
 | Standards (naming, testing, security, TUI) | Their existing single home under `docs/` | A second "guidelines" doc |
 
 ## Anti-bloat rules

--- a/docs/agents/project_review_pipeline.md
+++ b/docs/agents/project_review_pipeline.md
@@ -37,6 +37,24 @@ only vague claims such as "clean up architecture" or "improve tests", cover too
 many unrelated paths, require live broker/API access, or cannot be completed and
 verified in one bounded PR.
 
+## Canonical Artifacts In This Pipeline
+
+The pipeline moves a finding through several homes. Each stage has one canonical
+source; later stages may render or link the earlier packet, but they do not keep
+it as a second queue.
+
+| Stage | Canonical source | Allowed derived/display form | Validation / owner |
+|-------|------------------|------------------------------|--------------------|
+| Scout candidate | Local JSON packet with `schema_version: "gpt-trader.agent-finding.v1"` | Promoter dry-run body for human review | `uv run python scripts/maintenance/project_review_issue_promoter.py --packet <packet>` |
+| Promoted finding | GitHub issue with the hidden `finding_id` marker and routing labels | Packet details rendered into the issue body or refresh comments | `project_review_issue_promoter.py` plus GitHub issue state |
+| Implementation | GitHub issue or direct owner-routed package, then a PR | PR body links issue/finding/package source | PR checks and review state |
+| Review feedback | GitHub review thread, check output, or a bounded feedback packet copied into issue/PR comments | Short fix packet for the active executor | PR review/check evidence; `codex-review-feedback` label when it becomes queue work |
+| Review deliverable | Intended `review_artifacts/*.csv` or `review_artifacts/*.xlsx` file | PR body summary of provenance and purpose | `.gitignore` policy plus `git status` review |
+
+The packet is canonical only before promotion. After promotion, the GitHub issue
+is the durable queue item; local packet files are inputs or receipts, not the
+ongoing source of truth.
+
 ## Stage 1: Scout
 
 The scout is read-only and can run frequently. It should inspect current truth
@@ -85,6 +103,19 @@ unsafe.
 ## Stage 2: Normalize
 
 Candidate findings use schema `gpt-trader.agent-finding.v1`.
+
+The current contract authority is the in-repo promoter:
+
+- `SCHEMA_VERSION`, `validate_packet()`, and `example_packet()` in
+  `scripts/maintenance/project_review_issue_promoter.py`
+- `uv run python scripts/maintenance/project_review_issue_promoter.py --print-template`
+  for a starter packet
+- `uv run python scripts/maintenance/project_review_issue_promoter.py --packet <packet>`
+  for validation and dry-run rendering
+
+Do not introduce a second packet shape. Extract a standalone JSON Schema only
+when a second machine consumer needs it, and keep that schema generated from or
+tested against the promoter validator so the two contracts cannot drift.
 
 Required fields:
 
@@ -238,6 +269,11 @@ If the feedback contradicts the issue acceptance criteria or crosses an
 undecided policy boundary, label the issue or PR `decision-needed` and route a
 decision packet before implementation continues.
 
+Review-feedback packets are routing packets, not a new durable planning system.
+Keep them attached to the PR, the linked issue, or the active executor handoff.
+Use a structured JSON contract only if repeated review-feedback routing needs
+machine validation; until then, the bullet contract above is the source.
+
 ## Stage 7: Merge And Closeout
 
 After checks and review are clean, merge according to `AGENTS.md`:
@@ -253,12 +289,19 @@ follow-up. New work gets a new finding packet.
 
 Review and analysis artifacts (spreadsheets, CSVs, reports) produced by agent review lanes:
 
-- Committed only under `review_artifacts/`
-- Use narrow exceptions in `.gitignore` (for example, `!review_artifacts/*.csv`) so global `*.csv` and `data/` ignores do not swallow handoff deliverables.
-- Non-durable temps go in `review_artifacts/tmp/` (still ignored).
-- Document format/location in this file and AGENTS.md.
-- XLSX and targeted CSVs are allowed; avoid committing large datasets or secrets.
-- Verification: after creating artifact, `git status` should show only the intended review files; broad generated CSVs outside remain ignored.
+- Commit only intended root-level `review_artifacts/*.csv` and
+  `review_artifacts/*.xlsx` files under the existing `.gitignore` exceptions.
+- Put non-durable temps in `review_artifacts/tmp/` (still ignored).
+- Treat committed CSV/XLSX files as review deliverables, not canonical planning
+  state. The queue remains GitHub issues; project status remains `docs/STATUS.md`.
+- Name durable files with a stable subject and date or run id, and include enough
+  context in the PR body to explain provenance, source command, and intended
+  reviewer.
+- Avoid committing large datasets, secrets, runtime databases, or broad generated
+  CSVs. If a review needs those locally, keep them ignored.
+- Verification: after creating an artifact, `git status --short review_artifacts
+  .gitignore` should show only the intended review files; broad generated CSVs
+  outside remain ignored.
 
 This supports repeatable review workflow without polluting commits or losing handoff data.
 


### PR DESCRIPTION
## Summary
Related issue / finding / routed package: owner-routed `/goal` canonical source selection phase.

This PR defines GPT-Trader's canonical source selection model without changing product behavior, runtime execution, broker/API access, or generated artifacts.

Changes:
- Adds a canonical source matrix to `docs/INFORMATION_ARCHITECTURE.md` covering Markdown, JSON, YAML, CSV/XLSX, SQLite, JSONL, generated artifacts, runtime stores, and GitHub issues/PRs.
- Clarifies that `gpt-trader.agent-finding.v1` JSON is the canonical scout packet only before promotion; GitHub issues become the durable queue item after promotion.
- Clarifies review-feedback packet ownership and review artifact policy, including root-level `review_artifacts/*.csv` / `*.xlsx` deliverables and ignored temporary outputs.
- Explicitly defers JSON Schema extraction until a second machine consumer needs it.

## Type of change
- [ ] Refactor
- [ ] Feature
- [ ] Bug fix
- [ ] Tests only
- [x] CI/Docs/Tooling

## Scope & Impact
- Affected areas / components: `docs/INFORMATION_ARCHITECTURE.md`, `docs/agents/project_review_pipeline.md`
- Any behavior changes? No. Docs/process/schema policy only.
- Live trading / broker/API / production preflight / order submission: not touched.

## Baseline And Scope Notes
- Writable worktree: `/Users/rj/.codex/worktrees/canonical-source-selection/GPT-Trader`
- Branch: `codex/canonical-source-selection`
- Base at branch creation: `origin/main` `3ff9a468` (`Add PR readiness receipt agent tool (#1057)`)
- The saved checkout at `/Users/rj/Projects/GPT-Trader` was left untouched because local `main` had an unrelated ahead commit and was behind `origin/main` at intake.
- Live GitHub snapshot before PR creation: zero open PRs; the open issue queue remained the existing trade-ideas backlog.
- `docs/agents/project_boundaries.md` was not present in the fresh worktree, so it is intentionally not included.

## Test Plan
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Contract tests (if applicable)
- [ ] Ran locally: `pytest -m "unit and not slow"`
- [ ] Markers used appropriately (`unit`/`integration`/`slow`/`perf`)

Verification run for this docs-only PR:
- [x] `git diff --check` -> passed
- [x] `uv run python scripts/maintenance/docs_link_audit.py` -> passed (72 files scanned)
- [x] `uv run python scripts/maintenance/docs_reachability_check.py` -> passed (49 files reachable)
- [x] `uv run python scripts/maintenance/generate_decision_index.py --check` -> passed (7 records)
- [x] `uv run agent-regenerate --verify` -> passed; all context files up to date
- [x] `uv run python scripts/maintenance/docs_currency_scan.py --output work/canonical-source-selection-docs-currency.json` -> exited 0 and wrote an advisory report; existing report output listed 329 discrepancies (23 missing, 7 stale, 299 uncertain), not changed here

## Complexity & Quality Gates
- [ ] Mypy/type-check passed
- [ ] Xenon/radon complexity gate passed (CC ≤ 15 on live_trade execution)
- [ ] No `sys.path` hacks in tests
- [ ] No `MagicMock` on `async def` (use `AsyncMock`)
- [ ] Import-lint rules respected (no “import up the stack”)

Docs-only PR; code quality gates are not applicable.

## Observability & Errors
- [ ] Structured JSON logs for new/changed paths
- [ ] Errors include diagnostic context (symbol, order_id, correlation_id)
- [ ] Added/updated sampling examples in tests (if applicable)

Not applicable; no runtime paths changed.

## Configuration
- [ ] If config changed: `python -m gpt_trader.cli.config validate --profile <name>` passes
- [ ] Env docs re-generated (if applicable) and committed
- [ ] No `ConfigLoader` usages introduced (ConfigManager-only)

Not applicable; no config changed.

## Breaking Changes
- [x] None
- [ ] Documented in PR body and release notes if any

## Known Follow-Ups
- Extract a standalone JSON Schema for `gpt-trader.agent-finding.v1` only if a second machine consumer needs it.
- Treat docs currency scan discrepancies as a separate cleanup lane if the project wants that scanner to become blocking.

## Checklist
- [x] Acceptance criteria in linked issue(s), finding packet, or routed package met
- [x] Affected paths listed in PR description
- [ ] Changelog entry (if repo uses one)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified where different types of project knowledge and artifacts should live, including canonical locations and acceptable derived formats.
  * Expanded guidance on choosing the right format for prose, configuration, validation outputs, runtime data, and append-only logs.
  * Added clearer routing rules for scout findings and review handoffs.
  * Refined the project review pipeline instructions so review artifacts, feedback, and handoff files follow consistent, durable, and traceable handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->