### PR TITLE
feat(idea execution): paper-only lane skeleton with structural guarantees (#1144, PR 1)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -47,6 +47,7 @@ The system is organized into vertical feature slices under `src/gpt_trader/featu
 src/gpt_trader/features/
 ├── brokerages/          # Exchange integrations
 ├── data/                # Data acquisition helpers
+├── idea_execution/      # Paper-only execution lane for APPROVED trade ideas
 ├── intelligence/        # Strategy intelligence (sizing, regime, ensemble)
 │   └── sizing/          # Kelly criterion position sizing
 ├── live_trade/          # Production trading engine

--- a/scripts/ci/check_import_boundaries.py
+++ b/scripts/ci/check_import_boundaries.py
@@ -179,6 +179,24 @@ CROSS_SLICE_ALLOWED_EDGES: frozenset[tuple[str, str]] = frozenset(
     }
 )
 
+# Some slice-to-slice edges are narrower than the target slice root. Each entry
+# is (source_slice, target_slice, import prefix) and replaces the broad
+# gpt_trader.features.<target_slice> allowance for that source/target pair.
+CROSS_SLICE_NARROW_IMPORT_PREFIXES: frozenset[tuple[str, str, str]] = frozenset(
+    {
+        (
+            "idea_execution",
+            "brokerages",
+            "gpt_trader.features.brokerages.mock",
+        ),
+        (
+            "idea_execution",
+            "brokerages",
+            "gpt_trader.features.brokerages.paper",
+        ),
+    }
+)
+
 
 def _discover_feature_slices() -> tuple[str, ...]:
     """Enumerate feature slice packages so new slices are guarded automatically."""
@@ -195,8 +213,20 @@ def _discover_feature_slices() -> tuple[str, ...]:
 
 def _cross_slice_rule(slice_name: str) -> ImportRule:
     """Build the cross-slice ratchet rule for one feature slice."""
+    narrow_prefixes = sorted(
+        prefix
+        for source, _target, prefix in CROSS_SLICE_NARROW_IMPORT_PREFIXES
+        if source == slice_name
+    )
+    narrow_targets = {
+        target
+        for source, target, _prefix in CROSS_SLICE_NARROW_IMPORT_PREFIXES
+        if source == slice_name
+    }
     allowed_targets = sorted(
-        target for source, target in CROSS_SLICE_ALLOWED_EDGES if source == slice_name
+        target
+        for source, target in CROSS_SLICE_ALLOWED_EDGES
+        if source == slice_name and target not in narrow_targets
     )
     return ImportRule(
         name=f"features_{slice_name}_cross_slice_imports",
@@ -210,7 +240,8 @@ def _cross_slice_rule(slice_name: str) -> ImportRule:
         forbidden_prefixes=("gpt_trader.features",),
         allowlist_import_prefixes=tuple(
             f"gpt_trader.features.{target}" for target in (slice_name, *allowed_targets)
-        ),
+        )
+        + tuple(narrow_prefixes),
     )
 
 

--- a/scripts/ci/check_import_boundaries.py
+++ b/scripts/ci/check_import_boundaries.py
@@ -197,6 +197,13 @@ CROSS_SLICE_NARROW_IMPORT_PREFIXES: frozenset[tuple[str, str, str]] = frozenset(
     }
 )
 
+for _source, _target, _prefix in CROSS_SLICE_NARROW_IMPORT_PREFIXES:
+    if (_source, _target) not in CROSS_SLICE_ALLOWED_EDGES:
+        raise ValueError(
+            f"Narrow cross-slice prefix for {_source}->{_target} requires a matching "
+            "CROSS_SLICE_ALLOWED_EDGES entry."
+        )
+
 
 def _discover_feature_slices() -> tuple[str, ...]:
     """Enumerate feature slice packages so new slices are guarded automatically."""

--- a/scripts/ci/check_import_boundaries.py
+++ b/scripts/ci/check_import_boundaries.py
@@ -165,6 +165,10 @@ CROSS_SLICE_ALLOWED_EDGES: frozenset[tuple[str, str]] = frozenset(
         ("live_trade", "strategy_tools"),
         # engines/strategy.py trade-idea proposal workflow service.
         ("live_trade", "trade_ideas"),
+        # Paper execution lane consumes APPROVED ideas via TradeIdeaService and
+        # drives paper/mock brokers only (docs/decisions/adopt-five-role-composition.md).
+        ("idea_execution", "trade_ideas"),
+        ("idea_execution", "brokerages"),
         # RegimeAwareProposer overlays regime state; PositionSizer bridge
         # enriches sizing on trade-idea proposal records.
         ("trade_ideas", "intelligence"),

--- a/src/gpt_trader/features/idea_execution/__init__.py
+++ b/src/gpt_trader/features/idea_execution/__init__.py
@@ -1,0 +1,35 @@
+"""Paper execution lane for APPROVED trade ideas.
+
+First component of the accepted five-role composition
+(docs/decisions/adopt-five-role-composition.md): the executor arm that
+consumes ideas from the approval-gated workflow in
+``gpt_trader.features.trade_ideas`` and executes them against a paper broker.
+
+Lane contract (enforced in code, not convention):
+
+- **Paper-only.** The lane accepts exactly the paper/mock broker types in
+  ``PAPER_BROKER_TYPES``; anything else — including duck-typed lookalikes and
+  subclasses — is rejected at construction with ``PaperOnlyLaneError``. There
+  is no configuration path that routes a live broker into this slice.
+- **APPROVED ideas only.** Ideas in any other workflow state, or past their
+  ``expires_at``, are refused with ``IdeaNotExecutableError``.
+- Lifecycle facts are recorded only through ``TradeIdeaService`` so every
+  action lands on the append-only audit log with a system actor.
+
+Live order submission remains gated by docs/DIRECTION.md and recorded human
+approval; nothing in this slice weakens that boundary.
+"""
+
+from gpt_trader.features.idea_execution.executor import (
+    PAPER_BROKER_TYPES,
+    IdeaNotExecutableError,
+    PaperIdeaExecutor,
+    PaperOnlyLaneError,
+)
+
+__all__ = [
+    "PAPER_BROKER_TYPES",
+    "IdeaNotExecutableError",
+    "PaperIdeaExecutor",
+    "PaperOnlyLaneError",
+]

--- a/src/gpt_trader/features/idea_execution/executor.py
+++ b/src/gpt_trader/features/idea_execution/executor.py
@@ -1,0 +1,103 @@
+"""Paper idea executor: broker boundary and executability checks.
+
+This module ships the lane's structural guarantees ahead of any execution
+logic (issue #1144, first PR): the constructor contract that makes live
+brokers unreachable, and the refusal logic that admits only APPROVED,
+unexpired ideas. Order placement lands in a follow-up PR on top of these
+guarantees; no submission code exists here yet.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import UTC, datetime
+
+from gpt_trader.errors import ValidationError
+from gpt_trader.features.brokerages.mock import DeterministicBroker
+from gpt_trader.features.brokerages.paper import HybridPaperBroker
+from gpt_trader.features.trade_ideas import (
+    TradeIdeaService,
+    TradeIdeaState,
+    TradeIdeaView,
+)
+
+# The exhaustive set of broker types this lane may drive. Membership is
+# checked by exact type, not isinstance: a subclass could override fill
+# behavior into a live call path, and a duck-typed lookalike could wrap a
+# live client, so neither is admitted.
+PAPER_BROKER_TYPES: tuple[type, ...] = (DeterministicBroker, HybridPaperBroker)
+
+PaperBroker = DeterministicBroker | HybridPaperBroker
+
+
+class PaperOnlyLaneError(ValidationError):
+    """Raised when a non-paper broker is offered to the paper execution lane."""
+
+
+class IdeaNotExecutableError(ValidationError):
+    """Raised when an idea is not in an executable state for this lane."""
+
+
+def _require_paper_broker(broker: object) -> PaperBroker:
+    if type(broker) not in PAPER_BROKER_TYPES:
+        allowed = ", ".join(sorted(t.__name__ for t in PAPER_BROKER_TYPES))
+        raise PaperOnlyLaneError(
+            "Paper execution lane accepts only paper/mock brokers "
+            f"({allowed}); got {type(broker).__name__}",
+            field="broker",
+            value=type(broker).__name__,
+        )
+    return broker  # type: ignore[return-value]
+
+
+class PaperIdeaExecutor:
+    """Executes APPROVED trade ideas against a paper broker.
+
+    Construction enforces the paper-only boundary; ``resolve_approved_idea``
+    enforces the workflow-state boundary. Both are deliberate refusals, not
+    conveniences — tests pin them so later execution logic cannot loosen the
+    lane by accident.
+    """
+
+    def __init__(
+        self,
+        service: TradeIdeaService,
+        broker: PaperBroker,
+        *,
+        now_factory: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._service = service
+        self._broker = _require_paper_broker(broker)
+        self._now_factory = now_factory or (lambda: datetime.now(UTC))
+
+    @property
+    def broker(self) -> PaperBroker:
+        return self._broker
+
+    def resolve_approved_idea(self, decision_id: str) -> TradeIdeaView:
+        """Load an idea and admit it to the lane, or refuse with a typed error.
+
+        Admission requires workflow state APPROVED and an unexpired
+        ``time_horizon.expires_at``. Every other state — including SUBMITTED
+        (already being executed) and FILLED — is refused so the lane can never
+        double-execute or resurrect a terminal record.
+        """
+        view = self._service.get(decision_id)
+
+        if view.state is not TradeIdeaState.APPROVED:
+            raise IdeaNotExecutableError(
+                f"Idea {decision_id} is not executable: state is "
+                f"{view.state.value}, lane requires {TradeIdeaState.APPROVED.value}",
+                field="state",
+                value=view.state.value,
+            )
+
+        expires_at = view.idea.time_horizon.expires_at
+        if expires_at is not None and expires_at <= self._now_factory():
+            raise IdeaNotExecutableError(
+                f"Idea {decision_id} is not executable: expired at " f"{expires_at.isoformat()}",
+                field="expires_at",
+                value=expires_at.isoformat(),
+            )
+
+        return view

--- a/tests/unit/gpt_trader/features/idea_execution/test_executor.py
+++ b/tests/unit/gpt_trader/features/idea_execution/test_executor.py
@@ -1,0 +1,184 @@
+"""Lane-contract tests for the paper idea executor skeleton.
+
+These pin the structural guarantees from issue #1144 ahead of any execution
+logic: the paper-only broker boundary and the APPROVED/unexpired admission
+rule. Later execution PRs build on top of these tests, not around them.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from gpt_trader.features.brokerages.mock import DeterministicBroker
+from gpt_trader.features.brokerages.paper import HybridPaperBroker
+from gpt_trader.features.idea_execution import (
+    PAPER_BROKER_TYPES,
+    IdeaNotExecutableError,
+    PaperIdeaExecutor,
+    PaperOnlyLaneError,
+)
+from gpt_trader.features.trade_ideas import (
+    DEFAULT_RISK_BUDGET,
+    ActorType,
+    AutonomyMode,
+    Confidence,
+    ConfidenceLabel,
+    EntryZone,
+    MaxLoss,
+    ProductType,
+    SizingRecommendation,
+    TimeHorizon,
+    TradeDirection,
+    TradeIdea,
+    TradeIdeaService,
+)
+
+_NOW = datetime(2026, 7, 2, 12, 0, tzinfo=UTC)
+
+
+def _build_idea(decision_id: str, *, expires_at: datetime) -> TradeIdea:
+    return TradeIdea(
+        decision_id=decision_id,
+        autonomy_mode=AutonomyMode.HUMAN_APPROVED_EXECUTION,
+        thesis="Executor lane test: eligible fixture record",
+        instrument="BTC-USD",
+        product_type=ProductType.SPOT,
+        direction=TradeDirection.LONG,
+        entry_zone=EntryZone(lower=Decimal("60000"), upper=Decimal("61500")),
+        invalidation="Daily close below 58000",
+        target_exit="Take profit at 67000 or exit after 10 trading days",
+        max_loss=MaxLoss(
+            amount=Decimal("250"),
+            percent_of_account=Decimal("1.5"),
+            assumptions=("Fill at zone midpoint",),
+        ),
+        sizing_recommendation=SizingRecommendation(
+            quantity=Decimal("0.1"),
+            notional=Decimal("6075"),
+            rationale="Fixture sizing",
+        ),
+        time_horizon=TimeHorizon(expected_hold="3-10 days", expires_at=expires_at),
+        data_used=("test:fixture:no-market-data",),
+        confidence=Confidence(label=ConfidenceLabel.MEDIUM, rationale="fixture"),
+        failure_mode="Not applicable in tests",
+        do_not_trade_if=("fixture record",),
+    )
+
+
+@pytest.fixture
+def service(tmp_path: Path) -> TradeIdeaService:
+    trade_idea_service = TradeIdeaService(tmp_path, now_factory=lambda: _NOW)
+    trade_idea_service.update_budget(
+        replace(
+            DEFAULT_RISK_BUDGET,
+            version=2,
+            account_equity=Decimal("25000"),
+            reason="test: attest scratch equity",
+        ),
+        actor_type=ActorType.HUMAN,
+        actor_id="test-operator",
+    )
+    return trade_idea_service
+
+
+def _approved_idea(service: TradeIdeaService, decision_id: str) -> None:
+    idea = _build_idea(decision_id, expires_at=_NOW + timedelta(days=7))
+    service.propose(idea, actor_id="test-proposer")
+    service.approve(decision_id, actor_id="test-operator", reason="test approval")
+
+
+class TestPaperOnlyBrokerBoundary:
+    def test_accepts_deterministic_broker(self, service: TradeIdeaService) -> None:
+        broker = DeterministicBroker()
+        executor = PaperIdeaExecutor(service, broker)
+        assert executor.broker is broker
+
+    def test_accepts_hybrid_paper_broker(self, service: TradeIdeaService) -> None:
+        broker = HybridPaperBroker(client=object())  # type: ignore[arg-type]
+        executor = PaperIdeaExecutor(service, broker)
+        assert executor.broker is broker
+
+    def test_rejects_duck_typed_lookalike(self, service: TradeIdeaService) -> None:
+        class LooksLikeABroker:
+            """Implements broker-shaped methods but is not an allowed type."""
+
+            def place_order(self, *args: object, **kwargs: object) -> None: ...
+
+            def list_positions(self) -> list[object]:
+                return []
+
+            def list_balances(self) -> list[object]:
+                return []
+
+        with pytest.raises(PaperOnlyLaneError):
+            PaperIdeaExecutor(service, LooksLikeABroker())  # type: ignore[arg-type]
+
+    def test_rejects_subclass_of_allowed_broker(self, service: TradeIdeaService) -> None:
+        class SneakyBroker(DeterministicBroker):
+            """A subclass could reroute fills; exact-type matching refuses it."""
+
+        with pytest.raises(PaperOnlyLaneError):
+            PaperIdeaExecutor(service, SneakyBroker())
+
+    def test_allowlist_is_exactly_the_two_paper_brokers(self) -> None:
+        assert set(PAPER_BROKER_TYPES) == {DeterministicBroker, HybridPaperBroker}
+
+
+class TestApprovedIdeaAdmission:
+    def _executor(
+        self,
+        service: TradeIdeaService,
+        *,
+        now: datetime = _NOW,
+    ) -> PaperIdeaExecutor:
+        return PaperIdeaExecutor(service, DeterministicBroker(), now_factory=lambda: now)
+
+    def test_admits_approved_unexpired_idea(self, service: TradeIdeaService) -> None:
+        _approved_idea(service, "trade-20260702-exec-001")
+        view = self._executor(service).resolve_approved_idea("trade-20260702-exec-001")
+        assert view.idea.decision_id == "trade-20260702-exec-001"
+
+    def test_refuses_proposed_idea(self, service: TradeIdeaService) -> None:
+        idea = _build_idea("trade-20260702-exec-002", expires_at=_NOW + timedelta(days=7))
+        service.propose(idea, actor_id="test-proposer")
+        with pytest.raises(IdeaNotExecutableError, match="state is proposed"):
+            self._executor(service).resolve_approved_idea("trade-20260702-exec-002")
+
+    def test_refuses_rejected_idea(self, service: TradeIdeaService) -> None:
+        idea = _build_idea("trade-20260702-exec-003", expires_at=_NOW + timedelta(days=7))
+        service.propose(idea, actor_id="test-proposer")
+        service.reject("trade-20260702-exec-003", actor_id="test-operator", reason="no")
+        with pytest.raises(IdeaNotExecutableError, match="state is rejected"):
+            self._executor(service).resolve_approved_idea("trade-20260702-exec-003")
+
+    def test_refuses_submitted_idea_to_prevent_double_execution(
+        self, service: TradeIdeaService
+    ) -> None:
+        _approved_idea(service, "trade-20260702-exec-004")
+        service.record_submission(
+            "trade-20260702-exec-004",
+            actor_type=ActorType.HUMAN,
+            actor_id="test-operator",
+            venue="manual",
+            external_order_id="EXT-1",
+            reason="test submission",
+        )
+        with pytest.raises(IdeaNotExecutableError, match="state is submitted"):
+            self._executor(service).resolve_approved_idea("trade-20260702-exec-004")
+
+    def test_refuses_expired_approved_idea(self, service: TradeIdeaService) -> None:
+        _approved_idea(service, "trade-20260702-exec-005")
+        after_expiry = _NOW + timedelta(days=8)
+        with pytest.raises(IdeaNotExecutableError, match="expired at"):
+            self._executor(service, now=after_expiry).resolve_approved_idea(
+                "trade-20260702-exec-005"
+            )
+
+    def test_missing_idea_error_propagates(self, service: TradeIdeaService) -> None:
+        with pytest.raises(Exception, match="trade-20260702-exec-404"):
+            self._executor(service).resolve_approved_idea("trade-20260702-exec-404")

--- a/tests/unit/gpt_trader/features/idea_execution/test_executor.py
+++ b/tests/unit/gpt_trader/features/idea_execution/test_executor.py
@@ -36,6 +36,7 @@ from gpt_trader.features.trade_ideas import (
     TradeDirection,
     TradeIdea,
     TradeIdeaService,
+    UnknownTradeIdeaError,
 )
 
 _NOW = datetime(2026, 7, 2, 12, 0, tzinfo=UTC)
@@ -180,5 +181,5 @@ class TestApprovedIdeaAdmission:
             )
 
     def test_missing_idea_error_propagates(self, service: TradeIdeaService) -> None:
-        with pytest.raises(Exception, match="trade-20260702-exec-404"):
+        with pytest.raises(UnknownTradeIdeaError, match="trade-20260702-exec-404"):
             self._executor(service).resolve_approved_idea("trade-20260702-exec-404")

--- a/tests/unit/scripts/test_check_import_boundaries.py
+++ b/tests/unit/scripts/test_check_import_boundaries.py
@@ -242,6 +242,43 @@ def test_cross_slice_allowlisted_edge_passes(tmp_path, monkeypatch, capsys) -> N
     assert "Import boundary guard passed." in captured.out
 
 
+def test_cross_slice_narrow_prefixes_allow_only_paper_brokerages(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    slice_root = _configure_cross_slice_rule(monkeypatch, tmp_path, "idea_execution")
+    _write_file(
+        tmp_path,
+        "src/gpt_trader/features/idea_execution/executor.py",
+        "from gpt_trader.features.brokerages.mock import DeterministicBroker\n"
+        "from gpt_trader.features.brokerages.paper import HybridPaperBroker\n"
+        "from gpt_trader.features.trade_ideas import TradeIdeaService\n",
+    )
+
+    result = check_import_boundaries.scan([str(slice_root)])
+    captured = capsys.readouterr()
+
+    assert result == 0
+    assert "Import boundary guard passed." in captured.out
+
+
+def test_cross_slice_narrow_prefixes_reject_live_brokerage_import(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    slice_root = _configure_cross_slice_rule(monkeypatch, tmp_path, "idea_execution")
+    _write_file(
+        tmp_path,
+        "src/gpt_trader/features/idea_execution/live_leak.py",
+        "from gpt_trader.features.brokerages.coinbase.client import CoinbaseClient\n",
+    )
+
+    result = check_import_boundaries.scan([str(slice_root)])
+    captured = capsys.readouterr()
+
+    assert result == 1
+    assert "imports gpt_trader.features.brokerages.coinbase.client.CoinbaseClient" in captured.out
+    assert "CROSS_SLICE_ALLOWED_EDGES" in captured.out
+
+
 def test_cross_slice_new_edge_fails_with_allowlist_pointer(tmp_path, monkeypatch, capsys) -> None:
     slice_root = _configure_cross_slice_rule(monkeypatch, tmp_path, "data")
     _write_file(
@@ -279,6 +316,23 @@ def test_cross_slice_allowlist_is_frozen_topology() -> None:
             ("trade_ideas", "intelligence"),
             ("optimize", "live_trade"),
             ("strategy_tools", "trade_ideas"),
+        }
+    )
+
+
+def test_cross_slice_narrow_import_prefixes_are_frozen() -> None:
+    assert check_import_boundaries.CROSS_SLICE_NARROW_IMPORT_PREFIXES == frozenset(
+        {
+            (
+                "idea_execution",
+                "brokerages",
+                "gpt_trader.features.brokerages.mock",
+            ),
+            (
+                "idea_execution",
+                "brokerages",
+                "gpt_trader.features.brokerages.paper",
+            ),
         }
     )
 

--- a/tests/unit/scripts/test_check_import_boundaries.py
+++ b/tests/unit/scripts/test_check_import_boundaries.py
@@ -265,6 +265,10 @@ def test_cross_slice_allowlist_is_frozen_topology() -> None:
     # one is progress and should just update this test.
     assert check_import_boundaries.CROSS_SLICE_ALLOWED_EDGES == frozenset(
         {
+            # Paper execution lane consumes APPROVED ideas and drives paper/mock
+            # brokers only (docs/decisions/adopt-five-role-composition.md).
+            ("idea_execution", "trade_ideas"),
+            ("idea_execution", "brokerages"),
             ("intelligence", "live_trade"),
             ("live_trade", "brokerages"),
             ("live_trade", "intelligence"),

--- a/tests/unit/scripts/test_check_import_boundaries.py
+++ b/tests/unit/scripts/test_check_import_boundaries.py
@@ -337,6 +337,11 @@ def test_cross_slice_narrow_import_prefixes_are_frozen() -> None:
     )
 
 
+def test_cross_slice_narrow_import_prefixes_have_topology_edges() -> None:
+    for source, target, _prefix in check_import_boundaries.CROSS_SLICE_NARROW_IMPORT_PREFIXES:
+        assert (source, target) in check_import_boundaries.CROSS_SLICE_ALLOWED_EDGES
+
+
 def test_trade_ideas_allowed_prefixes_are_frozen() -> None:
     assert check_import_boundaries.TRADE_IDEAS_ALLOWED_IMPORT_PREFIXES == (
         "gpt_trader.core",

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -9,8 +9,8 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 5843,
-    "total_files": 699,
+    "total_tests": 5854,
+    "total_files": 700,
     "markers_used": 14
   },
   "quick_commands": {

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -9,7 +9,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 5857,
+    "total_tests": 5858,
     "total_files": 700,
     "markers_used": 14
   },

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -9,7 +9,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 5854,
+    "total_tests": 5857,
     "total_files": 700,
     "markers_used": 14
   },

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -92,7 +92,7 @@
     ]
   },
   "counts": {
-    "unit": 5686,
+    "unit": 5697,
     "asyncio": 302,
     "parametrize": 173,
     "integration": 80,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -92,7 +92,7 @@
     ]
   },
   "counts": {
-    "unit": 5700,
+    "unit": 5701,
     "asyncio": 302,
     "parametrize": 173,
     "integration": 80,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -92,7 +92,7 @@
     ]
   },
   "counts": {
-    "unit": 5697,
+    "unit": 5700,
     "asyncio": 302,
     "parametrize": 173,
     "integration": 80,


### PR DESCRIPTION
## Summary
First PR on #1144, per the accepted [adopt-five-role-composition](https://github.com/Solders-Girdles/GPT-Trader/blob/main/docs/decisions/adopt-five-role-composition.md) record: the executor arm's **boundary contract ships before any execution logic**, so later PRs build on pinned guarantees instead of loosening them by accident.

Related issue / finding / routed package: #1144 (does not close it — this is step 1 of the lane)

## Type of change
- [x] Feature

## Scope & Impact
- New slice `src/gpt_trader/features/idea_execution/` — `PaperIdeaExecutor` with two enforced refusals, no order placement anywhere in the slice:
  1. **Paper-only boundary:** construction admits exactly `DeterministicBroker` and `HybridPaperBroker` by **exact type** — duck-typed lookalikes and subclasses raise `PaperOnlyLaneError` (a subclass could reroute fills; a lookalike could wrap a live client). No env/config path selects this lane's broker; callers must pass an instance.
  2. **Admission rule:** `resolve_approved_idea()` admits only APPROVED, unexpired ideas; SUBMITTED is refused to prevent double-execution; terminal states refused.
- `scripts/ci/check_import_boundaries.py`: adds `idea_execution→{trade_ideas, brokerages}` with rationale. `features/trade_ideas` stays submission-free and dependency-frozen; the new slice is auto-guarded by the existing cross-slice ratchet.
- `docs/ARCHITECTURE.md` slice tree gains one line; `var/agents/testing/*` regenerated.

## Test Plan
- [x] 11 new lane-contract tests (`tests/unit/gpt_trader/features/idea_execution/`): accept/reject matrix for the broker boundary (incl. subclass + duck-type refusal, allowlist exactness) and the admission rule (proposed/rejected/submitted/expired/missing all refused; approved admitted)
- [x] `pytest tests/unit/.../idea_execution tests/unit/.../trade_ideas` — 332 passed
- [x] `check_import_boundaries.py`, `check_test_hygiene.py`, `agent-naming`, `mypy` (new slice), `make docs-audit` — all clean
- [x] `uv run agent-regenerate` — inventories refreshed and committed

## Safety boundary
Touches trading execution per #1144's classification, under the accepted decision gate: **paper-only, live brokers structurally unreachable, and no order placement exists in this slice yet.** Lifecycle writes (submission/fill recording) arrive in PR 2 and will go through `TradeIdeaService` with system actors on the audit log.

## Next PR on #1144
Execution logic: paper fill against the admitted idea, `decision_id`→`client_order_id` propagation, lifecycle recording via `TradeIdeaService`, and the Stage 1 smoke's machine leg.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a paper-only execution lane for approved trade ideas, with strict brokerage eligibility checks.
* **Documentation**
  * Updated the architecture “Vertical Slice Design” feature tree to include the new execution lane.
* **Tests**
  * Added unit tests covering brokerage eligibility, approved-workflow admission, and expiration rejection.
  * Expanded import-boundary tests to validate the lane’s permitted dependencies and narrowed allowances.
* **Chores**
  * Updated CI import-boundary configuration to support the new lane’s cross-slice rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->