### PR TITLE
docs(decisions): dated addenda recording the executed INTX removal

### DIFF
--- a/docs/decisions/accept-staged-autonomy-direction.md
+++ b/docs/decisions/accept-staged-autonomy-direction.md
@@ -35,6 +35,11 @@ and *where execution happens* — three decisions that must not be blended.
 - **INTX perpetuals:** frozen — no new work or tests; remove INTX-only surfaces
   opportunistically when they block other work. (Remaining default-hygiene item:
   [intx-default-derivatives-venue](intx-default-derivatives-venue.md).)
+  *Update 2026-07-01: overtaken by events — the freeze ended in removal. INTX is
+  no longer a selectable venue per the accepted
+  [intx-default-derivatives-venue](intx-default-derivatives-venue.md) decision
+  (implemented 2026-06-30); removals are recorded in
+  [Deprecations](../DEPRECATIONS.md).*
 - **Credentials:** CDP JWT only; legacy Coinbase credential support is removed.
   The TUI keeps format detection solely to reject legacy keys with guidance.
 - **Internal architecture:** broker-neutral trade-idea / risk / approval / audit

--- a/docs/decisions/intx-default-derivatives-venue.md
+++ b/docs/decisions/intx-default-derivatives-venue.md
@@ -15,6 +15,14 @@ Accepted (2026-06-30). A.1 landed earlier; the A.2 default-venue decision is now
 resolved in favor of **A2 + enablement alignment** (see [Decision](#decision)).
 INTX is being removed as a selectable venue, not merely demoted as a default.
 
+*Update 2026-07-01: the implementation plan (B0–B4) is fully executed — INTX was
+removed as a selectable venue and the follow-up docs scrub landed. This record is
+the removal authority. The [Authority](#authority), [Problem](#problem), and
+[Current Evidence](#current-evidence) sections below describe the pre-decision
+state (when INTX was merely "frozen") and are retained as the historical packet;
+they no longer describe the current tree. Removals are recorded in
+[Deprecations](../DEPRECATIONS.md).*
+
 This packet recorded an owner decision and now records its resolution. It is not
 a live-operation runbook and does not authorize broker/API calls, canary
 operations, live trading commands, money movement, or order submission.


### PR DESCRIPTION
## Summary
Follow-up to a post-merge P2 review finding on #1094: that PR cites [intx-default-derivatives-venue](docs/decisions/intx-default-derivatives-venue.md) as the removal authority, but the record's pre-decision **Authority/Problem/Current Evidence** sections still said INTX was *frozen*, and the [accept-staged-autonomy-direction](docs/decisions/accept-staged-autonomy-direction.md) scope bullet carried the same pre-removal framing — giving readers conflicting removed-vs-frozen guidance.

Fix per ADR convention: **dated addenda**, not body rewrites — the Status section of the venue record now marks the B0–B4 plan as executed and scopes the older sections as the historical packet; the staged-autonomy INTX bullet gets an *overtaken by events* update pointing at the removal decision and Deprecations.

Source: owner-routed package — rehabilitation plan Wave 2 follow-up (2026-07-01).

## Verification
- `uv run python scripts/maintenance/generate_decision_index.py --check` → ✓ current (9 records)
- `make docs-audit` → link audit, reachability (51 files), currency scan all pass

## Out of scope
No code changes; accepted ADR bodies untouched beyond the dated addenda.