### PR TITLE
ci: remove TUI compatibility shim jobs (#1084)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -445,26 +445,6 @@ jobs:
             sed -n '1,40p' var/agents/health/agent_regenerate_verify.txt >> $GITHUB_STEP_SUMMARY
           fi
 
-  tui-css-compat:
-    name: TUI CSS Check
-    runs-on: ubuntu-latest
-    timeout-minutes: 2
-    steps:
-      - name: TUI CSS check removed
-        run: |
-          echo "The Textual TUI subsystem and CSS build were removed."
-          echo "This compatibility job preserves the required check context until branch protection is updated."
-
-  tui-snapshots-compat:
-    name: TUI Snapshot Tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 2
-    steps:
-      - name: TUI snapshot tests removed
-        run: |
-          echo "The Textual TUI subsystem and snapshot tests were removed."
-          echo "This compatibility job preserves the required check context until branch protection is updated."
-
   test-guardrails:
     name: Test Guardrails
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes the branch-protection prune from #1084.

## What
Removes the no-op `tui-css-compat` / `tui-snapshots-compat` jobs from `ci.yml`. #1069 (Remove TUI subsystem) left these solely to keep the `TUI CSS Check` and `TUI Snapshot Tests` **required status contexts** satisfied so PRs could still merge.

## Why now
The two contexts have been removed from `main`'s branch protection (`required_status_checks` now lists only the 7 real contexts: Contract Tests, Docs Link Audit, Lint & Format, Property Tests, Test Guardrails, Type Check, Unit Tests (Core)). With nothing requiring them, the shims serve no purpose.

## Safety
- Ordering was **protection-first, then this PR** — the reverse would have blocked every PR on contexts no job reports.
- Verified: YAML valid; `0` remaining `tui` references; the removed jobs were the **only** producers of the 2 retired contexts; all other required contexts are still produced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed obsolete CI compatibility checks tied to removed TUI/CSS snapshot coverage.
  * Streamlined the workflow so it now moves directly from the existing freshness check to the next validation step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->