### PR TITLE
docs: tracked CLI conventions doc + CONTRIBUTING INTX fix (Workstream B slice 1)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ uv run pytest --cov=gpt_trader --cov-report=term-missing
 
 ## Running the Bot Locally
 
-To run the spot trading bot for development, use the `gpt-trader` command (derivatives stay gated behind INTX + `COINBASE_ENABLE_INTX_PERPS=1`):
+To run the spot trading bot for development, use the `gpt-trader` command (spot is the active trading path):
 
 ```bash
 uv run gpt-trader run --profile dev --dev-fast
@@ -115,6 +115,7 @@ For this repository, status/priority labels are intentionally deferred until the
 ### Code Quality
 - Clean, readable code with meaningful variable names
 - Adhere to [Naming Standards](docs/naming.md)
+- Follow [CLI conventions](docs/agents/conventions.md) for command output, exit codes, and `CliResponse`
 - Comprehensive docstrings for public functions
 - Type hints where beneficial
 - Maximum line length: 100 characters

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -14,6 +14,7 @@ Use this folder for AI-focused navigation aids and generated inventories.
 - [Recurring project review pipeline](project_review_pipeline.md)
 - Scratch logs: [Project regrounding 2026-06-28](scratch_logs/project_regrounding_20260628.md), [runtime architecture refactor 2026-06-29](scratch_logs/runtime_architecture_refactor_20260629.md)
 - [Glossary](glossary.md)
+- [CLI conventions](conventions.md)
 - [Environment variables](../../var/agents/configuration/environment_variables.md)
 - [Metrics catalog](../../var/agents/observability/metrics_catalog.md)
 - [Naming patterns config](../../config/agents/naming_patterns.yaml)

--- a/docs/agents/conventions.md
+++ b/docs/agents/conventions.md
@@ -1,0 +1,69 @@
+# CLI Conventions
+
+---
+status: current
+---
+
+Canonical conventions for `gpt-trader` CLI commands. Use repo-native commands
+(`uv run gpt-trader ...`, `uv run agent-*`) in docs and examples — not editor
+slash commands.
+
+## Command hierarchy
+
+- **Noun-first** for grouped operations under a domain: `gpt-trader broker test`,
+  `gpt-trader account balance`, `gpt-trader strategy run`.
+- **Verb-first** for standalone actions: `gpt-trader run`, `gpt-trader validate`,
+  `gpt-trader preflight`.
+
+## Human-readable output
+
+Simple status commands use a leading glyph and stable phrasing:
+
+- Success: `✓ <Service> <action> OK (<details>)` — exit code `0`.
+- Failure: `✗ <Service> <action> FAILED: <error>` — exit code `1`.
+
+Exit codes are `0` for success and `1` for failure. See
+[`coinbase.py`](../../src/gpt_trader/cli/commands/coinbase.py) (`connectivity OK
+(...)` / `FAILED: ...`) and [`ideas.py`](../../src/gpt_trader/cli/commands/ideas.py)
+for live examples.
+
+## Structured output (`--output-format json`)
+
+Commands that support programmatic use accept `--output-format json` and emit the
+[`CliResponse`](../../src/gpt_trader/cli/response.py) envelope:
+
+```json
+{
+  "success": true,
+  "exit_code": 0,
+  "command": "optimize list",
+  "data": {},
+  "errors": [],
+  "warnings": [],
+  "metadata": {"timestamp": "...", "was_noop": false, "version": "1.0"}
+}
+```
+
+Build responses with the factory methods rather than by hand:
+
+- `CliResponse.success_response(command, data=..., warnings=..., was_noop=...)`
+- `CliResponse.error_response(command, code, message, details=...)`
+
+Errors carry a machine-readable
+[`CliErrorCode`](../../src/gpt_trader/cli/response.py) (serialized as a plain
+string), e.g. `CONFIG_INVALID`, `RUN_NOT_FOUND`. In tests, compare against the
+enum value:
+
+```python
+assert response.errors[0].code == CliErrorCode.CONFIG_INVALID.value
+assert response.success is True
+assert response.data["key"] == expected_value
+```
+
+Use [`RawCliOutput`](../../src/gpt_trader/cli/response.py) when a command must emit
+its content exactly as provided, bypassing the envelope.
+
+## Worked example
+
+The trade-idea CLI applies these conventions end to end; see
+[`TRADE_IDEA_CLI_SPEC.md`](../specs/TRADE_IDEA_CLI_SPEC.md).


### PR DESCRIPTION
## Summary

First, conflict-free slice of **Workstream B** (agent-facing docs → single source of truth), part of the staged *reengineer project support structure* effort.

### Tracked home for the CLI-output convention
The `✓`/`✗` + `CliResponse` CLI convention had **no tracked home** — it lived only in the git-ignored `.claude/CLAUDE.md` and (self-canonically) the trade-idea specs. Adds **`docs/agents/conventions.md`** as the general tracked reference:
- Command hierarchy (noun-first vs verb-first), text status format + exit codes, and the `--output-format json` / `CliResponse` envelope.
- Grounded in source: [`cli/response.py`](src/gpt_trader/cli/response.py), with live examples in [`coinbase.py`](src/gpt_trader/cli/commands/coinbase.py) / [`ideas.py`](src/gpt_trader/cli/commands/ideas.py). (Also corrects the drifted `CliResponse.success(...)` snippet — the real factories are `success_response()` / `error_response()`.)
- Linked from the agent docs index and `CONTRIBUTING.md`.

### INTX drift fix
`CONTRIBUTING.md`'s dev-run instructions no longer advertise the deprecated `COINBASE_ENABLE_INTX_PERPS` toggle — spot is the active trading path.

## Scope / coordination
Deliberately **avoids `AGENTS.md`**, which the still-open #1071 also edits (concurrent-edit conflict). The AGENTS.md-canonical restructuring + TUI-reference cleanup are deferred until #1071 (and the TUI-removal branch) land. The trade-idea specs are left as-is (deliberately self-canonical).

## Verification
- `docs_link_audit`: passes (all new source links resolve).
- `docs_reachability_check`: passes (new doc reachable via the agent docs index).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contributor guidance to reflect the active spot trading bot workflow, removing outdated derivatives references.
  * Added a new CLI conventions reference covering command naming, consistent success/failure output, stable exit codes (0/1), and a structured `--output-format json` response contract.
  * Linked the new conventions reference from the agents documentation for easier discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->