### PR TITLE
fix(tests): stop norecursedirs from shadowing tests/*/scripts from collection

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -6,6 +6,11 @@ import warnings
 from pathlib import Path
 from typing import Any
 
+# Keep repo-root scripts/ (CLI helpers like scripts/maintenance/test_legacy_triage.py)
+# out of collection without a basename pattern in norecursedirs, which would also
+# shadow tests/unit/scripts and tests/integration/scripts (see pytest.ini).
+collect_ignore = ["scripts"]
+
 
 def pytest_configure(config: Any) -> None:  # pragma: no cover
     """Register optional warning filters.

--- a/pytest.ini
+++ b/pytest.ini
@@ -15,7 +15,7 @@ python_functions = test_*
 # them, letting a required CI lane false-pass). Keep only patterns that can
 # never name a test directory; the repo-root scripts/ dir is excluded via
 # collect_ignore in the root conftest.py instead. Guarded by
-# tests/unit/test_collection_shadowing.py.
+# tests/unit/support/test_collection_shadowing.py.
 norecursedirs = .* build dist node_modules venv
 
 # Output and reporting

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,7 +8,15 @@ testpaths = tests
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
-norecursedirs = archived scripts .hypothesis
+# norecursedirs patterns match directory *basenames* anywhere in the tree, so a
+# bare name like "scripts" would also shadow tests/unit/scripts and
+# tests/integration/scripts from recursive collection (`pytest tests/unit` would
+# silently skip them while an explicit `pytest tests/unit/scripts` still runs
+# them, letting a required CI lane false-pass). Keep only patterns that can
+# never name a test directory; the repo-root scripts/ dir is excluded via
+# collect_ignore in the root conftest.py instead. Guarded by
+# tests/unit/test_collection_shadowing.py.
+norecursedirs = .* build dist node_modules venv
 
 # Output and reporting
 # legacy_delete/legacy_modernize are empty-by-design queue markers for the

--- a/tests/unit/support/test_collection_shadowing.py
+++ b/tests/unit/support/test_collection_shadowing.py
@@ -9,8 +9,12 @@ required CI lane can false-pass on code its own guard tests reject (PR #1145:
 the Linux core lane reported green while the Windows lane failed
 ``test_cross_slice_allowlist_is_frozen_topology`` on the same commit).
 
-This test lives directly under ``tests/unit/`` — not in a subdirectory — so it
-cannot itself be shadowed unless ``tests`` or ``unit`` is excluded outright.
+This guard protects every directory under ``tests/`` except its own ancestors:
+if ``tests``, ``unit``, or ``support`` were ever added to ``norecursedirs``,
+the guard itself would be shadowed and could not fire. It lives in
+``tests/unit/support/`` because the test-hygiene gate requires that layout;
+do not move it into ``tests/unit/scripts/``, the directory it exists to
+protect.
 """
 
 from __future__ import annotations

--- a/tests/unit/test_collection_shadowing.py
+++ b/tests/unit/test_collection_shadowing.py
@@ -1,0 +1,52 @@
+"""Meta-guard: no test-bearing directory may be shadowed from collection.
+
+``norecursedirs`` patterns match directory *basenames* anywhere in the tree, so
+a pattern meant to exclude a repo-root directory (e.g. ``scripts``) also stops
+pytest from recursing into a same-named directory under ``tests/`` (e.g.
+``tests/unit/scripts``). ``pytest tests/unit`` then skips those tests entirely
+while an explicit ``pytest tests/unit/scripts`` still collects them, so a
+required CI lane can false-pass on code its own guard tests reject (PR #1145:
+the Linux core lane reported green while the Windows lane failed
+``test_cross_slice_allowlist_is_frozen_topology`` on the same commit).
+
+This test lives directly under ``tests/unit/`` — not in a subdirectory — so it
+cannot itself be shadowed unless ``tests`` or ``unit`` is excluded outright.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+from pathlib import Path
+
+import pytest
+
+
+def _contains_test_files(directory: Path, file_patterns: list[str]) -> bool:
+    return any(
+        path.is_file() and any(fnmatch.fnmatch(path.name, pattern) for pattern in file_patterns)
+        for path in directory.rglob("*")
+    )
+
+
+def test_no_test_directory_matches_norecursedirs(pytestconfig: pytest.Config) -> None:
+    dir_patterns = pytestconfig.getini("norecursedirs")
+    file_patterns = pytestconfig.getini("python_files")
+    tests_root = pytestconfig.rootpath / "tests"
+    assert tests_root.is_dir()
+
+    shadowed = sorted(
+        str(path.relative_to(pytestconfig.rootpath))
+        for path in tests_root.rglob("*")
+        if path.is_dir()
+        and any(fnmatch.fnmatch(path.name, pattern) for pattern in dir_patterns)
+        and _contains_test_files(path, file_patterns)
+    )
+
+    assert not shadowed, (
+        "norecursedirs patterns "
+        f"{dir_patterns!r} shadow test directories {shadowed} from recursive "
+        "collection: `pytest tests/...` silently skips them while explicit-path "
+        "lanes still run them. Rename the directory or narrow the pattern "
+        "(repo-root dirs can be excluded via collect_ignore in the root "
+        "conftest.py instead)."
+    )

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -9,8 +9,8 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 5843,
-    "total_files": 699,
+    "total_tests": 5844,
+    "total_files": 700,
     "markers_used": 14
   },
   "quick_commands": {

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -92,7 +92,7 @@
     ]
   },
   "counts": {
-    "unit": 5686,
+    "unit": 5687,
     "asyncio": 302,
     "parametrize": 173,
     "integration": 80,


### PR DESCRIPTION
## Summary
Root-cause fix for the CI contradiction on PR #1145 run 28601840211 (commit f0fdaa28): the required Linux "Unit Tests (Core)" lane reported 5935 passed while the Windows portability lane failed `test_cross_slice_allowlist_is_frozen_topology` on the same commit.

The failing test never passed on Linux — it was never collected. `pytest.ini`'s `norecursedirs = archived scripts .hypothesis` matches directory *basenames* anywhere in the tree, so `pytest tests/unit` silently skipped `tests/unit/scripts` (424 tests) and `pytest tests/integration` skipped `tests/integration/scripts`. The Windows lane passes `tests/unit/scripts` as an explicit argument, which bypasses `norecursedirs` — hence it alone saw the failure. The "5935 = local full run" observation holds because local runs share the same blind spot. The competing hypotheses were ruled out empirically: no other test references `check_import_boundaries` (no xdist pollution possible), `scripts/` is not packaged into the venv (no stale copy), and both jobs checked out the same commit.

Changes:
- `pytest.ini`: keep only basename patterns that can never name a test directory (`.* build dist node_modules venv`)
- `conftest.py`: exclude repo-root `scripts/` (CLI helpers like `scripts/maintenance/test_legacy_triage.py`) via `collect_ignore`, which is anchored to the root and cannot shadow same-named dirs under `tests/`
- `tests/unit/scripts/__init__.py`, `tests/integration/scripts/__init__.py`: the two `test_docs_currency_scan.py` files (unit vs integration variants, split in #1088) collide on module name once both dirs are collected in one run; package-ifying the dirs gives them unique dotted names
- `tests/unit/support/test_collection_shadowing.py`: meta-guard that fails if any `norecursedirs` pattern shadows a test-bearing directory under `tests/`. Under the old config it fails naming both shadowed dirs — it would have turned the PR #1145 core lane red. It lives in `tests/unit/support/` per the test-hygiene layout gate (deliberately not in `tests/unit/scripts/`, the directory it protects); the residual caveat that it cannot fire if its own ancestors are shadowed is documented in the module docstring
- `var/agents/testing/*`: regenerated test inventory (`agent-regenerate --verify` clean)

Branch also merges origin/main (post-#1145) — the regenerated-inventory conflict with #1145's merge was what kept `pull_request` workflows from running on this PR at first (GitHub skips them when the test-merge commit can't be created).

Related issue / finding / routed package: PR #1145 (f0fdaa28 false-pass, corrected in 15fa463e), CI run 28601840211

## Type of change
- [ ] Refactor
- [ ] Feature
- [x] Bug fix
- [x] Tests only
- [x] CI/Docs/Tooling

## Scope & Impact
- Affected areas / components: pytest collection config (`pytest.ini`, root `conftest.py`), `tests/unit/scripts`, `tests/integration/scripts`, `tests/unit/support`, generated test inventory
- Behavior changes: `pytest tests/unit` (core CI lane, `make test`, local-ci) now collects 424 previously-invisible tests in `tests/unit/scripts`; the integration lane now collects `tests/integration/scripts/test_docs_currency_scan.py` (adds ~85s to that lane). All newly-visible tests pass on this branch.

## Test Plan
- [x] Unit tests added/updated (`tests/unit/support/test_collection_shadowing.py`)
- [x] Integration tests added/updated (newly collected, none added)
- [ ] Contract tests (if applicable)
- [x] Ran locally: `uv run pytest tests/unit -n auto -q` → 6354 passed, 10 skipped (post-merge with main)
- [x] Markers used appropriately (`unit`/`integration`/`slow`/`perf`)

Reproduction evidence at f0fdaa28:
- before fix: `pytest tests/unit` collects 5935 tests, `test_check_import_boundaries.py` absent; `pytest tests/unit/scripts -q` → 1 failed, 423 passed
- after fix: `pytest tests/unit` collects 6360 tests and the core-lane invocation fails on the frozen-topology pin, as it should have in CI
- the new meta-guard under the old config fails with: shadowed `['tests/integration/scripts', 'tests/unit/scripts']`

## Quality Gates
- [x] Core unit tests green locally; `ruff check` and `black --check` clean on changed files; bare `pytest --collect-only` has no errors (was 1 module-name-collision error before the `__init__.py` fix); `scripts/ci/check_test_hygiene.py` clean
- [ ] `uv run mypy src/gpt_trader` — no `src/` changes in this PR
- [x] No `sys.path` hacks in tests; `AsyncMock` (not `MagicMock`) on `async def`
- [x] Import boundaries respected (`scripts/ci/check_import_boundaries.py`)

## Observability & Errors
- [x] Not applicable — no runtime code paths changed; the meta-guard's assertion message names the offending patterns and shadowed directories

## Agent Artifacts & Config (if touched)
- [x] Ran `uv run agent-regenerate` and committed refreshed `var/agents/testing/*`; `uv run agent-regenerate --verify` clean
- [ ] If docs changed: `make agent-docs-links` passes — no docs changed

## Breaking Changes
- [x] None
- [ ] Documented in PR body and the linked issue if any

## Checklist
- [x] Acceptance criteria met: the merge-safety lane can no longer false-pass on tests it never collected, and a regression guard pins that property
- [x] Affected paths listed in PR description

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015r25BSh97D13KcmzCtJgFq