### PR TITLE
chore(workflow): adopt exceptions-only issue labels and Task issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent-review-finding.md
+++ b/.github/ISSUE_TEMPLATE/agent-review-finding.md
@@ -1,7 +1,7 @@
 ---
 name: Agent review finding
 about: Promote a validated recurring-review finding for agent implementation
-labels: codex
+labels: agent-review
 ---
 
 <!-- gpt-trader-agent-finding-id: replace-with-stable-id -->

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,66 @@
+name: Task
+description: A bounded unit of work — build, fix, or clean up
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What needs to change and why it matters.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: >-
+        Commands, file paths, or links that ground the problem. At least one
+        concrete anchor an implementer can reproduce.
+      placeholder: |
+        - `uv run pytest ...`: current output
+        - `src/gpt_trader/...`: the code in question
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: Affected paths, and what is explicitly out of scope.
+      value: |
+        Affected paths:
+        -
+
+        Out of scope:
+        - Live trading or broker/account-capability changes unless explicitly approved
+    validations:
+      required: true
+  - type: dropdown
+    id: touches-trading-execution
+    attributes:
+      label: Touches trading execution
+      description: >-
+        Anything on the order-submission or execution-enablement path requires
+        a decision gate (docs/DIRECTION.md).
+      options:
+        - "false"
+        - "true"
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Checkboxes an implementer can verify mechanically.
+      placeholder: |
+        - [ ] ...
+    validations:
+      required: true
+  - type: textarea
+    id: verification
+    attributes:
+      label: Suggested verification
+      description: Commands that prove the change works.
+      placeholder: |
+        - `uv run pytest tests/unit -n auto -q`
+        - `make ci-required`
+    validations:
+      required: true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,4 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    labels: ["dependencies", "ci"]
+    labels: ["dependencies"]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,27 +92,30 @@ Before branching, make sure to:
 7. **Push to your fork** (`git push origin feature/amazing-feature`)
 8. **Open a Pull Request**
 
-## Issue Labeling for AI Routing
+## Issue Labels
 
-Issue labels drive repository issue routing for agents and humans. Keep them consistent and machine-friendly:
+Labels mark **exceptions, not categories**. An unlabeled open issue is ordinary
+ready work — specified well enough to pick up, sequenced by conversation with
+the owner, not by taxonomy. The full label set:
 
-- **Type label (required):** one of `bug`, `enhancement`, `architecture`, `chore`, `documentation`, `tests`, `ci`, or `security`.
-- **Area label(s) (required, 1–2):** one or two labels from the active domain set, e.g. `trade-ideas`, `live-trade`, `cli`, `mcp`, `reporting`, `runtime`, `monitoring`, `audit`, `closeout`, `broker-neutral`, `trading-safety`, or `coinbase`.
-- **Optional detail labels:** use tags like `persistence`, `reliability`, `packaging`, `deploy`, `developer-experience`, `tech-debt`, etc. as needed.
-- **Agent routing labels:** routing signals for the agent workflow; the detailed pipeline lives in [the agent review pipeline](docs/agents/project_review_pipeline.md#stage-4-queue).
-  - `agent-review` — produced by the recurring GPT-Trader agent review lane
-  - `agent-ready` — validated and ready for agent implementation (no decision/blocker gate)
-  - `decision-needed` — requires an explicit decision packet and agent recommendation before implementation (the single decision-gate label; `needs-human-decision` was retired 2026-07-01)
-  - `codex-review-feedback` — follow-up from Codex review comments or checks
-  - `claw-candidate` — candidate for Claw implementation
-- **Triage labels:** applied after an issue is sorted into the current queue shape.
-  - `triage:build-now` — core spine; build now, unblocks other work
-  - `triage:build-next` — valuable; build after the now-spine lands
-  - `triage:blocked` — valuable but sequenced behind a dependency
-  - `triage:defer` — premature or scope-creep; revisit later
-- **`codex` label:** routing signal for the agent-review / Codex workflow. Issues in this lane (e.g. the `agent-review-finding` template) are **exempt** from the Type/Area requirements above — `codex` alone is sufficient.
+| Label | Meaning |
+| --- | --- |
+| `agent-ready` | Validated, self-contained spec; an agent can execute it without further human input |
+| `decision-needed` | Requires an explicit decision packet and owner call before implementation |
+| `blocked` | Sequenced behind a named dependency (name it in the issue body) |
+| `trading-safety` | Touches trading safety controls or the execution boundary ([docs/DIRECTION.md](docs/DIRECTION.md)) |
+| `agent-review` | Provenance: produced by the recurring agent review lane |
+| `bug`, `enhancement`, `documentation`, `duplicate`, `dependencies` | GitHub/Dependabot defaults |
 
-For this repository, status/priority labels are intentionally deferred until they solve a real need. The default issue templates should already include the intended label shape so no extra manual steps are needed at issue creation.
+Deferred work is **closed with a comment**, not labeled: closed issues are the
+searchable archive, and reopening is cheap. Do not add labels beyond this set
+without first retiring this model — label taxonomies decay (the 45-label
+predecessor, including the `triage:*` scheduler, was retired 2026-07-02 because
+it had stopped being applied).
+
+Use the **Task** issue form when filing new work: it carries the same
+Summary / Evidence / Scope / Acceptance / Verification structure the agent
+promoter emits, so hand-written and promoted issues share one contract.
 
 ## Quality Standards
 

--- a/docs/INFORMATION_ARCHITECTURE.md
+++ b/docs/INFORMATION_ARCHITECTURE.md
@@ -84,7 +84,7 @@ copying a fact into a second home.
 |---------------------|-------------|-----------|
 | A decision — made **or** still open | `docs/decisions/<slug>.md` (status field carries the lifecycle) | STATUS, a roadmap "Needs Decision" table, a framework "Accepted Direction" section |
 | What is built / current state | `docs/STATUS.md` (small, pointer-only) + the code/tests/`var/agents/**` it points to | ARCHITECTURE prose, rubric stage tables, README |
-| A unit of work / something to build or fix | A **GitHub issue** (+ `triage:*` / `agent-ready` / `decision-needed` labels) | A roadmap "Ready Queue", a STATUS "spine" list |
+| A unit of work / something to build or fix | A **GitHub issue** (labels only for exceptions: `agent-ready`, `decision-needed`, `blocked`) | A roadmap "Ready Queue", a STATUS "spine" list |
 | Where we are going / the gates to get there | `docs/DIRECTION.md` | Multiple parallel rubric/framework/readiness docs |
 | How the code is structured | `docs/ARCHITECTURE.md` + generated maps in `var/agents/**` | Hand-maintained module inventories |
 | API / CLI / env-var / metric inventories | Generated `var/agents/**` (run `agent-regenerate`) | Hand-written reference tables that must be kept in sync |

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -12,8 +12,8 @@ backlog, or any decision. When a stage description elsewhere disagrees with
 observed code, this doc wins until the other is reconciled.
 
 Verify file/function/issue references before relying on them; they reflect the
-dated snapshot below. The next work is the live GitHub issue queue
-(`triage:build-now`), never a list copied here.
+dated snapshot below. The next work is the live GitHub issue queue,
+never a list copied here.
 
 ## Snapshot (2026-07-01)
 

--- a/docs/agents/project_review_pipeline.md
+++ b/docs/agents/project_review_pipeline.md
@@ -48,7 +48,7 @@ it as a second queue.
 | Scout candidate | Local JSON packet with `schema_version: "gpt-trader.agent-finding.v1"` | Promoter dry-run body for human review | `uv run python scripts/maintenance/project_review_issue_promoter.py --packet <packet>` |
 | Promoted finding | GitHub issue with the hidden `finding_id` marker and routing labels | Packet details rendered into the issue body or refresh comments | `project_review_issue_promoter.py` plus GitHub issue state |
 | Implementation | GitHub issue or direct owner-routed package, then a PR | PR body links issue/finding/package source | PR checks and review state |
-| Review feedback | GitHub review thread, check output, or a bounded feedback packet copied into issue/PR comments | Short fix packet for the active executor | PR review/check evidence; `codex-review-feedback` label when it becomes queue work |
+| Review feedback | GitHub review thread, check output, or a bounded feedback packet copied into issue/PR comments | Short fix packet for the active executor | PR review/check evidence; a follow-up issue when it becomes queue work |
 | Review deliverable | Intended `review_artifacts/*.csv` or `review_artifacts/*.xlsx` file | PR body summary of provenance and purpose | `.gitignore` policy plus `git status` review |
 
 The packet is canonical only before promotion. After promotion, the GitHub issue
@@ -206,14 +206,16 @@ instead of creating a duplicate.
 
 ## Stage 4: Queue
 
-GitHub issues are the durable queue. These labels are routing signals:
+GitHub issues are the durable queue. Labels mark exceptions only (the full
+model is owned by [CONTRIBUTING.md](../../CONTRIBUTING.md#issue-labels)); the
+promoter emits:
 
 | Label | Meaning |
 | --- | --- |
 | `agent-review` | Finding came from the recurring GPT-Trader review lane |
 | `agent-ready` | Finding passed promotion gates, has no decision/blocker gate, and is ready for implementation |
 | `decision-needed` | Requires an explicit decision packet and agent recommendation before implementation or execution |
-| `codex-review-feedback` | Follow-up from Codex review comments or checks |
+| `blocked` | The packet names `routing.blocked_by` dependencies |
 
 The promoter can create missing labels with `--create-labels`. If labels are
 missing and that flag is not used, it keeps routing in the issue body and omits

--- a/scripts/maintenance/project_review_issue_promoter.py
+++ b/scripts/maintenance/project_review_issue_promoter.py
@@ -42,22 +42,10 @@ CUSTOM_LABELS = {
         "color": "d876e3",
         "description": "Requires an explicit decision packet and agent recommendation",
     },
-    "codex-review-feedback": {
-        "color": "fbca04",
-        "description": "Follow-up from Codex review comments or checks",
+    "blocked": {
+        "color": "b60205",
+        "description": "Blocked on a dependency or decision",
     },
-}
-
-CATEGORY_LABELS = {
-    "architecture": "architecture",
-    "bug": "bug",
-    "ci": "ci",
-    "cleanup": "cleanup",
-    "docs": "documentation",
-    "security": "critical",
-    "tests": "tests",
-    "tooling": "ci",
-    "trading-readiness": "coinbase",
 }
 
 
@@ -251,23 +239,17 @@ def marker_for(finding_id: str) -> str:
 
 
 def packet_labels(packet: dict[str, Any]) -> list[str]:
-    labels = {"agent-review", "codex"}
-    category_label = CATEGORY_LABELS.get(str(packet.get("category")))
-    if category_label:
-        labels.add(category_label)
-    if packet.get("severity") == "critical":
-        labels.add("critical")
+    labels = {"agent-review"}
 
     routing = packet.get("routing", {})
     if isinstance(routing, dict):
         blocked_by = routing.get("blocked_by", [])
         candidates = routing.get("candidate_for", [])
         decision_candidate = isinstance(candidates, list) and "decision" in candidates
+        if blocked_by:
+            labels.add("blocked")
         if not routing.get("decision_needed") and not blocked_by and not decision_candidate:
             labels.add("agent-ready")
-        if isinstance(candidates, list):
-            if "codex-review" in candidates:
-                labels.add("codex-review-feedback")
         if routing.get("decision_needed") or decision_candidate:
             labels.add("decision-needed")
 


### PR DESCRIPTION
## Summary
Implements the issue-workflow redesign approved by the owner on 2026-07-02: labels mark exceptions, not categories. The 45-label taxonomy (including the four-state `triage:*` scheduler) had decayed — the newest issues carried no labels, and the `tui` label outlived the TUI subsystem. Label surgery on the repo (rename `triage:blocked`→`blocked`, delete 33 dead labels) was executed directly; this PR aligns code, templates, and docs with the new model.

Related issue / finding / routed package: workflow friction-reduction tracking issue (filed alongside this PR).

## Type of change
- [x] CI/Docs/Tooling

## Scope & Impact
- Affected areas: `.github/ISSUE_TEMPLATE/` (new `task.yml` issue form; `agent-review-finding.md` label swap), `.github/dependabot.yml`, `scripts/maintenance/project_review_issue_promoter.py`, CONTRIBUTING.md, docs/INFORMATION_ARCHITECTURE.md, docs/STATUS.md, docs/agents/project_review_pipeline.md.
- Behavior change: the promoter now emits only exception labels (`agent-review` + `agent-ready`/`decision-needed`/`blocked`); `routing.blocked_by` now maps to the `blocked` label. Covered by existing promoter unit tests (10 passed).

## Test Plan
- [x] Ran `uv run pytest tests/unit/scripts/test_project_review_issue_promoter.py -q` — 10 passed
- [x] Docs audits: link audit, reachability, currency scan all pass

## Quality Gates
- [x] ruff + black clean on changed Python; pre-commit hooks passed
- [x] Docs link audit / reachability pass

## Breaking Changes
- [x] None (promoter `--create-labels` can no longer resurrect retired labels — intended)

## Checklist
- [x] Affected paths listed above