### PR TITLE
docs(agents): record standing merge approval in merge discipline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,19 +70,24 @@ uv run local-ci --profile quick         # faster loop (skips readiness + artifac
 
 ## Merge discipline
 
-`main` is protected and merge is **not** part of packaging. Open the PR, then stop
-until the change is explicitly routed for merge. Before merging: re-read
-current-head review/reaction signals, resolve every review thread, and confirm
-generated artifacts are fresh. **Green CI is not sufficient** — run
-`uv run agent-pr-ready`, which reconciles real mergeability against green checks.
+`main` is protected. Merging carries standing operator approval (2026-07-02):
+no per-PR sign-off is needed once the readiness gate passes. Before merging:
+re-read current-head review/reaction signals, resolve every review thread, and
+confirm generated artifacts are fresh. **Green CI is not sufficient** — run
+`uv run agent-pr-ready`, which reconciles real mergeability against green
+checks, and merge only when it reports ready.
 
 ```bash
 git switch -c <branch>
 git push -u origin HEAD
 gh pr create --fill
-# Merge only once explicitly approved and all threads are resolved:
-# gh pr merge --squash --delete-branch
+# Merge once agent-pr-ready reports ready and all threads are resolved:
+gh pr merge --squash --delete-branch
 ```
+
+Standing approval covers PR merges only — live order submission and execution
+enablement still require recorded human approval (see the trading-safety
+boundary below and [docs/DIRECTION.md](docs/DIRECTION.md)).
 
 Merge mechanics that repeatedly bite agents (`agent-pr-ready` detects all three):
 


### PR DESCRIPTION
## Summary
- AGENTS.md merge discipline still instructed agents to open a PR and stop until explicitly routed for merge. The operator granted standing approval (2026-07-02) to merge once `agent-pr-ready` reports ready and all review threads are resolved.
- Updates the Merge discipline section to reflect that standing approval, keeps every readiness requirement (agent-pr-ready, thread resolution, fresh artifacts, stale-green caveats) intact, and adds an explicit note that standing approval covers PR merges only — live execution remains gated by docs/DIRECTION.md.
- Also updated the local (gitignored) .claude/CLAUDE.md pointer to match; that file is not part of this PR.

## Testing
- `uv run python scripts/maintenance/docs_link_audit.py` — passed (75 files scanned)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated merge guidance to reflect the new protected-main workflow and standing operator approval for PR merges.
  * Clarified that once readiness checks pass, per-PR sign-off is no longer needed for merges.
  * Refreshed the merge checklist and command example to match the current process.
  * Added a note that this approval applies to PR merges only, not to order submission or execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->