### PR TITLE
feat(workflow): machine-check branch protection and surface merge-mechanics hazards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,19 @@ gh pr create --fill
 # gh pr merge --squash --delete-branch
 ```
 
+Merge mechanics that repeatedly bite agents (`agent-pr-ready` detects all three):
+
+- **Prefer independent PRs over stacks.** Branch auto-delete on merge can close
+  a child PR whose base branch just vanished. Recovery: restore the deleted
+  branch from the merge SHA, reopen the child, retarget it. If you must stack,
+  merge base-first.
+- **Strict up-to-date serializes batch merges.** Every merge to `main` flips
+  other green PRs to BEHIND; run `gh pr update-branch <pr>` and let CI re-run
+  rather than treating stale green as mergeable.
+- **The protection contract is machine-checked.** `scripts/ci/check_branch_protection.py`
+  owns the expected required checks/settings; drift between it and live GitHub
+  settings surfaces as an `agent-pr-ready` warning.
+
 ## Trading-safety boundary
 
 Existing live profiles and broker adapters are implementation assets, **not**

--- a/docs/DEVELOPMENT_GUIDELINES.md
+++ b/docs/DEVELOPMENT_GUIDELINES.md
@@ -107,7 +107,10 @@ source of truth remains `.github/workflows/*.yml` plus GitHub branch protection.
 Current `main` branch protection requires only the named `CI` contexts listed in
 the first row below, with strict up-to-date checks and conversation resolution
 enabled. Selected context-specific lanes self-skip by changed path while keeping
-those check names stable.
+those check names stable. The expected protection settings are machine-checked:
+`uv run python scripts/ci/check_branch_protection.py` (also surfaced as an
+`agent-pr-ready` advisory) fails when live GitHub settings drift from the
+contract this table describes.
 
 | Check / workflow job | Tier | Trigger | Blocking status | Why it exists |
 | --- | --- | --- | --- | --- |

--- a/scripts/agents/pr_readiness.py
+++ b/scripts/agents/pr_readiness.py
@@ -42,6 +42,7 @@ import argparse
 import json
 import re
 import subprocess
+import sys
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from pathlib import Path
@@ -69,9 +70,15 @@ _SEVERITY_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     ("low", re.compile(r"\bP3\b|\bminor\b|\bnit\b", re.IGNORECASE)),
 )
 
+_DEFAULT_BASE_BRANCH = "main"
+
 # mergeStateStatus values that mean "not mergeable right now", with guidance.
 _BLOCKING_MERGE_STATES = {
-    "BEHIND": "Branch is behind the base; update/rebase so it is current.",
+    "BEHIND": (
+        "Branch is behind the base; run `gh pr update-branch <pr>` (or rebase onto the "
+        "base) and let CI re-run. Strict up-to-date serializes batch merges, so this is "
+        "expected after every merge to the base."
+    ),
     "DIRTY": "Branch has merge conflicts with the base.",
     "BLOCKED": "Branch protection is blocking the merge (see findings below).",
     "DRAFT": "Pull request is a draft; mark it ready for review before merging.",
@@ -314,6 +321,17 @@ def assess_readiness(
             Finding(
                 severity,
                 _describe_unresolved(unresolved, state.protection.conversation_resolution),
+            )
+        )
+
+    if state.base_ref_name != _DEFAULT_BASE_BRANCH:
+        findings.append(
+            Finding(
+                "warning",
+                f"Stacked PR: base branch is '{state.base_ref_name}', not "
+                f"'{_DEFAULT_BASE_BRANCH}'. Merging the base PR with branch auto-delete "
+                "can close this PR (recovery: restore the deleted branch, reopen, "
+                "retarget). Merge the base first, or re-slice the PRs to be independent.",
             )
         )
 
@@ -1115,6 +1133,35 @@ def apply_artifact_freshness(
     report.ready = not any(finding.severity == "blocker" for finding in report.findings)
 
 
+def apply_protection_drift(
+    report: ReadinessReport,
+    protection_raw: dict[str, Any] | None,
+    base_ref_name: str,
+) -> None:
+    """Advisory check of live branch protection against the expected contract.
+
+    The expected contract lives in scripts/ci/check_branch_protection.py and is
+    defined for the default branch only. Drift is always a warning: it never
+    flips readiness on its own.
+    """
+    if base_ref_name != _DEFAULT_BASE_BRANCH:
+        return
+    try:
+        if str(PROJECT_ROOT) not in sys.path:
+            sys.path.insert(0, str(PROJECT_ROOT))
+        from scripts.ci.check_branch_protection import assess_protection_drift
+    except ImportError as error:
+        report.findings.append(
+            Finding("warning", f"Branch-protection drift check unavailable: {error}")
+        )
+        return
+    drift = assess_protection_drift(protection_raw)
+    if drift:
+        _remove_clean_mergeable_info(report.findings)
+    for item in drift:
+        report.findings.append(Finding("warning", f"Branch protection drift: {item}"))
+
+
 def _process_summary(result: subprocess.CompletedProcess[str]) -> str:
     text = "\n".join(part for part in (result.stdout, result.stderr) if part)
     lines = [line.strip() for line in text.splitlines() if line.strip()]
@@ -1234,7 +1281,8 @@ def main(argv: list[str] | None = None) -> int:
             verify=not args.skip_artifact_verify,
             head_oid=str(pr_payload.get("headRefOid") or "") or None,
         )
-        protection = parse_branch_protection(fetch_branch_protection(repo, base_ref_name))
+        protection_raw = fetch_branch_protection(repo, base_ref_name)
+        protection = parse_branch_protection(protection_raw)
         head_committed_at, head_pushed_at = fetch_head_commit_timestamps(repo, pr)
         state = parse_pr_state(
             pr_payload,
@@ -1255,6 +1303,7 @@ def main(argv: list[str] | None = None) -> int:
         require_current_head_review_signal=args.require_current_head_review_signal,
     )
     apply_artifact_freshness(report, freshness)
+    apply_protection_drift(report, protection_raw, base_ref_name)
     print(_render(args.format, state, report))
     return 1 if (args.exit_on_not_ready and not report.ready) else 0
 

--- a/scripts/ci/check_branch_protection.py
+++ b/scripts/ci/check_branch_protection.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Check GitHub branch protection against the expected merge-gate contract.
+
+Usage:
+    uv run python scripts/ci/check_branch_protection.py
+    uv run python scripts/ci/check_branch_protection.py --repo owner/name --branch main
+
+The EXPECTED_* constants below are the machine-checkable source of truth for
+what `main` branch protection must require; the prose CI contract table in
+docs/DEVELOPMENT_GUIDELINES.md points here. Update them deliberately, in the
+same change that updates the GitHub setting. The merge-queue migration (#1127)
+will flip EXPECTED_STRICT to False when it lands.
+
+Requires `gh` auth with admin read on the repository (the protection API is
+admin-scoped), so this runs locally and in `agent-pr-ready` — not in the
+PR-blocking CI lane.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from typing import Any
+from urllib.parse import quote
+
+DEFAULT_REPOSITORY = "Solders-Girdles/GPT-Trader"
+DEFAULT_BRANCH = "main"
+
+EXPECTED_REQUIRED_CHECKS = frozenset(
+    {
+        "Lint & Format",
+        "Docs Link Audit",
+        "Type Check",
+        "Test Guardrails",
+        "Unit Tests (Core)",
+        "Property Tests",
+        "Contract Tests",
+        "Integration Tests",
+    }
+)
+EXPECTED_STRICT = True
+EXPECTED_ENFORCE_ADMINS = True
+EXPECTED_CONVERSATION_RESOLUTION = True
+EXPECTED_REQUIRED_APPROVING_REVIEWS = 0
+
+
+def assess_protection_drift(raw: dict[str, Any] | None) -> list[str]:
+    """Return human-readable drift findings; an empty list means the contract holds."""
+    if not isinstance(raw, dict) or not raw:
+        return ["branch protection payload is missing or empty"]
+
+    drift: list[str] = []
+
+    checks_block = raw.get("required_status_checks") or {}
+    modern = [
+        item.get("context", "")
+        for item in checks_block.get("checks") or []
+        if isinstance(item, dict) and item.get("context")
+    ]
+    legacy = [context for context in checks_block.get("contexts") or [] if isinstance(context, str)]
+    live_checks = set(modern) | set(legacy)
+    missing = sorted(EXPECTED_REQUIRED_CHECKS - live_checks)
+    extra = sorted(live_checks - EXPECTED_REQUIRED_CHECKS)
+    if missing:
+        drift.append(f"required checks missing: {', '.join(missing)}")
+    if extra:
+        drift.append(f"unexpected required checks: {', '.join(extra)}")
+
+    strict = bool(checks_block.get("strict", False))
+    if strict != EXPECTED_STRICT:
+        drift.append(f"strict up-to-date is {strict}, expected {EXPECTED_STRICT}")
+
+    enforce_admins = bool((raw.get("enforce_admins") or {}).get("enabled", False))
+    if enforce_admins != EXPECTED_ENFORCE_ADMINS:
+        drift.append(f"enforce_admins is {enforce_admins}, expected {EXPECTED_ENFORCE_ADMINS}")
+
+    conversation = bool((raw.get("required_conversation_resolution") or {}).get("enabled", False))
+    if conversation != EXPECTED_CONVERSATION_RESOLUTION:
+        drift.append(
+            f"required conversation resolution is {conversation}, "
+            f"expected {EXPECTED_CONVERSATION_RESOLUTION}"
+        )
+
+    reviews_block = raw.get("required_pull_request_reviews") or {}
+    review_count = int(reviews_block.get("required_approving_review_count", 0) or 0)
+    if review_count != EXPECTED_REQUIRED_APPROVING_REVIEWS:
+        drift.append(
+            f"required approving reviews is {review_count}, "
+            f"expected {EXPECTED_REQUIRED_APPROVING_REVIEWS}"
+        )
+
+    return drift
+
+
+def fetch_protection(repo: str, branch: str) -> dict[str, Any]:
+    encoded_branch = quote(branch, safe="")
+    result = subprocess.run(
+        ["gh", "api", f"repos/{repo}/branches/{encoded_branch}/protection"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "gh api call for branch protection failed")
+    payload = json.loads(result.stdout)
+    if not isinstance(payload, dict):
+        raise RuntimeError("unexpected branch protection payload shape")
+    return payload
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=DEFAULT_REPOSITORY, help="GitHub repository owner/name.")
+    parser.add_argument("--branch", default=DEFAULT_BRANCH, help="Protected branch to check.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        raw = fetch_protection(args.repo, args.branch)
+    except (RuntimeError, json.JSONDecodeError, OSError) as error:
+        print(f"✗ Branch protection check FAILED: {error}")
+        return 1
+
+    drift = assess_protection_drift(raw)
+    if drift:
+        for item in drift:
+            print(f"✗ Branch protection drift: {item}")
+        return 1
+
+    print(f"✓ Branch protection matches the expected contract ({args.repo}@{args.branch})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/scripts/test_check_branch_protection.py
+++ b/tests/unit/scripts/test_check_branch_protection.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from scripts.agents.pr_readiness import ReadinessReport, apply_protection_drift
+from scripts.ci import check_branch_protection as checker
+
+
+def _matching_payload() -> dict[str, Any]:
+    return {
+        "required_status_checks": {
+            "strict": True,
+            "contexts": sorted(checker.EXPECTED_REQUIRED_CHECKS),
+        },
+        "enforce_admins": {"enabled": True},
+        "required_conversation_resolution": {"enabled": True},
+        "required_pull_request_reviews": {"required_approving_review_count": 0},
+    }
+
+
+def test_matching_payload_has_no_drift() -> None:
+    assert checker.assess_protection_drift(_matching_payload()) == []
+
+
+def test_matching_payload_modern_checks_shape() -> None:
+    payload = _matching_payload()
+    payload["required_status_checks"] = {
+        "strict": True,
+        "checks": [{"context": name} for name in checker.EXPECTED_REQUIRED_CHECKS],
+    }
+    assert checker.assess_protection_drift(payload) == []
+
+
+def test_missing_payload_is_drift() -> None:
+    assert checker.assess_protection_drift(None) == [
+        "branch protection payload is missing or empty"
+    ]
+    assert checker.assess_protection_drift({}) == ["branch protection payload is missing or empty"]
+
+
+def test_missing_and_extra_required_checks_are_drift() -> None:
+    payload = _matching_payload()
+    contexts = set(payload["required_status_checks"]["contexts"])
+    contexts.discard("Unit Tests (Core)")
+    contexts.add("Nightly Extras")
+    payload["required_status_checks"]["contexts"] = sorted(contexts)
+
+    drift = checker.assess_protection_drift(payload)
+
+    assert any("missing: Unit Tests (Core)" in item for item in drift)
+    assert any("unexpected required checks: Nightly Extras" in item for item in drift)
+
+
+@pytest.mark.parametrize(
+    ("mutation", "expected_fragment"),
+    [
+        (lambda p: p["required_status_checks"].update(strict=False), "strict up-to-date is False"),
+        (lambda p: p.update(enforce_admins={"enabled": False}), "enforce_admins is False"),
+        (
+            lambda p: p.update(required_conversation_resolution={"enabled": False}),
+            "required conversation resolution is False",
+        ),
+        (
+            lambda p: p.update(
+                required_pull_request_reviews={"required_approving_review_count": 1}
+            ),
+            "required approving reviews is 1",
+        ),
+    ],
+)
+def test_each_contract_field_drifts_independently(mutation, expected_fragment: str) -> None:
+    payload = _matching_payload()
+    mutation(payload)
+
+    drift = checker.assess_protection_drift(payload)
+
+    assert len(drift) == 1
+    assert expected_fragment in drift[0]
+
+
+def test_main_reports_success(monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    monkeypatch.setattr(checker, "fetch_protection", lambda repo, branch: _matching_payload())
+
+    exit_code = checker.main([])
+
+    assert exit_code == 0
+    assert "✓ Branch protection matches the expected contract" in capsys.readouterr().out
+
+
+def test_main_reports_drift_and_fails(monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    payload = _matching_payload()
+    payload["required_status_checks"]["strict"] = False
+    monkeypatch.setattr(checker, "fetch_protection", lambda repo, branch: payload)
+
+    exit_code = checker.main([])
+
+    assert exit_code == 1
+    assert "✗ Branch protection drift: strict up-to-date is False" in capsys.readouterr().out
+
+
+def test_main_reports_fetch_failure(monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+    def _raise(repo: str, branch: str) -> dict[str, Any]:
+        raise RuntimeError("gh: Not Found (HTTP 404)")
+
+    monkeypatch.setattr(checker, "fetch_protection", _raise)
+
+    exit_code = checker.main([])
+
+    assert exit_code == 1
+    assert "✗ Branch protection check FAILED" in capsys.readouterr().out
+
+
+def test_fetch_protection_rejects_non_mapping(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Result:
+        returncode = 0
+        stdout = json.dumps(["not", "a", "mapping"])
+        stderr = ""
+
+    monkeypatch.setattr(checker.subprocess, "run", lambda *args, **kwargs: _Result())
+
+    with pytest.raises(RuntimeError, match="unexpected branch protection payload shape"):
+        checker.fetch_protection("owner/repo", "main")
+
+
+# --------------------------------------------------------------------------- #
+# agent-pr-ready wiring (apply_protection_drift)
+# --------------------------------------------------------------------------- #
+def test_apply_protection_drift_adds_warnings_on_main() -> None:
+    report = ReadinessReport(ready=True)
+    payload = _matching_payload()
+    payload["required_status_checks"]["strict"] = False
+
+    apply_protection_drift(report, payload, "main")
+
+    assert report.ready is True  # advisory only
+    warnings = [finding for finding in report.findings if finding.severity == "warning"]
+    assert any("Branch protection drift: strict up-to-date" in f.message for f in warnings)
+
+
+def test_apply_protection_drift_silent_when_contract_holds() -> None:
+    report = ReadinessReport(ready=True)
+
+    apply_protection_drift(report, _matching_payload(), "main")
+
+    assert report.findings == []
+
+
+def test_apply_protection_drift_skips_non_default_base() -> None:
+    report = ReadinessReport(ready=True)
+
+    apply_protection_drift(report, None, "feature/base-branch")
+
+    assert report.findings == []

--- a/tests/unit/scripts/test_pr_readiness_assess.py
+++ b/tests/unit/scripts/test_pr_readiness_assess.py
@@ -202,6 +202,42 @@ def test_behind_base_is_blocker() -> None:
     assert any("behind" in finding.message.lower() for finding in report.findings)
 
 
+def test_stacked_pr_base_branch_is_warning() -> None:
+    state = PullRequestState(
+        number=6,
+        head_oid="abc",
+        merge_state_status="CLEAN",
+        review_decision="",
+        checks=(CheckStatus("Unit Tests (Core)", "SUCCESS", required=True),),
+        threads=(),
+        protection=_protection(),
+        base_ref_name="feature/parent-branch",
+    )
+    report = assess_readiness(state)
+
+    assert report.ready is True  # warning, not blocker
+    stacked = [finding for finding in report.findings if "Stacked PR" in finding.message]
+    assert len(stacked) == 1
+    assert stacked[0].severity == "warning"
+    assert "feature/parent-branch" in stacked[0].message
+    assert "restore the deleted branch" in stacked[0].message
+
+
+def test_main_based_pr_has_no_stacked_warning() -> None:
+    state = PullRequestState(
+        number=7,
+        head_oid="abc",
+        merge_state_status="CLEAN",
+        review_decision="",
+        checks=(CheckStatus("Unit Tests (Core)", "SUCCESS", required=True),),
+        threads=(),
+        protection=_protection(),
+    )
+    report = assess_readiness(state)
+
+    assert not any("Stacked PR" in finding.message for finding in report.findings)
+
+
 def test_required_review_missing_is_blocker() -> None:
     state = PullRequestState(
         number=5,

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -9,8 +9,8 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 5829,
-    "total_files": 698,
+    "total_tests": 5843,
+    "total_files": 699,
     "markers_used": 14
   },
   "quick_commands": {

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -92,9 +92,9 @@
     ]
   },
   "counts": {
-    "unit": 5672,
+    "unit": 5686,
     "asyncio": 302,
-    "parametrize": 172,
+    "parametrize": 173,
     "integration": 80,
     "endpoints": 64,
     "property": 63,


### PR DESCRIPTION
## Summary
Implements #1128 and #1129 from the workflow friction-reduction effort (#1135) in one PR — combined deliberately because both touch `pr_readiness.py`, and splitting them would have required a stacked PR, which is one of the hazards this change eliminates. Closes #1128. Closes #1129.

Three changes:
1. **`scripts/ci/check_branch_protection.py`** — the expected `main` protection contract as machine-checkable constants (8 required contexts, strict up-to-date, enforce_admins, conversation resolution, 0 required approvals). `assess_protection_drift()` is pure; the CLI exits 1 on drift and names the drifted field. Verified against live settings: currently ✓ clean. The merge-queue migration (#1127) will flip `EXPECTED_STRICT` when it lands.
2. **`agent-pr-ready` hardening** — warns on stacked PRs (base branch ≠ main) including the auto-delete/close recovery path; BEHIND guidance now gives the exact command (`gh pr update-branch`); protection drift surfaces as an advisory warning on main-based PRs (never flips readiness by itself).
3. **Docs** — AGENTS.md merge discipline gains the three merge mechanics that previously lived only in agent session memory; the DEVELOPMENT_GUIDELINES CI table now points at the machine-checked contract.

Related issue / finding / routed package: #1128, #1129, tracking #1135.

## Type of change
- [x] Feature
- [x] CI/Docs/Tooling

## Scope & Impact
- Affected areas: `scripts/ci/`, `scripts/agents/pr_readiness.py`, AGENTS.md, docs/DEVELOPMENT_GUIDELINES.md, tests.
- Behavior change: `agent-pr-ready` output gains advisory warnings (stack, drift); no gate behavior changes — drift and stacking are warnings, not blockers.

## Test Plan
- [x] 15 new tests in `tests/unit/scripts/test_check_branch_protection.py` (drift per field, both payload shapes, CLI paths, pr-ready wiring)
- [x] 2 new stack-detection tests in `test_pr_readiness_assess.py`
- [x] Full `tests/unit/scripts` suite: 424 passed
- [x] Live run: `uv run python scripts/ci/check_branch_protection.py` → ✓ matches contract

## Quality Gates
- [x] ruff + black clean; pre-commit hooks passed
- [x] Docs link audit, reachability, currency scan pass

## Observability & Errors
- [x] CLI output follows the ✓/✗ convention (docs/agents/conventions.md); fetch failures are reported, not swallowed

## Breaking Changes
- [x] None

## Checklist
- [x] Acceptance criteria of #1128 and #1129 met (drift check runs in agent-pr-ready; stack/BEHIND detection with tests; merge mechanics documented in AGENTS.md)
- [x] Affected paths listed above