### PR TITLE
[codex] scrub stale contributor workflow references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ That's it! Now, every time you run `git commit`, the pre-commit hooks will run a
 ### Pre-PR Verification Checklist
 1. Review `docs/README.md` and prefer code + `var/agents/**` generated inventories for anything that drifts.
 2. Refresh dependencies: `uv sync`.
-3. Snapshot test discovery: `uv run pytest --collect-only`.
+3. Collect tests: `uv run pytest --collect-only`.
 4. Run the full unit suite: `uv run pytest tests/unit -q`.
 5. Execute slice-specific suites relevant to your change set (examples below).
 6. Validate docs links: `make agent-docs-links` (runs `scripts/maintenance/docs_link_audit.py`).
@@ -65,13 +65,6 @@ To run the spot trading bot for development, use the `gpt-trader` command (spot 
 
 ```bash
 uv run gpt-trader run --profile dev --dev-fast
-```
-
-Launch the TUI via the CLI entry point to keep uv-locked deps and env/logging setup consistent:
-
-```bash
-uv run gpt-trader tui               # Mode selector
-uv run gpt-trader tui --mode demo   # Skip selector for demos
 ```
 
 ## Development Workflow
@@ -104,8 +97,10 @@ Before branching, make sure to:
 Issue labels drive repository issue routing for agents and humans. Keep them consistent and machine-friendly:
 
 - **Type label (required):** one of `bug`, `enhancement`, `architecture`, `chore`, `documentation`, `tests`, `ci`, or `security`.
-- **Area label(s) (required, 1–2):** one or two labels from the domain set, e.g. `trade-ideas`, `live-trade`, `cli`, `tui`, `mcp`, `reporting`, `runtime`, `monitoring`, `audit`, `closeout`.
-- **Optional detail labels:** use tags like `persistence`, `broker-neutral`, `reliability`, `packaging`, `deploy`, etc. as needed.
+- **Area label(s) (required, 1–2):** one or two labels from the active domain set, e.g. `trade-ideas`, `live-trade`, `cli`, `mcp`, `reporting`, `runtime`, `monitoring`, `audit`, `closeout`, `broker-neutral`, `trading-safety`, or `coinbase`.
+- **Optional detail labels:** use tags like `persistence`, `reliability`, `packaging`, `deploy`, `developer-experience`, `tech-debt`, etc. as needed.
+- **Agent routing labels:** `agent-review`, `agent-ready`, `decision-needed`, `codex-review-feedback`, and `claw-candidate` are routing signals. Their detailed workflow lives in [the agent review pipeline](docs/agents/project_review_pipeline.md#stage-4-queue).
+- **Triage labels:** use `triage:build-now`, `triage:build-next`, `triage:blocked`, or `triage:defer` after an issue has been sorted into the current queue shape.
 - **`codex` label:** routing signal for the agent-review / Codex workflow. Issues in this lane (e.g. the `agent-review-finding` template) are **exempt** from the Type/Area requirements above — `codex` alone is sufficient.
 
 For this repository, status/priority labels are intentionally deferred until they solve a real need. The default issue templates should already include the intended label shape so no extra manual steps are needed at issue creation.
@@ -125,7 +120,7 @@ For this repository, status/priority labels are intentionally deferred until the
 - One assertion per test when possible
 - Use fixtures for shared setup
 - Use pytest `monkeypatch` for mocks; patch-style helpers are blocked in `tests/`
-- Keep test modules <= 240 lines unless allowlisted by `scripts/ci/check_test_hygiene.py`
+- Keep test modules <= 400 lines unless allowlisted by `scripts/ci/check_test_hygiene.py`
 - Avoid `time.sleep`; prefer deterministic `fake_clock`
 - Match marker conventions to folder (integration/contract/real_api)
 
@@ -275,32 +270,6 @@ uv run pytest tests/unit/gpt_trader/features/live_trade/execution/test_order_sub
 uv run pytest tests/unit --cov=src/gpt_trader --cov-report=term-missing
 ```
 
-### TUI CSS Regeneration
-
-The TUI uses concatenated CSS modules. After editing any `.tcss` file in `src/gpt_trader/tui/styles/`:
-
-```bash
-# Regenerate main.tcss from source modules
-python scripts/build_tui_css.py
-
-# Verify the TUI renders correctly
-uv run gpt-trader tui --mode demo
-```
-
-**Important**: Never edit `styles/main.tcss` directly - it's auto-generated.
-
-### TUI Snapshot Tests
-
-Snapshot tests verify TUI rendering consistency:
-
-```bash
-# Run snapshot tests
-uv run pytest tests/unit/gpt_trader/tui/test_snapshots_*.py -q
-
-# Update snapshots after intentional UI changes
-uv run pytest tests/unit/gpt_trader/tui/test_snapshots_*.py --snapshot-update
-```
-
 ### Naming Standards Check
 
 ```bash
@@ -315,8 +284,6 @@ uv run agent-naming
 | `black --check` | Formatting | Run `uv run black .` |
 | `ruff check` | Linting violations | Run `uv run ruff check --fix .` |
 | `mypy` errors | Type issues | Fix type annotations (pre-existing shim errors can be ignored) |
-| Snapshot mismatch | TUI changed | Review changes, run `--snapshot-update` if intentional |
-| CSS out of sync | Edited `.tcss` module | Run `python scripts/build_tui_css.py` |
 | Import error | Wrong module path | Use canonical paths (see `docs/DEPRECATIONS.md`) |
 | Test using deprecated path | Patch targets shim | Update to patch canonical module directly |
 
@@ -330,7 +297,7 @@ make ci-required
 
 For quick iteration the commands below cover the most common failures, but they
 are **not** a full substitute for `make ci-required` (which also runs docs
-audits, `agent-regenerate --verify`, TUI CSS, and test-guardrails):
+audits, `agent-regenerate --verify`, and test guardrails):
 
 ```bash
 uv run ruff check .
@@ -340,31 +307,15 @@ uv run pytest tests/unit -n auto -q
 pre-commit run --all-files
 ```
 
-## CI Lanes
+## CI Contract
 
-The CI workflow (`.github/workflows/ci.yml`) runs checks in parallel lanes for
-faster feedback and isolated failures. The compact blocking/advisory contract
-lives in
-[`docs/DEVELOPMENT_GUIDELINES.md`](docs/DEVELOPMENT_GUIDELINES.md#continuous-integration);
-keep this section as a local command quick-reference, not a second source of
-truth for branch protection.
+The compact blocking/advisory CI contract lives in
+[`docs/DEVELOPMENT_GUIDELINES.md`](docs/DEVELOPMENT_GUIDELINES.md#continuous-integration).
+Use that section for branch-protection context names, blocking status, and
+workflow semantics. Keep this section as a local command quick-reference, not a
+second CI-lane table.
 
-### Lane Overview
-
-| Lane | Job Name | Command | Purpose |
-|------|----------|---------|---------|
-| **Lint** | `lint` | `uv run ruff check . && uv run black --check .` | Code style |
-| **Docs Audit** | `docs-audit` | `uv run python scripts/maintenance/docs_link_audit.py && uv run python scripts/maintenance/docs_reachability_check.py` | Docs links and reachability |
-| **Type Check** | `typecheck` | `uv run mypy src` | Static typing |
-| **Agent Freshness** | `agent-freshness` | `uv run agent-regenerate --verify` | Generated agent inventories |
-| **TUI CSS** | `tui-css` | `python scripts/ci/check_tui_css_up_to_date.py` | Generated CSS in sync |
-| **Test Guardrails** | `test-guardrails` | `uv run python scripts/ci/check_test_hygiene.py` | Test hygiene and boundary checks |
-| **Unit (Core)** | `unit-tests` | `uv run pytest tests/unit -n auto -q --ignore-glob=tests/unit/gpt_trader/tui/test_snapshots_*.py` | Fast unit tests |
-| **TUI Snapshots** | `tui-snapshots` | `uv run pytest tests/unit/gpt_trader/tui/test_snapshots_*.py -v` | Visual regression |
-| **Property** | `property-tests` | `uv run pytest tests/property -v` | Property-based tests |
-| **Contract** | `contract-tests` | `uv run pytest tests/contract -v` | API contracts |
-
-### Running Lanes Locally
+### Local Command Quick Reference
 
 Makefile shortcuts:
 - `make lint` (ruff check + black --check)
@@ -380,14 +331,11 @@ uv run ruff check . && uv run black --check .
 # Type check lane
 uv run mypy src
 
-# TUI CSS lane
-python scripts/ci/check_tui_css_up_to_date.py
+# Test guardrails
+uv run python scripts/ci/check_test_hygiene.py
 
-# Unit tests (core, excluding TUI snapshots)
-uv run pytest tests/unit -n auto -q --ignore-glob=tests/unit/gpt_trader/tui/test_snapshots_*.py
-
-# TUI snapshot tests
-uv run pytest tests/unit/gpt_trader/tui/test_snapshots_*.py -v
+# Unit tests
+uv run pytest tests/unit -n auto -q
 
 # Property tests
 uv run pytest tests/property -v

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,13 +178,14 @@ The repository follows a standardized organization optimized for both human deve
 - `/src/gpt_trader/` - Active trading system (vertical slice architecture)
 - `/tests/` - Test files organized by component
 - `/config/` - Configuration files, trading profiles, and templates
-- `/scripts/` - Operational scripts organized by domain:
-  - `agents/` - Automation helpers and inventory tooling
-  - `analysis/` - Dependency and repository analysis utilities
-  - `ci/` - Validation and guardrail checks
-  - `maintenance/` - Cleanup and maintenance tasks
-  - `monitoring/` - Monitoring and dashboards
-  - Root `scripts/*.py` - Core runbooks and one-off utilities
+- `/scripts/` - Operational scripts organized by domain (see `scripts/README.md` for the full taxonomy):
+  - `agents/` - AI-agent and generated-inventory helpers
+  - `analysis/` - Offline analysis, demos, backtests, and regression probes
+  - `ci/` - Deterministic checks used by CI and quality gates
+  - `maintenance/` - Repo hygiene, docs audits, and scaffolding tools
+  - `monitoring/` - Monitoring exporters, dashboards, and canary observation harnesses
+  - `ops/` - Operator-facing probes and runbook helpers for live/canary workflows
+  - Root `scripts/*.py` - Reserved for a small set of sanctioned entrypoints (see "Root Exceptions" in `scripts/README.md`); new root scripts should be avoided
 
 #### Documentation Standards
 - `/docs/` - Canonical, low-overhead documentation (prefer flat structure)
@@ -207,7 +208,9 @@ kind of fact lives — read it before adding a doc. In short:
 - **Never**: archive directories or version-suffixed docs — retire by deleting and rely on git history
 
 #### New Scripts
-- **Core Operations**: `/scripts/` (root helpers)
+Place new scripts in the taxonomy directory that matches their purpose (see
+`scripts/README.md`); avoid adding new root-level scripts.
+- **Operator runbooks/probes**: `/scripts/ops/`
 - **Analysis/Benchmarks**: `/scripts/analysis/`
 - **CI/Validation**: `/scripts/ci/`
 - **Monitoring**: `/scripts/monitoring/`

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -204,14 +204,9 @@ make test
 
 This repo enforces lightweight hygiene checks in CI to keep the suite fast and maintainable:
 
-- `scripts/ci/check_test_hygiene.py`: caps `test_*.py` module size, enforces directory marker conventions, blocks `patch` usage in `tests/`, and flags `time.sleep` without `fake_clock`.
-- `scripts/ci/check_legacy_test_triage.py`: keeps `tests/_triage/legacy_tests.yaml` aligned with `pytest.mark.legacy_delete` / `pytest.mark.legacy_modernize` usage.
-
-## Hygiene checks
-
-- `uv run python scripts/ci/check_test_hygiene.py`
-- `uv run python scripts/ci/check_legacy_test_triage.py`
-- `uv run python scripts/ci/check_dedupe_manifest.py`
+- `uv run python scripts/ci/check_test_hygiene.py`: caps `test_*.py` module size, enforces directory marker conventions, blocks `patch` usage in `tests/`, and flags `time.sleep` without `fake_clock`.
+- `uv run python scripts/ci/check_legacy_test_triage.py`: keeps `tests/_triage/legacy_tests.yaml` aligned with `pytest.mark.legacy_delete` / `pytest.mark.legacy_modernize` usage.
+- `uv run python scripts/ci/check_dedupe_manifest.py`: keeps the test-duplication manifest current.
 
 ## Legacy Test Triage
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -200,14 +200,6 @@ make test-integration-fast
 make test
 ```
 
-## Snapshot Tests
-
-Snapshot tests should run separately from xdist to avoid flaky UI snapshots.
-
-```bash
-make test-snapshots
-```
-
 ## Guardrails
 
 This repo enforces lightweight hygiene checks in CI to keep the suite fast and maintainable:


### PR DESCRIPTION
## Summary
Related issue / finding / routed package: owner-routed GPT-Trader rehabilitation PR 1 package; follow-up integration repair issue filed as #1092.

- Remove stale TUI launch, CSS regeneration, and snapshot-test instructions from `CONTRIBUTING.md` and `docs/testing.md`.
- Replace the duplicated CI lane table with a pointer to `docs/DEVELOPMENT_GUIDELINES.md#continuous-integration` plus a local command quick reference.
- Update contributor-facing test hygiene guidance to the code-enforced 400-line cap and document current agent/triage routing labels.

## Type of change
- [ ] Refactor
- [ ] Feature
- [ ] Bug fix
- [ ] Tests only
- [x] CI/Docs/Tooling

## Scope & Impact
- Affected areas / components: contributor workflow docs, testing docs.
- Any behavior changes? No runtime or test behavior changes; docs-only cleanup.

## Test Plan
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Contract tests (if applicable)
- [x] Ran locally: `make ci-required`
- [x] Markers used appropriately (`unit`/`integration`/`slow`/`perf`)

## Quality Gates
- [x] `make ci-required` passes locally (lint/format, docs audits, type check, agent freshness, test guardrails, core unit tests)
- [x] `uv run mypy src/gpt_trader` clean, or new errors documented in the summary
- [x] No `sys.path` hacks in tests; `AsyncMock` (not `MagicMock`) on `async def`
- [x] Import boundaries respected (`scripts/ci/check_import_boundaries.py`)

## Observability & Errors
- [x] Structured JSON logs for new/changed paths
- [x] Errors include diagnostic context (symbol, order_id, correlation_id)

Docs-only; no logging or error-path behavior changed.

## Agent Artifacts & Config (if touched)
- [x] If your change can affect generated `var/agents/**` context: ran `uv run agent-regenerate` and committed the refreshed artifacts (`uv run agent-regenerate --verify` clean). The exact inputs and freshness/CI contract live in `docs/DEVELOPMENT_GUIDELINES.md` and the CI path classifier
- [x] If docs changed: `make agent-docs-links` passes

## Breaking Changes
- [x] None
- [ ] Documented in PR body and the linked issue if any

## Screenshots / Logs (optional)

Validation receipts:
- `make agent-docs-links` passed.
- `make ci-required` passed: 6068 unit tests passed, 10 skipped.
- Integration follow-up evidence for #1092: `uv run pytest -o addopts= -m "integration and not slow and not real_api" tests/integration` currently reports 8 failed, 67 passed, 3 deselected.

## Checklist
- [x] Acceptance criteria in linked issue(s), finding packet, or routed package met
- [x] Affected paths listed in PR description

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor and testing guidance with clearer CI and local verification steps.
  * Added an explicit test collection step before submitting changes.
  * Refined issue labeling and script organization instructions for easier routing and placement.
  * Simplified quality-gate references and quick-start command lists.
  * Consolidated testing guardrails into inline command examples and removed outdated snapshot/CSS regeneration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->