### PR TITLE
chore(license): adopt MIT license for the public repository

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025-2026 Solders-Girdles
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -190,3 +190,8 @@ Full documentation index: [docs/README.md](docs/README.md). AI agents start at
 This project uses **dependency injection** via `ApplicationContainer` in `src/gpt_trader/app/`. The legacy `orchestration/` layer was removed during the DI migration; prefer `app/` and `features/` paths.
 
 See [ARCHITECTURE.md](docs/ARCHITECTURE.md) for details.
+
+## License
+
+MIT — see [LICENSE](LICENSE). Decision record:
+[docs/decisions/adopt-mit-license.md](docs/decisions/adopt-mit-license.md).

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -68,6 +68,7 @@ markers. Regenerating cannot drift from the files.
 <!-- BEGIN GENERATED DECISION INDEX -->
 | Date | Decision | Status |
 |------|----------|--------|
+| 2026-07-03 | [MIT license for the public repository](adopt-mit-license.md) | accepted |
 | 2026-07-02 | [Account snapshot command — wire a real provider or remove it](account-snapshot-wire-or-remove.md) | accepted |
 | 2026-07-02 | [Adopt a measured-outcome operating rubric](adopt-measured-outcome-rubric.md) | accepted |
 | 2026-07-02 | [Canonical risk-limit vocabulary — budget vs runtime limits](canonical-risk-limit-vocabulary.md) | accepted |

--- a/docs/decisions/adopt-mit-license.md
+++ b/docs/decisions/adopt-mit-license.md
@@ -1,0 +1,49 @@
+# MIT license for the public repository
+
+---
+status: accepted
+date: 2026-07-03
+deciders: rj
+supersedes:
+superseded-by:
+---
+
+## Context
+
+The repository is public on GitHub but carried no LICENSE file and no
+`license` field in `pyproject.toml`, which leaves the code publicly visible
+yet all-rights-reserved by default. The original project scaffold's README
+claimed "MIT License. See LICENSE for details" against a LICENSE file that
+never existed; PR #1156 removed that unbacked claim. The owner confirmed the
+MIT claim was scaffold boilerplate, not a prior decision, so the license
+question had never actually been decided.
+
+## Options
+
+- **Option A — MIT.** Permissive, conventional for a solo open project. The
+  decisive property here: an explicit "AS IS" no-warranty disclaimer attached
+  to publicly visible trading software.
+- **Option B — Apache-2.0.** Same permissiveness plus a patent grant and
+  contribution terms; little added value for a solo project with no patent
+  surface.
+- **Option C — Stay unlicensed.** Keeps all rights reserved and defers the
+  choice, but leaves reuse ambiguity and no warranty disclaimer on public
+  code.
+
+## Decision
+
+Option A: MIT, copyright "Solders-Girdles" (the repository's pseudonymous
+GitHub identity). Chosen primarily for the explicit no-warranty disclaimer;
+permissive reuse is acceptable to the owner.
+
+## Consequences
+
+- [LICENSE](../../LICENSE) (MIT) at the repository root.
+- `license = "MIT"` (PEP 639 SPDX expression) in `pyproject.toml`; the build
+  requirement moves to `setuptools>=77`, the first version supporting it.
+- README regains a License section pointing at the LICENSE file.
+
+## Safety boundary
+
+This decision does not authorize any broker/API call, live execution, money
+movement, or autonomy change.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "gpt-trader"
 version = "0.1.0"
 description = "Coinbase Advanced Trade trading system with DI container, live spot/CFM futures support, and strategy tooling."
 readme = "README.md"
+license = "MIT"
 authors = [{name = "RJ + GPT-5"}]
 requires-python = ">=3.12,<3.13"
 dependencies = [
@@ -50,7 +51,7 @@ agent-dedupe = "gpt_trader.agents.cli:dedupe"
 agent-pr-ready = "gpt_trader.agents.cli:pr_ready"
 
 [build-system]
-requires = ["setuptools>=69", "wheel"]
+requires = ["setuptools>=77", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]


### PR DESCRIPTION
## Summary

The repository is public on GitHub but carried no LICENSE file and no `license` field in `pyproject.toml` — publicly visible yet all-rights-reserved by default. The old README "MIT" section was scaffold boilerplate pointing at a LICENSE file that never existed (removed as unbacked in #1156). RJ confirmed on 2026-07-03 that the license had never actually been decided, and chose **MIT, copyright Solders-Girdles** — primarily for the explicit "AS IS" no-warranty disclaimer on public trading software.

## Changes

- **LICENSE** — MIT, `Copyright (c) 2025-2026 Solders-Girdles`, at the repo root.
- **pyproject.toml** — `license = "MIT"` (PEP 639 SPDX expression); build requires bumped `setuptools>=69` → `>=77` (first version supporting License-Expression metadata). setuptools is resolved fresh via build isolation (not in uv.lock), so nothing else moves.
- **README.md** — License section restored, pointing at LICENSE and the decision record.
- **docs/decisions/adopt-mit-license.md** — decision record (status: accepted), with the index regenerated via `scripts/maintenance/generate_decision_index.py`.

## Verification

- `uv sync` builds the wheel cleanly under the new metadata; installed distribution reports `License-Expression: MIT` and `License-File: LICENSE` (auto-included by setuptools ≥77).
- `make agent-docs-links` (link audit, reachability, currency scan) passes.
- Pre-commit hooks passed on commit.

## Safety boundary

Docs + packaging metadata only. No broker/API, execution, or autonomy surface touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a license section to the README and linked to the project’s licensing decision record.
  * Updated the decisions index and added a new decision document for the licensing change.

* **Chores**
  * Added the MIT License text to the repository.
  * Updated project metadata to reflect MIT licensing and a newer build requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->