### PR TITLE
feat(ops): add Stage 1 rails end-to-end smoke and paper-day runbook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -524,6 +524,12 @@ jobs:
         # cleanup_workspace.py --apply, which deletes a root-level coverage.json).
         run: uv run pytest tests/unit -n auto -q --cov=src/gpt_trader --cov-report="json:$PWD/var/results/coverage/coverage.json"
 
+      - name: Stage 1 rails end-to-end smoke
+        # Offline operator-lifecycle smoke: unit tests cover the parts, this
+        # covers the loop (propose -> approve -> ticket -> fill -> closeout ->
+        # audit verify) through the real CLI. No network or credentials.
+        run: uv run python scripts/ops/stage1_rails_smoke.py
+
       - name: Upload coverage artifact
         if: always()
         # actions/upload-artifact@v7

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,9 @@ test-guardrails:
 	uv run python scripts/ci/check_dedupe_manifest.py
 	$(MAKE) test-triage-check
 
+stage1-smoke:
+	uv run python scripts/ops/stage1_rails_smoke.py
+
 ci-required:
 	$(MAKE) lint
 	uv run ruff check scripts/ops scripts/analysis/backtest_runner.py scripts/monitoring scripts/production_preflight.py
@@ -82,6 +85,7 @@ ci-required:
 	uv run agent-regenerate --verify || echo "::warning::Agent artifacts stale (advisory; run 'uv run agent-regenerate' to refresh). Non-PR CI still enforces this."
 	$(MAKE) test-guardrails
 	GPT_TRADER_STRICT_CONTAINER=1 PYTHONWARNINGS=default uv run pytest tests/unit -n auto -q
+	$(MAKE) stage1-smoke
 
 legacy-patterns:
 	uv run python scripts/ci/check_legacy_patterns.py

--- a/docs/DEVELOPMENT_GUIDELINES.md
+++ b/docs/DEVELOPMENT_GUIDELINES.md
@@ -134,7 +134,9 @@ make ci-required
 ```
 
 It runs lint/format, docs audits, mypy, agent artifacts freshness, test
-guardrails, and core unit tests, stopping on the first failure. Use
+guardrails, core unit tests, and the Stage 1 rails end-to-end smoke
+(`scripts/ops/stage1_rails_smoke.py`, also `make stage1-smoke`), stopping on
+the first failure. Use
 it when you want the local PR-readiness surface without optional suites or local
 readiness evidence. Agent artifacts freshness is advisory here: stale artifacts
 warn without stopping the run, while non-PR GitHub CI remains the blocking

--- a/docs/paper_trading.md
+++ b/docs/paper_trading.md
@@ -99,6 +99,58 @@ broker.set_mark("BTC-PERP", Decimal("50000"))
 # Set container._broker = broker before calling container.create_bot()
 ```
 
+## Stage 1 Paper Loop — One Honest Day
+
+The Stage 1 loop from [Direction](DIRECTION.md) — propose, review, paper-execute,
+attribute, report — can be run today as an operator procedure on real market
+data with no credentials and no broker access. Running it end to end is the
+project's ground truth: a component is trusted when its output shows up in the
+artifacts this loop produces (snapshots, audit events, closeouts, the report).
+
+The automated offline equivalent runs in CI and locally via `make stage1-smoke`
+(`scripts/ops/stage1_rails_smoke.py`), so the loop cannot silently break. The
+manual day below adds the real-data half.
+
+```bash
+# 0. Inspect the risk budget; attest account equity if unset (human action)
+uv run gpt-trader ideas budget show
+uv run gpt-trader ideas budget set --account-equity <equity> \
+  --actor <you> --reason "attest equity for paper day"
+
+# 1. Record the market view (read-only public candles -> snapshot artifact)
+uv run gpt-trader ideas snapshot build --from-coinbase \
+  --symbols BTC-USD,ETH-USD --granularity ONE_HOUR --lookback 200 \
+  --out var/data/snapshots/paper-day.json
+
+# 2. Propose from the recorded snapshot (deterministic proposer, ai actor)
+uv run gpt-trader ideas propose-baseline --snapshot var/data/snapshots/paper-day.json
+
+# 3. Review the queue and decide (human actions)
+uv run gpt-trader ideas queue-status
+uv run gpt-trader ideas list --state proposed
+uv run gpt-trader ideas show <decision-id>
+uv run gpt-trader ideas approve <decision-id> --actor <you> --reason "<why>"
+# ...or: ideas reject / ideas request-changes
+
+# 4. Export the ticket and paper-execute it by hand (no broker API calls)
+uv run gpt-trader ideas export-ticket --decision-id <decision-id> --venue manual
+uv run gpt-trader ideas mark-submitted <decision-id> --venue manual \
+  --external-order-id <paper-id> --actor <you> --actor-type human
+uv run gpt-trader ideas mark-filled <decision-id> --venue manual \
+  --external-order-id <paper-id> --actor <you>
+
+# 5. Attribute the outcome and close the day
+uv run gpt-trader ideas closeout record <decision-id> --resolution thesis_target \
+  --realized-profit-loss-amount <amount> --actor <you>
+uv run gpt-trader ideas report
+uv run gpt-trader ideas audit verify
+```
+
+Every step stamps an actor into the append-only audit log; proposals come from
+`ai` actors and approvals from `human` actors. None of these commands place,
+modify, or cancel broker orders. Ideas that expire unreviewed are swept with
+`uv run gpt-trader ideas expire`.
+
 ## Readiness Evidence Inputs
 
 Paper trading produces evidence that feeds the readiness checklist; it does not

--- a/scripts/ops/stage1_rails_smoke.py
+++ b/scripts/ops/stage1_rails_smoke.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+"""Offline end-to-end smoke for the Stage 0/1 trade-idea rails.
+
+Drives the real ``gpt-trader ideas`` CLI through the full record lifecycle in
+a scratch ideas root: propose -> (approval blocked without attested equity) ->
+budget attest -> approve -> export-ticket -> mark-submitted -> mark-filled ->
+closeout -> report -> audit verify.
+
+This is the "does the project still string together?" gate: unit tests cover
+the parts, this covers the operator-visible loop. It needs no network, broker,
+credentials, or pre-existing state, and finishes in well under a minute.
+
+Usage:
+    uv run python scripts/ops/stage1_rails_smoke.py [--keep-root]
+
+Exit code 0 iff every step succeeds (including the expected approval block).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+SMOKE_ACTOR_AI = "stage1-smoke-proposer"
+SMOKE_ACTOR_HUMAN = "stage1-smoke-operator"
+SMOKE_VENUE = "manual"
+SMOKE_EXTERNAL_ORDER_ID = "SMOKE-EXT-001"
+
+
+class SmokeStepError(RuntimeError):
+    """Raised when a lifecycle step does not behave as asserted."""
+
+
+def _build_idea_payload(decision_id: str) -> dict[str, Any]:
+    """Build one fully-populated, eligible spot trade idea as CLI JSON input."""
+    from decimal import Decimal
+
+    from gpt_trader.features.trade_ideas import (
+        AutonomyMode,
+        Confidence,
+        ConfidenceLabel,
+        EntryZone,
+        MaxLoss,
+        ProductType,
+        SizingRecommendation,
+        TimeHorizon,
+        TradeDirection,
+        TradeIdea,
+    )
+
+    idea = TradeIdea(
+        decision_id=decision_id,
+        autonomy_mode=AutonomyMode.HUMAN_APPROVED_EXECUTION,
+        thesis="Stage 1 rails smoke: fixed eligible record exercising the lifecycle",
+        instrument="BTC-USD",
+        product_type=ProductType.SPOT,
+        direction=TradeDirection.LONG,
+        entry_zone=EntryZone(lower=Decimal("60000"), upper=Decimal("61500")),
+        invalidation="Daily close below 58000",
+        target_exit="Take profit at 67000 or exit after 10 trading days",
+        max_loss=MaxLoss(
+            amount=Decimal("250"),
+            percent_of_account=Decimal("1.5"),
+            assumptions=("Fill at zone midpoint",),
+        ),
+        sizing_recommendation=SizingRecommendation(
+            quantity=Decimal("0.1"),
+            notional=Decimal("6075"),
+            rationale="Fixed smoke sizing; not a live recommendation",
+        ),
+        time_horizon=TimeHorizon(
+            expected_hold="3-10 days",
+            expires_at=datetime.now(UTC) + timedelta(days=7),
+        ),
+        data_used=("smoke:fixture:no-market-data",),
+        confidence=Confidence(
+            label=ConfidenceLabel.MEDIUM,
+            rationale="Smoke fixture confidence",
+        ),
+        failure_mode="Not applicable: smoke fixture never reaches a broker",
+        do_not_trade_if=("This is a smoke-test record",),
+    )
+    return idea.to_dict()
+
+
+def _run_ideas_cli(
+    ideas_root: Path,
+    *args: str,
+    expect_success: bool = True,
+) -> dict[str, Any]:
+    """Run one ``gpt-trader ideas`` command and return its parsed JSON envelope."""
+    command = [
+        sys.executable,
+        "-m",
+        "gpt_trader.cli",
+        "ideas",
+        *args,
+        "--ideas-root",
+        str(ideas_root),
+        "--format",
+        "json",
+    ]
+    completed = subprocess.run(command, capture_output=True, text=True, timeout=120)
+    succeeded = completed.returncode == 0
+    if succeeded != expect_success:
+        expectation = "succeed" if expect_success else "fail"
+        raise SmokeStepError(
+            f"expected `ideas {args[0]}` to {expectation} "
+            f"(exit={completed.returncode})\nstdout: {completed.stdout.strip()}"
+            f"\nstderr: {completed.stderr.strip()}"
+        )
+    try:
+        envelope: dict[str, Any] = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise SmokeStepError(
+            f"`ideas {args[0]}` did not emit a JSON envelope: {exc}"
+            f"\nstdout: {completed.stdout.strip()}"
+        ) from exc
+    return envelope
+
+
+def _assert(condition: bool, step: str, detail: str) -> None:
+    if not condition:
+        raise SmokeStepError(f"{step}: {detail}")
+
+
+def _step(label: str) -> None:
+    print(f"✓ {label}")
+
+
+def run_smoke(ideas_root: Path) -> None:
+    decision_id = f"trade-{datetime.now(UTC):%Y%m%d}-smoke-001"
+
+    idea_path = ideas_root / "smoke_idea.json"
+    idea_path.write_text(json.dumps(_build_idea_payload(decision_id)))
+
+    proposed = _run_ideas_cli(
+        ideas_root,
+        "propose",
+        "--file",
+        str(idea_path),
+        "--actor",
+        SMOKE_ACTOR_AI,
+        "--actor-type",
+        "ai",
+        "--reason",
+        "stage1 rails smoke",
+    )
+    _assert(
+        proposed["data"]["state"] == "proposed",
+        "propose",
+        f"unexpected state {proposed['data']}",
+    )
+    _step("propose (ai actor) -> proposed")
+
+    # The budget gate must refuse approval while account equity is unattested:
+    # a candidate idea can never supply its own notional denominator.
+    _run_ideas_cli(
+        ideas_root,
+        "approve",
+        decision_id,
+        "--actor",
+        SMOKE_ACTOR_HUMAN,
+        "--reason",
+        "smoke approval before equity attestation (must be blocked)",
+        expect_success=False,
+    )
+    _step("approve without attested equity -> blocked by budget gate")
+
+    budget = _run_ideas_cli(
+        ideas_root,
+        "budget",
+        "set",
+        "--account-equity",
+        "25000",
+        "--actor",
+        SMOKE_ACTOR_HUMAN,
+        "--reason",
+        "stage1 rails smoke: attest scratch equity",
+    )
+    _assert(
+        int(budget["data"]["version"]) >= 2,
+        "budget set",
+        f"expected a new budget version, got {budget['data']}",
+    )
+    _step("budget set (human attests account equity)")
+
+    approved = _run_ideas_cli(
+        ideas_root,
+        "approve",
+        decision_id,
+        "--actor",
+        SMOKE_ACTOR_HUMAN,
+        "--reason",
+        "stage1 rails smoke approval",
+    )
+    _assert(
+        approved["data"]["state"] == "approved",
+        "approve",
+        f"unexpected state {approved['data']}",
+    )
+    _step("approve (human actor) -> approved")
+
+    # export-ticket emits the raw ticket artifact, not the CliResponse envelope.
+    ticket = _run_ideas_cli(
+        ideas_root,
+        "export-ticket",
+        "--decision-id",
+        decision_id,
+        "--venue",
+        SMOKE_VENUE,
+    )
+    _assert(
+        bool(ticket.get("ticket_hash")) and bool(ticket.get("record_hash")),
+        "export-ticket",
+        f"missing ticket_hash/record_hash in keys {sorted(ticket)}",
+    )
+    _step("export-ticket -> deterministic ticket with content hash")
+
+    submitted = _run_ideas_cli(
+        ideas_root,
+        "mark-submitted",
+        decision_id,
+        "--venue",
+        SMOKE_VENUE,
+        "--external-order-id",
+        SMOKE_EXTERNAL_ORDER_ID,
+        "--actor",
+        SMOKE_ACTOR_HUMAN,
+        "--actor-type",
+        "human",
+        "--reason",
+        "stage1 rails smoke submission attestation",
+    )
+    _assert(
+        submitted["data"]["state"] == "submitted",
+        "mark-submitted",
+        f"unexpected state {submitted['data']}",
+    )
+    _step("mark-submitted (attestation) -> submitted")
+
+    filled = _run_ideas_cli(
+        ideas_root,
+        "mark-filled",
+        decision_id,
+        "--venue",
+        SMOKE_VENUE,
+        "--external-order-id",
+        SMOKE_EXTERNAL_ORDER_ID,
+        "--actor",
+        SMOKE_ACTOR_HUMAN,
+        "--reason",
+        "stage1 rails smoke fill attestation",
+    )
+    _assert(
+        filled["data"]["state"] == "filled",
+        "mark-filled",
+        f"unexpected state {filled['data']}",
+    )
+    _step("mark-filled (attestation) -> filled")
+
+    _run_ideas_cli(
+        ideas_root,
+        "closeout",
+        "record",
+        decision_id,
+        "--resolution",
+        "thesis_target",
+        "--realized-profit-loss-amount",
+        "120",
+        "--realized-profit-loss-percent",
+        "0.48",
+        "--evidence",
+        "stage1 rails smoke exit",
+        "--actor",
+        SMOKE_ACTOR_HUMAN,
+    )
+    _step("closeout record -> attribution captured")
+
+    report = _run_ideas_cli(ideas_root, "report")
+    report_data = report["data"]
+    _assert(
+        int(report_data["row_count"]) == 1,
+        "report",
+        f"expected exactly 1 idea, got row_count={report_data.get('row_count')}",
+    )
+    closeouts = report_data.get("closeouts", {})
+    _assert(
+        int(closeouts.get("missing_closeout_count", -1)) == 0,
+        "report",
+        f"expected full closeout coverage, got {closeouts}",
+    )
+    _step("report -> 1 idea, full closeout coverage")
+
+    verify = _run_ideas_cli(ideas_root, "audit", "verify")
+    _assert(
+        int(verify["data"].get("event_count", 0)) >= 4,
+        "audit verify",
+        f"expected >=4 chained events, got {verify['data']}",
+    )
+    _step(f"audit verify -> chain intact ({verify['data']['event_count']} events)")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--keep-root",
+        action="store_true",
+        help="Keep the scratch ideas root for inspection instead of deleting it",
+    )
+    args = parser.parse_args()
+
+    if args.keep_root:
+        ideas_root = Path(tempfile.mkdtemp(prefix="stage1-rails-smoke-"))
+        print(f"scratch ideas root: {ideas_root}")
+        return _execute(ideas_root)
+    with tempfile.TemporaryDirectory(prefix="stage1-rails-smoke-") as tmp:
+        return _execute(Path(tmp))
+
+
+def _execute(ideas_root: Path) -> int:
+    try:
+        run_smoke(ideas_root)
+    except SmokeStepError as exc:
+        print(f"✗ stage1 rails smoke FAILED: {exc}", file=sys.stderr)
+        return 1
+    print("✓ stage1 rails smoke OK: proposed -> approved -> filled -> closed, audit chain intact")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/gpt_trader/ci/local_ci.py
+++ b/src/gpt_trader/ci/local_ci.py
@@ -288,6 +288,10 @@ def build_steps(profile: LocalCIProfile, args: argparse.Namespace) -> list[Plann
             env=test_env,
         ),
         PlannedStep(
+            label="Stage 1 rails end-to-end smoke",
+            command=["uv", "run", "python", "scripts/ops/stage1_rails_smoke.py"],
+        ),
+        PlannedStep(
             label="Property tests",
             command=["uv", "run", "pytest", "tests/property", "-v"],
             env=test_env,


### PR DESCRIPTION
## Summary
First deliverable of the realignment path (M0): make the Stage 0/1 trade-idea loop an *executable, gated fact* instead of an assumption. Unit tests cover the parts; nothing covered whether the operator-visible loop still strings together. Now CI does.

Related issue / finding / routed package: realignment M0 (as-built review, 2026-07-02)

## Type of change
- [x] CI/Docs/Tooling
- [x] Feature

## Scope & Impact
- Affected areas: `scripts/ops` (new smoke), `.github/workflows/ci.yml` (one step inside the existing required **Unit Tests (Core)** job — no new required check name), `Makefile` (`stage1-smoke` target, appended to `ci-required`), `src/gpt_trader/ci/local_ci.py` (one planned step), `docs/paper_trading.md` (operator runbook), `docs/DEVELOPMENT_GUIDELINES.md` (bundle description).
- Behavior changes: none in trading code. No broker, network, or credential use anywhere in the new path.

## What the smoke asserts
Drives the real `gpt-trader ideas` CLI in a scratch `--ideas-root`:
1. `propose` (ai actor) → `proposed`
2. `approve` **before** equity attestation → must FAIL (budget gate regression-tested, not just happy path)
3. `budget set --account-equity` (human) → new budget version
4. `approve` (human) → `approved`
5. `export-ticket --venue manual` → deterministic artifact with `ticket_hash`/`record_hash`
6. `mark-submitted` → `mark-filled` → `closeout record`
7. `report` → 1 idea, zero missing closeouts
8. `audit verify` → hash chain intact

## Test Plan
- [x] Ran `make stage1-smoke` locally — all 10 steps pass (~25s)
- [x] `tests/unit/scripts/test_local_ci.py` — 10 passed
- [x] `make docs-audit`, `make test-guardrails`, `uv run agent-naming` — clean
- [x] `uv run mypy src/gpt_trader/ci/local_ci.py` — clean
- Full unit suite left to CI (no production-code behavior changed)

## Quality Gates
- [x] Lint/format/docs/type gates run locally (see above)
- [x] Import boundaries untouched (script lives in `scripts/ops`)

## Observability & Errors
- Smoke prints ✓/✗ per repo CLI convention; failures include the failing step, exit code, and captured stdout/stderr.

## Breaking Changes
- [x] None

## Follow-ups (not in this PR)
- M0 manual half: run the "one honest day" runbook (docs/paper_trading.md) on real snapshot data — needs RJ as the human approver.
- M1: paper executor consuming APPROVED ideas (closes the machine loop; new component, not more TradingEngine).
- Decision record for the five-role target shape (recorder / proposers / approval / executor / accountant).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new end-to-end smoke check to the CI and local workflow, covering a full paper-trading style lifecycle.
  * Expanded documentation with a step-by-step guide for running the Stage 1 paper loop and its offline equivalent.

* **Bug Fixes**
  * Improved CI gating so this workflow is now verified alongside existing tests before changes are accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->