### PR TITLE
docs: make AGENTS.md a first-stop routing guide, not an encyclopedia

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,100 @@
-# AGENTS.md
+# AGENTS.md — Start Here for AI Agents
 
-This file provides guidance to AI coding agents working with this repository.
+This is the **first stop** for any AI coding agent (and a fine one for humans).
+It routes; it does not restate policy. Each row below points at the one doc that
+owns that fact — read that doc for detail, and change facts there, not here.
 
-## Jules Setup
+Two rules keep this repo from sprawling:
 
-### Initial Setup Script
+1. **State each fact once; link, don't copy.** The authority on where every kind
+   of fact lives is [docs/INFORMATION_ARCHITECTURE.md](docs/INFORMATION_ARCHITECTURE.md).
+2. **Opening a PR is not merging.** Merge is a separate, later, explicitly
+   approved step (see [Merge discipline](#merge-discipline)).
 
-For Google Jules, paste this into the "Initial Setup" configuration window:
+## Where do I go?
+
+| I need to… | Canonical home |
+|------------|----------------|
+| Decide **where a fact/doc should live** | [docs/INFORMATION_ARCHITECTURE.md](docs/INFORMATION_ARCHITECTURE.md) |
+| Find **where code lives / where to change something** | [docs/agents/CODEBASE_MAP.md](docs/agents/CODEBASE_MAP.md) |
+| Understand the **system design** (slices, order pipeline) | [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) |
+| Browse the **full doc index** | [docs/README.md](docs/README.md) |
+| Know the **project direction, autonomy boundary, execution gates** | [docs/DIRECTION.md](docs/DIRECTION.md) |
+| See **current shipped state** | [docs/STATUS.md](docs/STATUS.md) |
+| Follow the **contribution workflow** (setup, PR checklist, test quality) | [CONTRIBUTING.md](CONTRIBUTING.md) |
+| Understand **local CI, the verification bundle, and the CI-lane contract** | [docs/DEVELOPMENT_GUIDELINES.md](docs/DEVELOPMENT_GUIDELINES.md) |
+| Apply **naming standards + approved abbreviations** | [docs/naming.md](docs/naming.md), [docs/agents/glossary.md](docs/agents/glossary.md) |
+| Use **dependency injection** (`ApplicationContainer`) | [docs/DI_POLICY.md](docs/DI_POLICY.md) |
+| Write or run **tests** | [docs/testing.md](docs/testing.md) |
+| Touch the **TUI** | [docs/TUI_STYLE_GUIDE.md](docs/TUI_STYLE_GUIDE.md) |
+| Run the **agent review/scout pipeline** or handle review artifacts | [docs/agents/project_review_pipeline.md](docs/agents/project_review_pipeline.md) |
+| Find **generated inventories/maps** (env vars, metrics, flows) | `var/agents/**` + [docs/agents/README.md](docs/agents/README.md) |
+
+## Environment (one time)
+
+Python **3.12**, package manager **uv**. Full setup and troubleshooting live in
+[CONTRIBUTING.md](CONTRIBUTING.md); the short version:
+
+```bash
+uv sync --all-extras --dev
+cp config/environments/.env.template .env   # set MOCK_BROKER=1 to run without credentials
+```
+
+## Everyday commands
+
+The commands you reach for on almost every task (full reference in
+[CONTRIBUTING.md](CONTRIBUTING.md) and [docs/DEVELOPMENT_GUIDELINES.md](docs/DEVELOPMENT_GUIDELINES.md)):
+
+```bash
+uv run pytest tests/unit -n auto -q     # fast unit tests
+uv run ruff check . --fix               # lint (auto-fix)
+uv run black .                          # format
+uv run mypy src/gpt_trader              # type check
+uv run agent-naming                     # naming conventions
+make ci-required                        # full local PR-readiness gate
+uv run local-ci --profile quick         # faster loop (skips readiness + artifact freshness)
+```
+
+## Before you open a PR
+
+- Run `make ci-required` (lint/format, docs audits, type check, agent-artifact
+  freshness, TUI CSS, test guardrails, core unit tests). The blocking/advisory
+  contract is owned by [docs/DEVELOPMENT_GUIDELINES.md](docs/DEVELOPMENT_GUIDELINES.md).
+- If you touched agent-artifact inputs (`scripts/agents/**` or
+  `config/environments/.env.template`), run `uv run agent-regenerate` and commit
+  the updated `var/agents/**`; confirm with `uv run agent-regenerate --verify`.
+- After editing any `.tcss` module, run `python scripts/build_tui_css.py`.
+- Fill out [.github/pull_request_template.md](.github/pull_request_template.md);
+  link the issue/finding with `Closes #<n>` when there is one.
+
+## Merge discipline
+
+`main` is protected and merge is **not** part of packaging. Open the PR, then stop
+until the change is explicitly routed for merge. Before merging: re-read
+current-head review/reaction signals, resolve every review thread, and confirm
+generated artifacts are fresh. **Green CI is not sufficient** — run
+`uv run agent-pr-ready`, which reconciles real mergeability against green checks.
+
+```bash
+git switch -c <branch>
+git push -u origin HEAD
+gh pr create --fill
+# Merge only once explicitly approved and all threads are resolved:
+# gh pr merge --squash --delete-branch
+```
+
+## Trading-safety boundary
+
+Existing live profiles and broker adapters are implementation assets, **not**
+approval to automate. Live order submission requires recorded human approval plus
+any scoped decision packet; verify venue/API/account capability before adding or
+enabling an execution path. The authority is [docs/DIRECTION.md](docs/DIRECTION.md);
+findings route through [docs/agents/project_review_pipeline.md](docs/agents/project_review_pipeline.md).
+
+## Hosted-agent setup (Google Jules)
+
+Paste this into the Jules "Initial Setup" window. It configures `.env` with safe
+mock defaults, then runs the core unit suite:
 
 ```bash
 set -euo pipefail
@@ -18,215 +106,11 @@ uv python install 3.12
 uv sync --all-extras --dev
 
 test -f .env || cp config/environments/.env.template .env
-
 uv run python -c "import re; from pathlib import Path; p=Path('.env'); p.write_text(re.sub(r'^MOCK_BROKER=.*$','MOCK_BROKER=1',p.read_text(),flags=re.M))"
 
 uv run python scripts/ci/check_tui_css_up_to_date.py
 uv run pytest tests/unit -n auto -q --ignore-glob=tests/unit/gpt_trader/tui/test_snapshots_*.py
 ```
 
-### Environment Variables (Optional)
-
-The setup script configures `.env` with safe defaults. If you need to override via Jules repo settings:
-
-```
-MOCK_BROKER=1
-DRY_RUN=1
-```
-
-Note: `PYTHONWARNINGS` value must be `default` (not `1`) if set.
-
-## Project Overview
-
-GPT-Trader is a Coinbase-oriented trading system using vertical slice architecture with modern Dependency Injection via `ApplicationContainer`. Trading strategies currently use technical analysis and rule-based decisioning, not LLM inference.
-
-Do not treat existing live profiles or broker adapters as proof that a product should be automated. Before migration or new execution work, use `docs/DIRECTION.md`: start from the current approval-gated execution phase (`human_approved_execution` compatibility label), keep broker-neutral records canonical, route unresolved live-control choices through `decision-needed` packets, and verify venue/API/account capability before adding or enabling execution paths.
-
-**Trading Modes:**
-- **Spot Trading** - Implemented Coinbase spot paths; require explicit profile and readiness gates
-- **CFM Futures** - Implemented/gated US-regulated futures paths; require account, product, and risk verification
-- **INTX Perpetuals** - Implemented/gated international derivatives paths; require eligible-region/account verification
-- **AI-assisted execution** - Planning and approval-gated tickets only; live order submission requires recorded human approval plus any explicitly scoped decision packet or runbook constraints before any order submission
-
-## Environment Setup
-
-**Python Version:** 3.12 (required)
-**Package Manager:** uv
-
-Install dependencies:
-```bash
-uv sync --all-extras --dev
-```
-
-Create environment config:
-```bash
-cp config/environments/.env.template .env
-```
-
-For testing without real API access, set `MOCK_BROKER=1` in `.env`.
-
-## Commands
-
-### Testing
-
-| Command | Purpose |
-|---------|---------|
-| `uv run pytest tests/unit -q` | Run unit tests |
-| `uv run pytest tests/unit -n auto -q` | Run tests in parallel |
-| `uv run pytest tests/unit/path/to/test.py -v` | Run single test file |
-| `uv run pytest tests/unit --cov=src/gpt_trader` | Run with coverage |
-
-### Local CI
-
-Run `make ci-required` when you want the local PR-readiness command set. It runs
-lint/format, docs audits, type checks, agent artifact freshness, TUI CSS checks,
-test guardrails, and core unit tests, stopping on the first local failure.
-Agent-artifact freshness is advisory locally — it warns on stale artifacts but
-does not stop the run. GitHub pull_request CI runs a related agent-freshness job,
-but stale artifacts are reported as non-blocking on pull requests. GitHub pull_request CI also does
-not run the canary readiness gate.
-
-Run `uv run local-ci` (or `python -m gpt_trader.ci.local_ci`) with the default
-strict/full profile when you also want local/live readiness evidence. Strict/full
-runs the local PR-readiness validation set plus the canary readiness gate and
-agent artifacts freshness; the CLI prints the selected profile and the
-readiness/artifact statuses before executing commands.
-
-For faster loops without readiness reports or regenerating `var/agents`, use the quick/dev profile via `--profile quick` or `--profile dev`. That profile disables the readiness gate and agent artifacts freshness steps (the output notes which checks were skipped and why). Run `make ci-required` for the local PR-readiness command set, and run strict `uv run local-ci` when you need the additional local/live readiness gate before operational readiness work.
-
-## GitHub Workflow
-
-`main` is protected: changes must land via pull request with required checks
-passing. Open the PR; **merge is a separate, later decision** — merge only when
-the change is explicitly routed/approved for merge and all review threads are
-resolved. Green CI is not sufficient (`uv run agent-pr-ready` reconciles real
-mergeability against green checks).
-
-```bash
-git switch -c <branch>
-git push -u origin HEAD
-gh pr create --fill
-# Merge only once explicitly approved/routed and review threads are resolved:
-# gh pr merge --squash --delete-branch
-```
-
-If you touch `var/agents/**` or any agent-artifact inputs (notably `scripts/agents/**` or `config/environments/.env.template`), run `uv run agent-regenerate` and commit the updated artifacts. Non-PR GitHub CI fails when they are stale; local `make ci-required` / strict `uv run local-ci` and GitHub pull request CI report stale artifacts as a non-blocking advisory warning. To check quickly: `uv run agent-regenerate --verify`.
-
-### Quality Checks
-
-| Command | Purpose |
-|---------|---------|
-| `uv run ruff check .` | Lint code |
-| `uv run ruff check . --fix` | Lint and auto-fix |
-| `uv run black .` | Format code |
-| `uv run mypy src/gpt_trader` | Type check |
-| `uv run agent-check` | Full quality gate (JSON output) |
-| `uv run agent-naming` | Check naming conventions |
-
-### TUI Development
-
-After editing `.tcss` files, rebuild CSS:
-```bash
-python scripts/build_tui_css.py
-```
-
-### Agent Review Artifacts
-
-Review and analysis artifacts that should be durable project records belong in
-`review_artifacts/`. Commit only intended review CSV/XLSX deliverables there;
-keep temporary review outputs under `review_artifacts/tmp/`, and do not commit
-large datasets or secrets.
-
-## Architecture
-
-### Source Structure
-
-| Path | Purpose |
-|------|---------|
-| `src/gpt_trader/app/` | Composition root - `ApplicationContainer`, config, bootstrap |
-| `src/gpt_trader/features/` | Vertical slices (brokerages, live_trade, data, intelligence) |
-| `src/gpt_trader/tui/` | Terminal UI (Textual-based) |
-| `src/gpt_trader/monitoring/` | Runtime guards, metrics |
-| `src/gpt_trader/validation/` | Declarative validators |
-| `src/gpt_trader/errors/` | Centralized error hierarchy |
-
-### Key Feature Slices
-
-| Slice | Purpose |
-|-------|---------|
-| `features/brokerages/coinbase/` | REST/WebSocket integration, client mixins |
-| `features/live_trade/` | Trading engine, strategies, risk management |
-| `features/live_trade/execution/` | Guards, validation, order submission |
-| `features/intelligence/sizing/` | Kelly criterion position sizing |
-
-### Dependency Injection
-
-Use `ApplicationContainer` for all new services (see `docs/DI_POLICY.md`):
-
-```python
-# Preferred: Receive container or service as parameter
-def my_function(container: ApplicationContainer) -> None:
-    service = container.my_service
-
-# Tests: Create own container instance
-@pytest.fixture
-def container(mock_config):
-    return ApplicationContainer(mock_config)
-```
-
-**Avoid:** Module-level singletons, service locators in business logic.
-
-## Naming Standards
-
-**Banned abbreviations:** `cfg`, `svc`, `mgr`, `util`, `utils`, `amt`, `calc`, `upd`
-
-Use `# naming: allow` to suppress warnings for external API fields.
-
-See `docs/agents/glossary.md` for approved abbreviations (e.g., `qty`, `PnL`, `API`).
-
-## Testing
-
-### Test Organization
-
-| Directory | Purpose | Default Run |
-|-----------|---------|-------------|
-| `tests/unit/` | Unit tests | Yes |
-| `tests/integration/` | Integration tests | No (marker excluded) |
-| `tests/property/` | Hypothesis property tests | Separate |
-| `tests/contract/` | API contract tests | Separate |
-
-### Markers
-
-Tests excluded by default: `integration`, `real_api`, `uses_mock_broker`, `legacy_delete`, `legacy_modernize`
-
-Run specific markers:
-```bash
-uv run pytest -m "spot" tests/unit         # Spot trading tests
-uv run pytest -m "risk" tests/unit         # Risk management tests
-uv run pytest -m "integration" tests/      # Integration tests (opt-in)
-```
-
-## Common Issues
-
-| Issue | Fix |
-|-------|-----|
-| `black --check` fails | Run `uv run black .` |
-| `ruff check` fails | Run `uv run ruff check --fix .` |
-| CSS out of sync | Run `python scripts/build_tui_css.py` |
-| Snapshot mismatch | Review changes, run `--snapshot-update` if intentional |
-
-## Key Documentation
-
-| Document | Purpose |
-|----------|---------|
-| `docs/ARCHITECTURE.md` | System design, order execution pipeline |
-| `docs/DI_POLICY.md` | Dependency injection patterns |
-| `docs/naming.md` | Naming conventions |
-| `docs/TUI_STYLE_GUIDE.md` | TUI development guide |
-| `CONTRIBUTING.md` | Full contribution workflow |
-
-### Review Artifacts Convention (run goal-pipeline-20260626-001-gpt-trader-clean-discovery-scout)
-Review deliverables (CSVs, spreadsheets from agent review lanes) are tracked only in `review_artifacts/`.
-- `!review_artifacts/` exception in .gitignore (global *.csv still protects data/).
-- See docs/agents/project_review_pipeline.md for details and verification.
-- Keeps handoff data durable without broad un-ignores.
+If you override env via Jules repo settings, use `MOCK_BROKER=1` and `DRY_RUN=1`
+(and set `PYTHONWARNINGS=default`, not `1`, if you set it at all).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,9 +60,12 @@ uv run local-ci --profile quick         # faster loop (skips readiness + artifac
 - Run `make ci-required` (lint/format, docs audits, type check, agent-artifact
   freshness, TUI CSS, test guardrails, core unit tests). The blocking/advisory
   contract is owned by [docs/DEVELOPMENT_GUIDELINES.md](docs/DEVELOPMENT_GUIDELINES.md).
-- If you touched agent-artifact inputs (`scripts/agents/**` or
-  `config/environments/.env.template`), run `uv run agent-regenerate` and commit
-  the updated `var/agents/**`; confirm with `uv run agent-regenerate --verify`.
+- If your change can affect generated `var/agents/**` context, run
+  `uv run agent-regenerate` and commit the updated artifacts; confirm with
+  `uv run agent-regenerate --verify`. The exact freshness/CI contract (which
+  inputs count and where it blocks vs. warns) lives in
+  [docs/DEVELOPMENT_GUIDELINES.md](docs/DEVELOPMENT_GUIDELINES.md) and the CI
+  classifier.
 - After editing any `.tcss` module, run `python scripts/build_tui_css.py`.
 - Fill out [.github/pull_request_template.md](.github/pull_request_template.md);
   link the issue/finding with `Closes #<n>` when there is one.
@@ -106,7 +109,7 @@ uv python install 3.12
 uv sync --all-extras --dev
 
 test -f .env || cp config/environments/.env.template .env
-uv run python -c "import re; from pathlib import Path; p=Path('.env'); p.write_text(re.sub(r'^MOCK_BROKER=.*$','MOCK_BROKER=1',p.read_text(),flags=re.M))"
+uv run python -c "import re; from pathlib import Path; p=Path('.env'); t=p.read_text(); t=re.sub(r'^MOCK_BROKER=.*$','MOCK_BROKER=1',t,flags=re.M); t=re.sub(r'^DRY_RUN=.*$','DRY_RUN=1',t,flags=re.M); p.write_text(t)"
 
 uv run python scripts/ci/check_tui_css_up_to_date.py
 uv run pytest tests/unit -n auto -q --ignore-glob=tests/unit/gpt_trader/tui/test_snapshots_*.py


### PR DESCRIPTION
## Summary
Related issue / finding / routed package: owner-routed package (instruction-surface consolidation goal)

`AGENTS.md` had grown to ~230 lines that mostly **restated** content owned by other docs, and the copies had started to drift. This rewrites it as a compact **first-stop routing guide** (116 lines): a "where do I go?" table that points at each canonical home, plus only the facts that are genuinely agent-owned and have no other home.

### What was duplicated (now redirected)
| AGENTS.md section (removed) | Canonical home it now links to |
|---|---|
| Project overview / trading-modes table | `README.md` + `docs/DIRECTION.md` |
| Testing commands, markers, quality-gate, common CI failures | `CONTRIBUTING.md` |
| Local-CI / verification bundle prose | `docs/DEVELOPMENT_GUIDELINES.md` |
| Source structure / feature slices | `docs/agents/CODEBASE_MAP.md` + `docs/ARCHITECTURE.md` |
| Dependency-injection example | `docs/DI_POLICY.md` |
| Naming standards / banned abbreviations | `docs/naming.md` + `docs/agents/glossary.md` |
| Review-artifacts convention (with stale run-id provenance tag) | `docs/agents/project_review_pipeline.md` |
| "Key Documentation" mini-index | `docs/README.md` |

### Drift removed
The old trading-modes table described **INTX as "Implemented/gated"** while every other surface (`README.md`, `docs/README.md`, `docs/DIRECTION.md`) marks it **"Frozen."** Redirecting instead of restating removes the contradiction.

### Kept (genuinely agent-owned, no other home)
Everyday-commands cheatsheet, merge discipline (`agent-pr-ready`, threads-resolved, green-CI-not-sufficient), the trading-safety boundary, the `agent-regenerate`/TUI-CSS gotchas, and the Jules hosted-agent setup script.

This aligns `AGENTS.md` with the role `docs/INFORMATION_ARCHITECTURE.md` already assigns it: *"Agent rules: `AGENTS.md` (canonical); everywhere else links to the one owner."*

## Type of change
- [x] CI/Docs/Tooling

## Scope & Impact
- Affected areas / components: `AGENTS.md` only (root). No code, tests, config, or generated `var/agents/**` inputs touched — `AGENTS.md` feeds no generated artifact.
- Any behavior changes? No. Documentation routing only.

## Test Plan
- [x] Not applicable (docs-only)

## Quality Gates
- [x] `scripts/maintenance/docs_link_audit.py` — pass (73 files scanned; every redirect target resolves)
- [x] `scripts/maintenance/docs_reachability_check.py` — pass (51 docs reachable)
- [x] No anchored inbound links to `AGENTS.md` exist, so heading changes break nothing
- [x] `pre-commit` hooks pass

## Breaking Changes
- [x] None

## Checklist
- [x] One bounded PR
- [x] Docs audits used as verification
- [x] No new support model / workflow / rubric introduced — consolidation only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reworked the repository guidance into a shorter “start here” guide for AI agents.
  * Added a clear map to the right canonical docs for common tasks.
  * Simplified setup, everyday commands, and pre-PR checks into quick-reference sections.
  * Clarified the separation between opening a PR and completing the approved merge step.
  * Streamlined hosted-agent setup instructions and updated safety guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->