### PR TITLE
feat(recorder): standalone gpt-trader record entrypoint with a real recorder identity

### DIFF
--- a/docs/architecture/ENTRYPOINTS.md
+++ b/docs/architecture/ENTRYPOINTS.md
@@ -23,6 +23,16 @@ This document lists the canonical runtime entrypoints and where they are wired.
   - `src/gpt_trader/app/container.py` (`ApplicationContainer.create_bot`)
   - `src/gpt_trader/features/live_trade/bot.py` (`TradingBot.run`)
 
+## Recorder (standalone market-data recording)
+
+- Invoked via: `gpt-trader record [--once]`
+- Handler: `src/gpt_trader/cli/commands/record.py` (`execute`)
+- Recording loop: `src/gpt_trader/features/recorder/market_data_recorder.py`
+  (`MarketDataRecorder`)
+- Read-only: polls tickers and persists `price_tick` events with a
+  `recorder:<profile>` identity; runs while the trading engine is halted
+  (docs/decisions/adopt-five-role-composition.md).
+
 ## Preflight CLI
 
 - Script entrypoint: `python scripts/production_preflight.py`

--- a/src/gpt_trader/cli/__init__.py
+++ b/src/gpt_trader/cli/__init__.py
@@ -32,6 +32,7 @@ from gpt_trader.cli.commands import (  # noqa: E402
     optimize,
     orders,
     preflight,
+    record,
     report,
     run,
     strategy_profile,
@@ -49,6 +50,7 @@ COMMAND_NAMES = {
     "controls",
     "ideas",
     "orders",
+    "record",
     "report",
     "optimize",
     "strategy",
@@ -190,6 +192,7 @@ def _build_parser() -> argparse.ArgumentParser:
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     run.register(subparsers)
+    record.register(subparsers)
     account.register(subparsers)
     coinbase.register(subparsers)
     controls.register(subparsers)

--- a/src/gpt_trader/cli/commands/record.py
+++ b/src/gpt_trader/cli/commands/record.py
@@ -70,6 +70,14 @@ def execute(args: Namespace) -> int:
             logger.error("No broker available for market-data reads")
             return 1
 
+        if config.interval is None or config.interval <= 0:
+            logger.error(
+                "Recording interval must be a positive number of seconds",
+                interval=config.interval,
+                operation="record",
+            )
+            return 1
+
         bot_id = derive_recorder_bot_id(config.profile)
         tick_store = PriceTickStore(
             event_store=container.event_store,
@@ -86,7 +94,15 @@ def execute(args: Namespace) -> int:
         )
 
         if args.once:
-            recorded = asyncio.run(recorder.record_once())
+            try:
+                recorded = asyncio.run(recorder.record_once())
+            except Exception as exc:
+                logger.error(
+                    "Recording poll failed",
+                    error=str(exc),
+                    operation="record",
+                )
+                return 1
             logger.info(
                 "Recorded one poll",
                 recorded_ticks=recorded,

--- a/src/gpt_trader/cli/commands/record.py
+++ b/src/gpt_trader/cli/commands/record.py
@@ -9,6 +9,7 @@ from types import FrameType
 from typing import Any
 
 from gpt_trader.app.config.validation import ConfigValidationError
+from gpt_trader.app.container import clear_application_container
 from gpt_trader.cli import options, services
 from gpt_trader.features.recorder import (
     MarketDataRecorder,
@@ -63,43 +64,47 @@ def execute(args: Namespace) -> int:
         logger.error(str(exc))
         return 1
 
-    broker = container.broker
-    if broker is None:
-        logger.error("No broker available for market-data reads")
-        return 1
+    try:
+        broker = container.broker
+        if broker is None:
+            logger.error("No broker available for market-data reads")
+            return 1
 
-    bot_id = derive_recorder_bot_id(config.profile)
-    tick_store = PriceTickStore(
-        event_store=container.event_store,
-        symbols=list(config.symbols),
-        bot_id=bot_id,
-    )
-    recorder = MarketDataRecorder(
-        broker=broker,
-        tick_store=tick_store,
-        config=MarketDataRecorderConfig(
-            symbols=tuple(config.symbols),
-            interval_seconds=float(config.interval),
-        ),
-    )
-
-    if args.once:
-        recorded = asyncio.run(recorder.record_once())
-        logger.info(
-            "Recorded one poll",
-            recorded_ticks=recorded,
+        bot_id = derive_recorder_bot_id(config.profile)
+        tick_store = PriceTickStore(
+            event_store=container.event_store,
             symbols=list(config.symbols),
             bot_id=bot_id,
-            operation="record",
         )
-        return 0 if recorded > 0 else 1
+        recorder = MarketDataRecorder(
+            broker=broker,
+            tick_store=tick_store,
+            config=MarketDataRecorderConfig(
+                symbols=tuple(config.symbols),
+                interval_seconds=float(config.interval),
+            ),
+        )
 
-    def signal_handler(sig: int, frame: FrameType | None) -> None:  # pragma: no cover - signal
-        logger.info(f"Signal {sig} received, stopping recorder...", operation="record")
-        recorder.stop()
+        if args.once:
+            recorded = asyncio.run(recorder.record_once())
+            logger.info(
+                "Recorded one poll",
+                recorded_ticks=recorded,
+                symbols=list(config.symbols),
+                bot_id=bot_id,
+                operation="record",
+            )
+            return 0 if recorded > 0 else 1
 
-    signal.signal(signal.SIGINT, signal_handler)
-    signal.signal(signal.SIGTERM, signal_handler)
+        def signal_handler(sig: int, frame: FrameType | None) -> None:  # pragma: no cover - signal
+            logger.info(f"Signal {sig} received, stopping recorder...", operation="record")
+            recorder.stop()
 
-    asyncio.run(recorder.run())
-    return 0
+        signal.signal(signal.SIGINT, signal_handler)
+        signal.signal(signal.SIGTERM, signal_handler)
+
+        asyncio.run(recorder.run())
+        return 0
+    finally:
+        # Clear container registry to prevent leaks between runs
+        clear_application_container()

--- a/src/gpt_trader/cli/commands/record.py
+++ b/src/gpt_trader/cli/commands/record.py
@@ -1,0 +1,105 @@
+"""Record command: standalone market-data recording without the trading engine."""
+
+from __future__ import annotations
+
+import asyncio
+import signal
+from argparse import Namespace
+from types import FrameType
+from typing import Any
+
+from gpt_trader.app.config.validation import ConfigValidationError
+from gpt_trader.cli import options, services
+from gpt_trader.features.recorder import (
+    MarketDataRecorder,
+    MarketDataRecorderConfig,
+    PriceTickStore,
+    derive_recorder_bot_id,
+)
+from gpt_trader.utilities.logging_patterns import get_logger
+
+logger = get_logger(__name__, component="cli")
+
+
+def register(subparsers: Any) -> None:
+    parser = subparsers.add_parser(
+        "record",
+        help="Record market data (price ticks) without running the trading engine",
+        description=(
+            "Standalone recorder role: poll read-only tickers for the profile's "
+            "symbols and persist price ticks to the EventStore, so observation "
+            "keeps running while execution is halted or paused. Never reads "
+            "accounts or places, modifies, or cancels orders."
+        ),
+    )
+    options.add_profile_option(parser, allow_missing_default=True)
+    parser.add_argument(
+        "--symbols",
+        type=str,
+        nargs="+",
+        help="Symbols to record (default: the profile's symbols)",
+    )
+    parser.add_argument(
+        "--interval",
+        type=int,
+        help="Poll interval in seconds (default: the profile's interval)",
+    )
+    parser.add_argument(
+        "--once",
+        action="store_true",
+        help="Record a single poll and exit (for verification)",
+    )
+    parser.set_defaults(handler=execute)
+
+
+def execute(args: Namespace) -> int:
+    try:
+        config = services.build_config_from_args(
+            args,
+            include={"symbols", "interval"},
+        )
+        container = services.instantiate_container(config)
+    except ConfigValidationError as exc:
+        logger.error(str(exc))
+        return 1
+
+    broker = container.broker
+    if broker is None:
+        logger.error("No broker available for market-data reads")
+        return 1
+
+    bot_id = derive_recorder_bot_id(config.profile)
+    tick_store = PriceTickStore(
+        event_store=container.event_store,
+        symbols=list(config.symbols),
+        bot_id=bot_id,
+    )
+    recorder = MarketDataRecorder(
+        broker=broker,
+        tick_store=tick_store,
+        config=MarketDataRecorderConfig(
+            symbols=tuple(config.symbols),
+            interval_seconds=float(config.interval),
+        ),
+    )
+
+    if args.once:
+        recorded = asyncio.run(recorder.record_once())
+        logger.info(
+            "Recorded one poll",
+            recorded_ticks=recorded,
+            symbols=list(config.symbols),
+            bot_id=bot_id,
+            operation="record",
+        )
+        return 0 if recorded > 0 else 1
+
+    def signal_handler(sig: int, frame: FrameType | None) -> None:  # pragma: no cover - signal
+        logger.info(f"Signal {sig} received, stopping recorder...", operation="record")
+        recorder.stop()
+
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
+
+    asyncio.run(recorder.run())
+    return 0

--- a/src/gpt_trader/cli/services.py
+++ b/src/gpt_trader/cli/services.py
@@ -16,6 +16,7 @@ from gpt_trader.app.config.profile_loader import (
 )
 from gpt_trader.app.config.validation import ConfigValidationError, validate_config
 from gpt_trader.app.container import (
+    ApplicationContainer,
     create_application_container,
     get_application_container,
     set_application_container,
@@ -207,8 +208,8 @@ def _apply_profile_kwargs(config: BotConfig, profile_kwargs: dict[str, Any]) -> 
         config.environment = profile_kwargs["environment"]
 
 
-def instantiate_bot(config: BotConfig) -> TradingBot:
-    """Instantiate a TradingBot using the ApplicationContainer.
+def instantiate_container(config: BotConfig) -> ApplicationContainer:
+    """Validate config and return the registered ApplicationContainer.
 
     Registers the container globally so services can resolve dependencies
     via get_application_container(). Avoids overriding an existing container
@@ -223,7 +224,7 @@ def instantiate_bot(config: BotConfig) -> TradingBot:
     existing = get_application_container()
     if existing is not None:
         logger.debug("Using existing application container")
-        return existing.create_bot()
+        return existing
 
     # Create and register new container
     container = create_application_container(config)
@@ -233,7 +234,12 @@ def instantiate_bot(config: BotConfig) -> TradingBot:
         logger.warning("Failed to persist startup config fingerprint: %s", exc)
     set_application_container(container)
     logger.debug("Created and registered application container")
-    return container.create_bot()
+    return container
+
+
+def instantiate_bot(config: BotConfig) -> TradingBot:
+    """Instantiate a TradingBot using the ApplicationContainer."""
+    return instantiate_container(config).create_bot()
 
 
 def _validate_startup_config(config: BotConfig) -> list[str]:

--- a/src/gpt_trader/features/recorder/__init__.py
+++ b/src/gpt_trader/features/recorder/__init__.py
@@ -4,11 +4,18 @@ Extraction of the recorder role from the accepted five-role composition
 (docs/decisions/adopt-five-role-composition.md): observation must outlive
 execution, so recording state is constructed by the composition root and
 injected into the trading engine rather than owned by it. This slice holds
-price-tick persistence/recovery and MarketSnapshot production over the
-read-only Coinbase candle transport; WS tick ingestion and a standalone
-``record`` entrypoint migrate here in later stages (issue #1158).
+price-tick persistence/recovery, MarketSnapshot production over the
+read-only Coinbase candle transport, and the standalone recording loop
+behind ``gpt-trader record`` (issue #1158). The engine's WS telemetry
+stream converges here only after strategy→proposer parity, per the
+decision record.
 """
 
+from gpt_trader.features.recorder.market_data_recorder import (
+    MarketDataRecorder,
+    MarketDataRecorderConfig,
+    derive_recorder_bot_id,
+)
 from gpt_trader.features.recorder.price_tick_store import (
     EVENT_PRICE_TICK,
     MAX_PRICE_HISTORY,
@@ -33,10 +40,13 @@ __all__ = [
     "EVENT_PRICE_TICK",
     "HistoricalCandleSource",
     "MAX_PRICE_HISTORY",
+    "MarketDataRecorder",
+    "MarketDataRecorderConfig",
     "MarketSnapshotBuildRequest",
     "MarketSnapshotBuilder",
     "PriceTickStore",
     "build_coinbase_market_snapshot",
     "canonical_granularity",
+    "derive_recorder_bot_id",
     "granularity_duration",
 ]

--- a/src/gpt_trader/features/recorder/market_data_recorder.py
+++ b/src/gpt_trader/features/recorder/market_data_recorder.py
@@ -174,4 +174,6 @@ def _extract_price(ticker: dict[str, Any] | None) -> Decimal | None:
         price = Decimal(str(raw_price))
     except (DecimalException, ValueError):
         return None
+    if not price.is_finite():
+        return None
     return price if price > 0 else None

--- a/src/gpt_trader/features/recorder/market_data_recorder.py
+++ b/src/gpt_trader/features/recorder/market_data_recorder.py
@@ -1,0 +1,177 @@
+"""Standalone market-data recording loop (REST ticker polling).
+
+The recorder role from the five-role composition: observation that runs
+regardless of execution state. The loop polls read-only tickers from an
+injected broker and records price ticks through ``PriceTickStore``, so tick
+history keeps accumulating while the trading engine is halted or paused.
+
+Cadence is injected — nothing here decides a recurrence beyond sleeping the
+configured interval between polls, per the frequency-headroom directive.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from decimal import Decimal, DecimalException
+from typing import Any
+
+from gpt_trader.features.recorder.price_tick_store import PriceTickStore
+from gpt_trader.utilities.logging_patterns import get_logger
+
+logger = get_logger(__name__, component="market_data_recorder")
+
+
+def derive_recorder_bot_id(profile: Any) -> str:
+    """Stable identity stamped into recorder-written events.
+
+    Ticks written by the standalone recorder carry a real identity (unlike
+    the engine flow's historical empty ``bot_id``) so recorded data is
+    attributable. Rehydration stays deliberately bot_id-agnostic: the store
+    filters by symbol only, so engine restarts pick up recorder-collected
+    history and vice versa.
+    """
+    profile_name = profile.value if hasattr(profile, "value") else str(profile or "")
+    profile_name = profile_name.strip().lower() or "default"
+    return f"recorder:{profile_name}"
+
+
+@dataclass(frozen=True)
+class MarketDataRecorderConfig:
+    """One recording run: which symbols to poll and how often."""
+
+    symbols: tuple[str, ...]
+    interval_seconds: float
+
+    def __post_init__(self) -> None:
+        if not self.symbols:
+            raise ValueError("MarketDataRecorder requires at least one symbol")
+        if self.interval_seconds <= 0:
+            raise ValueError("MarketDataRecorder interval must be positive")
+
+
+class MarketDataRecorder:
+    """Poll tickers on an injected cadence and persist price ticks.
+
+    Read-only by construction: the only broker methods used are
+    ``get_tickers``/``get_ticker``, and the only write path is the tick
+    store's EventStore persistence.
+    """
+
+    def __init__(
+        self,
+        *,
+        broker: Any,
+        tick_store: PriceTickStore,
+        config: MarketDataRecorderConfig,
+    ) -> None:
+        self._broker = broker
+        self._tick_store = tick_store
+        self._config = config
+        self._running = False
+        self._stop_event: asyncio.Event | None = None
+
+    @property
+    def running(self) -> bool:
+        return self._running
+
+    def stop(self) -> None:
+        """Request a graceful stop; safe to call from a signal handler."""
+        self._running = False
+        stop_event = self._stop_event
+        if stop_event is not None:
+            stop_event.set()
+
+    async def run(self) -> None:
+        """Poll until stopped. Poll failures are logged and do not end the run."""
+        self._running = True
+        self._stop_event = asyncio.Event()
+        logger.info(
+            "Market-data recording started",
+            symbols=list(self._config.symbols),
+            interval_seconds=self._config.interval_seconds,
+            operation="record",
+            stage="start",
+        )
+        try:
+            while self._running:
+                try:
+                    await self.record_once()
+                except Exception:
+                    logger.exception("Recording poll failed", operation="record")
+                try:
+                    await asyncio.wait_for(
+                        self._stop_event.wait(),
+                        timeout=self._config.interval_seconds,
+                    )
+                except TimeoutError:
+                    continue
+        finally:
+            self._running = False
+            self._stop_event = None
+            logger.info(
+                "Market-data recording stopped",
+                operation="record",
+                stage="stop",
+            )
+
+    async def record_once(self) -> int:
+        """Poll each configured symbol once; returns the number of ticks recorded."""
+        tickers = await self._fetch_batch_tickers()
+        recorded = 0
+        for symbol in self._config.symbols:
+            ticker = tickers.get(symbol)
+            if ticker is None:
+                ticker = await self._fetch_single_ticker(symbol)
+            price = _extract_price(ticker)
+            if price is None:
+                logger.warning(
+                    "No usable ticker price; skipping symbol this poll",
+                    symbol=symbol,
+                    operation="record",
+                )
+                continue
+            await self._tick_store.record_price_tick_async(symbol, price)
+            recorded += 1
+        return recorded
+
+    async def _fetch_batch_tickers(self) -> dict[str, dict[str, Any]]:
+        get_tickers = getattr(self._broker, "get_tickers", None)
+        if not callable(get_tickers):
+            return {}
+        try:
+            result = await asyncio.to_thread(get_tickers, list(self._config.symbols))
+        except Exception as exc:
+            logger.warning(
+                "Batch ticker poll failed; falling back to per-symbol fetch",
+                error=str(exc),
+                operation="record",
+            )
+            return {}
+        return result if isinstance(result, dict) else {}
+
+    async def _fetch_single_ticker(self, symbol: str) -> dict[str, Any] | None:
+        try:
+            ticker = await asyncio.to_thread(self._broker.get_ticker, symbol)
+        except Exception as exc:
+            logger.warning(
+                "Ticker poll failed",
+                symbol=symbol,
+                error=str(exc),
+                operation="record",
+            )
+            return None
+        return ticker if isinstance(ticker, dict) else None
+
+
+def _extract_price(ticker: dict[str, Any] | None) -> Decimal | None:
+    if not ticker:
+        return None
+    raw_price = ticker.get("price")
+    if raw_price is None:
+        return None
+    try:
+        price = Decimal(str(raw_price))
+    except (DecimalException, ValueError):
+        return None
+    return price if price > 0 else None

--- a/tests/_triage/dedupe_candidates.yaml
+++ b/tests/_triage/dedupe_candidates.yaml
@@ -8,7 +8,7 @@
 # Priorities: high | medium | low
 #
 version: 1
-generated_at: '2026-07-03T12:08:50.879499+00:00'
+generated_at: '2026-07-03T12:30:59.632850+00:00'
 summary:
   total_clusters: 208
   by_priority:

--- a/tests/unit/gpt_trader/features/recorder/test_market_data_recorder.py
+++ b/tests/unit/gpt_trader/features/recorder/test_market_data_recorder.py
@@ -1,0 +1,183 @@
+"""MarketDataRecorder: standalone polling loop behavior."""
+
+from __future__ import annotations
+
+import asyncio
+from decimal import Decimal
+from typing import Any
+
+import pytest
+
+from gpt_trader.features.recorder import (
+    EVENT_PRICE_TICK,
+    MarketDataRecorder,
+    MarketDataRecorderConfig,
+    PriceTickStore,
+    derive_recorder_bot_id,
+)
+
+
+class FakeEventStore:
+    def __init__(self) -> None:
+        self.stored: list[dict[str, Any]] = []
+
+    def store(self, event: dict[str, Any]) -> None:
+        self.stored.append(event)
+
+
+class BatchBroker:
+    def __init__(self, tickers: dict[str, dict[str, Any]]) -> None:
+        self.tickers = tickers
+        self.batch_calls = 0
+        self.single_calls: list[str] = []
+
+    def get_tickers(self, symbols: list[str]) -> dict[str, dict[str, Any]]:
+        self.batch_calls += 1
+        return self.tickers
+
+    def get_ticker(self, symbol: str) -> dict[str, Any] | None:
+        self.single_calls.append(symbol)
+        return self.tickers.get(symbol)
+
+
+class SingleOnlyBroker:
+    def __init__(self, tickers: dict[str, dict[str, Any]]) -> None:
+        self.tickers = tickers
+        self.single_calls: list[str] = []
+
+    def get_ticker(self, symbol: str) -> dict[str, Any] | None:
+        self.single_calls.append(symbol)
+        return self.tickers.get(symbol)
+
+
+def _recorder(
+    broker: Any,
+    symbols: tuple[str, ...] = ("BTC-USD", "ETH-USD"),
+    interval_seconds: float = 0.01,
+) -> tuple[MarketDataRecorder, PriceTickStore, FakeEventStore]:
+    event_store = FakeEventStore()
+    tick_store = PriceTickStore(
+        event_store=event_store,
+        symbols=list(symbols),
+        bot_id="recorder:test",
+    )
+    recorder = MarketDataRecorder(
+        broker=broker,
+        tick_store=tick_store,
+        config=MarketDataRecorderConfig(
+            symbols=symbols,
+            interval_seconds=interval_seconds,
+        ),
+    )
+    return recorder, tick_store, event_store
+
+
+@pytest.mark.asyncio
+async def test_record_once_uses_batch_tickers_and_persists() -> None:
+    broker = BatchBroker(
+        {
+            "BTC-USD": {"price": "50000.5"},
+            "ETH-USD": {"price": "2500"},
+        }
+    )
+    recorder, tick_store, event_store = _recorder(broker)
+
+    recorded = await recorder.record_once()
+
+    assert recorded == 2
+    assert broker.batch_calls == 1
+    assert broker.single_calls == []
+    assert list(tick_store.price_history["BTC-USD"]) == [Decimal("50000.5")]
+    assert [event["type"] for event in event_store.stored] == [EVENT_PRICE_TICK] * 2
+    assert {event["data"]["bot_id"] for event in event_store.stored} == {"recorder:test"}
+
+
+@pytest.mark.asyncio
+async def test_record_once_falls_back_to_single_ticker() -> None:
+    broker = SingleOnlyBroker({"BTC-USD": {"price": "50000"}, "ETH-USD": {"price": "2500"}})
+    recorder, _tick_store, event_store = _recorder(broker)
+
+    recorded = await recorder.record_once()
+
+    assert recorded == 2
+    assert broker.single_calls == ["BTC-USD", "ETH-USD"]
+    assert len(event_store.stored) == 2
+
+
+@pytest.mark.asyncio
+async def test_record_once_skips_missing_and_invalid_prices() -> None:
+    broker = BatchBroker(
+        {
+            "BTC-USD": {"price": "not-a-price"},
+            "ETH-USD": {"price": "0"},
+        }
+    )
+    recorder, tick_store, event_store = _recorder(broker)
+
+    recorded = await recorder.record_once()
+
+    assert recorded == 0
+    assert event_store.stored == []
+    assert tick_store.price_history == {}
+
+
+@pytest.mark.asyncio
+async def test_record_once_survives_broker_errors_per_symbol() -> None:
+    class FlakyBroker:
+        def get_ticker(self, symbol: str) -> dict[str, Any]:
+            if symbol == "BTC-USD":
+                raise RuntimeError("ticker down")
+            return {"price": "2500"}
+
+    recorder, _tick_store, event_store = _recorder(FlakyBroker())
+
+    recorded = await recorder.record_once()
+
+    assert recorded == 1
+    assert event_store.stored[0]["data"]["symbol"] == "ETH-USD"
+
+
+@pytest.mark.asyncio
+async def test_run_polls_until_stopped_and_survives_poll_failures() -> None:
+    polls = 0
+
+    class CountingBroker:
+        def get_tickers(self, symbols: list[str]) -> dict[str, dict[str, Any]]:
+            nonlocal polls
+            polls += 1
+            if polls == 1:
+                raise RuntimeError("transient outage")
+            return {symbol: {"price": "100"} for symbol in symbols}
+
+    recorder, _tick_store, event_store = _recorder(CountingBroker(), interval_seconds=0.01)
+
+    async def _stop_after_ticks() -> None:
+        while not event_store.stored:
+            await asyncio.sleep(0.005)
+        recorder.stop()
+
+    await asyncio.wait_for(
+        asyncio.gather(recorder.run(), _stop_after_ticks()),
+        timeout=5.0,
+    )
+
+    assert polls >= 2  # first poll failed, later polls recorded
+    assert event_store.stored
+    assert recorder.running is False
+
+
+def test_recorder_config_validates_inputs() -> None:
+    with pytest.raises(ValueError, match="at least one symbol"):
+        MarketDataRecorderConfig(symbols=(), interval_seconds=1.0)
+    with pytest.raises(ValueError, match="interval must be positive"):
+        MarketDataRecorderConfig(symbols=("BTC-USD",), interval_seconds=0)
+
+
+def test_derive_recorder_bot_id_handles_enum_and_str_profiles() -> None:
+    class FakeProfile:
+        value = "prod"
+
+    assert derive_recorder_bot_id(FakeProfile()) == "recorder:prod"
+    assert derive_recorder_bot_id("Dev") == "recorder:dev"
+    assert derive_recorder_bot_id(None) == "recorder:default"
+    assert derive_recorder_bot_id("") == "recorder:default"

--- a/tests/unit/gpt_trader/features/recorder/test_market_data_recorder.py
+++ b/tests/unit/gpt_trader/features/recorder/test_market_data_recorder.py
@@ -122,6 +122,26 @@ async def test_record_once_skips_missing_and_invalid_prices() -> None:
 
 
 @pytest.mark.asyncio
+async def test_record_once_skips_non_finite_prices() -> None:
+    # NaN comparisons raise InvalidOperation and Infinity is not a usable
+    # price; both must be skipped like any other invalid quote instead of
+    # aborting the poll or persisting garbage.
+    broker = BatchBroker(
+        {
+            "BTC-USD": {"price": "NaN"},
+            "ETH-USD": {"price": "Infinity"},
+        }
+    )
+    recorder, tick_store, event_store = _recorder(broker)
+
+    recorded = await recorder.record_once()
+
+    assert recorded == 0
+    assert event_store.stored == []
+    assert tick_store.price_history == {}
+
+
+@pytest.mark.asyncio
 async def test_record_once_survives_broker_errors_per_symbol() -> None:
     class FlakyBroker:
         def get_ticker(self, symbol: str) -> dict[str, Any]:

--- a/tests/unit/gpt_trader/features/recorder/test_price_tick_store_edges.py
+++ b/tests/unit/gpt_trader/features/recorder/test_price_tick_store_edges.py
@@ -39,6 +39,30 @@ def test_rehydrate_skips_non_ticks_and_invalid_events() -> None:
     assert list(store.price_history["BTC-USD"]) == [Decimal("1")]
 
 
+def test_rehydrate_is_bot_id_agnostic_across_mixed_writers() -> None:
+    # Deliberate semantics (#1158): the store filters by symbol only, so an
+    # engine restart picks up ticks the standalone recorder collected while
+    # execution was halted — including legacy events with an empty bot_id.
+    event_store = MagicMock()
+    event_store.get_recent.return_value = [
+        {"type": EVENT_PRICE_TICK, "data": {"symbol": "BTC-USD", "price": "1", "bot_id": ""}},
+        {
+            "type": EVENT_PRICE_TICK,
+            "data": {"symbol": "BTC-USD", "price": "2", "bot_id": "recorder:dev"},
+        },
+        {
+            "type": EVENT_PRICE_TICK,
+            "data": {"symbol": "BTC-USD", "price": "3", "bot_id": "some-engine"},
+        },
+    ]
+    store = PriceTickStore(event_store=event_store, symbols=["BTC-USD"], bot_id="some-engine")
+
+    restored = store.rehydrate()
+
+    assert restored == 3
+    assert list(store.price_history["BTC-USD"]) == [Decimal("1"), Decimal("2"), Decimal("3")]
+
+
 def test_rehydrate_skips_invalid_price_values() -> None:
     event_store = MagicMock()
     event_store.get_recent.return_value = [

--- a/var/agents/configuration/environment_variables.json
+++ b/var/agents/configuration/environment_variables.json
@@ -518,7 +518,7 @@
       ],
       "code_references": [
         {
-          "line": 226,
+          "line": 229,
           "path": "src/gpt_trader/cli/__init__.py",
           "reader": "_env_flag"
         },
@@ -2271,7 +2271,7 @@
       ],
       "code_references": [
         {
-          "line": 226,
+          "line": 229,
           "path": "src/gpt_trader/cli/__init__.py",
           "reader": "_env_flag"
         },

--- a/var/agents/logging/event_catalog.json
+++ b/var/agents/logging/event_catalog.json
@@ -59,6 +59,7 @@
       "log_submission_attempt",
       "process_rejection",
       "readiness_update",
+      "record",
       "record_decision_trace",
       "record_preview",
       "record_rejection",
@@ -1462,6 +1463,29 @@
       ],
       "statuses": null
     },
+    "record": {
+      "common_fields": [
+        "bot_id",
+        "error",
+        "interval_seconds",
+        "recorded_ticks",
+        "stage",
+        "symbol",
+        "symbols"
+      ],
+      "components": null,
+      "levels": [
+        "ERROR",
+        "INFO",
+        "WARNING"
+      ],
+      "occurrence_count": 8,
+      "source_files": [
+        "cli/commands/record.py",
+        "features/recorder/market_data_recorder.py"
+      ],
+      "statuses": null
+    },
     "record_decision_trace": {
       "common_fields": [
         "error_message",
@@ -2311,7 +2335,7 @@
     "consecutive_failures": 6,
     "details": 5,
     "environment": 12,
-    "error": 54,
+    "error": 56,
     "error_message": 86,
     "error_type": 86,
     "event_type": 7,
@@ -2331,17 +2355,17 @@
     "secret_ref": 6,
     "service": 9,
     "side": 25,
-    "stage": 130,
-    "symbol": 79,
+    "stage": 132,
+    "symbol": 81,
     "timestamp": 4
   },
   "level_distribution": {
     "CRITICAL": 1,
     "DEBUG": 37,
-    "ERROR": 110,
-    "INFO": 81,
-    "WARNING": 98
+    "ERROR": 111,
+    "INFO": 85,
+    "WARNING": 101
   },
-  "total_event_types": 125,
+  "total_event_types": 126,
   "version": "1.0"
 }

--- a/var/agents/logging/event_catalog.json
+++ b/var/agents/logging/event_catalog.json
@@ -1467,6 +1467,7 @@
       "common_fields": [
         "bot_id",
         "error",
+        "interval",
         "interval_seconds",
         "recorded_ticks",
         "stage",
@@ -1479,7 +1480,7 @@
         "INFO",
         "WARNING"
       ],
-      "occurrence_count": 8,
+      "occurrence_count": 10,
       "source_files": [
         "cli/commands/record.py",
         "features/recorder/market_data_recorder.py"
@@ -2335,7 +2336,7 @@
     "consecutive_failures": 6,
     "details": 5,
     "environment": 12,
-    "error": 56,
+    "error": 57,
     "error_message": 86,
     "error_type": 86,
     "event_type": 7,
@@ -2362,7 +2363,7 @@
   "level_distribution": {
     "CRITICAL": 1,
     "DEBUG": 37,
-    "ERROR": 111,
+    "ERROR": 113,
     "INFO": 85,
     "WARNING": 101
   },

--- a/var/agents/logging/index.json
+++ b/var/agents/logging/index.json
@@ -28,7 +28,7 @@
       "collateral_update",
       "collect_runtime_guard_state"
     ],
-    "total_events": 125
+    "total_events": 126
   },
   "usage": {
     "correlation": "Use correlation_id field to trace requests across logs",

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -9,7 +9,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 5840,
+    "total_tests": 5841,
     "total_files": 696,
     "markers_used": 14
   },

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -9,8 +9,8 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 5832,
-    "total_files": 695,
+    "total_tests": 5840,
+    "total_files": 696,
     "markers_used": 14
   },
   "quick_commands": {

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -92,8 +92,8 @@
     ]
   },
   "counts": {
-    "unit": 5675,
-    "asyncio": 304,
+    "unit": 5683,
+    "asyncio": 309,
     "parametrize": 173,
     "integration": 80,
     "endpoints": 64,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -92,8 +92,8 @@
     ]
   },
   "counts": {
-    "unit": 5683,
-    "asyncio": 309,
+    "unit": 5684,
+    "asyncio": 310,
     "parametrize": 173,
     "integration": 80,
     "endpoints": 64,


### PR DESCRIPTION
## Summary

PR 3 of #1158 (recorder extraction, five-role composition — M3 sequencing). This lands the last open acceptance criterion: **recording runs standalone via its own entrypoint and keeps collecting while execution is halted/paused.**

- **`features/recorder/market_data_recorder.py`** — `MarketDataRecorder`: polls read-only tickers on an injected cadence (batch `get_tickers` with per-symbol `get_ticker` fallback, mirroring the engine's fetch semantics) and persists price ticks through `PriceTickStore`. Poll failures are logged and never end the run; `stop()` is signal-safe. Nothing in the loop decides a recurrence beyond sleeping the injected interval, per the frequency-headroom directive.
- **`gpt-trader record`** — new CLI command: builds the profile's `ApplicationContainer` (MOCK_BROKER honored), constructs a recorder-owned tick store, runs until SIGINT/SIGTERM. `--once` records a single poll and exits non-zero if nothing was recorded, for verification/scheduling probes. Read-only by construction: the only broker calls are ticker reads.
- **Recorder identity** — `derive_recorder_bot_id` stamps `recorder:<profile>` into recorded events, addressing the #1158 design note about `bot_id=""`. The rehydration semantics for mixed empty/non-empty `bot_id` events are decided deliberately and pinned by a test: `PriceTickStore.rehydrate` filters by **symbol only**, so an engine restart picks up ticks the standalone recorder collected while execution was down (that is the point of the role), and legacy empty-`bot_id` events keep restoring.
- **`cli/services.py`** — `instantiate_container` extracted from `instantiate_bot` (identical validation, fingerprint persistence, and global registration; `instantiate_bot` now delegates) so the record entrypoint composes container services without creating a `TradingBot`.
- **`docs/architecture/ENTRYPOINTS.md`** gains the recorder section.

With this, all #1158 acceptance criteria are met (injected tick state — PR #1159; single snapshot source — PR #1162; standalone recording — here). The engine's WS telemetry stream deliberately stays engine-side until strategy→proposer parity, per docs/decisions/adopt-five-role-composition.md ("the live engine's direct decide→submit path retires only after proposer parity").

## Verification

- `uv run pytest tests/unit -n auto -q` — 6335 passed, 10 skipped (new: 6 recorder-loop tests, identity tests, mixed-bot_id rehydration pin)
- `make ci-required` — green end-to-end (lint, docs audit, typecheck, artifact verify, guardrails, strict-container suite, stage1 smoke)
- `MOCK_BROKER=1 gpt-trader record --profile dev --once` — exit 0; `price_tick` events persisted to `runtime_data/dev/events.db` with `bot_id=recorder:dev` (verified by direct sqlite query)
- `MOCK_BROKER=1 gpt-trader record --profile dev --interval 1` + SIGINT after ~4s — polls on cadence, graceful "recording stopped", exit 0; 14 ticks persisted across runs
- `MOCK_BROKER=1 gpt-trader run --profile dev --dev-fast` — engine unchanged, clean cycle + shutdown
- ruff / black / mypy / agent-naming — clean

Part of #1158.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a standalone `record` CLI command to capture market data without starting trading.
  * Supports continuous recording or `--once`, with selectable profile, optional symbols, and polling interval.
  * Persists captured price tick events under a dedicated recorder identity.
  * Updated architecture documentation with the canonical `record` runtime entrypoint.
* **Bug Fixes**
  * Improved polling resilience (continues after transient failures) with batch-to-per-symbol fallback.
* **Refactor**
  * Centralized container instantiation for consistent bot startup.
* **Tests**
  * Added unit coverage for polling, fetching modes, validation, stop behavior, and recorder identity/rehydration edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->