### PR TITLE
Align candle granularity tables and pin their agreement in tests

### DIFF
--- a/src/gpt_trader/features/brokerages/coinbase/historical_candles.py
+++ b/src/gpt_trader/features/brokerages/coinbase/historical_candles.py
@@ -11,6 +11,20 @@ from decimal import Decimal
 from gpt_trader.core import Candle
 from gpt_trader.features.brokerages.coinbase.client.client import CoinbaseClient
 
+# Granularities accepted by the Coinbase Advanced Trade candles endpoint,
+# mapped to their candle duration in seconds.
+GRANULARITY_SECONDS = {
+    "ONE_MINUTE": 60,
+    "FIVE_MINUTE": 300,
+    "FIFTEEN_MINUTE": 900,
+    "THIRTY_MINUTE": 1800,
+    "ONE_HOUR": 3600,
+    "TWO_HOUR": 7200,
+    "FOUR_HOUR": 14400,
+    "SIX_HOUR": 21600,
+    "ONE_DAY": 86400,
+}
+
 
 class CoinbaseHistoricalFetcher:
     """
@@ -151,18 +165,7 @@ class CoinbaseHistoricalFetcher:
 
     def _granularity_to_seconds(self, granularity: str) -> int:
         """Convert granularity string to seconds."""
-        mapping = {
-            "ONE_MINUTE": 60,
-            "FIVE_MINUTE": 300,
-            "FIFTEEN_MINUTE": 900,
-            "THIRTY_MINUTE": 1800,
-            "ONE_HOUR": 3600,
-            "TWO_HOUR": 7200,
-            "FOUR_HOUR": 14400,
-            "SIX_HOUR": 21600,
-            "ONE_DAY": 86400,
-        }
-        return mapping.get(granularity, 60)
+        return GRANULARITY_SECONDS.get(granularity, 60)
 
     def _create_chunks(
         self,

--- a/src/gpt_trader/features/trade_ideas/replay.py
+++ b/src/gpt_trader/features/trade_ideas/replay.py
@@ -731,41 +731,52 @@ def _bar_outcome_price(
     return None
 
 
+# Must stay in agreement with the recorder snapshot builder's granularity
+# alias table, but the frozen trade_ideas dependency set (core, errors, itself)
+# forbids importing it from gpt_trader.features.recorder; agreement is pinned
+# by tests instead.
+_GRANULARITY_DURATION_BY_ALIAS = {
+    "1M": timedelta(minutes=1),
+    "1MIN": timedelta(minutes=1),
+    "1MINUTE": timedelta(minutes=1),
+    "ONE_MINUTE": timedelta(minutes=1),
+    "5M": timedelta(minutes=5),
+    "5MIN": timedelta(minutes=5),
+    "5MINUTE": timedelta(minutes=5),
+    "FIVE_MINUTE": timedelta(minutes=5),
+    "15M": timedelta(minutes=15),
+    "15MIN": timedelta(minutes=15),
+    "15MINUTE": timedelta(minutes=15),
+    "FIFTEEN_MINUTE": timedelta(minutes=15),
+    "30M": timedelta(minutes=30),
+    "30MIN": timedelta(minutes=30),
+    "30MINUTE": timedelta(minutes=30),
+    "THIRTY_MINUTE": timedelta(minutes=30),
+    "1H": timedelta(hours=1),
+    "1HR": timedelta(hours=1),
+    "1HOUR": timedelta(hours=1),
+    "ONE_HOUR": timedelta(hours=1),
+    "2H": timedelta(hours=2),
+    "2HR": timedelta(hours=2),
+    "2HOUR": timedelta(hours=2),
+    "TWO_HOUR": timedelta(hours=2),
+    "4H": timedelta(hours=4),
+    "4HR": timedelta(hours=4),
+    "4HOUR": timedelta(hours=4),
+    "FOUR_HOUR": timedelta(hours=4),
+    "6H": timedelta(hours=6),
+    "6HR": timedelta(hours=6),
+    "6HOUR": timedelta(hours=6),
+    "SIX_HOUR": timedelta(hours=6),
+    "1D": timedelta(days=1),
+    "1DAY": timedelta(days=1),
+    "ONE_DAY": timedelta(days=1),
+}
+
+
 def _granularity_duration(granularity: str) -> timedelta | None:
     normalized = granularity.strip().upper().replace("-", "_")
-    return {
-        "1M": timedelta(minutes=1),
-        "1MIN": timedelta(minutes=1),
-        "1MINUTE": timedelta(minutes=1),
-        "ONE_MINUTE": timedelta(minutes=1),
-        "5M": timedelta(minutes=5),
-        "5MIN": timedelta(minutes=5),
-        "5MINUTE": timedelta(minutes=5),
-        "FIVE_MINUTE": timedelta(minutes=5),
-        "15M": timedelta(minutes=15),
-        "15MIN": timedelta(minutes=15),
-        "15MINUTE": timedelta(minutes=15),
-        "FIFTEEN_MINUTE": timedelta(minutes=15),
-        "30M": timedelta(minutes=30),
-        "30MIN": timedelta(minutes=30),
-        "30MINUTE": timedelta(minutes=30),
-        "THIRTY_MINUTE": timedelta(minutes=30),
-        "1H": timedelta(hours=1),
-        "1HR": timedelta(hours=1),
-        "1HOUR": timedelta(hours=1),
-        "ONE_HOUR": timedelta(hours=1),
-        "2H": timedelta(hours=2),
-        "2HR": timedelta(hours=2),
-        "2HOUR": timedelta(hours=2),
-        "TWO_HOUR": timedelta(hours=2),
-        "6H": timedelta(hours=6),
-        "6HR": timedelta(hours=6),
-        "6HOUR": timedelta(hours=6),
-        "SIX_HOUR": timedelta(hours=6),
-        "1D": timedelta(days=1),
-        "1DAY": timedelta(days=1),
-        "ONE_DAY": timedelta(days=1),
-    }.get(normalized)
+    return _GRANULARITY_DURATION_BY_ALIAS.get(normalized)
 
 
 def _result(

--- a/tests/unit/gpt_trader/cli/commands/test_ideas_replay_baseline.py
+++ b/tests/unit/gpt_trader/cli/commands/test_ideas_replay_baseline.py
@@ -147,6 +147,22 @@ def test_replay_baseline_rejects_unsupported_granularity(
     assert "Unsupported replay granularity: BAD" in response["errors"][0]["message"]
 
 
+def test_replay_baseline_accepts_four_hour_granularity(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    fixture = _write_fixture(tmp_path / "candles.json", _baseline_hit_fixture())
+    argv = _baseline_args(fixture)
+    granularity_index = argv.index("--granularity") + 1
+    argv[granularity_index] = "FOUR_HOUR"
+
+    exit_code, response = _run_json(capsys, argv)
+
+    assert exit_code == 0
+    assert response["success"] is True
+    assert response["data"]["granularity"] == "FOUR_HOUR"
+
+
 def test_replay_baseline_preserves_json_number_precision(tmp_path: Path) -> None:
     fixture = tmp_path / "precise-candles.json"
     fixture.write_text(

--- a/tests/unit/gpt_trader/features/brokerages/coinbase/test_historical_candles_edges.py
+++ b/tests/unit/gpt_trader/features/brokerages/coinbase/test_historical_candles_edges.py
@@ -10,7 +10,12 @@ import pytest
 
 from gpt_trader.core import Candle
 from gpt_trader.features.brokerages.coinbase.historical_candles import (
+    GRANULARITY_SECONDS,
     CoinbaseHistoricalFetcher,
+)
+from gpt_trader.features.recorder.snapshot_builder import (
+    _CANONICAL_GRANULARITY_BY_ALIAS,
+    granularity_duration,
 )
 
 
@@ -106,6 +111,23 @@ def test_granularity_to_seconds_unknown_defaults() -> None:
     fetcher = CoinbaseHistoricalFetcher(client=Mock())
 
     assert fetcher._granularity_to_seconds("UNKNOWN") == 60
+
+
+def test_every_builder_granularity_is_fetchable() -> None:
+    """Every granularity the snapshot builder accepts must be fetchable.
+
+    The builder normalizes aliases to Coinbase enum names before calling the
+    candle source, so its canonical set must exactly match the fetcher's
+    granularity map — a builder-only entry would pass input validation and
+    then fail at the REST fetch, while a fetcher-only entry is unreachable.
+    """
+    builder_granularities = set(_CANONICAL_GRANULARITY_BY_ALIAS.values())
+
+    assert builder_granularities == set(GRANULARITY_SECONDS)
+    for alias, canonical in _CANONICAL_GRANULARITY_BY_ALIAS.items():
+        duration = granularity_duration(alias)
+        assert duration is not None, alias
+        assert duration.total_seconds() == GRANULARITY_SECONDS[canonical]
 
 
 def test_granularity_to_seconds_supports_four_hour() -> None:

--- a/tests/unit/gpt_trader/features/trade_ideas/test_replay.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_replay.py
@@ -322,3 +322,24 @@ def test_replay_scoring_does_not_mutate_live_closeout_records(tmp_path: Path) ->
     assert result.outcome is ReplayOutcome.TARGET_HIT
     assert service.get_closeout_attribution(idea.decision_id) is None
     assert not service.closeout_log.path.exists()
+
+
+def test_replay_granularity_table_agrees_with_recorder_builder() -> None:
+    """Replay's private granularity table must match the recorder builder's.
+
+    The frozen trade_ideas dependency set (core, errors, itself) forbids
+    replay from importing the recorder's shared helper, so the two tables
+    are kept in exact agreement here instead — a snapshot the builder can
+    produce must never be rejected or mis-scored by replay, and vice versa.
+    """
+    from gpt_trader.features.recorder.snapshot_builder import (
+        _CANONICAL_GRANULARITY_BY_ALIAS,
+        granularity_duration,
+    )
+    from gpt_trader.features.trade_ideas.replay import _GRANULARITY_DURATION_BY_ALIAS
+
+    recorder_table = {
+        alias: granularity_duration(alias) for alias in _CANONICAL_GRANULARITY_BY_ALIAS
+    }
+
+    assert _GRANULARITY_DURATION_BY_ALIAS == recorder_table


### PR DESCRIPTION
## Summary
The recorder snapshot builder's granularity alias table (`features/recorder/snapshot_builder.py`) accepts `FOUR_HOUR`, while `trade_ideas/replay.py` kept a private `_granularity_duration` copy that omitted it — so `ideas snapshot build` and `ideas replay` disagreed on the supported set. `FOUR_HOUR` is a valid Coinbase Advanced Trade candles granularity: the Get Product Candles OpenAPI schema enumerates `["UNKNOWN_GRANULARITY","ONE_MINUTE","FIVE_MINUTE","FIFTEEN_MINUTE","THIRTY_MINUTE","ONE_HOUR","TWO_HOUR","FOUR_HOUR","SIX_HOUR","ONE_DAY"]`, and the live public endpoint (`GET /api/v3/brokerage/market/products/BTC-USD/candles?granularity=FOUR_HOUR`) returns real 4-hour candles. The builder table is therefore canonical, and replay's divergent copy is the bug.

Deduplicating replay's copy onto the recorder helper was considered but is forbidden by the import-boundary rules: the trade_ideas dependency freeze allows only `core`, `errors`, and itself, and the `recorder → trade_ideas` edge is deliberately one-way ("producer imports contract, never the reverse"). So instead:

- Fix replay's table in place (add `4H`/`4HR`/`4HOUR`/`FOUR_HOUR`), hoist it to a module constant `_GRANULARITY_DURATION_BY_ALIAS`, and pin exact agreement with the recorder builder's table in a test (tests may import across slices).
- Hoist `CoinbaseHistoricalFetcher`'s granularity-seconds map (`features/brokerages/coinbase/historical_candles.py`) to a module constant `GRANULARITY_SECONDS` so tests can pin it.

Related issue / finding / routed package: routed finding — granularity alias tables disagree between snapshot builder and replay.

## Type of change
- [x] Bug fix
- [ ] Refactor
- [ ] Feature
- [ ] Tests only
- [ ] CI/Docs/Tooling

## Scope & Impact
- Affected areas / components: `gpt_trader/features/trade_ideas/replay.py`, `gpt_trader/features/brokerages/coinbase/historical_candles.py`, and their unit tests.
- Behavior changes: `ideas replay baseline|tournament|optimize` now accept `FOUR_HOUR` (and its `4H`/`4HR`/`4HOUR` aliases) instead of rejecting them with "Unsupported replay granularity"; pinned by `test_replay_baseline_accepts_four_hour_granularity`. No other behavior changes — the fetcher map is unchanged in content, only hoisted to a constant.

## Test Plan
- [x] Unit tests added/updated
  - `test_every_builder_granularity_is_fetchable` pins that the recorder builder's canonical granularity set exactly matches `GRANULARITY_SECONDS` keys (both directions) and that alias durations agree with the fetcher's seconds.
  - `test_replay_granularity_table_agrees_with_recorder_builder` pins replay's private table to exact equality with the recorder builder's alias table, so the two can't drift again despite the boundary-mandated duplication.
  - `test_replay_baseline_accepts_four_hour_granularity` pins the replay CLI accepting `FOUR_HOUR`.
- [ ] Integration tests added/updated (n/a — pure table alignment)
- [ ] Contract tests (if applicable) (n/a)
- [x] Ran locally: full `tests/unit` — 6339 passed, 10 skipped (optional OTel)
- [x] Markers used appropriately (`unit`/`integration`/`slow`/`perf`)

## Quality Gates
- [x] `make ci-required` passes locally (lint/format, docs audits, type check, agent freshness, test guardrails, core unit tests)
- [x] `uv run mypy` clean on touched files
- [x] No `sys.path` hacks in tests; `AsyncMock` (not `MagicMock`) on `async def`
- [x] Import boundaries respected (`scripts/ci/check_import_boundaries.py` passes; the trade_ideas dependency freeze is why the tables are pinned by tests rather than deduplicated)

## Observability & Errors
- [x] Errors include diagnostic context — unsupported-granularity errors keep `field="granularity"` context; no new logging paths.

## Agent Artifacts & Config (if touched)
- [ ] Not touched — no `var/agents/**`-affecting changes, no docs changes.

## Breaking Changes
- [x] None

## Checklist
- [x] Acceptance criteria in routed finding met: canonical set decided (FOUR_HOUR supported, proven against Coinbase), both tables aligned, dedup considered and documented as blocked by the import-boundary freeze, and tests pin builder↔replay and builder↔fetcher agreement.
- [x] Affected paths listed in PR description

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016MraPLBrke69RdKo8PdiHK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded support for additional 4-hour granularity formats, making replay and historical data requests more flexible.
* **Bug Fixes**
  * Improved granularity handling so supported time intervals are resolved more consistently across trading workflows.
* **Tests**
  * Added coverage to verify 4-hour granularity works end-to-end and that granularity support stays aligned across related features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->