### PR TITLE
feat(idea execution): close the paper machine loop from approved idea to fill

### DIFF
--- a/docs/paper_trading.md
+++ b/docs/paper_trading.md
@@ -132,7 +132,15 @@ uv run gpt-trader ideas show <decision-id>
 uv run gpt-trader ideas approve <decision-id> --actor <you> --reason "<why>"
 # ...or: ideas reject / ideas request-changes
 
-# 4. Export the ticket and paper-execute it by hand (no broker API calls)
+# 4. Paper-execute the approved idea (machine loop, no attestation).
+#    Places one simulated market order on the offline deterministic paper
+#    broker (client_order_id = decision id) and records the submission and
+#    fill on the audit log; live brokers are structurally unreachable here.
+#    Pass the price you observe so the simulated fill is honest.
+uv run gpt-trader ideas execute-paper <decision-id> --mark <observed-price>
+
+# 4-alt. Or paper-execute by hand against a real external venue: export the
+#        ticket and attest the lifecycle yourself (no broker API calls).
 uv run gpt-trader ideas export-ticket --decision-id <decision-id> --venue manual
 uv run gpt-trader ideas mark-submitted <decision-id> --venue manual \
   --external-order-id <paper-id> --actor <you> --actor-type human
@@ -147,9 +155,10 @@ uv run gpt-trader ideas audit verify
 ```
 
 Every step stamps an actor into the append-only audit log; proposals come from
-`ai` actors and approvals from `human` actors. None of these commands place,
-modify, or cancel broker orders. Ideas that expire unreviewed are swept with
-`uv run gpt-trader ideas expire`.
+`ai` actors, approvals from `human` actors, and `execute-paper` lifecycle
+events from the `paper-idea-executor` system actor under the `paper` venue.
+None of these commands touch a live broker or account. Ideas that expire
+unreviewed are swept with `uv run gpt-trader ideas expire`.
 
 ## Readiness Evidence Inputs
 

--- a/scripts/ops/stage1_rails_smoke.py
+++ b/scripts/ops/stage1_rails_smoke.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
 """Offline end-to-end smoke for the Stage 0/1 trade-idea rails.
 
-Drives the real ``gpt-trader ideas`` CLI through the full record lifecycle in
-a scratch ideas root: propose -> (approval blocked without attested equity) ->
-budget attest -> approve -> export-ticket -> mark-submitted -> mark-filled ->
-closeout -> report -> audit verify.
+Drives the real ``gpt-trader ideas`` CLI through both execution legs in a
+scratch ideas root. Manual leg: propose -> (approval blocked without attested
+equity) -> budget attest -> approve -> export-ticket -> mark-submitted ->
+mark-filled -> closeout. Machine leg: propose -> approve -> execute-paper
+(deterministic paper broker, no attestation) -> refused re-execution ->
+closeout. Then: report over both -> audit verify.
 
 This is the "does the project still string together?" gate: unit tests cover
 the parts, this covers the operator-visible loop. It needs no network, broker,
@@ -283,12 +285,104 @@ def run_smoke(ideas_root: Path) -> None:
     )
     _step("closeout record -> attribution captured")
 
+    # --- Machine leg: approved -> paper fill with no manual attestation. ---
+    machine_decision_id = f"trade-{datetime.now(UTC):%Y%m%d}-smoke-002"
+    machine_idea_path = ideas_root / "smoke_idea_machine.json"
+    machine_idea_path.write_text(json.dumps(_build_idea_payload(machine_decision_id)))
+
+    machine_proposed = _run_ideas_cli(
+        ideas_root,
+        "propose",
+        "--file",
+        str(machine_idea_path),
+        "--actor",
+        SMOKE_ACTOR_AI,
+        "--actor-type",
+        "ai",
+        "--reason",
+        "stage1 rails smoke machine leg",
+    )
+    _assert(
+        machine_proposed["data"]["state"] == "proposed",
+        "propose (machine leg)",
+        f"unexpected state {machine_proposed['data']}",
+    )
+    machine_approved = _run_ideas_cli(
+        ideas_root,
+        "approve",
+        machine_decision_id,
+        "--actor",
+        SMOKE_ACTOR_HUMAN,
+        "--reason",
+        "stage1 rails smoke machine-leg approval",
+    )
+    _assert(
+        machine_approved["data"]["state"] == "approved",
+        "approve (machine leg)",
+        f"unexpected state {machine_approved['data']}",
+    )
+    _step("machine leg: propose (ai actor) -> approve (human actor)")
+
+    # Fill at the entry-zone midpoint so the simulated execution is priced
+    # like the idea, not at the broker's arbitrary default mark.
+    executed = _run_ideas_cli(
+        ideas_root,
+        "execute-paper",
+        machine_decision_id,
+        "--mark",
+        "60750",
+    )
+    executed_data = executed["data"]
+    _assert(
+        executed_data["final_state"] == "filled",
+        "execute-paper",
+        f"expected filled, got {executed_data}",
+    )
+    _assert(
+        executed_data["client_order_id"] == machine_decision_id,
+        "execute-paper",
+        f"client_order_id must be the decision id, got {executed_data}",
+    )
+    _assert(
+        executed_data["reconciliation"]["recorded_fill"] is True,
+        "execute-paper",
+        f"fill was not recorded through the reconciler, got {executed_data}",
+    )
+    _step("execute-paper (system actor) -> submitted and filled, no attestation")
+
+    # The lane must refuse to execute the same idea twice.
+    _run_ideas_cli(
+        ideas_root,
+        "execute-paper",
+        machine_decision_id,
+        expect_success=False,
+    )
+    _step("execute-paper again -> refused (no double execution)")
+
+    _run_ideas_cli(
+        ideas_root,
+        "closeout",
+        "record",
+        machine_decision_id,
+        "--resolution",
+        "thesis_target",
+        "--realized-profit-loss-amount",
+        "35",
+        "--realized-profit-loss-percent",
+        "0.14",
+        "--evidence",
+        "stage1 rails smoke machine-leg exit",
+        "--actor",
+        SMOKE_ACTOR_HUMAN,
+    )
+    _step("closeout record (machine leg) -> attribution captured")
+
     report = _run_ideas_cli(ideas_root, "report")
     report_data = report["data"]
     _assert(
-        int(report_data["row_count"]) == 1,
+        int(report_data["row_count"]) == 2,
         "report",
-        f"expected exactly 1 idea, got row_count={report_data.get('row_count')}",
+        f"expected exactly 2 ideas, got row_count={report_data.get('row_count')}",
     )
     closeouts = report_data.get("closeouts", {})
     _assert(
@@ -296,13 +390,13 @@ def run_smoke(ideas_root: Path) -> None:
         "report",
         f"expected full closeout coverage, got {closeouts}",
     )
-    _step("report -> 1 idea, full closeout coverage")
+    _step("report -> 2 ideas, full closeout coverage")
 
     verify = _run_ideas_cli(ideas_root, "audit", "verify")
     _assert(
-        int(verify["data"].get("event_count", 0)) >= 4,
+        int(verify["data"].get("event_count", 0)) >= 8,
         "audit verify",
-        f"expected >=4 chained events, got {verify['data']}",
+        f"expected >=8 chained events, got {verify['data']}",
     )
     _step(f"audit verify -> chain intact ({verify['data']['event_count']} events)")
 
@@ -330,7 +424,10 @@ def _execute(ideas_root: Path) -> int:
     except SmokeStepError as exc:
         print(f"✗ stage1 rails smoke FAILED: {exc}", file=sys.stderr)
         return 1
-    print("✓ stage1 rails smoke OK: proposed -> approved -> filled -> closed, audit chain intact")
+    print(
+        "✓ stage1 rails smoke OK: manual and machine legs "
+        "proposed -> approved -> filled -> closed, audit chain intact"
+    )
     return 0
 
 

--- a/src/gpt_trader/cli/commands/ideas.py
+++ b/src/gpt_trader/cli/commands/ideas.py
@@ -1,8 +1,10 @@
 """Trade-idea CLI commands.
 
 This module is an operator-facing adapter over ``TradeIdeaService``. It never
-submits, modifies, or cancels broker orders; submission and fill commands only
-append audit records for tickets executed elsewhere.
+submits, modifies, or cancels live broker orders; ``mark-submitted`` and
+``mark-filled`` only append audit records for tickets executed elsewhere, and
+``execute-paper`` drives the paper-only execution lane, whose types make live
+brokers structurally unreachable.
 """
 
 from __future__ import annotations
@@ -35,6 +37,11 @@ from gpt_trader.cli.commands.ideas_input import (
 )
 from gpt_trader.cli.response import CliError, CliErrorCode, CliResponse, RawCliOutput
 from gpt_trader.errors import ValidationError
+from gpt_trader.features.brokerages.mock import DeterministicBroker
+from gpt_trader.features.idea_execution import (
+    DEFAULT_PAPER_EXECUTION_ACTOR_ID,
+    PaperIdeaExecutor,
+)
 from gpt_trader.features.intelligence.regime import RegimeConfig
 from gpt_trader.features.trade_ideas import (
     DEFAULT_TIME_IN_FORCE,
@@ -873,6 +880,33 @@ def register(subparsers: Any) -> None:
         handler=_handle_reconcile_paper_fills,
         subcommand="reconcile-paper-fills",
     )
+
+    execute_paper = ideas_subparsers.add_parser(
+        "execute-paper",
+        help="Execute an APPROVED idea against the offline deterministic paper broker",
+        description=(
+            "Machine leg of the Stage 1 paper lane: place a simulated market order "
+            "for an approved idea (client_order_id = decision id) and record the "
+            "submission and fill through TradeIdeaService. Only the deterministic "
+            "paper broker is reachable from this command; it never contacts a live "
+            "broker or account."
+        ),
+    )
+    _add_common_options(execute_paper)
+    _add_actor_options(
+        execute_paper,
+        default_description=f"{DEFAULT_PAPER_EXECUTION_ACTOR_ID} unless --actor is provided",
+    )
+    execute_paper.add_argument("decision_id", help="Trade idea decision identifier")
+    execute_paper.add_argument(
+        "--mark",
+        type=_positive_decimal_value,
+        help=(
+            "Mark price for the idea's instrument on the deterministic broker "
+            "(default: the broker's built-in mark)"
+        ),
+    )
+    execute_paper.set_defaults(handler=_handle_execute_paper, subcommand="execute-paper")
 
     budget = ideas_subparsers.add_parser("budget", help="Inspect or update risk budget")
     budget_subparsers = budget.add_subparsers(dest="budget_command", required=True)
@@ -2246,6 +2280,36 @@ def _handle_reconcile_paper_fills(args: Namespace) -> CliResponse:
         _paper_reconciliation_text(command, payload),
         was_noop=not args.apply or payload["recorded_count"] == 0,
     )
+
+
+def _paper_execution_actor_id(args: Namespace) -> str:
+    explicit_actor = getattr(args, "actor", None)
+    return resolve_trade_idea_actor_id(explicit_actor or DEFAULT_PAPER_EXECUTION_ACTOR_ID)
+
+
+def _handle_execute_paper(args: Namespace) -> CliResponse:
+    command = "ideas execute-paper"
+    decision_id_error = _decision_id_error(command, args, args.decision_id)
+    if decision_id_error is not None:
+        return decision_id_error
+    try:
+        service = _service(args)
+        broker = DeterministicBroker()
+        if args.mark is not None:
+            broker.set_mark(service.get(args.decision_id).idea.instrument, args.mark)
+        result = PaperIdeaExecutor(service, broker).execute(
+            args.decision_id,
+            actor_id=_paper_execution_actor_id(args),
+        )
+    except Exception as error:
+        return _mapped_error(command, args, error)
+    text = _status_line(
+        command,
+        "OK",
+        f"decision={result.decision_id} state={result.final_state} "
+        f"order={result.order_id} fill_price={result.fill_price}",
+    )
+    return _success(command, args, result.to_dict(), text)
 
 
 def _handle_budget_show(args: Namespace) -> CliResponse:

--- a/src/gpt_trader/features/idea_execution/__init__.py
+++ b/src/gpt_trader/features/idea_execution/__init__.py
@@ -14,22 +14,34 @@ Lane contract (enforced in code, not convention):
 - **APPROVED ideas only.** Ideas in any other workflow state, or past their
   ``expires_at``, are refused with ``IdeaNotExecutableError``.
 - Lifecycle facts are recorded only through ``TradeIdeaService`` so every
-  action lands on the append-only audit log with a system actor.
+  action lands on the append-only audit log with a system actor, under the
+  dedicated ``paper`` audit venue.
+- **At-most-once.** ``execute`` records the submission before touching the
+  broker; a crash in between leaves the idea SUBMITTED, which admission
+  refuses, so the same idea can never be placed twice.
 
 Live order submission remains gated by docs/DIRECTION.md and recorded human
 approval; nothing in this slice weakens that boundary.
 """
 
 from gpt_trader.features.idea_execution.executor import (
+    DEFAULT_PAPER_EXECUTION_ACTOR_ID,
     PAPER_BROKER_TYPES,
+    PAPER_EXECUTION_VENUE,
     IdeaNotExecutableError,
+    PaperExecutionError,
+    PaperExecutionResult,
     PaperIdeaExecutor,
     PaperOnlyLaneError,
 )
 
 __all__ = [
+    "DEFAULT_PAPER_EXECUTION_ACTOR_ID",
     "PAPER_BROKER_TYPES",
+    "PAPER_EXECUTION_VENUE",
     "IdeaNotExecutableError",
+    "PaperExecutionError",
+    "PaperExecutionResult",
     "PaperIdeaExecutor",
     "PaperOnlyLaneError",
 ]

--- a/src/gpt_trader/features/idea_execution/executor.py
+++ b/src/gpt_trader/features/idea_execution/executor.py
@@ -1,21 +1,34 @@
-"""Paper idea executor: broker boundary and executability checks.
+"""Paper idea executor: the machine lane from APPROVED idea to paper fill.
 
-This module ships the lane's structural guarantees ahead of any execution
-logic (issue #1144, first PR): the constructor contract that makes live
-brokers unreachable, and the refusal logic that admits only APPROVED,
-unexpired ideas. Order placement lands in a follow-up PR on top of these
-guarantees; no submission code exists here yet.
+This module carries the lane's structural guarantees (issue #1144, first PR)
+— the constructor contract that makes live brokers unreachable and the
+refusal logic that admits only APPROVED, unexpired ideas — plus the execution
+logic built on them: ``execute`` places one simulated market order per idea
+(``client_order_id`` = decision id) and records the SUBMITTED/FILLED
+lifecycle only through ``TradeIdeaService``, so every machine action lands on
+the append-only audit log.
 """
 
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
 
+from gpt_trader.core import OrderStatus
 from gpt_trader.errors import ValidationError
 from gpt_trader.features.brokerages.mock import DeterministicBroker
 from gpt_trader.features.brokerages.paper import HybridPaperBroker
 from gpt_trader.features.trade_ideas import (
+    ActorType,
+    PaperFillEvent,
+    PaperFillReconciler,
+    PaperFillReconciliationEntry,
+    TicketVenue,
+    TradeDirection,
+    TradeIdea,
     TradeIdeaService,
     TradeIdeaState,
     TradeIdeaView,
@@ -29,6 +42,9 @@ PAPER_BROKER_TYPES: tuple[type, ...] = (DeterministicBroker, HybridPaperBroker)
 
 PaperBroker = DeterministicBroker | HybridPaperBroker
 
+PAPER_EXECUTION_VENUE = TicketVenue.PAPER.value
+DEFAULT_PAPER_EXECUTION_ACTOR_ID = "paper-idea-executor"
+
 
 class PaperOnlyLaneError(ValidationError):
     """Raised when a non-paper broker is offered to the paper execution lane."""
@@ -36,6 +52,43 @@ class PaperOnlyLaneError(ValidationError):
 
 class IdeaNotExecutableError(ValidationError):
     """Raised when an idea is not in an executable state for this lane."""
+
+
+class PaperExecutionError(ValidationError):
+    """Raised when an admitted idea's paper order does not reach a recorded fill.
+
+    By the time this is raised the idea is already SUBMITTED on the audit log,
+    so admission refuses reruns; the operator resolves it with ``ideas cancel``
+    or ``ideas mark-filled`` rather than by executing again.
+    """
+
+
+@dataclass(frozen=True, slots=True)
+class PaperExecutionResult:
+    """Outcome of one paper execution: the order placed and the audit trail it left."""
+
+    decision_id: str
+    client_order_id: str
+    order_id: str
+    symbol: str
+    side: str
+    quantity: Decimal
+    fill_price: Decimal | None
+    final_state: str
+    reconciliation: PaperFillReconciliationEntry
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "decision_id": self.decision_id,
+            "client_order_id": self.client_order_id,
+            "order_id": self.order_id,
+            "symbol": self.symbol,
+            "side": self.side,
+            "quantity": str(self.quantity),
+            "fill_price": str(self.fill_price) if self.fill_price is not None else None,
+            "final_state": self.final_state,
+            "reconciliation": self.reconciliation.to_dict(),
+        }
 
 
 def _require_paper_broker(broker: object) -> PaperBroker:
@@ -101,3 +154,113 @@ class PaperIdeaExecutor:
             )
 
         return view
+
+    def execute(
+        self,
+        decision_id: str,
+        *,
+        actor_id: str = DEFAULT_PAPER_EXECUTION_ACTOR_ID,
+    ) -> PaperExecutionResult:
+        """Execute one APPROVED idea as a paper market order and audit the lifecycle.
+
+        The submission is recorded before the broker is touched: if the process
+        dies in between, the idea is SUBMITTED and admission refuses a rerun, so
+        the lane can never place the same idea twice. The resulting fill is
+        recorded through ``PaperFillReconciler`` — the same code path that
+        reconciles persisted paper fills — so its payload-conflict and dedupe
+        checks also guard the machine leg.
+        """
+        view = self.resolve_approved_idea(decision_id)
+        symbol = view.idea.instrument
+        side = _order_side(view.idea)
+        quantity = _order_quantity(view.idea)
+        client_order_id = decision_id
+
+        self._service.record_submission(
+            decision_id,
+            actor_id=actor_id,
+            venue=PAPER_EXECUTION_VENUE,
+            external_order_id=client_order_id,
+            reason=f"Paper executor submitting market {side} {quantity} {symbol}",
+            actor_type=ActorType.SYSTEM,
+        )
+
+        order = self._broker.place_order(
+            symbol,
+            side=side,
+            order_type="market",
+            quantity=quantity,
+            client_id=client_order_id,
+        )
+
+        if order.status is not OrderStatus.FILLED:
+            raise PaperExecutionError(
+                f"Paper broker did not fill order for idea {decision_id}: "
+                f"status is {order.status.value}; idea remains submitted",
+                field="order_status",
+                value=order.status.value,
+            )
+
+        fill_event = PaperFillEvent(
+            order_id=order.id,
+            client_order_id=order.client_id or client_order_id,
+            symbol=order.symbol,
+            side=order.side.value.lower(),
+            quantity=order.filled_quantity,
+            price=order.avg_fill_price,
+            status="filled",
+            decision_id=decision_id,
+        )
+        report = PaperFillReconciler(
+            self._service,
+            actor_id=actor_id,
+            venue=PAPER_EXECUTION_VENUE,
+        ).reconcile_fills((fill_event,), apply=True)
+
+        if report.recorded_count != 1:
+            entries = (*report.matched, *report.unmatched, *report.skipped)
+            reason = entries[0].reason if entries else "no reconciliation entry produced"
+            raise PaperExecutionError(
+                f"Paper fill for idea {decision_id} was not recorded: {reason}; "
+                "idea remains submitted",
+                field="reconciliation",
+                value=reason,
+            )
+
+        final_view = self._service.get(decision_id)
+        return PaperExecutionResult(
+            decision_id=decision_id,
+            client_order_id=client_order_id,
+            order_id=order.id,
+            symbol=order.symbol,
+            side=side,
+            quantity=order.filled_quantity,
+            fill_price=order.avg_fill_price,
+            final_state=final_view.state.value,
+            reconciliation=report.matched[0],
+        )
+
+
+def _order_side(idea: TradeIdea) -> str:
+    if idea.direction is TradeDirection.LONG:
+        return "buy"
+    if idea.direction is TradeDirection.SHORT:
+        return "sell"
+    raise IdeaNotExecutableError(
+        f"Idea {idea.decision_id} is not executable: direction must be long or "
+        f"short, got {idea.direction.value}",
+        field="direction",
+        value=idea.direction.value,
+    )
+
+
+def _order_quantity(idea: TradeIdea) -> Decimal:
+    quantity = idea.sizing_recommendation.quantity
+    if quantity is None or quantity <= 0:
+        raise IdeaNotExecutableError(
+            f"Idea {idea.decision_id} is not executable: "
+            f"sizing_recommendation.quantity must be positive, got {quantity}",
+            field="sizing_recommendation.quantity",
+            value=str(quantity),
+        )
+    return quantity

--- a/src/gpt_trader/features/trade_ideas/models.py
+++ b/src/gpt_trader/features/trade_ideas/models.py
@@ -59,6 +59,7 @@ class ConfidenceLabel(str, Enum):
 class TicketVenue(str, Enum):
     COINBASE = "coinbase"
     MANUAL = "manual"
+    PAPER = "paper"
     NONE = "none"
 
 

--- a/src/gpt_trader/features/trade_ideas/service.py
+++ b/src/gpt_trader/features/trade_ideas/service.py
@@ -91,7 +91,7 @@ OPEN_BUDGET_EXPOSURE_STATES = frozenset(
         TradeIdeaState.SUBMITTED,
     }
 )
-_AUDIT_VENUES = frozenset({TicketVenue.COINBASE, TicketVenue.MANUAL})
+_AUDIT_VENUES = frozenset({TicketVenue.COINBASE, TicketVenue.MANUAL, TicketVenue.PAPER})
 _CONFIDENCE_RANK = {
     ConfidenceLabel.LOW: 0,
     ConfidenceLabel.MEDIUM: 1,

--- a/tests/unit/gpt_trader/cli/commands/test_ideas_execute_paper.py
+++ b/tests/unit/gpt_trader/cli/commands/test_ideas_execute_paper.py
@@ -1,0 +1,171 @@
+"""CLI tests for ``ideas execute-paper``: the machine leg of the paper lane.
+
+The executor library's contract is pinned in
+tests/unit/gpt_trader/features/idea_execution/test_executor.py; these tests
+cover the thin CLI adapter: envelope shape, actor stamping, --mark plumbing,
+and error mapping for refused executions.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from gpt_trader import cli
+from gpt_trader.features.trade_ideas import TimeHorizon
+from tests.unit.gpt_trader.cli.commands.conftest import attest_ideas_root
+from tests.unit.gpt_trader.features.trade_ideas.conftest import build_trade_idea
+
+_DECISION_ID = "trade-20260702-paper-001"
+
+
+def _run_json(capsys: pytest.CaptureFixture[str], argv: list[str]) -> tuple[int, dict[str, Any]]:
+    exit_code = cli.main(argv)
+    output = capsys.readouterr().out
+    assert output
+    return exit_code, json.loads(output)
+
+
+def _root_args(root: Path) -> list[str]:
+    return ["--ideas-root", str(root), "--format", "json"]
+
+
+def _approved_idea(capsys: pytest.CaptureFixture[str], root: Path) -> None:
+    attest_ideas_root(root)
+    payload = build_trade_idea(
+        decision_id=_DECISION_ID,
+        time_horizon=TimeHorizon(
+            expected_hold="3-10 days",
+            expires_at=datetime(2036, 6, 19, 16, 0, tzinfo=UTC),
+        ),
+    ).to_dict()
+    idea_path = root.parent / "idea.json"
+    idea_path.write_text(json.dumps(payload), encoding="utf-8")
+    exit_code, response = _run_json(
+        capsys,
+        [
+            "ideas",
+            "propose",
+            *_root_args(root),
+            "--actor",
+            "idea-generator-v1",
+            "--file",
+            str(idea_path),
+        ],
+    )
+    assert exit_code == 0 and response["success"] is True
+    exit_code, response = _run_json(
+        capsys,
+        [
+            "ideas",
+            "approve",
+            _DECISION_ID,
+            *_root_args(root),
+            "--actor",
+            "human-reviewer",
+            "--reason",
+            "test approval",
+        ],
+    )
+    assert exit_code == 0 and response["success"] is True
+
+
+def test_execute_paper_fills_approved_idea(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    root = tmp_path / "ideas"
+    _approved_idea(capsys, root)
+
+    exit_code, response = _run_json(
+        capsys,
+        ["ideas", "execute-paper", _DECISION_ID, *_root_args(root), "--mark", "60750"],
+    )
+
+    assert exit_code == 0
+    assert response["success"] is True
+    data = response["data"]
+    assert data["final_state"] == "filled"
+    assert data["client_order_id"] == _DECISION_ID
+    assert data["fill_price"] == "60750"
+    assert data["reconciliation"]["recorded_fill"] is True
+
+    exit_code, audit = _run_json(capsys, ["ideas", "audit", "verify", *_root_args(root)])
+    assert exit_code == 0
+    assert audit["success"] is True
+
+
+def test_execute_paper_stamps_default_system_actor(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    root = tmp_path / "ideas"
+    _approved_idea(capsys, root)
+    exit_code, _ = _run_json(capsys, ["ideas", "execute-paper", _DECISION_ID, *_root_args(root)])
+    assert exit_code == 0
+
+    exit_code, listed = _run_json(
+        capsys,
+        ["ideas", "audit", "list", *_root_args(root), "--decision-id", _DECISION_ID],
+    )
+    assert exit_code == 0
+    events = listed["data"]["events"]
+    submitted = [event for event in events if event["action"] == "submitted"]
+    assert len(submitted) == 1
+    assert submitted[0]["actor_id"] == "paper-idea-executor"
+    assert submitted[0]["actor_type"] == "system"
+    assert submitted[0]["venue"] == "paper"
+
+
+def test_execute_paper_refuses_unapproved_idea(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    root = tmp_path / "ideas"
+    attest_ideas_root(root)
+    payload = build_trade_idea(
+        decision_id=_DECISION_ID,
+        time_horizon=TimeHorizon(
+            expected_hold="3-10 days",
+            expires_at=datetime(2036, 6, 19, 16, 0, tzinfo=UTC),
+        ),
+    ).to_dict()
+    idea_path = root.parent / "idea.json"
+    idea_path.write_text(json.dumps(payload), encoding="utf-8")
+    exit_code, _ = _run_json(
+        capsys,
+        [
+            "ideas",
+            "propose",
+            *_root_args(root),
+            "--actor",
+            "idea-generator-v1",
+            "--file",
+            str(idea_path),
+        ],
+    )
+    assert exit_code == 0
+
+    exit_code, response = _run_json(
+        capsys, ["ideas", "execute-paper", _DECISION_ID, *_root_args(root)]
+    )
+    assert exit_code != 0
+    assert response["success"] is False
+    assert "state is proposed" in response["errors"][0]["message"]
+
+
+def test_execute_paper_refuses_double_execution(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    root = tmp_path / "ideas"
+    _approved_idea(capsys, root)
+    exit_code, _ = _run_json(capsys, ["ideas", "execute-paper", _DECISION_ID, *_root_args(root)])
+    assert exit_code == 0
+
+    exit_code, response = _run_json(
+        capsys, ["ideas", "execute-paper", _DECISION_ID, *_root_args(root)]
+    )
+    assert exit_code != 0
+    assert response["success"] is False
+    assert "state is filled" in response["errors"][0]["message"]

--- a/tests/unit/gpt_trader/features/idea_execution/test_executor.py
+++ b/tests/unit/gpt_trader/features/idea_execution/test_executor.py
@@ -1,8 +1,10 @@
-"""Lane-contract tests for the paper idea executor skeleton.
+"""Lane-contract and execution tests for the paper idea executor.
 
-These pin the structural guarantees from issue #1144 ahead of any execution
-logic: the paper-only broker boundary and the APPROVED/unexpired admission
-rule. Later execution PRs build on top of these tests, not around them.
+The contract tests pin the structural guarantees from issue #1144: the
+paper-only broker boundary and the APPROVED/unexpired admission rule. The
+execution tests pin the machine leg built on them: submission recorded before
+the broker is touched, decision_id propagated as client_order_id, and fills
+recorded only through the reconciler's guarded path.
 """
 
 from __future__ import annotations
@@ -14,17 +16,21 @@ from pathlib import Path
 
 import pytest
 
+from gpt_trader.core import Order, OrderSide, OrderStatus, OrderType
 from gpt_trader.features.brokerages.mock import DeterministicBroker
 from gpt_trader.features.brokerages.paper import HybridPaperBroker
 from gpt_trader.features.idea_execution import (
     PAPER_BROKER_TYPES,
+    PAPER_EXECUTION_VENUE,
     IdeaNotExecutableError,
+    PaperExecutionError,
     PaperIdeaExecutor,
     PaperOnlyLaneError,
 )
 from gpt_trader.features.trade_ideas import (
     DEFAULT_RISK_BUDGET,
     ActorType,
+    AuditAction,
     AutonomyMode,
     Confidence,
     ConfidenceLabel,
@@ -36,6 +42,7 @@ from gpt_trader.features.trade_ideas import (
     TradeDirection,
     TradeIdea,
     TradeIdeaService,
+    TradeIdeaState,
     UnknownTradeIdeaError,
 )
 
@@ -183,3 +190,179 @@ class TestApprovedIdeaAdmission:
     def test_missing_idea_error_propagates(self, service: TradeIdeaService) -> None:
         with pytest.raises(UnknownTradeIdeaError, match="trade-20260702-exec-404"):
             self._executor(service).resolve_approved_idea("trade-20260702-exec-404")
+
+
+def _rejected_order(symbol: str, client_id: str) -> Order:
+    return Order(
+        id="MOCK_REJECTED",
+        client_id=client_id,
+        symbol=symbol,
+        side=OrderSide.BUY,
+        type=OrderType.MARKET,
+        quantity=Decimal("0.1"),
+        price=None,
+        stop_price=None,
+        tif=None,
+        status=OrderStatus.REJECTED,
+        filled_quantity=Decimal("0"),
+        avg_fill_price=None,
+        submitted_at=_NOW,
+        updated_at=_NOW,
+    )
+
+
+class TestPaperExecution:
+    def _executor(
+        self,
+        service: TradeIdeaService,
+        broker: DeterministicBroker | None = None,
+    ) -> PaperIdeaExecutor:
+        return PaperIdeaExecutor(
+            service,
+            broker or DeterministicBroker(),
+            now_factory=lambda: _NOW,
+        )
+
+    def test_execute_fills_and_audits_full_lifecycle(self, service: TradeIdeaService) -> None:
+        decision_id = "trade-20260702-exec-101"
+        _approved_idea(service, decision_id)
+        broker = DeterministicBroker()
+        broker.set_mark("BTC-USD", Decimal("60750"))
+
+        result = self._executor(service, broker).execute(decision_id)
+
+        assert result.final_state == TradeIdeaState.FILLED.value
+        assert result.client_order_id == decision_id
+        assert result.symbol == "BTC-USD"
+        assert result.side == "buy"
+        assert result.quantity == Decimal("0.1")
+        assert result.fill_price == Decimal("60750")
+        assert result.reconciliation.recorded_fill is True
+
+        view = service.get(decision_id)
+        assert view.state is TradeIdeaState.FILLED
+        submitted = [event for event in view.events if event.action is AuditAction.SUBMITTED]
+        filled = [event for event in view.events if event.action is AuditAction.FILLED]
+        assert len(submitted) == 1 and len(filled) == 1
+        assert submitted[0].actor_type is ActorType.SYSTEM
+        assert submitted[0].venue == PAPER_EXECUTION_VENUE
+        assert submitted[0].external_order_id == decision_id
+        assert filled[0].actor_type is ActorType.VENUE
+        assert filled[0].venue == PAPER_EXECUTION_VENUE
+        assert filled[0].external_order_id == result.order_id
+        # The lifecycle must land on the tamper-evident chain, not around it:
+        # verify() raises on any break and returns every chained event.
+        chained_event_ids = {event.event_id for event in service.audit_log.verify()}
+        assert {event.event_id for event in view.events} <= chained_event_ids
+
+    def test_execute_propagates_decision_id_as_broker_client_id(
+        self, service: TradeIdeaService
+    ) -> None:
+        decision_id = "trade-20260702-exec-102"
+        _approved_idea(service, decision_id)
+        broker = DeterministicBroker()
+        captured: dict[str, object] = {}
+        original_place_order = broker.place_order
+
+        def capture_place_order(*args: object, **kwargs: object) -> Order:
+            captured.update(kwargs)
+            return original_place_order(*args, **kwargs)
+
+        broker.place_order = capture_place_order  # type: ignore[method-assign]
+        self._executor(service, broker).execute(decision_id)
+        assert captured["client_id"] == decision_id
+
+    def test_execute_refuses_second_attempt(self, service: TradeIdeaService) -> None:
+        decision_id = "trade-20260702-exec-103"
+        _approved_idea(service, decision_id)
+        executor = self._executor(service)
+        executor.execute(decision_id)
+        with pytest.raises(IdeaNotExecutableError, match="state is filled"):
+            executor.execute(decision_id)
+
+    def test_broker_rejection_leaves_idea_submitted(self, service: TradeIdeaService) -> None:
+        decision_id = "trade-20260702-exec-104"
+        _approved_idea(service, decision_id)
+        broker = DeterministicBroker()
+        broker.place_order = (  # type: ignore[method-assign]
+            lambda *args, **kwargs: _rejected_order("BTC-USD", decision_id)
+        )
+        with pytest.raises(PaperExecutionError, match="status is REJECTED"):
+            self._executor(service, broker).execute(decision_id)
+        view = service.get(decision_id)
+        assert view.state is TradeIdeaState.SUBMITTED
+        assert not any(event.action is AuditAction.FILLED for event in view.events)
+
+    def test_conflicting_fill_payload_is_not_recorded(self, service: TradeIdeaService) -> None:
+        decision_id = "trade-20260702-exec-105"
+        _approved_idea(service, decision_id)
+        broker = DeterministicBroker()
+        original_place_order = broker.place_order
+
+        def mangled_place_order(*args: object, **kwargs: object) -> Order:
+            return replace(original_place_order(*args, **kwargs), symbol="ETH-USD")
+
+        broker.place_order = mangled_place_order  # type: ignore[method-assign]
+        with pytest.raises(PaperExecutionError, match="was not recorded"):
+            self._executor(service, broker).execute(decision_id)
+        view = service.get(decision_id)
+        assert view.state is TradeIdeaState.SUBMITTED
+        assert not any(event.action is AuditAction.FILLED for event in view.events)
+
+    def test_execute_refuses_unsizable_idea_before_submission(
+        self, service: TradeIdeaService
+    ) -> None:
+        decision_id = "trade-20260702-exec-106"
+        # Notional-only sizing passes the approval budget gate but gives the
+        # machine lane no base quantity to place; execution must refuse it
+        # before any submission is recorded.
+        idea = replace(
+            _build_idea(decision_id, expires_at=_NOW + timedelta(days=7)),
+            sizing_recommendation=SizingRecommendation(
+                notional=Decimal("6075"),
+                rationale="notional-only sizing",
+            ),
+        )
+        service.propose(idea, actor_id="test-proposer")
+        service.approve(decision_id, actor_id="test-operator", reason="test approval")
+        with pytest.raises(IdeaNotExecutableError, match="quantity must be positive"):
+            self._executor(service).execute(decision_id)
+        view = service.get(decision_id)
+        assert view.state is TradeIdeaState.APPROVED
+        assert not any(event.action is AuditAction.SUBMITTED for event in view.events)
+
+    def test_execute_refuses_non_directional_idea_before_submission(
+        self, service: TradeIdeaService
+    ) -> None:
+        decision_id = "trade-20260702-exec-107"
+        idea = replace(
+            _build_idea(decision_id, expires_at=_NOW + timedelta(days=7)),
+            direction=TradeDirection.SPREAD,
+        )
+        service.propose(idea, actor_id="test-proposer")
+        service.approve(decision_id, actor_id="test-operator", reason="test approval")
+        with pytest.raises(IdeaNotExecutableError, match="direction must be long or short"):
+            self._executor(service).execute(decision_id)
+        assert service.get(decision_id).state is TradeIdeaState.APPROVED
+
+    def test_execute_short_idea_places_sell_order(self, service: TradeIdeaService) -> None:
+        decision_id = "trade-20260702-exec-108"
+        service.update_budget(
+            replace(
+                service.current_budget(),
+                version=3,
+                allow_naked_shorts=True,
+                reason="test: allow short idea",
+            ),
+            actor_type=ActorType.HUMAN,
+            actor_id="test-operator",
+        )
+        idea = replace(
+            _build_idea(decision_id, expires_at=_NOW + timedelta(days=7)),
+            direction=TradeDirection.SHORT,
+        )
+        service.propose(idea, actor_id="test-proposer")
+        service.approve(decision_id, actor_id="test-operator", reason="test approval")
+        result = self._executor(service).execute(decision_id)
+        assert result.side == "sell"
+        assert result.final_state == TradeIdeaState.FILLED.value

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -9,8 +9,8 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 5859,
-    "total_files": 701,
+    "total_tests": 5871,
+    "total_files": 702,
     "markers_used": 14
   },
   "quick_commands": {

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -92,7 +92,7 @@
     ]
   },
   "counts": {
-    "unit": 5702,
+    "unit": 5714,
     "asyncio": 302,
     "parametrize": 173,
     "integration": 80,


### PR DESCRIPTION
## Summary

Second PR on #1144, building the execution logic on top of the merged lane skeleton (dd44f136). `PaperIdeaExecutor.execute()` places one simulated market order per APPROVED idea and records the SUBMITTED/FILLED lifecycle only through `TradeIdeaService`, closing the Stage 1 machine loop — approved → paper fill → reconciled — with no manual attestation.

## Design decisions

- **At-most-once by ordering.** The submission is recorded on the audit log *before* the broker is touched. A crash in between leaves the idea SUBMITTED, which admission refuses, so the lane can never place the same idea twice. The typed `PaperExecutionError` tells the operator to resolve via `ideas cancel` / `ideas mark-filled`, not by re-executing.
- **Fills flow through `PaperFillReconciler`** (per the issue): the executor feeds the broker's returned order into the same guarded path that reconciles persisted paper fills, so its payload-conflict and dedupe checks also protect the machine leg. A mangled broker response is refused loudly and the idea stays SUBMITTED.
- **`decision_id` → `client_order_id`.** Both paper brokers echo `client_id`, and the reconciler's explicit-id matching keys on it, so `ideas reconcile-paper-fills` also matches these fills from a persisted event store with no manual input.
- **New `paper` audit venue** (`TicketVenue.PAPER`, allowed for audit events only): machine-lane events no longer have to mislabel themselves as `manual`. Ticket export venues are unchanged.
- **CLI stays paper-only.** `ideas execute-paper` constructs only `DeterministicBroker`; no flag or config value can route another broker in. `--mark <price>` lets the operator pin the simulated fill to the observed market price. `HybridPaperBroker` stays library-reachable but CLI-unwired (needs market-data plumbing; follow-up).

## Acceptance criteria (#1144)

- [x] APPROVED-only admission, expired refused (PR 1, re-verified here)
- [x] Live brokers structurally unreachable (PR 1 types + paper-only CLI adapter)
- [x] Lifecycle recorded via `TradeIdeaService` with system actor; audit chain verifies
- [x] `decision_id` propagates as `client_order_id`; reconciler matches without manual input
- [x] Stage 1 rails smoke extended with the machine leg (execute → refused re-execution → closeout → report over both legs)
- [x] Import-boundary check passes; `trade_ideas` slice itself remains submission-free

Closes #1144.

## Touches trading execution

Paper-only, as gated by the accepted five-role composition record (docs/decisions/adopt-five-role-composition.md). No live broker, account, or approval-flow behavior changes; approval remains a human event.

## Verification

- `make ci-required` exit 0 (includes the extended `stage1-smoke`)
- `uv run pytest tests/unit -n auto -q` — 6366 passed, 10 skipped
- `uv run mypy src/gpt_trader` / `ruff` / `black` / `agent-naming` / `check_import_boundaries.py` all clean
- `uv run agent-regenerate` artifacts included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new paper-trading execution path for approved ideas, including automatic execution and a manual fallback workflow.
  * Expanded paper-trading reporting and audit checks to cover both manual and machine-executed trades.

* **Bug Fixes**
  * Strengthened execution safeguards so ideas can only be executed once and only when eligible.
  * Improved handling of fill outcomes and reconciliation to ensure trade records stay consistent.

* **Tests**
  * Added broader CLI and execution coverage for approved, rejected, short, and double-execution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->