### PR TITLE
docs(pr-template): broaden agent-artifact checklist trigger, defer contract

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -31,7 +31,7 @@ Related issue / finding / routed package:
 - [ ] Errors include diagnostic context (symbol, order_id, correlation_id)
 
 ## Agent Artifacts & Config (if touched)
-- [ ] If `var/agents/**` inputs changed (`scripts/agents/**`, `config/environments/.env.template`): ran `uv run agent-regenerate` and committed artifacts (`uv run agent-regenerate --verify` clean)
+- [ ] If your change can affect generated `var/agents/**` context: ran `uv run agent-regenerate` and committed the refreshed artifacts (`uv run agent-regenerate --verify` clean). The exact inputs and freshness/CI contract live in `docs/DEVELOPMENT_GUIDELINES.md` and the CI path classifier
 - [ ] If docs changed: `make agent-docs-links` passes
 
 ## Breaking Changes


### PR DESCRIPTION
## Summary
The **Agent Artifacts & Config** checklist item in `.github/pull_request_template.md` carried a too-narrow artifact-input list (`scripts/agents/**`, `config/environments/.env.template`) — the same wording just corrected in `AGENTS.md` via #1077 (commit `90249b33`). The codex review on #1077 established the CI path classifier also treats `src/*`, `tests/*`, `scripts/**/*.py`, `config/agents/*`, and `var/agents/*` as agent-artifact inputs. Because local/PR freshness is advisory, a contributor following the narrow list could skip committing refreshed `var/agents/**` after a source change.

This rewords the checklist item to trigger on *"if your change can affect generated `var/agents/**` context"* and defers the exact input set / freshness contract to `docs/DEVELOPMENT_GUIDELINES.md` and the CI path classifier, rather than pasting the brittle glob list into the template. Phrasing mirrors what landed in `AGENTS.md` in #1077 for consistency.

Related issue / finding / routed package: follow-up to #1077 (codex review on the narrow artifact-input list)

## Type of change
- [x] CI/Docs/Tooling

## Scope & Impact
- Affected areas / components: `.github/pull_request_template.md` only (one checklist line under "Agent Artifacts & Config").
- Any behavior changes? No. Documentation/checklist wording only — no code, tests, config, or generated `var/agents/**` inputs touched.

## Test Plan
- [x] Not applicable (docs/template-only)

## Quality Gates
- [x] `uv run python scripts/maintenance/docs_link_audit.py` — pass (73 files scanned; markdown link audit passed). Note: the PR template is not under `docs/`, so currency/reachability scanners don't cover it.

## Agent Artifacts & Config (if touched)
- [x] No `var/agents/**` context inputs touched — template/docs wording only, so no regeneration needed.

## Breaking Changes
- [x] None

## Checklist
- [x] One small bounded PR, scoped to `.github/pull_request_template.md`
- [x] Affected paths listed in PR description
- [x] Mirrors the phrasing landed in `AGENTS.md` in #1077; no brittle glob list pasted into the template

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019EKm6b9kcFcZWTnQSwWeiu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the pull request template guidance for regenerating agent artifacts, clarifying that regeneration should be run whenever changes could affect generated context.
  * Kept the reminder to verify that generated output is up to date before submitting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->