### PR TITLE
fix(tests): repair rotted integration suite against current engine/optimize APIs

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -35,12 +35,26 @@ def _integration_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.fixture
+def optuna():
+    """Provide the optuna module, skipping only the tests that need a real import.
+
+    optuna is an optional extra (gpt-trader[optimize]). Optimization tests that
+    drive real optuna studies request this fixture so they skip cleanly when the
+    extra is absent instead of erroring inside OptimizationStudyManager.
+    Mirrors the fixture-scoped importorskip pattern from the optimize unit tests.
+    """
+    return pytest.importorskip("optuna")
+
+
+@pytest.fixture
 def integration_config() -> BotConfig:
     """Create BotConfig for integration tests with deterministic broker.
 
     Settings optimized for fast, deterministic tests:
-    - mock_broker=True: Use DeterministicBroker
-    - dry_run=True: Don't actually trade
+    - mock_broker=True: Use DeterministicBroker (no network, isolated fills)
+    - dry_run=False: dry-run wraps the broker in ReadOnlyBroker, which
+      suppresses place_order and returns REJECTED orders; the mock broker
+      already provides isolation, and order-flow tests need real fills
     - enable_order_preview=False: Skip preview calls
     - Small interval for fast execution
     """
@@ -48,7 +62,7 @@ def integration_config() -> BotConfig:
         symbols=["BTC-USD"],
         interval=1,  # Fast interval
         mock_broker=True,
-        dry_run=True,
+        dry_run=False,
         enable_order_preview=False,
         perps_enable_streaming=False,
         perps_position_fraction=0.04,  # 4% position sizing

--- a/tests/integration/test_optimize_feature_end_to_end.py
+++ b/tests/integration/test_optimize_feature_end_to_end.py
@@ -20,7 +20,7 @@ class TestOptimizationEndToEnd:
     """End-to-end tests for the optimization pipeline."""
 
     @pytest.mark.asyncio
-    async def test_optimization_runs_multiple_trials(self) -> None:
+    async def test_optimization_runs_multiple_trials(self, optuna) -> None:
         """Test that optimization executes multiple trials and collects results."""
         parameter_space = ParameterSpace(
             strategy_parameters=[
@@ -72,7 +72,7 @@ class TestOptimizationEndToEnd:
         assert study.best_trial is not None, "Study should have a best trial"
 
     @pytest.mark.asyncio
-    async def test_optimization_identifies_best_parameters(self) -> None:
+    async def test_optimization_identifies_best_parameters(self, optuna) -> None:
         """Test that optimization correctly identifies better parameters."""
         parameter_space = ParameterSpace(
             strategy_parameters=[

--- a/tests/integration/test_optimize_feature_failures.py
+++ b/tests/integration/test_optimize_feature_failures.py
@@ -24,7 +24,7 @@ class TestOptimizationFailures:
     """Tests for optimization error handling."""
 
     @pytest.mark.asyncio
-    async def test_trial_handles_strategy_error_gracefully(self) -> None:
+    async def test_trial_handles_strategy_error_gracefully(self, optuna) -> None:
         """Test that a failing strategy doesn't crash the optimization."""
 
         def failing_strategy_factory(params: dict) -> BaselinePerpsStrategy:

--- a/tests/integration/test_optimize_feature_results_and_params.py
+++ b/tests/integration/test_optimize_feature_results_and_params.py
@@ -20,7 +20,7 @@ class TestOptimizationResultsAndParameters:
     """Tests for optimization result objects and parameter spaces."""
 
     @pytest.mark.asyncio
-    async def test_trial_result_contains_metrics(self) -> None:
+    async def test_trial_result_contains_metrics(self, optuna) -> None:
         """Test that trial results include risk metrics and trade statistics."""
         parameter_space = ParameterSpace(
             strategy_parameters=[
@@ -59,7 +59,7 @@ class TestOptimizationResultsAndParameters:
         assert result.error_message is None
 
     @pytest.mark.asyncio
-    async def test_parameter_space_with_multiple_types(self) -> None:
+    async def test_parameter_space_with_multiple_types(self, optuna) -> None:
         """Test optimization with integer and float parameters."""
         parameter_space = ParameterSpace(
             strategy_parameters=[


### PR DESCRIPTION
## Summary
Source: owner-routed package — rehabilitation plan Wave 1 (2026-07-01), PR 4/5. Prepares the suite to become a CI lane (Wave 2).

The integration suite is excluded from the default pytest run and never runs in CI, so it rotted. At origin/main (0c5eb7fc): `uv run pytest -o addopts= -m "integration and not slow and not real_api" tests/integration -q` → **8 failed, 67 passed**. Every failure was diagnosed before touching anything; all 8 are **test drift** — **no real src regression was found**, and **no src files are changed** in this PR (trading-safety boundary respected: zero changes to order-submission, guard, or risk behavior).

### Per-test diagnosis

| Test | Root cause | Fix class |
|---|---|---|
| `test_order_flow.py::TestTradingEngineOrderFlow::test_happy_path_creates_trade_event` | Shared `integration_config` fixture pinned pre-#442 dry-run semantics (`dry_run=True` + `mock_broker=True`). Since `m1 guardrails` (b0cc24bb, Jan 30), `dry_run=True` wraps even `DeterministicBroker` in `ReadOnlyBroker`, whose `place_order` intentionally returns `OrderStatus.REJECTED` (`reason=broker_status`), so `submit_order` can never succeed | Test drift → fixture modernized to `dry_run=False` (mock broker already provides isolation); behavioral assertions unchanged |
| `test_order_flow.py::TestTradingEngineOrderFlow::test_multiple_orders_record_multiple_events` | Same as above | Same fixture fix |
| `test_order_flow.py::TestOrderFlowMetrics::test_order_submission_metric_incremented_on_success` | Same as above (`result.success is True` fails under ReadOnlyBroker) | Same fixture fix |
| `test_optimize_feature_end_to_end.py::test_optimization_runs_multiple_trials` | Constructs `OptimizationStudyManager` without guarding the optional `optimize` extra → `MissingOptimizeDependencyError` when `optuna` absent | Test hardening → fixture-scoped `pytest.importorskip("optuna")` (same pattern as optimize unit tests, PR #1065) |
| `test_optimize_feature_end_to_end.py::test_optimization_identifies_best_parameters` | Same | Same |
| `test_optimize_feature_failures.py::test_trial_handles_strategy_error_gracefully` | Same | Same |
| `test_optimize_feature_results_and_params.py::test_trial_result_contains_metrics` | Same | Same |
| `test_optimize_feature_results_and_params.py::test_parameter_space_with_multiple_types` | Same | Same |

Notes for reviewers:
- The order-flow root cause dates the rot precisely: the tests last passed before b0cc24bb (#442) changed `create_brokerage` to wrap **any** broker (including the mock) in `ReadOnlyBroker` when `dry_run=True`. That is intentional dry-run-safety design, not a regression — but it means `dry_run=True` fixtures can never exercise the fill path. The 2 guard-stack tests in the same file kept passing because they block before reaching the broker.
- Observation (out of scope, not changed here): `ReadOnlyBroker` (`src/gpt_trader/features/brokerages/read_only.py`) has zero direct test coverage and nothing else references its `order_suppressed` events.
- All optimize tests pass unmodified once `optuna` is installed — the fix only makes the missing-extra case a clean skip instead of an error, matching the repo's established fixture-scoped importorskip pattern (module-level skip would lose absent-extra coverage semantics).

## Type of change
- [x] Tests only

## Scope & Impact
- Affected areas / components: `tests/integration/conftest.py`, `tests/integration/test_optimize_feature_{end_to_end,failures,results_and_params}.py`
- Any behavior changes? No src changes. Test-visible change: integration order-flow tests now run against the deterministic broker's real fill path instead of the dry-run rejection path; optimize integration tests skip (not error) without the `optimize` extra.

## Test Plan
- [x] Integration tests added/updated
- [x] Ran locally: `uv run pytest -o addopts= -m "integration and not slow and not real_api" tests/integration -q` → **75 passed, 3 deselected** (was 8 failed, 67 passed)
- [x] Absent-extra path verified: with `optuna` uninstalled, the 5 optimize tests → **5 skipped** (previously 5 errors)
- [x] `uv run pytest tests/unit -n auto -q` → **6078 passed** (no collateral)
- [x] Markers used appropriately (`integration` pytestmark unchanged)

## Quality Gates
- [x] `make ci-required` passes locally (lint/format, docs audits, type check, agent freshness, test guardrails, core unit tests — 6078 passed)
- [x] `make test-guardrails` green (hygiene, legacy patterns, triage, dedupe manifest)
- [x] No `sys.path` hacks in tests; no `unittest.mock.patch` introduced (monkeypatch/fixtures only)
- [x] Import boundaries respected (test-only change)

## Observability & Errors
- N/A (tests only)

## Agent Artifacts & Config (if touched)
- [x] `uv run agent-regenerate --verify` → "All context files are up-to-date" (no test files added/removed, so `testing/source_test_map.json` unchanged)

## Breaking Changes
- [x] None

## Checklist
- [x] Acceptance criteria in routed package met: suite green, per-test diagnosis table, explicit regression verdict (none found), no src changes
- [x] Affected paths listed in PR description

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved integration coverage for optimization workflows, helping ensure trials, results, and error handling behave more reliably.
  * Optional optimization-related tests now skip cleanly when the extra dependency isn’t installed.
  * Updated test configuration so order-flow scenarios use a more realistic isolated execution path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->