### PR TITLE
fix(agents): make freshness verify respect git-ignored generated outputs

### DIFF
--- a/scripts/agents/regenerate_all.py
+++ b/scripts/agents/regenerate_all.py
@@ -249,16 +249,22 @@ def _diff_directories(committed_dir: Path, generated_dir: Path) -> str | None:
             f"{generated_dir.as_posix()})."
         )
 
-    ignored_paths = _git_ignored_paths_under(committed_dir)
+    # Exclude git-ignored generated outputs from the freshness comparison. Some
+    # generated files are intentionally not committed (e.g. large, high-churn
+    # inventories); a fresh regeneration recreating them must not read as
+    # "stale". Detection is rule-based (git check-ignore) so it is independent of
+    # whether the file happens to be present in a given checkout, and it is
+    # applied to BOTH sides so the comparison stays symmetric.
+    candidate_relatives = _relative_files(committed_dir) | _relative_files(generated_dir)
+    ignored_paths = _git_ignored_relatives(committed_dir, candidate_relatives)
     if ignored_paths:
         with tempfile.TemporaryDirectory(prefix="agent-diff-") as temp_dir:
-            filtered_committed_dir = Path(temp_dir) / committed_dir.name
-            _copy_directory_without_paths(
-                committed_dir,
-                filtered_committed_dir,
-                ignored_paths,
-            )
-            return _run_directory_diff(filtered_committed_dir, generated_dir)
+            temp_root = Path(temp_dir)
+            filtered_committed_dir = temp_root / "committed" / committed_dir.name
+            filtered_generated_dir = temp_root / "generated" / generated_dir.name
+            _copy_directory_without_paths(committed_dir, filtered_committed_dir, ignored_paths)
+            _copy_directory_without_paths(generated_dir, filtered_generated_dir, ignored_paths)
+            return _run_directory_diff(filtered_committed_dir, filtered_generated_dir)
 
     return _run_directory_diff(committed_dir, generated_dir)
 
@@ -289,39 +295,43 @@ def _run_directory_diff(committed_dir: Path, generated_dir: Path) -> str | None:
     return f"git diff failed ({diff_result.returncode}): {message}"
 
 
-def _git_ignored_paths_under(directory: Path) -> set[Path]:
-    try:
-        repo_relative_dir = directory.resolve().relative_to(PROJECT_ROOT.resolve())
-    except ValueError:
+def _relative_files(directory: Path) -> set[Path]:
+    """Return every file under `directory` as a path relative to it."""
+    return {path.relative_to(directory) for path in directory.rglob("*") if path.is_file()}
+
+
+def _git_ignored_relatives(in_repo_base: Path, relatives: set[Path]) -> set[Path]:
+    """Return the subset of `relatives` whose in-repo path is git-ignored.
+
+    `in_repo_base` is the committed artifact directory (inside the repo). Each
+    relative path is resolved against it and tested with ``git check-ignore``,
+    which is rule-based and therefore independent of whether the file currently
+    exists on disk. This lets freshness diffs drop generated-but-git-ignored
+    outputs on both the committed and freshly generated sides.
+    """
+    if not relatives:
         return set()
 
+    query_to_relative: dict[str, Path] = {
+        (in_repo_base / relative).as_posix(): relative for relative in relatives
+    }
     result = subprocess.run(
-        [
-            "git",
-            "ls-files",
-            "--others",
-            "--ignored",
-            "--exclude-standard",
-            "-z",
-            "--",
-            repo_relative_dir.as_posix(),
-        ],
+        ["git", "check-ignore", "--stdin", "-z"],
+        input="\0".join(query_to_relative) + "\0",
         cwd=PROJECT_ROOT,
         capture_output=True,
         text=True,
     )
-    if result.returncode != 0:
+    # Exit 0 = at least one path ignored, 1 = none ignored; anything else is an
+    # error, in which case fail open (treat nothing as ignored).
+    if result.returncode not in (0, 1):
         return set()
 
-    ignored_paths: set[Path] = set()
-    for raw_path in result.stdout.split("\0"):
-        if not raw_path:
-            continue
-        try:
-            ignored_paths.add(Path(raw_path).relative_to(repo_relative_dir))
-        except ValueError:
-            continue
-    return ignored_paths
+    return {
+        query_to_relative[token]
+        for token in result.stdout.split("\0")
+        if token in query_to_relative
+    }
 
 
 def _copy_directory_without_paths(

--- a/tests/unit/scripts/test_regenerate_all_verify.py
+++ b/tests/unit/scripts/test_regenerate_all_verify.py
@@ -229,3 +229,43 @@ def test_diff_directories_still_reports_tracked_stale_health_files(
     assert diff_text is not None
     assert "agent_health_schema.json" in diff_text
     assert "health_report.json" not in diff_text
+
+
+def test_diff_directories_ignores_git_ignored_generated_output_absent_from_commit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A generated output that is git-ignored and NOT committed must not read as
+    # stale even though it only exists on the freshly generated side. This
+    # regression-guards un-committing large regenerated inventories: the file is
+    # present on the generated side but absent from a fresh checkout.
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    _init_git_repo(repo_root)
+    (repo_root / ".gitignore").write_text(
+        "var/agents/testing/test_inventory.json\n",
+        encoding="utf-8",
+    )
+
+    committed_dir = repo_root / "var" / "agents" / "testing"
+    generated_dir = tmp_path / "generated" / "testing"
+    committed_dir.mkdir(parents=True)
+    generated_dir.mkdir(parents=True)
+
+    # Committed side: only the tracked index; test_inventory.json is uncommitted.
+    (committed_dir / "index.json").write_text('{"summary": 1}\n', encoding="utf-8")
+    subprocess.run(
+        ["git", "add", ".gitignore", "var/agents/testing/index.json"],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    # Generated side: the same index plus the git-ignored inventory.
+    (generated_dir / "index.json").write_text('{"summary": 1}\n', encoding="utf-8")
+    (generated_dir / "test_inventory.json").write_text('{"big": "data"}\n', encoding="utf-8")
+
+    monkeypatch.setattr(regenerate_all, "PROJECT_ROOT", repo_root)
+
+    assert regenerate_all._diff_directories(committed_dir, generated_dir) is None

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -7,7 +7,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 7046,
+    "total_tests": 7047,
     "total_files": 836,
     "markers_used": 16
   },

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     ]
   },
   "counts": {
-    "unit": 6879,
+    "unit": 6880,
     "asyncio": 442,
     "parametrize": 203,
     "property": 82,

--- a/var/agents/testing/test_inventory.json
+++ b/var/agents/testing/test_inventory.json
@@ -2,7 +2,7 @@
   "version": "1.0",
   "description": "Machine-readable test inventory for GPT-Trader",
   "summary": {
-    "total_tests": 7046,
+    "total_tests": 7047,
     "total_files": 836,
     "markers_used": 16
   },
@@ -102,7 +102,7 @@
     ]
   },
   "marker_counts": {
-    "unit": 6879,
+    "unit": 6880,
     "asyncio": 442,
     "parametrize": 203,
     "property": 82,
@@ -64659,6 +64659,14 @@
       {
         "name": "test_diff_directories_still_reports_tracked_stale_health_files",
         "line": 188,
+        "markers": [
+          "unit"
+        ],
+        "docstring": ""
+      },
+      {
+        "name": "test_diff_directories_ignores_git_ignored_generated_output_absent_from_commit",
+        "line": 234,
         "markers": [
           "unit"
         ],


### PR DESCRIPTION
## Summary

Part of the staged **reengineer project support structure** effort (Workstream C). This is the **prerequisite fix** that makes it safe to un-commit large generated inventories (C4, follow-up).

`_diff_directories` (the engine behind `agent-regenerate --verify`) filtered git-ignored files out of the **committed** side only, using presence-based detection (`git ls-files --others --ignored`). That works for git-ignored *runtime* files a generator never recreates (the existing `var/agents/health/*` outputs), but **breaks for a git-ignored file that a generator recreates**: on regeneration it exists only on the generated side and reads as **STALE**. On `pull_request` that's advisory, but on `merge_group` / `push` the freshness job is blocking — so it would **block the merge queue**.

### Fix
- Detect git-ignored artifacts with **`git check-ignore`** (rule-based, so it's independent of whether the file exists in a given checkout) over the **union** of files on both sides, and exclude them from **both** the committed and freshly generated trees before diffing.
- This is a **no-op today** (no generated output is git-ignored yet) and preserves all existing behavior, including the health/chaos handling.
- Replaces the presence-based `_git_ignored_paths_under` helper.

### Tests
- New regression test: a git-ignored generated output present on the generated side but **absent** from a fresh checkout must read as *not stale*. (Fails on `main`, passes here.)
- Existing `_diff_directories` tests (ignore health reports / still catch tracked staleness) still pass.
- Regenerated `var/agents/testing/*` to reflect the added test (small delta).

## Verification
- `test_regenerate_all_verify.py` + `test_regenerate_all.py`: 7 passed.
- Full `uv run agent-regenerate --verify`: **all context files up-to-date**.
- End-to-end: simulating the git-ignore of `test_inventory.json` now passes verify in **both** the present (local) and absent (fresh-checkout/CI) states — the exact failure reproduced on `main` before this change.
- black / ruff / mypy clean; pre-commit hooks pass.

## Follow-up
**C4** (add `var/agents/testing/test_inventory.json` — 1.8 MB, ~70% of the tree, high-churn, not doc-linked — to `.gitignore` and `git rm --cached` it) stacks on this change and is now safe/trivial thanks to the fix + regression test here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Freshness checks now ignore intentionally excluded generated files on both sides, reducing false “out of date” results.
  * Comparing regenerated outputs is now more consistent when files are present only in generated artifacts.

* **Tests**
  * Added coverage for ignored generated files to ensure they do not trigger stale diffs.
  * Updated test inventory counts to reflect the new test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->