### PR TITLE
chore(ci): set workflow-level least-privilege GITHUB_TOKEN default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   changes:
     name: CI Change Classifier
@@ -492,8 +495,6 @@ jobs:
     name: Unit Tests (Core)
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    permissions:
-      contents: read
     env:
       GPT_TRADER_STRICT_CONTAINER: "1"
       PYTHONWARNINGS: default
@@ -544,8 +545,6 @@ jobs:
     name: Integration Tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    permissions:
-      contents: read
     env:
       GPT_TRADER_STRICT_CONTAINER: "1"
       PYTHONWARNINGS: default
@@ -579,8 +578,6 @@ jobs:
     name: Windows Unit Tests (Portability)
     runs-on: windows-latest
     timeout-minutes: 15
-    permissions:
-      contents: read
     env:
       GPT_TRADER_STRICT_CONTAINER: "1"
       PYTHONWARNINGS: default


### PR DESCRIPTION
## Summary
Follow-up to the job-level `permissions` fix on #1147: instead of hardening one job at a time, set `permissions: contents: read` at the workflow level in `ci.yml` so every job defaults to a least-privilege token, and remove the now-redundant per-job blocks (`unit-tests`, `integration-tests`, `windows-unit-tests`). No job in this workflow needs write access.

## Verification
- YAML parses; `git diff --check` clean
- `uvx zizmor --format plain .github/workflows/ci.yml` no longer reports the excessive-permissions class; remaining output is 2 pre-existing informational `template-injection` findings (lines 238/435, low confidence), untouched here

## Interaction with #1147
#1147 adds a `dependency-audit` job carrying its own `permissions: contents: read`. Once both merge that block is redundant but harmless; deliberately kept so #1147 is least-privilege even if it merges first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CI workflow’s permission settings to use a shared read-only access rule across test jobs.
  * No user-facing behavior or product functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->