### PR TITLE
docs(decisions): propose stopping commits of high-churn agent inventories

### DIFF
--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -73,6 +73,7 @@ markers. Regenerating cannot drift from the files.
 | 2026-07-02 | [Canonical risk-limit vocabulary — budget vs runtime limits](canonical-risk-limit-vocabulary.md) | accepted |
 | 2026-07-02 | [Event JSONL: accepted fallback or import-only historical data](event-jsonl-compatibility.md) | accepted |
 | 2026-07-02 | [Meaning of the prod and canary profiles under the approval ladder](prod-canary-profile-meaning.md) | accepted |
+| 2026-07-02 | [Stop committing high-churn generated agent inventories](stop-committing-high-churn-agent-inventories.md) | proposed |
 | 2026-07-01 | [Remove the unwired account manager and strategy-dev lab](remove-unwired-account-manager-and-strategy-lab.md) | accepted |
 | 2026-06-30 | [Remove the TUI subsystem](remove-tui-subsystem.md) | accepted |
 | 2026-06-28 | [INTX default derivatives venue](intx-default-derivatives-venue.md) | accepted |

--- a/docs/decisions/stop-committing-high-churn-agent-inventories.md
+++ b/docs/decisions/stop-committing-high-churn-agent-inventories.md
@@ -14,9 +14,13 @@ Generated `var/agents/**` inventories are derived truth, but the committed
 subset still dominates repo churn: 103 of 181 commits since 2026-06-01 touched
 `var/agents`, and the 2026-07-01 gitignore pass
 ([canonical_sources.md](../agents/canonical_sources.md)) barely moved the rate
-(19 of 35 commits since). The file-touch breakdown since 2026-07-01 is
-`testing/**` 41, `reasoning/*.md` 26, `configuration` 10 — the `testing`
-inventory regenerates whenever tests change, which is nearly every PR.
+(19 of 35 commits since). The ongoing driver is `testing/**`: 41 file-touches
+since 2026-07-01, all committed JSON, because the inventory regenerates
+whenever tests change — which is nearly every PR. (`reasoning/` shows 26
+touches in the same window, but 22 of those are the one-time removal of the
+already-gitignored `*.{json,dot}` machine forms during the 2026-07-01 pass
+itself; the committed `reasoning/*.md` summaries account for only 4.)
+`configuration` adds 10.
 
 The cost compounds with the merge gate: strict up-to-date branch protection
 means every merge to `main` invalidates other green PRs, and each rebase of a
@@ -35,7 +39,9 @@ demand — executed 2026-07-01 with owner approval.
 
 - **Option A — Extend the `optional_files` precedent to the remaining
   high-churn groups.** Gitignore `var/agents/testing/index.json` and
-  `testing/markers.json` (and evaluate `reasoning/*.md`); consumers run
+  `testing/markers.json` — the measured churn driver. (`reasoning/*.md` shows
+  only 4 post-pass touches, so decommitting those curated summaries is not
+  evidence-driven; keep them committed unless churn reappears.) Consumers run
   `uv run agent-regenerate` on demand. This includes the validator contract:
   `scripts/agents/agent_artifacts.py` currently hard-requires
   `testing/index.json` with a positive `total_tests`

--- a/docs/decisions/stop-committing-high-churn-agent-inventories.md
+++ b/docs/decisions/stop-committing-high-churn-agent-inventories.md
@@ -1,0 +1,68 @@
+# Stop committing high-churn generated agent inventories
+
+---
+status: proposed
+date: 2026-07-02
+deciders: rj
+supersedes:
+superseded-by:
+---
+
+## Context
+
+Generated `var/agents/**` inventories are derived truth, but the committed
+subset still dominates repo churn: 103 of 181 commits since 2026-06-01 touched
+`var/agents`, and the 2026-07-01 gitignore pass
+([canonical_sources.md](../agents/canonical_sources.md)) barely moved the rate
+(19 of 35 commits since). The file-touch breakdown since 2026-07-01 is
+`testing/**` 41, `reasoning/*.md` 26, `configuration` 10 — the `testing`
+inventory regenerates whenever tests change, which is nearly every PR.
+
+The cost compounds with the merge gate: strict up-to-date branch protection
+means every merge to `main` invalidates other green PRs, and each rebase of a
+PR that touches these inputs requires another `agent-regenerate` cycle.
+Generated-file merge conflicts follow. Committing derived truth is a cache, and
+the freshness gate (`agent-regenerate --verify`, the Agent Artifacts Freshness
+CI lane, the scheduled refresh workflow) is the invalidation machinery that
+cache demands.
+
+The repo already has a precedent: `testing/test_inventory.json`,
+`testing/source_test_map.json`, and `reasoning/*.{json,dot}` are gitignored,
+registered as `optional_files` in `var/agents/index.json`, and regenerated on
+demand — executed 2026-07-01 with owner approval.
+
+## Options
+
+- **Option A — Extend the `optional_files` precedent to the remaining
+  high-churn groups.** Gitignore `var/agents/testing/index.json` and
+  `testing/markers.json` (and evaluate `reasoning/*.md`); consumers run
+  `uv run agent-regenerate` on demand. Trade-off: hosted or read-only agents
+  lose pre-baked context in a fresh checkout and must regenerate (the scheduled
+  refresh package still ships them).
+- **Option B — Keep committing, but decouple from the PR loop.** Keep the trees
+  committed, drop them from `agent-regenerate --verify`'s default surface, and
+  let only the scheduled refresh workflow reconcile them via its automation
+  branch. Trade-off: committed copies go intentionally stale between refreshes,
+  which reintroduces exactly the drift the freshness gate was built to prevent.
+- **Option C — Status quo.** Keep committing and freshness-gating everything.
+  Trade-off: the measured ~55% commit-churn tax and rebase/regenerate loops
+  continue.
+
+## Decision
+
+_Open. Recommendation: Option A — it follows the repo's own "prefer derived
+over authored" rule and the already-approved 2026-07-01 precedent, and it is
+the only option that removes the churn rather than hiding it._
+
+## Consequences
+
+Fill in when accepted. Expected shape for Option A: gitignore + `optional_files`
+registration for the affected groups, freshness gate shrinks to the remaining
+committed set, and the measured share of commits touching `var/agents` drops
+from ~55% to under 15%. Follow-up work will be filed as a GitHub issue linked
+here.
+
+## Safety boundary
+
+This decision authorizes no broker/API call, live execution, money movement, or
+autonomy change. It affects only generated development-context artifacts.

--- a/docs/decisions/stop-committing-high-churn-agent-inventories.md
+++ b/docs/decisions/stop-committing-high-churn-agent-inventories.md
@@ -36,9 +36,14 @@ demand — executed 2026-07-01 with owner approval.
 - **Option A — Extend the `optional_files` precedent to the remaining
   high-churn groups.** Gitignore `var/agents/testing/index.json` and
   `testing/markers.json` (and evaluate `reasoning/*.md`); consumers run
-  `uv run agent-regenerate` on demand. Trade-off: hosted or read-only agents
-  lose pre-baked context in a fresh checkout and must regenerate (the scheduled
-  refresh package still ships them).
+  `uv run agent-regenerate` on demand. This includes the validator contract:
+  `scripts/agents/agent_artifacts.py` currently hard-requires
+  `testing/index.json` with a positive `total_tests`
+  (`validate` fails on a fresh checkout if the file is absent), so its
+  per-resource expectations must become absent-tolerant for `optional_files`
+  while still validating content when the files are present. Trade-off: hosted
+  or read-only agents lose pre-baked context in a fresh checkout and must
+  regenerate (the scheduled refresh package still ships them).
 - **Option B — Keep committing, but decouple from the PR loop.** Keep the trees
   committed, drop them from `agent-regenerate --verify`'s default surface, and
   let only the scheduled refresh workflow reconcile them via its automation
@@ -57,10 +62,10 @@ the only option that removes the churn rather than hiding it._
 ## Consequences
 
 Fill in when accepted. Expected shape for Option A: gitignore + `optional_files`
-registration for the affected groups, freshness gate shrinks to the remaining
+registration for the affected groups, absent-tolerant validation in
+`agent_artifacts.py` for those groups, freshness gate shrinks to the remaining
 committed set, and the measured share of commits touching `var/agents` drops
-from ~55% to under 15%. Follow-up work will be filed as a GitHub issue linked
-here.
+from ~55% to under 15%. Follow-up work is tracked in issue #1130.
 
 ## Safety boundary
 


### PR DESCRIPTION
## Summary
Files the artifact-churn decision from the 2026-07-02 workflow friction-reduction effort as a `status: proposed` decision record, per the repo's decision lifecycle. **No behavior changes** — this PR adds one ADR and its regenerated index entry.

Measured evidence in the record: ~55% of commits carry `var/agents` diffs even after the 2026-07-01 gitignore pass; the churn is dominated by the `testing` inventory (regenerates whenever tests change) and `reasoning/*.md`. Recommendation is Option A (extend the owner-approved `optional_files` precedent).

Related issue / finding / routed package: workflow friction-reduction tracking issue (filed alongside this PR).

## Type of change
- [x] CI/Docs/Tooling

## Scope & Impact
- Affected areas: `docs/decisions/stop-committing-high-churn-agent-inventories.md` (new), `docs/decisions/README.md` (regenerated index).
- Behavior changes: none.

## Test Plan
- [x] `generate_decision_index.py --check` — index current (12 records)
- [x] Docs link audit + reachability pass

## Breaking Changes
- [x] None

## Checklist
- [x] Affected paths listed above