### PR TITLE
feat(idea execution): add scheduled Stage-1 paper cycle turn

### DIFF
--- a/scripts/ops/stage1_rails_smoke.py
+++ b/scripts/ops/stage1_rails_smoke.py
@@ -1,12 +1,15 @@
 #!/usr/bin/env python3
 """Offline end-to-end smoke for the Stage 0/1 trade-idea rails.
 
-Drives the real ``gpt-trader ideas`` CLI through both execution legs in a
+Drives the real ``gpt-trader ideas`` CLI through the execution legs in a
 scratch ideas root. Manual leg: propose -> (approval blocked without attested
 equity) -> budget attest -> approve -> export-ticket -> mark-submitted ->
 mark-filled -> closeout. Machine leg: propose -> approve -> execute-paper
 (deterministic paper broker, no attestation) -> refused re-execution ->
-closeout. Then: report over both -> audit verify.
+closeout. Cycle leg (issue #1150): `ideas cycle` over a fixture snapshot
+proposes; a human approves between turns; the next turn paper-executes at the
+snapshot mark and each turn appends a manifest row. Then: report over all
+legs -> audit verify.
 
 This is the "does the project still string together?" gate: unit tests cover
 the parts, this covers the operator-visible loop. It needs no network, broker,
@@ -89,6 +92,41 @@ def _build_idea_payload(decision_id: str) -> dict[str, Any]:
         do_not_trade_if=("This is a smoke-test record",),
     )
     return idea.to_dict()
+
+
+def _build_cycle_snapshot_payload(symbol: str) -> dict[str, Any]:
+    """Synthesize a snapshot whose 10/50 MA golden cross lands in the last 3 bars."""
+    from decimal import Decimal
+
+    from gpt_trader.core import Candle
+    from gpt_trader.features.trade_ideas import (
+        MarketSnapshot,
+        SymbolSeries,
+        market_snapshot_to_payload,
+    )
+
+    as_of = datetime.now(UTC)
+    closes = [Decimal("100")] * 57 + [Decimal("120"), Decimal("125"), Decimal("130")]
+    volumes = [Decimal("10")] * 59 + [Decimal("100")]
+    start = as_of - timedelta(hours=len(closes))
+    series = SymbolSeries(
+        symbol=symbol,
+        granularity="ONE_HOUR",
+        candles=tuple(
+            Candle(
+                ts=start + timedelta(hours=index),
+                open=close,
+                high=close,
+                low=close,
+                close=close,
+                volume=volume,
+            )
+            for index, (close, volume) in enumerate(zip(closes, volumes, strict=True))
+        ),
+    )
+    return market_snapshot_to_payload(
+        MarketSnapshot(as_of=as_of, source="smoke:fixture:cycle", series=(series,))
+    )
 
 
 def _run_ideas_cli(
@@ -377,12 +415,102 @@ def run_smoke(ideas_root: Path) -> None:
     )
     _step("closeout record (machine leg) -> attribution captured")
 
+    # --- Cycle leg: one scheduled turn proposes; a human approves between
+    # turns; the next turn paper-executes at the snapshot mark. ---
+    cycle_snapshot_path = ideas_root / "smoke_cycle_snapshot.json"
+    cycle_snapshot_path.write_text(json.dumps(_build_cycle_snapshot_payload("SOL-USD")))
+
+    cycle_first = _run_ideas_cli(
+        ideas_root,
+        "cycle",
+        "--snapshot",
+        str(cycle_snapshot_path),
+    )
+    cycle_first_data = cycle_first["data"]
+    baseline_turn = cycle_first_data["proposers"][0]
+    _assert(
+        int(baseline_turn["proposal_count"]) == 1,
+        "cycle (first turn)",
+        f"expected 1 baseline proposal, got {cycle_first_data['proposers']}",
+    )
+    cycle_decision_id = baseline_turn["proposed_decision_ids"][0]
+    _assert(
+        cycle_first_data["execution"]["executed"] == [],
+        "cycle (first turn)",
+        f"nothing was approved yet, but got executions {cycle_first_data['execution']}",
+    )
+    _step("cycle turn 1 -> proposed from fixture snapshot, nothing executed")
+
+    cycle_approved = _run_ideas_cli(
+        ideas_root,
+        "approve",
+        cycle_decision_id,
+        "--actor",
+        SMOKE_ACTOR_HUMAN,
+        "--reason",
+        "stage1 rails smoke cycle-leg approval",
+    )
+    _assert(
+        cycle_approved["data"]["state"] == "approved",
+        "approve (cycle leg)",
+        f"unexpected state {cycle_approved['data']}",
+    )
+    _step("cycle leg: approve (human actor) between turns")
+
+    cycle_second = _run_ideas_cli(
+        ideas_root,
+        "cycle",
+        "--snapshot",
+        str(cycle_snapshot_path),
+    )
+    cycle_executed = cycle_second["data"]["execution"]["executed"]
+    _assert(
+        len(cycle_executed) == 1 and cycle_executed[0]["decision_id"] == cycle_decision_id,
+        "cycle (second turn)",
+        f"expected the approved idea to execute, got {cycle_second['data']['execution']}",
+    )
+    _assert(
+        cycle_executed[0]["fill_price"] == "130",
+        "cycle (second turn)",
+        f"expected fill at the snapshot mark 130, got {cycle_executed[0]}",
+    )
+    _step("cycle turn 2 -> approved idea paper-executed at the snapshot mark")
+
+    manifest_path = ideas_root / "cycle" / "manifest.jsonl"
+    manifest_rows = [
+        json.loads(line) for line in manifest_path.read_text().splitlines() if line.strip()
+    ]
+    _assert(
+        len(manifest_rows) == 2 and all(row["outcome"] == "completed" for row in manifest_rows),
+        "cycle manifest",
+        f"expected 2 completed manifest rows, got {manifest_rows}",
+    )
+    _step("cycle manifest -> exactly one completed row per turn")
+
+    _run_ideas_cli(
+        ideas_root,
+        "closeout",
+        "record",
+        cycle_decision_id,
+        "--resolution",
+        "thesis_target",
+        "--realized-profit-loss-amount",
+        "12",
+        "--realized-profit-loss-percent",
+        "0.05",
+        "--evidence",
+        "stage1 rails smoke cycle-leg exit",
+        "--actor",
+        SMOKE_ACTOR_HUMAN,
+    )
+    _step("closeout record (cycle leg) -> attribution captured")
+
     report = _run_ideas_cli(ideas_root, "report")
     report_data = report["data"]
     _assert(
-        int(report_data["row_count"]) == 2,
+        int(report_data["row_count"]) == 3,
         "report",
-        f"expected exactly 2 ideas, got row_count={report_data.get('row_count')}",
+        f"expected exactly 3 ideas, got row_count={report_data.get('row_count')}",
     )
     closeouts = report_data.get("closeouts", {})
     _assert(
@@ -390,13 +518,13 @@ def run_smoke(ideas_root: Path) -> None:
         "report",
         f"expected full closeout coverage, got {closeouts}",
     )
-    _step("report -> 2 ideas, full closeout coverage")
+    _step("report -> 3 ideas, full closeout coverage")
 
     verify = _run_ideas_cli(ideas_root, "audit", "verify")
     _assert(
-        int(verify["data"].get("event_count", 0)) >= 8,
+        int(verify["data"].get("event_count", 0)) >= 12,
         "audit verify",
-        f"expected >=8 chained events, got {verify['data']}",
+        f"expected >=12 chained events, got {verify['data']}",
     )
     _step(f"audit verify -> chain intact ({verify['data']['event_count']} events)")
 
@@ -425,7 +553,7 @@ def _execute(ideas_root: Path) -> int:
         print(f"✗ stage1 rails smoke FAILED: {exc}", file=sys.stderr)
         return 1
     print(
-        "✓ stage1 rails smoke OK: manual and machine legs "
+        "✓ stage1 rails smoke OK: manual, machine, and cycle legs "
         "proposed -> approved -> filled -> closed, audit chain intact"
     )
     return 0

--- a/src/gpt_trader/cli/commands/ideas.py
+++ b/src/gpt_trader/cli/commands/ideas.py
@@ -40,6 +40,7 @@ from gpt_trader.errors import ValidationError
 from gpt_trader.features.brokerages.mock import DeterministicBroker
 from gpt_trader.features.idea_execution import (
     DEFAULT_PAPER_EXECUTION_ACTOR_ID,
+    PaperCycleRunner,
     PaperIdeaExecutor,
 )
 from gpt_trader.features.intelligence.regime import RegimeConfig
@@ -90,6 +91,7 @@ from gpt_trader.features.trade_ideas import (
     market_snapshot_to_payload,
     optimize_replay_min_history,
     replay_optimize_baseline_candidates,
+    resolve_ideas_root,
     resolve_trade_idea_actor_id,
     validate_paper_reconciliation_profile,
 )
@@ -110,6 +112,7 @@ from gpt_trader.features.trade_ideas.report import (
 from gpt_trader.persistence.event_store import EventStore
 
 VENUE_CHOICES = ("coinbase", "manual")
+CYCLE_PROPOSER_CHOICES = ("baseline", "regime-aware")
 PAPER_RECONCILIATION_PROFILE_CHOICES = tuple(sorted({*options.PROFILE_CHOICES, "mock"}))
 TEXT_JSON_FORMATS = ("text", "json")
 REPORT_FORMATS = ("text", "json", "csv")
@@ -907,6 +910,71 @@ def register(subparsers: Any) -> None:
         ),
     )
     execute_paper.set_defaults(handler=_handle_execute_paper, subcommand="execute-paper")
+
+    cycle = ideas_subparsers.add_parser(
+        "cycle",
+        help="Run one turn of the Stage 1 paper cycle (snapshot -> propose -> execute approved)",
+        description=(
+            "One scheduled turn of the Stage 1 paper loop: sweep expired ideas, run "
+            "the selected proposers over one market snapshot, paper-execute ideas a "
+            "human already approved (priced from the same snapshot), and append one "
+            "manifest row of evidence. Recurrence comes from an external scheduler "
+            "(launchd/cron); this command never decides a cadence, never approves "
+            "ideas, and never contacts a live broker or account."
+        ),
+    )
+    _add_common_options(cycle)
+    cycle_snapshot_source = cycle.add_mutually_exclusive_group(required=True)
+    cycle_snapshot_source.add_argument(
+        "--snapshot",
+        type=Path,
+        help="Run offline from a local MarketSnapshot JSON file",
+    )
+    cycle_snapshot_source.add_argument(
+        "--from-coinbase",
+        action="store_true",
+        help="Fetch read-only public Coinbase market candles for this turn",
+    )
+    cycle.add_argument(
+        "--symbols",
+        help="Comma-separated Coinbase product ids (required with --from-coinbase)",
+    )
+    cycle.add_argument(
+        "--granularity",
+        help="Candle granularity, for example ONE_HOUR or ONE_DAY (required with --from-coinbase)",
+    )
+    cycle.add_argument(
+        "--lookback",
+        type=_positive_int_value,
+        help="Completed candles per symbol (required with --from-coinbase)",
+    )
+    cycle.add_argument(
+        "--coinbase-base-url",
+        default=None,
+        help="Override the public Coinbase market-data base URL",
+    )
+    cycle.add_argument(
+        "--source-label",
+        default="coinbase:market-candles",
+        help="Source label stamped into snapshot metadata",
+    )
+    cycle.add_argument(
+        "--proposer",
+        dest="proposers",
+        action="append",
+        choices=CYCLE_PROPOSER_CHOICES,
+        help=(
+            "Proposer to run this turn; repeatable "
+            f"(default: {', '.join(CYCLE_PROPOSER_CHOICES)})"
+        ),
+    )
+    cycle.add_argument(
+        "--no-execute-approved",
+        dest="execute_approved",
+        action="store_false",
+        help="Skip the paper-execution leg for APPROVED ideas this turn",
+    )
+    cycle.set_defaults(handler=_handle_cycle, subcommand="cycle", execute_approved=True)
 
     budget = ideas_subparsers.add_parser("budget", help="Inspect or update risk budget")
     budget_subparsers = budget.add_subparsers(dest="budget_command", required=True)
@@ -2310,6 +2378,78 @@ def _handle_execute_paper(args: Namespace) -> CliResponse:
         f"order={result.order_id} fill_price={result.fill_price}",
     )
     return _success(command, args, result.to_dict(), text)
+
+
+_CYCLE_PROPOSER_FACTORIES: dict[str, Callable[[TradeIdeaService], Proposer]] = {
+    "baseline": lambda service: BaselineProposer(sizing_bridge=_LazyBudgetSizingBridge(service)),
+    "regime-aware": lambda service: RegimeAwareProposer(
+        sizing_bridge=_LazyBudgetSizingBridge(service)
+    ),
+}
+
+
+def _handle_cycle(args: Namespace) -> CliResponse:
+    command = "ideas cycle"
+    try:
+        if args.snapshot is not None:
+            snapshot_path = args.snapshot
+
+            def snapshot_provider() -> tuple[MarketSnapshot, str]:
+                return _load_market_snapshot(snapshot_path), str(snapshot_path)
+
+        else:
+            missing = [
+                flag
+                for flag, value in (
+                    ("--symbols", args.symbols),
+                    ("--granularity", args.granularity),
+                    ("--lookback", args.lookback),
+                )
+                if value is None
+            ]
+            if missing:
+                return _failure(
+                    command,
+                    args,
+                    CliErrorCode.MISSING_ARGUMENT,
+                    f"--from-coinbase requires {', '.join(missing)}",
+                )
+            request = MarketSnapshotBuildRequest(
+                symbols=_snapshot_symbols(args.symbols),
+                granularity=_snapshot_granularity(args.granularity),
+                lookback=args.lookback,
+                as_of=datetime.now(UTC),
+            )
+
+            def snapshot_provider() -> tuple[MarketSnapshot, str]:
+                snapshot = asyncio.run(_build_coinbase_market_snapshot(args, request))
+                return snapshot, snapshot.source
+
+        service = _service(args)
+        selected_proposers = tuple(dict.fromkeys(args.proposers or CYCLE_PROPOSER_CHOICES))
+        runner = PaperCycleRunner(
+            service,
+            cycle_root=resolve_ideas_root(getattr(args, "ideas_root", None)) / "cycle",
+            proposers=[_CYCLE_PROPOSER_FACTORIES[name](service) for name in selected_proposers],
+            broker=DeterministicBroker(),
+            execute_approved=args.execute_approved,
+        )
+        result = runner.run(snapshot_provider)
+    except (SnapshotInputError, InputPayloadError) as error:
+        return _input_error(command, args, error)
+    except Exception as error:
+        return _mapped_error(command, args, error)
+
+    proposed_total = sum(turn.proposal_count for turn in result.proposer_turns)
+    executed_total = len(result.execution.executed)
+    text = _status_line(
+        command,
+        "OK",
+        f"run={result.run_id} proposed={proposed_total} executed={executed_total} "
+        f"pending={result.queue.get('pending_total')}",
+    )
+    was_noop = proposed_total == 0 and executed_total == 0 and not result.expired_decision_ids
+    return _success(command, args, result.to_dict(), text, was_noop=was_noop)
 
 
 def _handle_budget_show(args: Namespace) -> CliResponse:

--- a/src/gpt_trader/cli/commands/ideas.py
+++ b/src/gpt_trader/cli/commands/ideas.py
@@ -950,8 +950,8 @@ def register(subparsers: Any) -> None:
     )
     cycle.add_argument(
         "--coinbase-base-url",
-        default=None,
-        help="Override the public Coinbase market-data base URL",
+        default="https://api.coinbase.com",
+        help="Coinbase API base URL for market-data reads",
     )
     cycle.add_argument(
         "--source-label",

--- a/src/gpt_trader/features/idea_execution/__init__.py
+++ b/src/gpt_trader/features/idea_execution/__init__.py
@@ -24,6 +24,15 @@ Live order submission remains gated by docs/DIRECTION.md and recorded human
 approval; nothing in this slice weakens that boundary.
 """
 
+from gpt_trader.features.idea_execution.cycle import (
+    DEFAULT_CYCLE_ACTOR_ID,
+    ExecutionTurn,
+    PaperCycleLockError,
+    PaperCycleResult,
+    PaperCycleRunner,
+    ProposerTurn,
+    SnapshotProvider,
+)
 from gpt_trader.features.idea_execution.executor import (
     DEFAULT_PAPER_EXECUTION_ACTOR_ID,
     PAPER_BROKER_TYPES,
@@ -36,12 +45,19 @@ from gpt_trader.features.idea_execution.executor import (
 )
 
 __all__ = [
+    "DEFAULT_CYCLE_ACTOR_ID",
     "DEFAULT_PAPER_EXECUTION_ACTOR_ID",
     "PAPER_BROKER_TYPES",
     "PAPER_EXECUTION_VENUE",
     "IdeaNotExecutableError",
     "PaperExecutionError",
     "PaperExecutionResult",
+    "ExecutionTurn",
+    "PaperCycleLockError",
+    "PaperCycleResult",
+    "PaperCycleRunner",
     "PaperIdeaExecutor",
     "PaperOnlyLaneError",
+    "ProposerTurn",
+    "SnapshotProvider",
 ]

--- a/src/gpt_trader/features/idea_execution/cycle.py
+++ b/src/gpt_trader/features/idea_execution/cycle.py
@@ -73,6 +73,10 @@ paper-only.
 """
 
 
+def _instrument_key(instrument: str) -> str:
+    return instrument.casefold()
+
+
 class PaperCycleLockError(ValidationError):
     """Raised when another cycle turn already holds the ideas-root lock."""
 
@@ -303,14 +307,15 @@ class PaperCycleRunner:
         known_decision_ids: set[str] = set()
         for view in self._service.list_views():
             known_decision_ids.add(view.idea.decision_id)
+            instrument_key = _instrument_key(view.idea.instrument)
             if view.state in _OPEN_STATES:
-                busy_instruments[view.idea.instrument] = (
+                busy_instruments[instrument_key] = (
                     view.idea.decision_id,
                     "instrument already has an open idea",
                 )
             elif view.state is TradeIdeaState.FILLED and view.closeout_attribution is None:
                 busy_instruments.setdefault(
-                    view.idea.instrument,
+                    instrument_key,
                     (view.idea.decision_id, "instrument has a filled idea awaiting closeout"),
                 )
         admitted = []
@@ -328,7 +333,8 @@ class PaperCycleRunner:
                     }
                 )
                 continue
-            busy = busy_instruments.get(idea.instrument)
+            instrument_key = _instrument_key(idea.instrument)
+            busy = busy_instruments.get(instrument_key)
             if busy is not None:
                 existing_decision_id, reason = busy
                 skipped.append(
@@ -341,7 +347,7 @@ class PaperCycleRunner:
                 continue
             admitted.append(idea)
             known_decision_ids.add(idea.decision_id)
-            busy_instruments[idea.instrument] = (
+            busy_instruments[instrument_key] = (
                 idea.decision_id,
                 "instrument already has an open idea",
             )
@@ -377,7 +383,9 @@ class PaperCycleRunner:
         approved_before_turn: tuple[str, ...],
     ) -> ExecutionTurn:
         marks = {
-            series.symbol: series.candles[-1].close for series in snapshot.series if series.candles
+            _instrument_key(series.symbol): series.candles[-1].close
+            for series in snapshot.series
+            if series.candles
         }
         executed: list[dict[str, Any]] = []
         skipped: list[dict[str, str]] = []
@@ -394,7 +402,7 @@ class PaperCycleRunner:
                     }
                 )
                 continue
-            mark = marks.get(view.idea.instrument)
+            mark = marks.get(_instrument_key(view.idea.instrument))
             if mark is None:
                 skipped.append(
                     {

--- a/src/gpt_trader/features/idea_execution/cycle.py
+++ b/src/gpt_trader/features/idea_execution/cycle.py
@@ -1,0 +1,395 @@
+"""One turn of the Stage-1 paper cycle (issue #1150).
+
+A turn strings the existing rails together with no new authority: sweep
+expired ideas, run the configured proposers over one market snapshot, paper-
+execute any human-APPROVED ideas priced by that same snapshot, and leave
+evidence. Recurrence is supplied by an external scheduler (launchd/cron);
+nothing in this module knows or decides a cadence.
+
+Evidence contract: every turn — including failed ones — appends exactly one
+JSON line to ``<cycle_root>/manifest.jsonl`` and writes its artifacts under
+``<cycle_root>/runs/<run_id>/``. "N consecutive unattended days" is computed
+from the manifest alone.
+
+The turn acquires a lock for its whole duration so overlapping scheduler
+ticks cannot interleave; a second invocation is refused with
+``PaperCycleLockError`` and leaves no manifest row (a refused start is not a
+turn). Approval remains a human event: the proposer leg only queues ideas,
+and the execution leg touches only ideas a human already approved, through
+the paper-only lane in this slice.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import secrets
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from filelock import FileLock, Timeout
+
+from gpt_trader.errors import ValidationError
+from gpt_trader.features.brokerages.mock import DeterministicBroker
+from gpt_trader.features.idea_execution.executor import (
+    IdeaNotExecutableError,
+    PaperExecutionError,
+    PaperIdeaExecutor,
+)
+from gpt_trader.features.trade_ideas import (
+    ActorType,
+    MarketSnapshot,
+    Proposer,
+    TradeIdeaService,
+    TradeIdeaState,
+    market_snapshot_to_payload,
+)
+from gpt_trader.features.trade_ideas.report import build_trade_idea_track_record_report
+
+DEFAULT_CYCLE_ACTOR_ID = "paper-cycle"
+
+# States in which an instrument already has a live idea in the pipeline. The
+# baseline proposers re-emit an ongoing signal on consecutive turns (their
+# crossover window spans several bars), so unattended operation must not queue
+# near-duplicate ideas for the same instrument.
+_OPEN_STATES = frozenset(
+    {
+        TradeIdeaState.PROPOSED,
+        TradeIdeaState.NEEDS_CHANGES,
+        TradeIdeaState.APPROVED,
+        TradeIdeaState.SUBMITTED,
+    }
+)
+
+SnapshotProvider = Callable[[], tuple[MarketSnapshot, str]]
+"""Returns the turn's snapshot plus a human-readable source reference.
+
+The provider owns acquisition (network fetch or file load); the runner never
+imports a market-data client, so the paper lane's import topology stays
+paper-only.
+"""
+
+
+class PaperCycleLockError(ValidationError):
+    """Raised when another cycle turn already holds the ideas-root lock."""
+
+
+@dataclass(frozen=True, slots=True)
+class ProposerTurn:
+    """Outcome of one proposer over the turn's snapshot."""
+
+    proposer_id: str
+    proposal_count: int
+    proposed_decision_ids: tuple[str, ...]
+    skipped_open_instruments: tuple[dict[str, str], ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "proposer_id": self.proposer_id,
+            "proposal_count": self.proposal_count,
+            "proposed_decision_ids": list(self.proposed_decision_ids),
+            "skipped_open_instruments": list(self.skipped_open_instruments),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ExecutionTurn:
+    """Outcome of the execute-approved leg."""
+
+    enabled: bool
+    executed: tuple[dict[str, Any], ...] = ()
+    skipped: tuple[dict[str, str], ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "enabled": self.enabled,
+            "executed": list(self.executed),
+            "skipped": list(self.skipped),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class PaperCycleResult:
+    """One completed turn; failed turns raise and leave only a manifest row."""
+
+    run_id: str
+    started_at: datetime
+    finished_at: datetime
+    snapshot: dict[str, Any]
+    expired_decision_ids: tuple[str, ...]
+    proposer_turns: tuple[ProposerTurn, ...]
+    execution: ExecutionTurn
+    queue: dict[str, Any] = field(default_factory=dict)
+    report_summary: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "started_at": self.started_at.isoformat(),
+            "finished_at": self.finished_at.isoformat(),
+            "outcome": "completed",
+            "snapshot": self.snapshot,
+            "expired_decision_ids": list(self.expired_decision_ids),
+            "proposers": [turn.to_dict() for turn in self.proposer_turns],
+            "execution": self.execution.to_dict(),
+            "queue": self.queue,
+            "report": self.report_summary,
+        }
+
+
+class PaperCycleRunner:
+    """Runs one turn of the Stage-1 paper cycle.
+
+    The runner is composition only: proposers, the paper broker, and the
+    snapshot provider are injected, so cadence, granularity, and strategy set
+    are the caller's configuration — never constants here.
+
+    The broker is the deterministic one specifically: the execution leg prices
+    every fill from the turn's own snapshot via ``set_mark``, which is the
+    honesty contract of a scheduled offline turn. ``HybridPaperBroker`` prices
+    from its own live feed, so wiring it here needs a pricing decision first
+    (deferred with its CLI wiring).
+    """
+
+    def __init__(
+        self,
+        service: TradeIdeaService,
+        *,
+        cycle_root: Path,
+        proposers: Sequence[Proposer],
+        broker: DeterministicBroker,
+        execute_approved: bool = True,
+        actor_id: str = DEFAULT_CYCLE_ACTOR_ID,
+        now_factory: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._service = service
+        self._cycle_root = cycle_root
+        self._proposers = tuple(proposers)
+        self._executor = PaperIdeaExecutor(service, broker)
+        self._broker = broker
+        self._execute_approved = execute_approved
+        self._actor_id = actor_id
+        self._now_factory = now_factory or (lambda: datetime.now(UTC))
+
+    def run(self, snapshot_provider: SnapshotProvider) -> PaperCycleResult:
+        """Run one turn; append exactly one manifest row whatever happens."""
+        lock = FileLock(str(self._cycle_root / "cycle.lock"))
+        self._cycle_root.mkdir(parents=True, exist_ok=True)
+        try:
+            lock.acquire(timeout=0)
+        except Timeout as error:
+            raise PaperCycleLockError(
+                "Another paper-cycle turn is already running for this ideas root",
+                field="cycle_root",
+                value=str(self._cycle_root),
+            ) from error
+
+        started_at = self._now_factory()
+        run_id = f"cycle-{started_at:%Y%m%dT%H%M%SZ}-{secrets.token_hex(3)}"
+        row: dict[str, Any] = {
+            "run_id": run_id,
+            "started_at": started_at.isoformat(),
+            "outcome": "failed",
+            "error": None,
+        }
+        try:
+            result = self._run_steps(run_id, started_at, snapshot_provider, row)
+            row.update(result.to_dict())
+            return result
+        except Exception as error:
+            row["error"] = f"{type(error).__name__}: {error}"
+            row["finished_at"] = self._now_factory().isoformat()
+            raise
+        finally:
+            self._append_manifest_row(row)
+            lock.release()
+
+    def _run_steps(
+        self,
+        run_id: str,
+        started_at: datetime,
+        snapshot_provider: SnapshotProvider,
+        row: dict[str, Any],
+    ) -> PaperCycleResult:
+        run_dir = self._cycle_root / "runs" / run_id
+        run_dir.mkdir(parents=True, exist_ok=True)
+
+        snapshot, snapshot_reference = snapshot_provider()
+        snapshot_info = self._persist_snapshot(snapshot, snapshot_reference, run_dir)
+        row["snapshot"] = snapshot_info
+
+        expired_views = self._service.expire_due_ideas(
+            actor_id=self._actor_id,
+            reason="paper-cycle expiry sweep",
+            actor_type=ActorType.SYSTEM,
+        )
+        expired_decision_ids = tuple(view.idea.decision_id for view in expired_views)
+        row["expired_decision_ids"] = list(expired_decision_ids)
+
+        proposer_turns: list[ProposerTurn] = []
+        for proposer in self._proposers:
+            turn = self._run_proposer(proposer, snapshot, snapshot_reference)
+            proposer_turns.append(turn)
+            row["proposers"] = [item.to_dict() for item in proposer_turns]
+
+        execution = (
+            self._execute_approved_ideas(snapshot)
+            if self._execute_approved
+            else ExecutionTurn(enabled=False)
+        )
+        row["execution"] = execution.to_dict()
+
+        report = build_trade_idea_track_record_report(self._service, now=self._now_factory())
+        (run_dir / "report.json").write_text(
+            f"{json.dumps(report, indent=2, sort_keys=True, default=str)}\n",
+            encoding="utf-8",
+        )
+        report_summary = {
+            "row_count": report.get("row_count"),
+            "closeouts": report.get("closeouts"),
+        }
+
+        queue_status = self._service.queue_status()
+        queue_summary = {
+            "as_of": queue_status.as_of.isoformat(),
+            "proposed_count": queue_status.proposed_count,
+            "needs_changes_count": queue_status.needs_changes_count,
+            "pending_total": queue_status.pending_total,
+        }
+
+        return PaperCycleResult(
+            run_id=run_id,
+            started_at=started_at,
+            finished_at=self._now_factory(),
+            snapshot=snapshot_info,
+            expired_decision_ids=expired_decision_ids,
+            proposer_turns=tuple(proposer_turns),
+            execution=execution,
+            queue=queue_summary,
+            report_summary=report_summary,
+        )
+
+    def _run_proposer(
+        self,
+        proposer: Proposer,
+        snapshot: MarketSnapshot,
+        snapshot_reference: str,
+    ) -> ProposerTurn:
+        candidates = proposer.propose(snapshot)
+
+        open_instruments = {
+            view.idea.instrument: view.idea.decision_id
+            for view in self._service.list_views()
+            if view.state in _OPEN_STATES
+        }
+        admitted = []
+        skipped: list[dict[str, str]] = []
+        for idea in candidates:
+            existing_decision_id = open_instruments.get(idea.instrument)
+            if existing_decision_id is not None:
+                skipped.append(
+                    {
+                        "instrument": idea.instrument,
+                        "reason": "instrument already has an open idea",
+                        "existing_decision_id": existing_decision_id,
+                    }
+                )
+                continue
+            admitted.append(idea)
+            open_instruments[idea.instrument] = idea.decision_id
+
+        proposed_decision_ids: tuple[str, ...] = ()
+        if admitted:
+            batch = tuple(admitted)
+            self._service.validate_new_proposals(batch)
+            views = self._service.propose_batch(
+                batch,
+                actor_id=proposer.proposer_id,
+                actor_type=ActorType.AI,
+                reason="paper-cycle scheduled proposal",
+                evidence=(
+                    f"proposer_id={proposer.proposer_id}",
+                    f"snapshot_reference={snapshot_reference}",
+                    f"snapshot_source={snapshot.source}",
+                    f"snapshot_as_of={snapshot.as_of.isoformat()}",
+                ),
+            )
+            proposed_decision_ids = tuple(view.idea.decision_id for view in views)
+
+        return ProposerTurn(
+            proposer_id=proposer.proposer_id,
+            proposal_count=len(proposed_decision_ids),
+            proposed_decision_ids=proposed_decision_ids,
+            skipped_open_instruments=tuple(skipped),
+        )
+
+    def _execute_approved_ideas(self, snapshot: MarketSnapshot) -> ExecutionTurn:
+        marks = {
+            series.symbol: series.candles[-1].close for series in snapshot.series if series.candles
+        }
+        executed: list[dict[str, Any]] = []
+        skipped: list[dict[str, str]] = []
+        for view in self._service.list_views(TradeIdeaState.APPROVED):
+            decision_id = view.idea.decision_id
+            mark = marks.get(view.idea.instrument)
+            if mark is None:
+                skipped.append(
+                    {
+                        "decision_id": decision_id,
+                        "reason": (
+                            "no fresh mark for instrument "
+                            f"{view.idea.instrument} in this turn's snapshot"
+                        ),
+                    }
+                )
+                continue
+            self._broker.set_mark(view.idea.instrument, mark)
+            try:
+                result = self._executor.execute(decision_id, actor_id=self._actor_id)
+            except (IdeaNotExecutableError, PaperExecutionError) as error:
+                # Typed refusals are the lane's admission rules working (for
+                # example the idea expired between sweep and execution); they
+                # are evidence, not turn failures.
+                skipped.append({"decision_id": decision_id, "reason": str(error)})
+                continue
+            executed.append(
+                {
+                    "decision_id": result.decision_id,
+                    "order_id": result.order_id,
+                    "client_order_id": result.client_order_id,
+                    "symbol": result.symbol,
+                    "side": result.side,
+                    "quantity": str(result.quantity),
+                    "fill_price": str(result.fill_price) if result.fill_price is not None else None,
+                    "final_state": result.final_state,
+                }
+            )
+        return ExecutionTurn(enabled=True, executed=tuple(executed), skipped=tuple(skipped))
+
+    def _persist_snapshot(
+        self,
+        snapshot: MarketSnapshot,
+        snapshot_reference: str,
+        run_dir: Path,
+    ) -> dict[str, Any]:
+        payload = market_snapshot_to_payload(snapshot)
+        canonical = json.dumps(payload, indent=2, sort_keys=True)
+        snapshot_path = run_dir / "snapshot.json"
+        snapshot_path.write_text(f"{canonical}\n", encoding="utf-8")
+        return {
+            "reference": snapshot_reference,
+            "path": str(snapshot_path),
+            "sha256": hashlib.sha256(canonical.encode("utf-8")).hexdigest(),
+            "source": snapshot.source,
+            "as_of": snapshot.as_of.isoformat(),
+            "symbols": [series.symbol for series in snapshot.series],
+            "granularities": sorted({series.granularity for series in snapshot.series}),
+        }
+
+    def _append_manifest_row(self, row: dict[str, Any]) -> None:
+        manifest_path = self._cycle_root / "manifest.jsonl"
+        with manifest_path.open("a", encoding="utf-8") as manifest_file:
+            manifest_file.write(f"{json.dumps(row, sort_keys=True, default=str)}\n")

--- a/src/gpt_trader/features/idea_execution/cycle.py
+++ b/src/gpt_trader/features/idea_execution/cycle.py
@@ -219,10 +219,6 @@ class PaperCycleRunner:
         run_dir = self._cycle_root / "runs" / run_id
         run_dir.mkdir(parents=True, exist_ok=True)
 
-        snapshot, snapshot_reference = snapshot_provider()
-        snapshot_info = self._persist_snapshot(snapshot, snapshot_reference, run_dir)
-        row["snapshot"] = snapshot_info
-
         expired_views = self._service.expire_due_ideas(
             actor_id=self._actor_id,
             reason="paper-cycle expiry sweep",
@@ -231,13 +227,19 @@ class PaperCycleRunner:
         expired_decision_ids = tuple(view.idea.decision_id for view in expired_views)
         row["expired_decision_ids"] = list(expired_decision_ids)
 
-        # Capture the execution candidates before the proposer leg: the
-        # approval CLI does not take the cycle lock, so an idea approved while
-        # this turn is running must wait for the next turn — approval lands
-        # between turns, never inside one.
+        # Capture the execution candidates before any slow turn work — the
+        # snapshot fetch is a network call and the approval CLI does not take
+        # the cycle lock, so an approval landing anywhere inside the turn must
+        # wait for the next turn: approval lands between turns, never inside
+        # one. Only the local expiry sweep runs first, so already-stale ideas
+        # are not captured.
         approved_before_turn = tuple(
             view.idea.decision_id for view in self._service.list_views(TradeIdeaState.APPROVED)
         )
+
+        snapshot, snapshot_reference = snapshot_provider()
+        snapshot_info = self._persist_snapshot(snapshot, snapshot_reference, run_dir)
+        row["snapshot"] = snapshot_info
 
         proposer_turns: list[ProposerTurn] = []
         for proposer in self._proposers:

--- a/src/gpt_trader/features/idea_execution/cycle.py
+++ b/src/gpt_trader/features/idea_execution/cycle.py
@@ -204,8 +204,10 @@ class PaperCycleRunner:
             row["finished_at"] = self._now_factory().isoformat()
             raise
         finally:
-            self._append_manifest_row(row)
-            lock.release()
+            try:
+                self._append_manifest_row(row)
+            finally:
+                lock.release()
 
     def _run_steps(
         self,

--- a/src/gpt_trader/features/idea_execution/cycle.py
+++ b/src/gpt_trader/features/idea_execution/cycle.py
@@ -168,11 +168,14 @@ class PaperCycleRunner:
         self._service = service
         self._cycle_root = cycle_root
         self._proposers = tuple(proposers)
-        self._executor = PaperIdeaExecutor(service, broker)
         self._broker = broker
         self._execute_approved = execute_approved
         self._actor_id = actor_id
         self._now_factory = now_factory or (lambda: datetime.now(UTC))
+        # The executor must share the turn's clock: with an injected clock
+        # (deterministic or historical turns) a wall-clock expiry check would
+        # refuse ideas the rest of the turn still considers live.
+        self._executor = PaperIdeaExecutor(service, broker, now_factory=self._now_factory)
 
     def run(self, snapshot_provider: SnapshotProvider) -> PaperCycleResult:
         """Run one turn; append exactly one manifest row whatever happens."""
@@ -297,7 +300,9 @@ class PaperCycleRunner:
         # recorded, the trade is unresolved and the same ongoing signal must
         # not pyramid a second position onto it.
         busy_instruments: dict[str, tuple[str, str]] = {}
+        known_decision_ids: set[str] = set()
         for view in self._service.list_views():
+            known_decision_ids.add(view.idea.decision_id)
             if view.state in _OPEN_STATES:
                 busy_instruments[view.idea.instrument] = (
                     view.idea.decision_id,
@@ -311,6 +316,18 @@ class PaperCycleRunner:
         admitted = []
         skipped: list[dict[str, str]] = []
         for idea in candidates:
+            # Deterministic proposers emit the same decision_id for the same
+            # snapshot, so a rerun over a saved snapshot must skip
+            # idempotently rather than fail the turn on a duplicate id.
+            if idea.decision_id in known_decision_ids:
+                skipped.append(
+                    {
+                        "instrument": idea.instrument,
+                        "reason": "decision id already recorded (idempotent rerun)",
+                        "existing_decision_id": idea.decision_id,
+                    }
+                )
+                continue
             busy = busy_instruments.get(idea.instrument)
             if busy is not None:
                 existing_decision_id, reason = busy
@@ -323,6 +340,7 @@ class PaperCycleRunner:
                 )
                 continue
             admitted.append(idea)
+            known_decision_ids.add(idea.decision_id)
             busy_instruments[idea.instrument] = (
                 idea.decision_id,
                 "instrument already has an open idea",

--- a/src/gpt_trader/features/idea_execution/cycle.py
+++ b/src/gpt_trader/features/idea_execution/cycle.py
@@ -229,6 +229,14 @@ class PaperCycleRunner:
         expired_decision_ids = tuple(view.idea.decision_id for view in expired_views)
         row["expired_decision_ids"] = list(expired_decision_ids)
 
+        # Capture the execution candidates before the proposer leg: the
+        # approval CLI does not take the cycle lock, so an idea approved while
+        # this turn is running must wait for the next turn — approval lands
+        # between turns, never inside one.
+        approved_before_turn = tuple(
+            view.idea.decision_id for view in self._service.list_views(TradeIdeaState.APPROVED)
+        )
+
         proposer_turns: list[ProposerTurn] = []
         for proposer in self._proposers:
             turn = self._run_proposer(proposer, snapshot, snapshot_reference)
@@ -236,7 +244,7 @@ class PaperCycleRunner:
             row["proposers"] = [item.to_dict() for item in proposer_turns]
 
         execution = (
-            self._execute_approved_ideas(snapshot)
+            self._execute_approved_ideas(snapshot, approved_before_turn)
             if self._execute_approved
             else ExecutionTurn(enabled=False)
         )
@@ -280,26 +288,41 @@ class PaperCycleRunner:
     ) -> ProposerTurn:
         candidates = proposer.propose(snapshot)
 
-        open_instruments = {
-            view.idea.instrument: view.idea.decision_id
-            for view in self._service.list_views()
-            if view.state in _OPEN_STATES
-        }
+        # An instrument is busy while an idea for it is open, and also while a
+        # filled trade awaits closeout attribution: until the outcome is
+        # recorded, the trade is unresolved and the same ongoing signal must
+        # not pyramid a second position onto it.
+        busy_instruments: dict[str, tuple[str, str]] = {}
+        for view in self._service.list_views():
+            if view.state in _OPEN_STATES:
+                busy_instruments[view.idea.instrument] = (
+                    view.idea.decision_id,
+                    "instrument already has an open idea",
+                )
+            elif view.state is TradeIdeaState.FILLED and view.closeout_attribution is None:
+                busy_instruments.setdefault(
+                    view.idea.instrument,
+                    (view.idea.decision_id, "instrument has a filled idea awaiting closeout"),
+                )
         admitted = []
         skipped: list[dict[str, str]] = []
         for idea in candidates:
-            existing_decision_id = open_instruments.get(idea.instrument)
-            if existing_decision_id is not None:
+            busy = busy_instruments.get(idea.instrument)
+            if busy is not None:
+                existing_decision_id, reason = busy
                 skipped.append(
                     {
                         "instrument": idea.instrument,
-                        "reason": "instrument already has an open idea",
+                        "reason": reason,
                         "existing_decision_id": existing_decision_id,
                     }
                 )
                 continue
             admitted.append(idea)
-            open_instruments[idea.instrument] = idea.decision_id
+            busy_instruments[idea.instrument] = (
+                idea.decision_id,
+                "instrument already has an open idea",
+            )
 
         proposed_decision_ids: tuple[str, ...] = ()
         if admitted:
@@ -326,14 +349,29 @@ class PaperCycleRunner:
             skipped_open_instruments=tuple(skipped),
         )
 
-    def _execute_approved_ideas(self, snapshot: MarketSnapshot) -> ExecutionTurn:
+    def _execute_approved_ideas(
+        self,
+        snapshot: MarketSnapshot,
+        approved_before_turn: tuple[str, ...],
+    ) -> ExecutionTurn:
         marks = {
             series.symbol: series.candles[-1].close for series in snapshot.series if series.candles
         }
         executed: list[dict[str, Any]] = []
         skipped: list[dict[str, str]] = []
-        for view in self._service.list_views(TradeIdeaState.APPROVED):
-            decision_id = view.idea.decision_id
+        for decision_id in approved_before_turn:
+            view = self._service.get(decision_id)
+            if view.state is not TradeIdeaState.APPROVED:
+                # The state moved while the turn was running (for example a
+                # human cancelled it); the lane would refuse it anyway, so
+                # record the observation instead of attempting execution.
+                skipped.append(
+                    {
+                        "decision_id": decision_id,
+                        "reason": f"state changed to {view.state.value} during the turn",
+                    }
+                )
+                continue
             mark = marks.get(view.idea.instrument)
             if mark is None:
                 skipped.append(

--- a/tests/unit/gpt_trader/cli/commands/test_ideas_cycle.py
+++ b/tests/unit/gpt_trader/cli/commands/test_ideas_cycle.py
@@ -1,0 +1,158 @@
+"""CLI tests for ``ideas cycle``: one offline turn of the Stage-1 paper loop.
+
+Runner contracts are pinned in
+tests/unit/gpt_trader/features/idea_execution/test_cycle.py; these tests cover
+the adapter: snapshot-file injection, proposer selection, the human-approval
+seam between two turns, and envelope shape.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from gpt_trader import cli
+from gpt_trader.core import Candle
+from gpt_trader.features.trade_ideas import (
+    MarketSnapshot,
+    SymbolSeries,
+    market_snapshot_to_payload,
+)
+from tests.unit.gpt_trader.cli.commands.conftest import attest_ideas_root
+
+_AS_OF = datetime(2026, 7, 3, 12, 0, tzinfo=UTC)
+
+
+def _crossover_snapshot_payload() -> dict[str, Any]:
+    closes = [Decimal("100")] * 57 + [Decimal("120"), Decimal("125"), Decimal("130")]
+    volumes = [Decimal("10")] * 59 + [Decimal("100")]
+    start = _AS_OF - timedelta(hours=len(closes))
+    series = SymbolSeries(
+        symbol="BTC-USD",
+        granularity="ONE_HOUR",
+        candles=tuple(
+            Candle(
+                ts=start + timedelta(hours=index),
+                open=close,
+                high=close,
+                low=close,
+                close=close,
+                volume=volume,
+            )
+            for index, (close, volume) in enumerate(zip(closes, volumes, strict=True))
+        ),
+    )
+    return market_snapshot_to_payload(
+        MarketSnapshot(as_of=_AS_OF, source="test:fixture", series=(series,))
+    )
+
+
+def _run_json(capsys: pytest.CaptureFixture[str], argv: list[str]) -> tuple[int, dict[str, Any]]:
+    exit_code = cli.main(argv)
+    output = capsys.readouterr().out
+    assert output
+    return exit_code, json.loads(output)
+
+
+def _root_args(root: Path) -> list[str]:
+    return ["--ideas-root", str(root), "--format", "json"]
+
+
+@pytest.fixture
+def snapshot_path(tmp_path: Path) -> Path:
+    path = tmp_path / "snapshot.json"
+    path.write_text(json.dumps(_crossover_snapshot_payload()), encoding="utf-8")
+    return path
+
+
+def test_cycle_proposes_then_executes_after_human_approval(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path, snapshot_path: Path
+) -> None:
+    root = tmp_path / "ideas"
+    attest_ideas_root(root)
+
+    exit_code, first = _run_json(
+        capsys,
+        ["ideas", "cycle", "--snapshot", str(snapshot_path), *_root_args(root)],
+    )
+    assert exit_code == 0
+    assert first["success"] is True
+    baseline_turn, regime_turn = first["data"]["proposers"]
+    assert baseline_turn["proposal_count"] == 1
+    (decision_id,) = baseline_turn["proposed_decision_ids"]
+    # The second proposer sees the instrument already queued and defers.
+    assert regime_turn["proposal_count"] == 0
+    assert regime_turn["skipped_open_instruments"][0]["existing_decision_id"] == decision_id
+    assert first["data"]["execution"]["executed"] == []
+
+    exit_code, approved = _run_json(
+        capsys,
+        [
+            "ideas",
+            "approve",
+            decision_id,
+            *_root_args(root),
+            "--actor",
+            "human-reviewer",
+            "--reason",
+            "cycle CLI test approval",
+        ],
+    )
+    assert exit_code == 0 and approved["success"] is True
+
+    exit_code, second = _run_json(
+        capsys,
+        ["ideas", "cycle", "--snapshot", str(snapshot_path), *_root_args(root)],
+    )
+    assert exit_code == 0
+    (executed,) = second["data"]["execution"]["executed"]
+    assert executed["decision_id"] == decision_id
+    assert executed["client_order_id"] == decision_id
+    assert executed["fill_price"] == "130"
+    assert executed["final_state"] == "filled"
+
+    manifest_path = root / "cycle" / "manifest.jsonl"
+    rows = [json.loads(line) for line in manifest_path.read_text().splitlines() if line]
+    assert len(rows) == 2
+    assert all(row["outcome"] == "completed" for row in rows)
+
+
+def test_cycle_proposer_selection_is_configuration(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path, snapshot_path: Path
+) -> None:
+    root = tmp_path / "ideas"
+    attest_ideas_root(root)
+    exit_code, response = _run_json(
+        capsys,
+        [
+            "ideas",
+            "cycle",
+            "--snapshot",
+            str(snapshot_path),
+            "--proposer",
+            "baseline",
+            *_root_args(root),
+        ],
+    )
+    assert exit_code == 0
+    (only_turn,) = response["data"]["proposers"]
+    assert only_turn["proposer_id"].startswith("baseline")
+
+
+def test_cycle_from_coinbase_requires_market_parameters(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    root = tmp_path / "ideas"
+    exit_code, response = _run_json(
+        capsys,
+        ["ideas", "cycle", "--from-coinbase", *_root_args(root)],
+    )
+    assert exit_code != 0
+    assert response["success"] is False
+    message = response["errors"][0]["message"]
+    assert "--symbols" in message and "--granularity" in message and "--lookback" in message

--- a/tests/unit/gpt_trader/features/idea_execution/conftest.py
+++ b/tests/unit/gpt_trader/features/idea_execution/conftest.py
@@ -1,0 +1,157 @@
+"""Shared fixtures and builders for the paper cycle test modules.
+
+test_cycle.py pins turn behavior (propose/execute/expiry legs);
+test_cycle_evidence.py pins the manifest, artifact, and locking contract.
+Both drive the runner through the same synthetic snapshots built here.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from gpt_trader.core import Candle
+from gpt_trader.features.brokerages.mock import DeterministicBroker
+from gpt_trader.features.idea_execution import PaperCycleRunner
+from gpt_trader.features.trade_ideas import (
+    DEFAULT_RISK_BUDGET,
+    ActorType,
+    AutonomyMode,
+    BaselineProposer,
+    Confidence,
+    ConfidenceLabel,
+    EntryZone,
+    MarketSnapshot,
+    MaxLoss,
+    ProductType,
+    SizingRecommendation,
+    SymbolSeries,
+    TimeHorizon,
+    TradeDirection,
+    TradeIdea,
+    TradeIdeaService,
+)
+
+CYCLE_NOW = datetime(2026, 7, 3, 12, 0, tzinfo=UTC)
+
+
+def crossover_series(symbol: str, *, as_of: datetime = CYCLE_NOW) -> SymbolSeries:
+    """Sixty hourly candles whose 10/50 MA golden cross lands in the last 3 bars."""
+    closes = [Decimal("100")] * 57 + [Decimal("120"), Decimal("125"), Decimal("130")]
+    volumes = [Decimal("10")] * 59 + [Decimal("100")]
+    start = as_of - timedelta(hours=len(closes))
+    candles = tuple(
+        Candle(
+            ts=start + timedelta(hours=index),
+            open=close,
+            high=close,
+            low=close,
+            close=close,
+            volume=volume,
+        )
+        for index, (close, volume) in enumerate(zip(closes, volumes, strict=True))
+    )
+    return SymbolSeries(symbol=symbol, granularity="ONE_HOUR", candles=candles)
+
+
+def flat_series(symbol: str) -> SymbolSeries:
+    """Sixty flat candles: never triggers the baseline proposer."""
+    start = CYCLE_NOW - timedelta(hours=60)
+    candles = tuple(
+        Candle(
+            ts=start + timedelta(hours=index),
+            open=Decimal("100"),
+            high=Decimal("100"),
+            low=Decimal("100"),
+            close=Decimal("100"),
+            volume=Decimal("10"),
+        )
+        for index in range(60)
+    )
+    return SymbolSeries(symbol=symbol, granularity="ONE_HOUR", candles=candles)
+
+
+def snapshot(*series: SymbolSeries, as_of: datetime = CYCLE_NOW) -> MarketSnapshot:
+    return MarketSnapshot(as_of=as_of, source="test:fixture", series=tuple(series))
+
+
+def snapshot_provider(market_snapshot: MarketSnapshot):
+    return lambda: (market_snapshot, "test:fixture:reference")
+
+
+def build_cycle_idea(decision_id: str, *, instrument: str = "BTC-USD") -> TradeIdea:
+    return TradeIdea(
+        decision_id=decision_id,
+        autonomy_mode=AutonomyMode.HUMAN_APPROVED_EXECUTION,
+        thesis="Cycle test: eligible fixture record",
+        instrument=instrument,
+        product_type=ProductType.SPOT,
+        direction=TradeDirection.LONG,
+        entry_zone=EntryZone(lower=Decimal("60000"), upper=Decimal("61500")),
+        invalidation="Daily close below 58000",
+        target_exit="Take profit at 67000",
+        max_loss=MaxLoss(
+            amount=Decimal("250"),
+            percent_of_account=Decimal("1.5"),
+            assumptions=("Fill at zone midpoint",),
+        ),
+        sizing_recommendation=SizingRecommendation(
+            quantity=Decimal("0.1"),
+            notional=Decimal("6075"),
+            rationale="Fixture sizing",
+        ),
+        time_horizon=TimeHorizon(
+            expected_hold="3-10 days",
+            expires_at=CYCLE_NOW + timedelta(days=7),
+        ),
+        data_used=("test:fixture:no-market-data",),
+        confidence=Confidence(label=ConfidenceLabel.MEDIUM, rationale="fixture"),
+        failure_mode="Not applicable in tests",
+        do_not_trade_if=("fixture record",),
+    )
+
+
+@pytest.fixture
+def cycle_service(tmp_path: Path) -> TradeIdeaService:
+    trade_idea_service = TradeIdeaService(tmp_path / "ideas", now_factory=lambda: CYCLE_NOW)
+    trade_idea_service.update_budget(
+        replace(
+            DEFAULT_RISK_BUDGET,
+            version=2,
+            account_equity=Decimal("25000"),
+            reason="test: attest scratch equity",
+        ),
+        actor_type=ActorType.HUMAN,
+        actor_id="test-operator",
+    )
+    return trade_idea_service
+
+
+def make_cycle_runner(
+    service: TradeIdeaService,
+    tmp_path: Path,
+    *,
+    proposers: list | None = None,
+    execute_approved: bool = True,
+) -> PaperCycleRunner:
+    return PaperCycleRunner(
+        service,
+        cycle_root=tmp_path / "cycle",
+        proposers=proposers if proposers is not None else [BaselineProposer()],
+        broker=DeterministicBroker(),
+        execute_approved=execute_approved,
+        now_factory=lambda: CYCLE_NOW,
+    )
+
+
+def manifest_rows(tmp_path: Path) -> list[dict[str, Any]]:
+    manifest_path = tmp_path / "cycle" / "manifest.jsonl"
+    if not manifest_path.exists():
+        return []
+    return [json.loads(line) for line in manifest_path.read_text().splitlines() if line]

--- a/tests/unit/gpt_trader/features/idea_execution/test_cycle.py
+++ b/tests/unit/gpt_trader/features/idea_execution/test_cycle.py
@@ -215,6 +215,25 @@ class TestExecuteApprovedLeg:
         (executed,) = second.execution.executed
         assert executed["decision_id"] == decision_id
 
+    def test_approval_during_snapshot_fetch_waits_for_the_next_turn(
+        self, cycle_service: TradeIdeaService, tmp_path: Path
+    ) -> None:
+        # The snapshot fetch is the slowest part of a real --from-coinbase
+        # turn; an approval landing during it must also wait for the next
+        # turn, so candidates are captured before the provider is called.
+        decision_id = "trade-20260703-cycle-fetch-race"
+        cycle_service.propose(build_cycle_idea(decision_id), actor_id="test-proposer")
+
+        def approving_provider():
+            cycle_service.approve(
+                decision_id, actor_id="test-operator", reason="approval during fetch"
+            )
+            return snapshot(crossover_series("BTC-USD")), "test:fixture:slow-fetch"
+
+        result = make_cycle_runner(cycle_service, tmp_path, proposers=[]).run(approving_provider)
+        assert result.execution.executed == ()
+        assert cycle_service.get(decision_id).state is TradeIdeaState.APPROVED
+
     def test_cancelled_during_turn_is_recorded_not_executed(
         self, cycle_service: TradeIdeaService, tmp_path: Path
     ) -> None:

--- a/tests/unit/gpt_trader/features/idea_execution/test_cycle.py
+++ b/tests/unit/gpt_trader/features/idea_execution/test_cycle.py
@@ -76,6 +76,33 @@ class TestProposeLeg:
         assert skip["instrument"] == "BTC-USD"
         assert skip["existing_decision_id"] == first.proposer_turns[0].proposed_decision_ids[0]
 
+    def test_open_instrument_match_is_case_insensitive(
+        self, cycle_service: TradeIdeaService, tmp_path: Path
+    ) -> None:
+        existing_decision_id = "trade-20260703-cycle-lower-open"
+        cycle_service.propose(
+            build_cycle_idea(existing_decision_id, instrument="btc-usd"),
+            actor_id="test-proposer",
+        )
+
+        class UppercaseProposer:
+            proposer_id = "test-uppercase-proposer"
+
+            def propose(self, market_snapshot: MarketSnapshot) -> list:
+                return [build_cycle_idea("trade-20260703-cycle-upper-candidate")]
+
+        result = make_cycle_runner(
+            cycle_service,
+            tmp_path,
+            proposers=[UppercaseProposer()],
+        ).run(snapshot_provider(snapshot(flat_series("BTC-USD"))))
+
+        (proposer_turn,) = result.proposer_turns
+        assert proposer_turn.proposal_count == 0
+        (skip,) = proposer_turn.skipped_open_instruments
+        assert skip["instrument"] == "BTC-USD"
+        assert skip["existing_decision_id"] == existing_decision_id
+
     def test_rerun_over_resolved_idea_skips_duplicate_id_idempotently(
         self, cycle_service: TradeIdeaService, tmp_path: Path
     ) -> None:
@@ -158,6 +185,26 @@ class TestExecuteApprovedLeg:
         assert executed["decision_id"] == decision_id
         assert executed["client_order_id"] == decision_id
         # Priced from the turn's snapshot: the fixture's last close is 130.
+        assert executed["fill_price"] == "130"
+        assert cycle_service.get(decision_id).state is TradeIdeaState.FILLED
+
+    def test_executes_approved_idea_when_snapshot_symbol_case_differs(
+        self, cycle_service: TradeIdeaService, tmp_path: Path
+    ) -> None:
+        decision_id = "trade-20260703-cycle-lower-approved"
+        cycle_service.propose(
+            build_cycle_idea(decision_id, instrument="btc-usd"),
+            actor_id="test-proposer",
+        )
+        cycle_service.approve(decision_id, actor_id="test-operator", reason="test approval")
+
+        result = make_cycle_runner(cycle_service, tmp_path, proposers=[]).run(
+            snapshot_provider(snapshot(crossover_series("BTC-USD")))
+        )
+
+        (executed,) = result.execution.executed
+        assert executed["decision_id"] == decision_id
+        assert executed["symbol"] == "btc-usd"
         assert executed["fill_price"] == "130"
         assert cycle_service.get(decision_id).state is TradeIdeaState.FILLED
 

--- a/tests/unit/gpt_trader/features/idea_execution/test_cycle.py
+++ b/tests/unit/gpt_trader/features/idea_execution/test_cycle.py
@@ -24,7 +24,10 @@ from tests.unit.gpt_trader.features.idea_execution.conftest import (
     snapshot_provider,
 )
 
+from gpt_trader.features.brokerages.mock import DeterministicBroker
+from gpt_trader.features.idea_execution import PaperCycleRunner
 from gpt_trader.features.trade_ideas import (
+    DEFAULT_RISK_BUDGET,
     ActorType,
     MarketSnapshot,
     TimeHorizon,
@@ -72,6 +75,25 @@ class TestProposeLeg:
         (skip,) = proposer_turn.skipped_open_instruments
         assert skip["instrument"] == "BTC-USD"
         assert skip["existing_decision_id"] == first.proposer_turns[0].proposed_decision_ids[0]
+
+    def test_rerun_over_resolved_idea_skips_duplicate_id_idempotently(
+        self, cycle_service: TradeIdeaService, tmp_path: Path
+    ) -> None:
+        # The deterministic proposer emits the same decision_id for the same
+        # snapshot; a rerun after the prior idea resolved (cancelled here)
+        # must skip instead of failing the turn on a duplicate id.
+        runner = make_cycle_runner(cycle_service, tmp_path)
+        provider = snapshot_provider(snapshot(crossover_series("BTC-USD")))
+        first = runner.run(provider)
+        (decision_id,) = first.proposer_turns[0].proposed_decision_ids
+        cycle_service.reject(decision_id, actor_id="test-operator", reason="not this one")
+
+        second = runner.run(provider)
+        (proposer_turn,) = second.proposer_turns
+        assert proposer_turn.proposal_count == 0
+        (skip,) = proposer_turn.skipped_open_instruments
+        assert skip["reason"] == "decision id already recorded (idempotent rerun)"
+        assert skip["existing_decision_id"] == decision_id
 
     def test_filled_idea_awaiting_closeout_blocks_reproposal(
         self, cycle_service: TradeIdeaService, tmp_path: Path
@@ -257,6 +279,48 @@ class TestExecuteApprovedLeg:
         (skip,) = result.execution.skipped
         assert skip["decision_id"] == decision_id
         assert "state changed to cancelled" in skip["reason"]
+
+    def test_executor_uses_the_turn_clock_not_the_wall_clock(self, tmp_path: Path) -> None:
+        # A historical/offline turn runs entirely on the injected clock: an
+        # idea live at the turn's own time must execute even when its expiry
+        # is in the wall-clock past.
+        turn_time = CYCLE_NOW - timedelta(days=400)
+        historical_service = TradeIdeaService(tmp_path / "ideas", now_factory=lambda: turn_time)
+        historical_service.update_budget(
+            replace(
+                DEFAULT_RISK_BUDGET,
+                version=2,
+                account_equity=Decimal("25000"),
+                reason="test: attest scratch equity",
+            ),
+            actor_type=ActorType.HUMAN,
+            actor_id="test-operator",
+        )
+        decision_id = "trade-20250529-cycle-clock"
+        idea = replace(
+            build_cycle_idea(decision_id),
+            time_horizon=TimeHorizon(
+                expected_hold="3-10 days",
+                expires_at=turn_time + timedelta(days=7),
+            ),
+        )
+        historical_service.propose(idea, actor_id="test-proposer")
+        historical_service.approve(decision_id, actor_id="test-operator", reason="test approval")
+
+        runner = PaperCycleRunner(
+            historical_service,
+            cycle_root=tmp_path / "cycle",
+            proposers=[],
+            broker=DeterministicBroker(),
+            now_factory=lambda: turn_time,
+        )
+        result = runner.run(
+            snapshot_provider(
+                snapshot(crossover_series("BTC-USD", as_of=turn_time), as_of=turn_time)
+            )
+        )
+        (executed,) = result.execution.executed
+        assert executed["decision_id"] == decision_id
 
 
 class TestExpirySweep:

--- a/tests/unit/gpt_trader/features/idea_execution/test_cycle.py
+++ b/tests/unit/gpt_trader/features/idea_execution/test_cycle.py
@@ -1,220 +1,135 @@
-"""Turn-contract tests for the Stage-1 paper cycle runner (issue #1150).
+"""Turn-behavior tests for the Stage-1 paper cycle runner (issue #1150).
 
-These pin the evidence and safety contract of one unattended turn: exactly one
-manifest row per turn (including failed turns), lock-protected concurrency, the
-open-instrument dedup filter, snapshot-priced execution of human-approved ideas
-only, and the absence of any cadence knowledge in the runner.
+These pin the propose, execute-approved, and expiry legs of one unattended
+turn: the open-instrument and awaiting-closeout dedup filters, snapshot-priced
+execution of pre-turn-approved ideas only, and the human-approval seam between
+turns. The manifest/artifact/locking contract is pinned in
+test_cycle_evidence.py; shared builders live in conftest.py.
 """
 
 from __future__ import annotations
 
-import json
 from dataclasses import replace
-from datetime import UTC, datetime, timedelta
+from datetime import timedelta
 from decimal import Decimal
 from pathlib import Path
 
-import pytest
-from filelock import FileLock
-
-from gpt_trader.core import Candle
-from gpt_trader.features.brokerages.mock import DeterministicBroker
-from gpt_trader.features.idea_execution import (
-    PaperCycleLockError,
-    PaperCycleRunner,
+from tests.unit.gpt_trader.features.idea_execution.conftest import (
+    CYCLE_NOW,
+    build_cycle_idea,
+    crossover_series,
+    flat_series,
+    make_cycle_runner,
+    snapshot,
+    snapshot_provider,
 )
+
 from gpt_trader.features.trade_ideas import (
-    DEFAULT_RISK_BUDGET,
     ActorType,
-    AuditAction,
-    AutonomyMode,
-    BaselineProposer,
-    Confidence,
-    ConfidenceLabel,
-    EntryZone,
     MarketSnapshot,
-    MaxLoss,
-    ProductType,
-    SizingRecommendation,
-    SymbolSeries,
     TimeHorizon,
-    TradeDirection,
-    TradeIdea,
     TradeIdeaService,
     TradeIdeaState,
 )
 
-_NOW = datetime(2026, 7, 3, 12, 0, tzinfo=UTC)
-
-
-def _crossover_series(symbol: str) -> SymbolSeries:
-    """Sixty hourly candles whose 10/50 MA golden cross lands in the last 3 bars."""
-    closes = [Decimal("100")] * 57 + [Decimal("120"), Decimal("125"), Decimal("130")]
-    volumes = [Decimal("10")] * 59 + [Decimal("100")]
-    start = _NOW - timedelta(hours=len(closes))
-    candles = tuple(
-        Candle(
-            ts=start + timedelta(hours=index),
-            open=close,
-            high=close,
-            low=close,
-            close=close,
-            volume=volume,
-        )
-        for index, (close, volume) in enumerate(zip(closes, volumes, strict=True))
-    )
-    return SymbolSeries(symbol=symbol, granularity="ONE_HOUR", candles=candles)
-
-
-def _flat_series(symbol: str) -> SymbolSeries:
-    """Sixty flat candles: never triggers the baseline proposer."""
-    start = _NOW - timedelta(hours=60)
-    candles = tuple(
-        Candle(
-            ts=start + timedelta(hours=index),
-            open=Decimal("100"),
-            high=Decimal("100"),
-            low=Decimal("100"),
-            close=Decimal("100"),
-            volume=Decimal("10"),
-        )
-        for index in range(60)
-    )
-    return SymbolSeries(symbol=symbol, granularity="ONE_HOUR", candles=candles)
-
-
-def _snapshot(*series: SymbolSeries) -> MarketSnapshot:
-    return MarketSnapshot(as_of=_NOW, source="test:fixture", series=tuple(series))
-
-
-def _snapshot_provider(snapshot: MarketSnapshot):
-    return lambda: (snapshot, "test:fixture:reference")
-
-
-def _build_idea(decision_id: str, *, instrument: str = "BTC-USD") -> TradeIdea:
-    return TradeIdea(
-        decision_id=decision_id,
-        autonomy_mode=AutonomyMode.HUMAN_APPROVED_EXECUTION,
-        thesis="Cycle test: eligible fixture record",
-        instrument=instrument,
-        product_type=ProductType.SPOT,
-        direction=TradeDirection.LONG,
-        entry_zone=EntryZone(lower=Decimal("60000"), upper=Decimal("61500")),
-        invalidation="Daily close below 58000",
-        target_exit="Take profit at 67000",
-        max_loss=MaxLoss(
-            amount=Decimal("250"),
-            percent_of_account=Decimal("1.5"),
-            assumptions=("Fill at zone midpoint",),
-        ),
-        sizing_recommendation=SizingRecommendation(
-            quantity=Decimal("0.1"),
-            notional=Decimal("6075"),
-            rationale="Fixture sizing",
-        ),
-        time_horizon=TimeHorizon(
-            expected_hold="3-10 days",
-            expires_at=_NOW + timedelta(days=7),
-        ),
-        data_used=("test:fixture:no-market-data",),
-        confidence=Confidence(label=ConfidenceLabel.MEDIUM, rationale="fixture"),
-        failure_mode="Not applicable in tests",
-        do_not_trade_if=("fixture record",),
-    )
-
-
-@pytest.fixture
-def service(tmp_path: Path) -> TradeIdeaService:
-    trade_idea_service = TradeIdeaService(tmp_path / "ideas", now_factory=lambda: _NOW)
-    trade_idea_service.update_budget(
-        replace(
-            DEFAULT_RISK_BUDGET,
-            version=2,
-            account_equity=Decimal("25000"),
-            reason="test: attest scratch equity",
-        ),
-        actor_type=ActorType.HUMAN,
-        actor_id="test-operator",
-    )
-    return trade_idea_service
-
-
-def _runner(
-    service: TradeIdeaService,
-    tmp_path: Path,
-    *,
-    proposers: list | None = None,
-    execute_approved: bool = True,
-) -> PaperCycleRunner:
-    return PaperCycleRunner(
-        service,
-        cycle_root=tmp_path / "cycle",
-        proposers=proposers if proposers is not None else [BaselineProposer()],
-        broker=DeterministicBroker(),
-        execute_approved=execute_approved,
-        now_factory=lambda: _NOW,
-    )
-
-
-def _manifest_rows(tmp_path: Path) -> list[dict]:
-    manifest_path = tmp_path / "cycle" / "manifest.jsonl"
-    if not manifest_path.exists():
-        return []
-    return [json.loads(line) for line in manifest_path.read_text().splitlines() if line]
-
 
 class TestProposeLeg:
     def test_crossover_snapshot_proposes_idea(
-        self, service: TradeIdeaService, tmp_path: Path
+        self, cycle_service: TradeIdeaService, tmp_path: Path
     ) -> None:
-        result = _runner(service, tmp_path).run(
-            _snapshot_provider(_snapshot(_crossover_series("BTC-USD")))
+        result = make_cycle_runner(cycle_service, tmp_path).run(
+            snapshot_provider(snapshot(crossover_series("BTC-USD")))
         )
 
         (proposer_turn,) = result.proposer_turns
         assert proposer_turn.proposal_count == 1
         (decision_id,) = proposer_turn.proposed_decision_ids
-        view = service.get(decision_id)
+        view = cycle_service.get(decision_id)
         assert view.state is TradeIdeaState.PROPOSED
         assert view.events[0].actor_type is ActorType.AI
         assert view.events[0].actor_id == proposer_turn.proposer_id
 
-    def test_flat_snapshot_is_honest_noop(self, service: TradeIdeaService, tmp_path: Path) -> None:
-        result = _runner(service, tmp_path).run(
-            _snapshot_provider(_snapshot(_flat_series("BTC-USD")))
+    def test_flat_snapshot_is_honest_noop(
+        self, cycle_service: TradeIdeaService, tmp_path: Path
+    ) -> None:
+        result = make_cycle_runner(cycle_service, tmp_path).run(
+            snapshot_provider(snapshot(flat_series("BTC-USD")))
         )
         (proposer_turn,) = result.proposer_turns
         assert proposer_turn.proposal_count == 0
-        rows = _manifest_rows(tmp_path)
-        assert len(rows) == 1
-        assert rows[0]["outcome"] == "completed"
 
     def test_open_instrument_is_not_reproposed(
-        self, service: TradeIdeaService, tmp_path: Path
+        self, cycle_service: TradeIdeaService, tmp_path: Path
     ) -> None:
-        runner = _runner(service, tmp_path)
-        snapshot_provider = _snapshot_provider(_snapshot(_crossover_series("BTC-USD")))
-        first = runner.run(snapshot_provider)
+        runner = make_cycle_runner(cycle_service, tmp_path)
+        provider = snapshot_provider(snapshot(crossover_series("BTC-USD")))
+        first = runner.run(provider)
         assert first.proposer_turns[0].proposal_count == 1
 
-        second = runner.run(snapshot_provider)
+        second = runner.run(provider)
         (proposer_turn,) = second.proposer_turns
         assert proposer_turn.proposal_count == 0
         (skip,) = proposer_turn.skipped_open_instruments
         assert skip["instrument"] == "BTC-USD"
         assert skip["existing_decision_id"] == first.proposer_turns[0].proposed_decision_ids[0]
 
+    def test_filled_idea_awaiting_closeout_blocks_reproposal(
+        self, cycle_service: TradeIdeaService, tmp_path: Path
+    ) -> None:
+        # The same crossover stays signal-worthy for several bars; until the
+        # filled trade's outcome is attributed, the next turns must not
+        # pyramid a second position onto the unresolved one.
+        runner = make_cycle_runner(cycle_service, tmp_path)
+        first = runner.run(snapshot_provider(snapshot(crossover_series("BTC-USD"))))
+        (decision_id,) = first.proposer_turns[0].proposed_decision_ids
+        cycle_service.approve(decision_id, actor_id="test-operator", reason="test approval")
+
+        # Turn 2: the proposer leg still sees the APPROVED (open) idea; the
+        # execution leg then fills it.
+        later = CYCLE_NOW + timedelta(hours=1)
+        second = runner.run(
+            snapshot_provider(snapshot(crossover_series("BTC-USD", as_of=later), as_of=later))
+        )
+        assert second.execution.executed[0]["decision_id"] == decision_id
+
+        # Turn 3: the trade is FILLED but unattributed — still busy.
+        third_time = CYCLE_NOW + timedelta(hours=2)
+        third = runner.run(
+            snapshot_provider(
+                snapshot(crossover_series("BTC-USD", as_of=third_time), as_of=third_time)
+            )
+        )
+        (skip,) = third.proposer_turns[0].skipped_open_instruments
+        assert skip["reason"] == "instrument has a filled idea awaiting closeout"
+        assert skip["existing_decision_id"] == decision_id
+
+        cycle_service.record_closeout_attribution(
+            decision_id,
+            actor_id="test-operator",
+            resolution="thesis_target",
+            realized_profit_loss_amount=Decimal("10"),
+            realized_profit_loss_percent=Decimal("0.04"),
+            evidence=("test closeout",),
+        )
+        fourth_time = CYCLE_NOW + timedelta(hours=3)
+        fourth = runner.run(
+            snapshot_provider(
+                snapshot(crossover_series("BTC-USD", as_of=fourth_time), as_of=fourth_time)
+            )
+        )
+        assert fourth.proposer_turns[0].proposal_count == 1
+
 
 class TestExecuteApprovedLeg:
     def test_executes_approved_idea_at_snapshot_mark(
-        self, service: TradeIdeaService, tmp_path: Path
+        self, cycle_service: TradeIdeaService, tmp_path: Path
     ) -> None:
         decision_id = "trade-20260703-cycle-001"
-        service.propose(_build_idea(decision_id), actor_id="test-proposer")
-        service.approve(decision_id, actor_id="test-operator", reason="test approval")
+        cycle_service.propose(build_cycle_idea(decision_id), actor_id="test-proposer")
+        cycle_service.approve(decision_id, actor_id="test-operator", reason="test approval")
 
-        result = _runner(service, tmp_path, proposers=[]).run(
-            _snapshot_provider(_snapshot(_crossover_series("BTC-USD")))
+        result = make_cycle_runner(cycle_service, tmp_path, proposers=[]).run(
+            snapshot_provider(snapshot(crossover_series("BTC-USD")))
         )
 
         (executed,) = result.execution.executed
@@ -222,138 +137,126 @@ class TestExecuteApprovedLeg:
         assert executed["client_order_id"] == decision_id
         # Priced from the turn's snapshot: the fixture's last close is 130.
         assert executed["fill_price"] == "130"
-        assert service.get(decision_id).state is TradeIdeaState.FILLED
+        assert cycle_service.get(decision_id).state is TradeIdeaState.FILLED
 
     def test_skips_approved_idea_without_fresh_mark(
-        self, service: TradeIdeaService, tmp_path: Path
+        self, cycle_service: TradeIdeaService, tmp_path: Path
     ) -> None:
         decision_id = "trade-20260703-cycle-002"
-        service.propose(_build_idea(decision_id, instrument="ETH-USD"), actor_id="test-proposer")
-        service.approve(decision_id, actor_id="test-operator", reason="test approval")
+        cycle_service.propose(
+            build_cycle_idea(decision_id, instrument="ETH-USD"), actor_id="test-proposer"
+        )
+        cycle_service.approve(decision_id, actor_id="test-operator", reason="test approval")
 
-        result = _runner(service, tmp_path, proposers=[]).run(
-            _snapshot_provider(_snapshot(_crossover_series("BTC-USD")))
+        result = make_cycle_runner(cycle_service, tmp_path, proposers=[]).run(
+            snapshot_provider(snapshot(crossover_series("BTC-USD")))
         )
 
         assert result.execution.executed == ()
         (skip,) = result.execution.skipped
         assert skip["decision_id"] == decision_id
         assert "no fresh mark" in skip["reason"]
-        assert service.get(decision_id).state is TradeIdeaState.APPROVED
+        assert cycle_service.get(decision_id).state is TradeIdeaState.APPROVED
 
-    def test_execution_leg_can_be_disabled(self, service: TradeIdeaService, tmp_path: Path) -> None:
+    def test_execution_leg_can_be_disabled(
+        self, cycle_service: TradeIdeaService, tmp_path: Path
+    ) -> None:
         decision_id = "trade-20260703-cycle-003"
-        service.propose(_build_idea(decision_id), actor_id="test-proposer")
-        service.approve(decision_id, actor_id="test-operator", reason="test approval")
+        cycle_service.propose(build_cycle_idea(decision_id), actor_id="test-proposer")
+        cycle_service.approve(decision_id, actor_id="test-operator", reason="test approval")
 
-        result = _runner(service, tmp_path, proposers=[], execute_approved=False).run(
-            _snapshot_provider(_snapshot(_crossover_series("BTC-USD")))
-        )
+        result = make_cycle_runner(
+            cycle_service, tmp_path, proposers=[], execute_approved=False
+        ).run(snapshot_provider(snapshot(crossover_series("BTC-USD"))))
 
         assert result.execution.enabled is False
-        assert service.get(decision_id).state is TradeIdeaState.APPROVED
+        assert cycle_service.get(decision_id).state is TradeIdeaState.APPROVED
 
     def test_proposed_ideas_are_never_executed_in_same_turn(
-        self, service: TradeIdeaService, tmp_path: Path
+        self, cycle_service: TradeIdeaService, tmp_path: Path
     ) -> None:
         # The turn proposes AND has the execution leg enabled; the freshly
         # proposed idea must stay PROPOSED because approval is a human event.
-        result = _runner(service, tmp_path).run(
-            _snapshot_provider(_snapshot(_crossover_series("BTC-USD")))
+        result = make_cycle_runner(cycle_service, tmp_path).run(
+            snapshot_provider(snapshot(crossover_series("BTC-USD")))
         )
         (decision_id,) = result.proposer_turns[0].proposed_decision_ids
         assert result.execution.executed == ()
-        assert service.get(decision_id).state is TradeIdeaState.PROPOSED
+        assert cycle_service.get(decision_id).state is TradeIdeaState.PROPOSED
+
+    def test_mid_turn_approval_waits_for_the_next_turn(
+        self, cycle_service: TradeIdeaService, tmp_path: Path
+    ) -> None:
+        # The approval CLI does not take the cycle lock, so an approval that
+        # lands while the turn is running must not execute until the next
+        # turn: the seam is approval BETWEEN turns.
+        decision_id = "trade-20260703-cycle-race"
+        cycle_service.propose(build_cycle_idea(decision_id), actor_id="test-proposer")
+
+        class ApprovesMidTurn:
+            """Stands in for a slow proposer during which a human approves."""
+
+            proposer_id = "test-mid-turn-approver"
+
+            def propose(self, market_snapshot: MarketSnapshot) -> list:
+                cycle_service.approve(
+                    decision_id, actor_id="test-operator", reason="mid-turn approval"
+                )
+                return []
+
+        runner = make_cycle_runner(cycle_service, tmp_path, proposers=[ApprovesMidTurn()])
+        provider = snapshot_provider(snapshot(crossover_series("BTC-USD")))
+
+        first = runner.run(provider)
+        assert first.execution.executed == ()
+        assert cycle_service.get(decision_id).state is TradeIdeaState.APPROVED
+
+        second = make_cycle_runner(cycle_service, tmp_path, proposers=[]).run(provider)
+        (executed,) = second.execution.executed
+        assert executed["decision_id"] == decision_id
+
+    def test_cancelled_during_turn_is_recorded_not_executed(
+        self, cycle_service: TradeIdeaService, tmp_path: Path
+    ) -> None:
+        decision_id = "trade-20260703-cycle-cancel"
+        cycle_service.propose(build_cycle_idea(decision_id), actor_id="test-proposer")
+        cycle_service.approve(decision_id, actor_id="test-operator", reason="test approval")
+
+        class CancelsMidTurn:
+            proposer_id = "test-mid-turn-canceller"
+
+            def propose(self, market_snapshot: MarketSnapshot) -> list:
+                cycle_service.cancel(
+                    decision_id, actor_id="test-operator", reason="changed my mind"
+                )
+                return []
+
+        result = make_cycle_runner(cycle_service, tmp_path, proposers=[CancelsMidTurn()]).run(
+            snapshot_provider(snapshot(crossover_series("BTC-USD")))
+        )
+        assert result.execution.executed == ()
+        (skip,) = result.execution.skipped
+        assert skip["decision_id"] == decision_id
+        assert "state changed to cancelled" in skip["reason"]
 
 
 class TestExpirySweep:
     def test_stale_idea_is_swept_before_proposing(
-        self, service: TradeIdeaService, tmp_path: Path
+        self, cycle_service: TradeIdeaService, tmp_path: Path
     ) -> None:
         decision_id = "trade-20260703-cycle-004"
         stale = replace(
-            _build_idea(decision_id),
+            build_cycle_idea(decision_id),
             time_horizon=TimeHorizon(
                 expected_hold="3-10 days",
-                expires_at=_NOW - timedelta(hours=1),
+                expires_at=CYCLE_NOW - timedelta(hours=1),
             ),
         )
-        service.propose(stale, actor_id="test-proposer")
+        cycle_service.propose(stale, actor_id="test-proposer")
 
-        result = _runner(service, tmp_path, proposers=[]).run(
-            _snapshot_provider(_snapshot(_flat_series("BTC-USD")))
+        result = make_cycle_runner(cycle_service, tmp_path, proposers=[]).run(
+            snapshot_provider(snapshot(flat_series("BTC-USD")))
         )
 
         assert result.expired_decision_ids == (decision_id,)
-        assert service.get(decision_id).state is TradeIdeaState.EXPIRED
-
-
-class TestEvidenceContract:
-    def test_every_turn_appends_exactly_one_manifest_row(
-        self, service: TradeIdeaService, tmp_path: Path
-    ) -> None:
-        runner = _runner(service, tmp_path, proposers=[])
-        snapshot_provider = _snapshot_provider(_snapshot(_flat_series("BTC-USD")))
-        runner.run(snapshot_provider)
-        runner.run(snapshot_provider)
-        rows = _manifest_rows(tmp_path)
-        assert len(rows) == 2
-        assert len({row["run_id"] for row in rows}) == 2
-        assert all(row["outcome"] == "completed" for row in rows)
-
-    def test_failed_turn_appends_honest_failure_row(
-        self, service: TradeIdeaService, tmp_path: Path
-    ) -> None:
-        def broken_provider():
-            raise ConnectionError("market data unreachable")
-
-        with pytest.raises(ConnectionError, match="market data unreachable"):
-            _runner(service, tmp_path, proposers=[]).run(broken_provider)
-
-        (row,) = _manifest_rows(tmp_path)
-        assert row["outcome"] == "failed"
-        assert "market data unreachable" in row["error"]
-        assert row["finished_at"]
-
-    def test_snapshot_artifact_is_persisted_with_hash(
-        self, service: TradeIdeaService, tmp_path: Path
-    ) -> None:
-        result = _runner(service, tmp_path, proposers=[]).run(
-            _snapshot_provider(_snapshot(_flat_series("BTC-USD")))
-        )
-        snapshot_path = Path(result.snapshot["path"])
-        assert snapshot_path.exists()
-        assert result.snapshot["sha256"]
-        assert result.snapshot["symbols"] == ["BTC-USD"]
-        report_path = snapshot_path.parent / "report.json"
-        assert report_path.exists()
-
-    def test_audit_chain_stays_intact_across_turns(
-        self, service: TradeIdeaService, tmp_path: Path
-    ) -> None:
-        decision_id = "trade-20260703-cycle-005"
-        service.propose(_build_idea(decision_id), actor_id="test-proposer")
-        service.approve(decision_id, actor_id="test-operator", reason="test approval")
-        _runner(service, tmp_path).run(_snapshot_provider(_snapshot(_crossover_series("BTC-USD"))))
-        events = service.audit_log.verify()
-        filled = [event for event in events if event.action is AuditAction.FILLED]
-        assert len(filled) == 1
-        assert filled[0].actor_id == "paper-cycle"
-
-
-class TestLocking:
-    def test_concurrent_turn_is_refused_without_manifest_row(
-        self, service: TradeIdeaService, tmp_path: Path
-    ) -> None:
-        cycle_root = tmp_path / "cycle"
-        cycle_root.mkdir(parents=True)
-        held = FileLock(str(cycle_root / "cycle.lock"))
-        held.acquire()
-        try:
-            with pytest.raises(PaperCycleLockError, match="already running"):
-                _runner(service, tmp_path, proposers=[]).run(
-                    _snapshot_provider(_snapshot(_flat_series("BTC-USD")))
-                )
-        finally:
-            held.release()
-        assert _manifest_rows(tmp_path) == []
+        assert cycle_service.get(decision_id).state is TradeIdeaState.EXPIRED

--- a/tests/unit/gpt_trader/features/idea_execution/test_cycle.py
+++ b/tests/unit/gpt_trader/features/idea_execution/test_cycle.py
@@ -1,0 +1,359 @@
+"""Turn-contract tests for the Stage-1 paper cycle runner (issue #1150).
+
+These pin the evidence and safety contract of one unattended turn: exactly one
+manifest row per turn (including failed turns), lock-protected concurrency, the
+open-instrument dedup filter, snapshot-priced execution of human-approved ideas
+only, and the absence of any cadence knowledge in the runner.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+from filelock import FileLock
+
+from gpt_trader.core import Candle
+from gpt_trader.features.brokerages.mock import DeterministicBroker
+from gpt_trader.features.idea_execution import (
+    PaperCycleLockError,
+    PaperCycleRunner,
+)
+from gpt_trader.features.trade_ideas import (
+    DEFAULT_RISK_BUDGET,
+    ActorType,
+    AuditAction,
+    AutonomyMode,
+    BaselineProposer,
+    Confidence,
+    ConfidenceLabel,
+    EntryZone,
+    MarketSnapshot,
+    MaxLoss,
+    ProductType,
+    SizingRecommendation,
+    SymbolSeries,
+    TimeHorizon,
+    TradeDirection,
+    TradeIdea,
+    TradeIdeaService,
+    TradeIdeaState,
+)
+
+_NOW = datetime(2026, 7, 3, 12, 0, tzinfo=UTC)
+
+
+def _crossover_series(symbol: str) -> SymbolSeries:
+    """Sixty hourly candles whose 10/50 MA golden cross lands in the last 3 bars."""
+    closes = [Decimal("100")] * 57 + [Decimal("120"), Decimal("125"), Decimal("130")]
+    volumes = [Decimal("10")] * 59 + [Decimal("100")]
+    start = _NOW - timedelta(hours=len(closes))
+    candles = tuple(
+        Candle(
+            ts=start + timedelta(hours=index),
+            open=close,
+            high=close,
+            low=close,
+            close=close,
+            volume=volume,
+        )
+        for index, (close, volume) in enumerate(zip(closes, volumes, strict=True))
+    )
+    return SymbolSeries(symbol=symbol, granularity="ONE_HOUR", candles=candles)
+
+
+def _flat_series(symbol: str) -> SymbolSeries:
+    """Sixty flat candles: never triggers the baseline proposer."""
+    start = _NOW - timedelta(hours=60)
+    candles = tuple(
+        Candle(
+            ts=start + timedelta(hours=index),
+            open=Decimal("100"),
+            high=Decimal("100"),
+            low=Decimal("100"),
+            close=Decimal("100"),
+            volume=Decimal("10"),
+        )
+        for index in range(60)
+    )
+    return SymbolSeries(symbol=symbol, granularity="ONE_HOUR", candles=candles)
+
+
+def _snapshot(*series: SymbolSeries) -> MarketSnapshot:
+    return MarketSnapshot(as_of=_NOW, source="test:fixture", series=tuple(series))
+
+
+def _snapshot_provider(snapshot: MarketSnapshot):
+    return lambda: (snapshot, "test:fixture:reference")
+
+
+def _build_idea(decision_id: str, *, instrument: str = "BTC-USD") -> TradeIdea:
+    return TradeIdea(
+        decision_id=decision_id,
+        autonomy_mode=AutonomyMode.HUMAN_APPROVED_EXECUTION,
+        thesis="Cycle test: eligible fixture record",
+        instrument=instrument,
+        product_type=ProductType.SPOT,
+        direction=TradeDirection.LONG,
+        entry_zone=EntryZone(lower=Decimal("60000"), upper=Decimal("61500")),
+        invalidation="Daily close below 58000",
+        target_exit="Take profit at 67000",
+        max_loss=MaxLoss(
+            amount=Decimal("250"),
+            percent_of_account=Decimal("1.5"),
+            assumptions=("Fill at zone midpoint",),
+        ),
+        sizing_recommendation=SizingRecommendation(
+            quantity=Decimal("0.1"),
+            notional=Decimal("6075"),
+            rationale="Fixture sizing",
+        ),
+        time_horizon=TimeHorizon(
+            expected_hold="3-10 days",
+            expires_at=_NOW + timedelta(days=7),
+        ),
+        data_used=("test:fixture:no-market-data",),
+        confidence=Confidence(label=ConfidenceLabel.MEDIUM, rationale="fixture"),
+        failure_mode="Not applicable in tests",
+        do_not_trade_if=("fixture record",),
+    )
+
+
+@pytest.fixture
+def service(tmp_path: Path) -> TradeIdeaService:
+    trade_idea_service = TradeIdeaService(tmp_path / "ideas", now_factory=lambda: _NOW)
+    trade_idea_service.update_budget(
+        replace(
+            DEFAULT_RISK_BUDGET,
+            version=2,
+            account_equity=Decimal("25000"),
+            reason="test: attest scratch equity",
+        ),
+        actor_type=ActorType.HUMAN,
+        actor_id="test-operator",
+    )
+    return trade_idea_service
+
+
+def _runner(
+    service: TradeIdeaService,
+    tmp_path: Path,
+    *,
+    proposers: list | None = None,
+    execute_approved: bool = True,
+) -> PaperCycleRunner:
+    return PaperCycleRunner(
+        service,
+        cycle_root=tmp_path / "cycle",
+        proposers=proposers if proposers is not None else [BaselineProposer()],
+        broker=DeterministicBroker(),
+        execute_approved=execute_approved,
+        now_factory=lambda: _NOW,
+    )
+
+
+def _manifest_rows(tmp_path: Path) -> list[dict]:
+    manifest_path = tmp_path / "cycle" / "manifest.jsonl"
+    if not manifest_path.exists():
+        return []
+    return [json.loads(line) for line in manifest_path.read_text().splitlines() if line]
+
+
+class TestProposeLeg:
+    def test_crossover_snapshot_proposes_idea(
+        self, service: TradeIdeaService, tmp_path: Path
+    ) -> None:
+        result = _runner(service, tmp_path).run(
+            _snapshot_provider(_snapshot(_crossover_series("BTC-USD")))
+        )
+
+        (proposer_turn,) = result.proposer_turns
+        assert proposer_turn.proposal_count == 1
+        (decision_id,) = proposer_turn.proposed_decision_ids
+        view = service.get(decision_id)
+        assert view.state is TradeIdeaState.PROPOSED
+        assert view.events[0].actor_type is ActorType.AI
+        assert view.events[0].actor_id == proposer_turn.proposer_id
+
+    def test_flat_snapshot_is_honest_noop(self, service: TradeIdeaService, tmp_path: Path) -> None:
+        result = _runner(service, tmp_path).run(
+            _snapshot_provider(_snapshot(_flat_series("BTC-USD")))
+        )
+        (proposer_turn,) = result.proposer_turns
+        assert proposer_turn.proposal_count == 0
+        rows = _manifest_rows(tmp_path)
+        assert len(rows) == 1
+        assert rows[0]["outcome"] == "completed"
+
+    def test_open_instrument_is_not_reproposed(
+        self, service: TradeIdeaService, tmp_path: Path
+    ) -> None:
+        runner = _runner(service, tmp_path)
+        snapshot_provider = _snapshot_provider(_snapshot(_crossover_series("BTC-USD")))
+        first = runner.run(snapshot_provider)
+        assert first.proposer_turns[0].proposal_count == 1
+
+        second = runner.run(snapshot_provider)
+        (proposer_turn,) = second.proposer_turns
+        assert proposer_turn.proposal_count == 0
+        (skip,) = proposer_turn.skipped_open_instruments
+        assert skip["instrument"] == "BTC-USD"
+        assert skip["existing_decision_id"] == first.proposer_turns[0].proposed_decision_ids[0]
+
+
+class TestExecuteApprovedLeg:
+    def test_executes_approved_idea_at_snapshot_mark(
+        self, service: TradeIdeaService, tmp_path: Path
+    ) -> None:
+        decision_id = "trade-20260703-cycle-001"
+        service.propose(_build_idea(decision_id), actor_id="test-proposer")
+        service.approve(decision_id, actor_id="test-operator", reason="test approval")
+
+        result = _runner(service, tmp_path, proposers=[]).run(
+            _snapshot_provider(_snapshot(_crossover_series("BTC-USD")))
+        )
+
+        (executed,) = result.execution.executed
+        assert executed["decision_id"] == decision_id
+        assert executed["client_order_id"] == decision_id
+        # Priced from the turn's snapshot: the fixture's last close is 130.
+        assert executed["fill_price"] == "130"
+        assert service.get(decision_id).state is TradeIdeaState.FILLED
+
+    def test_skips_approved_idea_without_fresh_mark(
+        self, service: TradeIdeaService, tmp_path: Path
+    ) -> None:
+        decision_id = "trade-20260703-cycle-002"
+        service.propose(_build_idea(decision_id, instrument="ETH-USD"), actor_id="test-proposer")
+        service.approve(decision_id, actor_id="test-operator", reason="test approval")
+
+        result = _runner(service, tmp_path, proposers=[]).run(
+            _snapshot_provider(_snapshot(_crossover_series("BTC-USD")))
+        )
+
+        assert result.execution.executed == ()
+        (skip,) = result.execution.skipped
+        assert skip["decision_id"] == decision_id
+        assert "no fresh mark" in skip["reason"]
+        assert service.get(decision_id).state is TradeIdeaState.APPROVED
+
+    def test_execution_leg_can_be_disabled(self, service: TradeIdeaService, tmp_path: Path) -> None:
+        decision_id = "trade-20260703-cycle-003"
+        service.propose(_build_idea(decision_id), actor_id="test-proposer")
+        service.approve(decision_id, actor_id="test-operator", reason="test approval")
+
+        result = _runner(service, tmp_path, proposers=[], execute_approved=False).run(
+            _snapshot_provider(_snapshot(_crossover_series("BTC-USD")))
+        )
+
+        assert result.execution.enabled is False
+        assert service.get(decision_id).state is TradeIdeaState.APPROVED
+
+    def test_proposed_ideas_are_never_executed_in_same_turn(
+        self, service: TradeIdeaService, tmp_path: Path
+    ) -> None:
+        # The turn proposes AND has the execution leg enabled; the freshly
+        # proposed idea must stay PROPOSED because approval is a human event.
+        result = _runner(service, tmp_path).run(
+            _snapshot_provider(_snapshot(_crossover_series("BTC-USD")))
+        )
+        (decision_id,) = result.proposer_turns[0].proposed_decision_ids
+        assert result.execution.executed == ()
+        assert service.get(decision_id).state is TradeIdeaState.PROPOSED
+
+
+class TestExpirySweep:
+    def test_stale_idea_is_swept_before_proposing(
+        self, service: TradeIdeaService, tmp_path: Path
+    ) -> None:
+        decision_id = "trade-20260703-cycle-004"
+        stale = replace(
+            _build_idea(decision_id),
+            time_horizon=TimeHorizon(
+                expected_hold="3-10 days",
+                expires_at=_NOW - timedelta(hours=1),
+            ),
+        )
+        service.propose(stale, actor_id="test-proposer")
+
+        result = _runner(service, tmp_path, proposers=[]).run(
+            _snapshot_provider(_snapshot(_flat_series("BTC-USD")))
+        )
+
+        assert result.expired_decision_ids == (decision_id,)
+        assert service.get(decision_id).state is TradeIdeaState.EXPIRED
+
+
+class TestEvidenceContract:
+    def test_every_turn_appends_exactly_one_manifest_row(
+        self, service: TradeIdeaService, tmp_path: Path
+    ) -> None:
+        runner = _runner(service, tmp_path, proposers=[])
+        snapshot_provider = _snapshot_provider(_snapshot(_flat_series("BTC-USD")))
+        runner.run(snapshot_provider)
+        runner.run(snapshot_provider)
+        rows = _manifest_rows(tmp_path)
+        assert len(rows) == 2
+        assert len({row["run_id"] for row in rows}) == 2
+        assert all(row["outcome"] == "completed" for row in rows)
+
+    def test_failed_turn_appends_honest_failure_row(
+        self, service: TradeIdeaService, tmp_path: Path
+    ) -> None:
+        def broken_provider():
+            raise ConnectionError("market data unreachable")
+
+        with pytest.raises(ConnectionError, match="market data unreachable"):
+            _runner(service, tmp_path, proposers=[]).run(broken_provider)
+
+        (row,) = _manifest_rows(tmp_path)
+        assert row["outcome"] == "failed"
+        assert "market data unreachable" in row["error"]
+        assert row["finished_at"]
+
+    def test_snapshot_artifact_is_persisted_with_hash(
+        self, service: TradeIdeaService, tmp_path: Path
+    ) -> None:
+        result = _runner(service, tmp_path, proposers=[]).run(
+            _snapshot_provider(_snapshot(_flat_series("BTC-USD")))
+        )
+        snapshot_path = Path(result.snapshot["path"])
+        assert snapshot_path.exists()
+        assert result.snapshot["sha256"]
+        assert result.snapshot["symbols"] == ["BTC-USD"]
+        report_path = snapshot_path.parent / "report.json"
+        assert report_path.exists()
+
+    def test_audit_chain_stays_intact_across_turns(
+        self, service: TradeIdeaService, tmp_path: Path
+    ) -> None:
+        decision_id = "trade-20260703-cycle-005"
+        service.propose(_build_idea(decision_id), actor_id="test-proposer")
+        service.approve(decision_id, actor_id="test-operator", reason="test approval")
+        _runner(service, tmp_path).run(_snapshot_provider(_snapshot(_crossover_series("BTC-USD"))))
+        events = service.audit_log.verify()
+        filled = [event for event in events if event.action is AuditAction.FILLED]
+        assert len(filled) == 1
+        assert filled[0].actor_id == "paper-cycle"
+
+
+class TestLocking:
+    def test_concurrent_turn_is_refused_without_manifest_row(
+        self, service: TradeIdeaService, tmp_path: Path
+    ) -> None:
+        cycle_root = tmp_path / "cycle"
+        cycle_root.mkdir(parents=True)
+        held = FileLock(str(cycle_root / "cycle.lock"))
+        held.acquire()
+        try:
+            with pytest.raises(PaperCycleLockError, match="already running"):
+                _runner(service, tmp_path, proposers=[]).run(
+                    _snapshot_provider(_snapshot(_flat_series("BTC-USD")))
+                )
+        finally:
+            held.release()
+        assert _manifest_rows(tmp_path) == []

--- a/tests/unit/gpt_trader/features/idea_execution/test_cycle_evidence.py
+++ b/tests/unit/gpt_trader/features/idea_execution/test_cycle_evidence.py
@@ -1,0 +1,99 @@
+"""Evidence and locking contract of the Stage-1 paper cycle (issue #1150).
+
+Every turn — including failed ones — appends exactly one manifest row and
+persists its snapshot/report artifacts; a lock-refused start is not a turn and
+leaves no row. Turn behavior (propose/execute/expiry legs) is pinned in
+test_cycle.py; shared builders live in conftest.py.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from filelock import FileLock
+from tests.unit.gpt_trader.features.idea_execution.conftest import (
+    build_cycle_idea,
+    crossover_series,
+    flat_series,
+    make_cycle_runner,
+    manifest_rows,
+    snapshot,
+    snapshot_provider,
+)
+
+from gpt_trader.features.idea_execution import PaperCycleLockError
+from gpt_trader.features.trade_ideas import AuditAction, TradeIdeaService
+
+
+class TestEvidenceContract:
+    def test_every_turn_appends_exactly_one_manifest_row(
+        self, cycle_service: TradeIdeaService, tmp_path: Path
+    ) -> None:
+        runner = make_cycle_runner(cycle_service, tmp_path, proposers=[])
+        provider = snapshot_provider(snapshot(flat_series("BTC-USD")))
+        runner.run(provider)
+        runner.run(provider)
+        rows = manifest_rows(tmp_path)
+        assert len(rows) == 2
+        assert len({row["run_id"] for row in rows}) == 2
+        assert all(row["outcome"] == "completed" for row in rows)
+
+    def test_failed_turn_appends_honest_failure_row(
+        self, cycle_service: TradeIdeaService, tmp_path: Path
+    ) -> None:
+        def broken_provider():
+            raise ConnectionError("market data unreachable")
+
+        with pytest.raises(ConnectionError, match="market data unreachable"):
+            make_cycle_runner(cycle_service, tmp_path, proposers=[]).run(broken_provider)
+
+        (row,) = manifest_rows(tmp_path)
+        assert row["outcome"] == "failed"
+        assert "market data unreachable" in row["error"]
+        assert row["finished_at"]
+
+    def test_snapshot_artifact_is_persisted_with_hash(
+        self, cycle_service: TradeIdeaService, tmp_path: Path
+    ) -> None:
+        result = make_cycle_runner(cycle_service, tmp_path, proposers=[]).run(
+            snapshot_provider(snapshot(flat_series("BTC-USD")))
+        )
+        snapshot_path = Path(result.snapshot["path"])
+        assert snapshot_path.exists()
+        assert result.snapshot["sha256"]
+        assert result.snapshot["symbols"] == ["BTC-USD"]
+        report_path = snapshot_path.parent / "report.json"
+        assert report_path.exists()
+
+    def test_audit_chain_stays_intact_across_turns(
+        self, cycle_service: TradeIdeaService, tmp_path: Path
+    ) -> None:
+        decision_id = "trade-20260703-cycle-005"
+        cycle_service.propose(build_cycle_idea(decision_id), actor_id="test-proposer")
+        cycle_service.approve(decision_id, actor_id="test-operator", reason="test approval")
+        make_cycle_runner(cycle_service, tmp_path).run(
+            snapshot_provider(snapshot(crossover_series("BTC-USD")))
+        )
+        events = cycle_service.audit_log.verify()
+        filled = [event for event in events if event.action is AuditAction.FILLED]
+        assert len(filled) == 1
+        assert filled[0].actor_id == "paper-cycle"
+
+
+class TestLocking:
+    def test_concurrent_turn_is_refused_without_manifest_row(
+        self, cycle_service: TradeIdeaService, tmp_path: Path
+    ) -> None:
+        cycle_root = tmp_path / "cycle"
+        cycle_root.mkdir(parents=True)
+        held = FileLock(str(cycle_root / "cycle.lock"))
+        held.acquire()
+        try:
+            with pytest.raises(PaperCycleLockError, match="already running"):
+                make_cycle_runner(cycle_service, tmp_path, proposers=[]).run(
+                    snapshot_provider(snapshot(flat_series("BTC-USD")))
+                )
+        finally:
+            held.release()
+        assert manifest_rows(tmp_path) == []

--- a/tests/unit/gpt_trader/features/idea_execution/test_cycle_evidence.py
+++ b/tests/unit/gpt_trader/features/idea_execution/test_cycle_evidence.py
@@ -82,6 +82,22 @@ class TestEvidenceContract:
 
 
 class TestLocking:
+    def test_lock_releases_even_when_manifest_write_fails(
+        self, cycle_service: TradeIdeaService, tmp_path: Path
+    ) -> None:
+        cycle_root = tmp_path / "cycle"
+        # A directory at the manifest path makes the append raise.
+        (cycle_root / "manifest.jsonl").mkdir(parents=True)
+        runner = make_cycle_runner(cycle_service, tmp_path, proposers=[])
+        provider = snapshot_provider(snapshot(flat_series("BTC-USD")))
+        with pytest.raises(IsADirectoryError):
+            runner.run(provider)
+
+        # The lock must not leak: a follow-up turn acquires it normally.
+        (cycle_root / "manifest.jsonl").rmdir()
+        result = runner.run(provider)
+        assert result.run_id
+
     def test_concurrent_turn_is_refused_without_manifest_row(
         self, cycle_service: TradeIdeaService, tmp_path: Path
     ) -> None:

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -9,7 +9,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 5891,
+    "total_tests": 5892,
     "total_files": 705,
     "markers_used": 14
   },

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -9,8 +9,8 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 5871,
-    "total_files": 702,
+    "total_tests": 5887,
+    "total_files": 704,
     "markers_used": 14
   },
   "quick_commands": {

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -9,7 +9,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 5894,
+    "total_tests": 5896,
     "total_files": 705,
     "markers_used": 14
   },

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -9,7 +9,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 5890,
+    "total_tests": 5891,
     "total_files": 705,
     "markers_used": 14
   },

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -9,7 +9,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 5892,
+    "total_tests": 5894,
     "total_files": 705,
     "markers_used": 14
   },

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -9,8 +9,8 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 5887,
-    "total_files": 704,
+    "total_tests": 5890,
+    "total_files": 705,
     "markers_used": 14
   },
   "quick_commands": {

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -92,7 +92,7 @@
     ]
   },
   "counts": {
-    "unit": 5734,
+    "unit": 5735,
     "asyncio": 302,
     "parametrize": 173,
     "integration": 80,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -92,7 +92,7 @@
     ]
   },
   "counts": {
-    "unit": 5714,
+    "unit": 5730,
     "asyncio": 302,
     "parametrize": 173,
     "integration": 80,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -92,7 +92,7 @@
     ]
   },
   "counts": {
-    "unit": 5735,
+    "unit": 5737,
     "asyncio": 302,
     "parametrize": 173,
     "integration": 80,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -92,7 +92,7 @@
     ]
   },
   "counts": {
-    "unit": 5737,
+    "unit": 5739,
     "asyncio": 302,
     "parametrize": 173,
     "integration": 80,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -92,7 +92,7 @@
     ]
   },
   "counts": {
-    "unit": 5733,
+    "unit": 5734,
     "asyncio": 302,
     "parametrize": 173,
     "integration": 80,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -92,7 +92,7 @@
     ]
   },
   "counts": {
-    "unit": 5730,
+    "unit": 5733,
     "asyncio": 302,
     "parametrize": 173,
     "integration": 80,


### PR DESCRIPTION
## Summary

PR 1 of #1150 (M2, functioning-project path). `gpt-trader ideas cycle` runs **one turn** of the Stage-1 paper loop: lock → snapshot (network fetch, or `--snapshot PATH` for fully offline turns) → expire sweep → configured proposers → paper-execute human-APPROVED ideas priced from the same snapshot → report/queue artifacts → exactly one manifest JSONL row. Recurrence comes from an external scheduler (launchd/cron); runbook and scheduler assets follow as PR 2.

This stays entirely within DIRECTION **Stage 1**: the command never approves ideas (the approval seam between turns is a human event), and it is not Stage 2 auto-approval (#1039, blocked).

## Design decisions

- **No cadence in code.** Cadence, granularity, symbols, and the proposer set are flags/config of a generic turn — the recorded design constraint from the honest-day review. The same command serves a daily ONE_DAY run or a 5-minute multi-proposer loop by changing only the scheduler entry.
- **The lane stays paper-only.** `PaperCycleRunner` lives in `features/idea_execution` and takes an injected snapshot provider; the read-only Coinbase market-data client stays in the CLI layer (same as `ideas snapshot build` today), so the lane's import topology is unchanged and no live-broker client enters the slice.
- **Snapshot-priced execution.** The execution leg sets the deterministic broker's mark from the turn's own snapshot before each fill — honest pricing from the same artifact the proposers saw. Ideas without a fresh mark in the snapshot are reported as skips, never priced by guess. `HybridPaperBroker` wiring is deferred (it prices from its own feed; needs a pricing decision first).
- **Open-instrument dedup.** The baseline proposers re-emit an ongoing signal on consecutive turns (their crossover window spans several bars). A turn skips proposals for instruments that already have a non-terminal idea and records the skip + existing decision id in the manifest, so unattended operation cannot spam the queue with near-duplicates.
- **Evidence contract.** Every turn — including failed ones (e.g. market data unreachable) — appends exactly one manifest row; failed turns record the error and exit nonzero so cron surfaces them. A lock-refused start is not a turn and leaves no row. "N consecutive unattended days" is computable from `<ideas-root>/cycle/manifest.jsonl` alone.
- **Typed lane refusals are evidence, not failures.** If an approved idea expires between sweep and execution, or the lane refuses admission, the turn records the reason and continues — that's the rails working, and it must not wedge an unattended scheduler.

## Acceptance criteria (#1150) covered here

- [x] One command runs one full turn; with `--snapshot` fully offline (no network, no credentials)
- [x] Cadence/granularity/symbols/proposers from flags; no cadence constant in code
- [x] Concurrent invocation lock-protected, exits cleanly with explicit outcome
- [x] Execute-approved leg: at most once per idea (lane admission), snapshot-priced only, skips with reasons
- [x] Exactly one manifest row per turn incl. failures
- [x] Stage 1 smoke gains the cycle leg (propose turn → human approval between turns → executing turn at snapshot mark → manifest assertions)
- [ ] Runbook + launchd/cron examples → PR 2

## Touches trading execution

Paper-only: the execution leg drives the `features/idea_execution` lane (PR #1149) whose types make live brokers structurally unreachable; approval remains a human event. Decision gates: docs/decisions/adopt-five-role-composition.md + DIRECTION v1 rule; scope per #1150.

## Verification

- `make ci-required` exit 0 (includes the three-leg `stage1-smoke`: manual, machine, cycle)
- `uv run pytest tests/unit -n auto -q` — 6382 passed, 10 skipped (13 new runner tests + 3 CLI tests)
- `mypy` / `ruff` / `black` / `agent-naming` / `check_import_boundaries.py` clean; `agent-regenerate` artifacts included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an operator command (`ideas cycle`) to run an end-to-end “Stage 1” paper cycle from a saved snapshot or Coinbase candle inputs.
  * Generates cycle artifacts (canonical snapshot, per-turn reports) and tracks per-turn manifest progress with approval-gated execution.

* **Bug Fixes**
  * Enforced single-cycle concurrency via a run lock and guaranteed lock release even when manifest persistence fails.
  * Improved correctness around queued/filled instruments, fresh-mark requirements, and expiry/skip handling.

* **Tests**
  * Added unit tests for proposer selection, propose→approve→execute flow, manifest row counts, locking/evidence behavior, and Coinbase input validation.

* **Documentation**
  * Updated stage-1 rails smoke flow with a new cycle leg and revised reporting/audit expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->