### PR TITLE
feat(strategy tools): run baseline strategies as proposers over recorded snapshots

### DIFF
--- a/src/gpt_trader/features/strategy_tools/__init__.py
+++ b/src/gpt_trader/features/strategy_tools/__init__.py
@@ -7,6 +7,10 @@ from gpt_trader.features.strategy_tools.filters import (
     create_conservative_filters,
 )
 from gpt_trader.features.strategy_tools.guards import RiskGuards, create_standard_risk_guards
+from gpt_trader.features.strategy_tools.snapshot_proposer import (
+    SnapshotDecider,
+    SnapshotStrategyProposer,
+)
 from gpt_trader.features.strategy_tools.trade_idea_adapter import (
     StrategyDecisionSignal,
     StrategySignalContext,
@@ -17,6 +21,8 @@ from gpt_trader.features.strategy_tools.trade_idea_adapter import (
 __all__ = [
     "MarketConditionFilters",
     "RiskGuards",
+    "SnapshotDecider",
+    "SnapshotStrategyProposer",
     "StrategyDecisionSignal",
     "StrategyEnhancements",
     "StrategySignalContext",

--- a/src/gpt_trader/features/strategy_tools/snapshot_proposer.py
+++ b/src/gpt_trader/features/strategy_tools/snapshot_proposer.py
@@ -1,0 +1,142 @@
+"""Run existing live-trade strategies as proposers over recorded snapshots.
+
+First strategy→proposer convergence step of the accepted five-role composition
+decision (#1164): wraps a strategy's pure ``decide(...)`` surface into the
+``Proposer`` snapshot contract, so the same intelligence that drives the live
+engine can be replayed and scored over recorder-produced ``MarketSnapshot``
+artifacts instead of growing a second proposer brain.
+
+The wrapper derives every ``decide`` input from the snapshot alone: the mark
+window is the series' candle closes, the current mark is the last close, the
+book is flat (``position_state=None``), and equity is zero because account
+state is not part of the snapshot contract — executable sizing comes from the
+offline ``TradeIdeaPositionSizingBridge`` instead. The strategy is injected as
+a factory and constructed fresh per symbol series, so no strategy state can
+bleed across symbols or snapshots and identical snapshots yield identical
+ideas. Strategies are injected structurally (:class:`SnapshotDecider`), which
+keeps this slice free of ``features.live_trade`` imports; composition roots
+own strategy construction.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any, Protocol, runtime_checkable
+
+from gpt_trader.errors import ValidationError
+from gpt_trader.features.strategy_tools.trade_idea_adapter import (
+    StrategyDecisionSignal,
+    StrategySignalContext,
+    StrategySignalToTradeIdeaAdapter,
+    StrategySignalToTradeIdeaAdapterConfig,
+)
+from gpt_trader.features.trade_ideas import (
+    MarketSnapshot,
+    SymbolSeries,
+    TradeIdea,
+    TradeIdeaPositionSizingBridge,
+)
+
+SNAPSHOT_STRATEGY_PROPOSER_PREFIX = "snapshot-strategy"
+
+
+@runtime_checkable
+class SnapshotDecider(Protocol):
+    """Structural slice of the live ``TradingStrategy`` surface the wrapper drives.
+
+    Mirrors ``features.live_trade.interfaces.TradingStrategy.decide`` without
+    importing the live-trade slice. Only strategies whose ``decide`` is a pure
+    function of these arguments are replay-safe here; strategies that mutate
+    internal state per call need fresh-state-per-snapshot handling first.
+    """
+
+    def decide(
+        self,
+        symbol: str,
+        current_mark: Decimal,
+        position_state: dict[str, Any] | None,
+        recent_marks: Sequence[Decimal],
+        equity: Decimal,
+        product: Any,
+        market_data: Any = None,
+        candles: Sequence[Any] | None = None,
+    ) -> StrategyDecisionSignal: ...
+
+
+StrategyFactory = Callable[[], SnapshotDecider]
+
+
+class SnapshotStrategyProposer:
+    """Adapt an injected strategy factory onto the ``Proposer`` contract."""
+
+    def __init__(
+        self,
+        strategy_factory: StrategyFactory,
+        *,
+        strategy_name: str,
+        adapter: StrategySignalToTradeIdeaAdapter | None = None,
+    ) -> None:
+        if not strategy_name.strip():
+            raise ValidationError("strategy_name must be non-empty", field="strategy_name")
+        self._strategy_factory = strategy_factory
+        self._strategy_name = strategy_name
+        self._adapter = adapter or StrategySignalToTradeIdeaAdapter(
+            StrategySignalToTradeIdeaAdapterConfig(
+                enabled=True,
+                proposer_id_prefix=SNAPSHOT_STRATEGY_PROPOSER_PREFIX,
+            ),
+            sizing_bridge=TradeIdeaPositionSizingBridge(),
+        )
+
+    @property
+    def proposer_id(self) -> str:
+        return self._adapter.actor_id(self._strategy_name)
+
+    def propose(self, snapshot: MarketSnapshot) -> list[TradeIdea]:
+        ideas: list[TradeIdea] = []
+        for series in snapshot.series:
+            idea = self._propose_for_series(snapshot, series)
+            if idea is not None:
+                ideas.append(idea)
+        return ideas
+
+    def _propose_for_series(
+        self, snapshot: MarketSnapshot, series: SymbolSeries
+    ) -> TradeIdea | None:
+        if not series.candles:
+            return None
+        closes = [candle.close for candle in series.candles]
+        strategy = self._strategy_factory()
+        decision = strategy.decide(
+            symbol=series.symbol,
+            current_mark=closes[-1],
+            position_state=None,
+            recent_marks=closes,
+            equity=Decimal("0"),
+            product=None,
+            candles=series.candles,
+        )
+        context = StrategySignalContext(
+            symbol=series.symbol,
+            current_mark=closes[-1],
+            as_of=_utc_aware(snapshot.as_of),
+            strategy_name=self._strategy_name,
+            data_source=f"{snapshot.source}:{series.granularity}",
+        )
+        return self._adapter.map_decision(decision, context)
+
+
+def _utc_aware(value: datetime) -> datetime:
+    if value.tzinfo is None or value.utcoffset() is None:
+        return value.replace(tzinfo=UTC)
+    return value
+
+
+__all__ = [
+    "SNAPSHOT_STRATEGY_PROPOSER_PREFIX",
+    "SnapshotDecider",
+    "SnapshotStrategyProposer",
+    "StrategyFactory",
+]

--- a/src/gpt_trader/features/strategy_tools/snapshot_proposer.py
+++ b/src/gpt_trader/features/strategy_tools/snapshot_proposer.py
@@ -81,14 +81,16 @@ class SnapshotStrategyProposer:
         if not strategy_name.strip():
             raise ValidationError("strategy_name must be non-empty", field="strategy_name")
         self._strategy_factory = strategy_factory
-        self._strategy_name = strategy_name
-        self._adapter = adapter or StrategySignalToTradeIdeaAdapter(
-            StrategySignalToTradeIdeaAdapterConfig(
-                enabled=True,
-                proposer_id_prefix=SNAPSHOT_STRATEGY_PROPOSER_PREFIX,
-            ),
-            sizing_bridge=TradeIdeaPositionSizingBridge(),
-        )
+        self._strategy_name = strategy_name.strip()
+        if adapter is None:
+            adapter = StrategySignalToTradeIdeaAdapter(
+                StrategySignalToTradeIdeaAdapterConfig(
+                    enabled=True,
+                    proposer_id_prefix=SNAPSHOT_STRATEGY_PROPOSER_PREFIX,
+                ),
+                sizing_bridge=TradeIdeaPositionSizingBridge(),
+            )
+        self._adapter = adapter
 
     @property
     def proposer_id(self) -> str:

--- a/src/gpt_trader/features/strategy_tools/snapshot_proposer.py
+++ b/src/gpt_trader/features/strategy_tools/snapshot_proposer.py
@@ -16,6 +16,12 @@ bleed across symbols or snapshots and identical snapshots yield identical
 ideas. Strategies are injected structurally (:class:`SnapshotDecider`), which
 keeps this slice free of ``features.live_trade`` imports; composition roots
 own strategy construction.
+
+The lane is long-only and spot-only today: non-buy decisions (including a
+perps strategy's short entries) are dropped by the adapter, and a non-spot
+``product_type`` fails closed through the adapter's spot-only validation
+rather than recording a futures signal as a spot idea — the same fail-closed
+stance the live proposal gate takes.
 """
 
 from __future__ import annotations
@@ -34,6 +40,7 @@ from gpt_trader.features.strategy_tools.trade_idea_adapter import (
 )
 from gpt_trader.features.trade_ideas import (
     MarketSnapshot,
+    ProductType,
     SymbolSeries,
     TradeIdea,
     TradeIdeaPositionSizingBridge,
@@ -76,12 +83,14 @@ class SnapshotStrategyProposer:
         strategy_factory: StrategyFactory,
         *,
         strategy_name: str,
+        product_type: ProductType = ProductType.SPOT,
         adapter: StrategySignalToTradeIdeaAdapter | None = None,
     ) -> None:
         if not strategy_name.strip():
             raise ValidationError("strategy_name must be non-empty", field="strategy_name")
         self._strategy_factory = strategy_factory
         self._strategy_name = strategy_name.strip()
+        self._product_type = product_type
         if adapter is None:
             adapter = StrategySignalToTradeIdeaAdapter(
                 StrategySignalToTradeIdeaAdapterConfig(
@@ -126,6 +135,7 @@ class SnapshotStrategyProposer:
             as_of=_utc_aware(snapshot.as_of),
             strategy_name=self._strategy_name,
             data_source=f"{snapshot.source}:{series.granularity}",
+            product_type=self._product_type,
         )
         return self._adapter.map_decision(decision, context)
 

--- a/src/gpt_trader/features/strategy_tools/trade_idea_adapter.py
+++ b/src/gpt_trader/features/strategy_tools/trade_idea_adapter.py
@@ -4,6 +4,11 @@ The adapter is intentionally outside ``features.trade_ideas`` so the
 broker-neutral trade-idea slice does not import live strategy modules. It maps
 an existing strategy signal into a complete ``TradeIdea`` and, when requested,
 submits that idea through ``TradeIdeaService.propose`` only.
+
+Sizing is advisory by default. When a ``TradeIdeaPositionSizingBridge`` is
+injected, mapped ideas instead carry executable sizing (positive quantity and
+notional, estimated ``max_loss.amount``) computed against the same offline
+equity/budget inputs ``BaselineProposer`` uses — never live account state.
 """
 
 from __future__ import annotations
@@ -30,7 +35,9 @@ from gpt_trader.features.trade_ideas import (
     TimeHorizon,
     TradeDirection,
     TradeIdea,
+    TradeIdeaPositionSizingBridge,
     TradeIdeaService,
+    TradeIdeaSizingContext,
     TradeIdeaView,
     evaluate_eligibility,
 )
@@ -90,16 +97,26 @@ class StrategySignalToTradeIdeaAdapterConfig:
 class StrategySignalToTradeIdeaAdapter:
     """Map strategy decisions to proposed trade ideas without execution side effects."""
 
-    def __init__(self, config: StrategySignalToTradeIdeaAdapterConfig | None = None) -> None:
+    def __init__(
+        self,
+        config: StrategySignalToTradeIdeaAdapterConfig | None = None,
+        *,
+        sizing_bridge: TradeIdeaPositionSizingBridge | None = None,
+    ) -> None:
         self._config = config or StrategySignalToTradeIdeaAdapterConfig()
+        self._sizing_bridge = sizing_bridge
 
     @property
     def enabled(self) -> bool:
         return self._config.enabled
 
+    def actor_id(self, strategy_name: str) -> str:
+        """Stable AI actor id for a strategy, independent of any single signal."""
+        return f"{_safe_slug(self._config.proposer_id_prefix)}-{_safe_slug(strategy_name)}"
+
     def proposer_id(self, context: StrategySignalContext) -> str:
         """Return the stable AI actor id recorded on proposal events."""
-        return f"{_safe_slug(self._config.proposer_id_prefix)}-{_safe_slug(context.strategy_name)}"
+        return self.actor_id(context.strategy_name)
 
     def map_decision(
         self,
@@ -170,6 +187,54 @@ class StrategySignalToTradeIdeaAdapter:
             target=target,
         )
         reason = _idea_reason(decision, context)
+        confidence = _confidence(confidence_value)
+        data_used = self._data_used(decision, context, as_of, confidence_value)
+
+        if self._sizing_bridge is None:
+            max_loss = MaxLoss(
+                percent_of_account=config.risk_per_idea_pct,
+                assumptions=(
+                    f"Strategy bridge uses a {config.stop_loss_pct}% stop from current mark {mark}",
+                    "Sizing remains advisory until a human approves the idea",
+                ),
+            )
+            sizing_recommendation = SizingRecommendation(
+                rationale=(
+                    f"Size so a stop-out near {stop_level} risks no more than "
+                    f"{config.risk_per_idea_pct}% of account equity"
+                ),
+            )
+        else:
+            # Size against the worst permitted long entry (the top of the entry
+            # zone): a fill at entry_upper is explicitly allowed, so the
+            # persisted risk snapshot must not assume a cheaper fill at the mark.
+            sizing = self._sizing_bridge.recommend(
+                TradeIdeaSizingContext(
+                    symbol=context.symbol,
+                    current_price=entry_upper,
+                    confidence_label=confidence.label,
+                    stop_loss_distance=entry_upper - stop_level,
+                    take_profit_distance=target - entry_upper,
+                    max_loss_pct=config.risk_per_idea_pct,
+                )
+            )
+            stop_distance_pct = ((entry_upper - stop_level) / entry_upper * 100).quantize(
+                Decimal("0.01")
+            )
+            max_loss = MaxLoss(
+                amount=sizing.estimated_loss_amount,
+                percent_of_account=sizing.estimated_loss_pct,
+                assumptions=(
+                    f"Strategy bridge uses a {config.stop_loss_pct}% stop from current mark {mark}",
+                    f"PositionSizer notional {sizing.recommendation.notional} implies "
+                    f"an estimated stop-out loss of {sizing.estimated_loss_amount}",
+                    f"Risk budget cap remains {sizing.effective_max_loss_pct}% per idea",
+                    f"Sized at the worst permitted entry {entry_upper}; stop distance "
+                    f"is {stop_distance_pct}% from there",
+                ),
+            )
+            sizing_recommendation = sizing.recommendation
+            data_used = (*data_used, sizing.data_used)
 
         return TradeIdea(
             decision_id=self._decision_id(decision, context, as_of),
@@ -183,25 +248,14 @@ class StrategySignalToTradeIdeaAdapter:
             entry_zone=EntryZone(lower=entry_lower, upper=entry_upper),
             invalidation=f"Close below the strategy stop level {stop_level}",
             target_exit=f"Take profit near {target} or exit at expiry",
-            max_loss=MaxLoss(
-                percent_of_account=config.risk_per_idea_pct,
-                assumptions=(
-                    f"Strategy bridge uses a {config.stop_loss_pct}% stop from current mark {mark}",
-                    "Sizing remains advisory until a human approves the idea",
-                ),
-            ),
-            sizing_recommendation=SizingRecommendation(
-                rationale=(
-                    f"Size so a stop-out near {stop_level} risks no more than "
-                    f"{config.risk_per_idea_pct}% of account equity"
-                ),
-            ),
+            max_loss=max_loss,
+            sizing_recommendation=sizing_recommendation,
             time_horizon=TimeHorizon(
                 expected_hold=config.expected_hold,
                 expires_at=as_of + timedelta(hours=config.expiry_hours),
             ),
-            data_used=self._data_used(decision, context, as_of, confidence_value),
-            confidence=_confidence(confidence_value),
+            data_used=data_used,
+            confidence=confidence,
             failure_mode=(
                 "Strategy signal fails if price rejects the entry zone and closes below "
                 "the mapped invalidation level"

--- a/tests/unit/gpt_trader/features/strategy_tools/test_snapshot_proposer.py
+++ b/tests/unit/gpt_trader/features/strategy_tools/test_snapshot_proposer.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from typing import Any
+
+from gpt_trader.core import Candle
+from gpt_trader.features.live_trade.strategies.baseline import (
+    Action,
+    BaselinePerpsStrategy,
+    Decision,
+    SpotStrategy,
+)
+from gpt_trader.features.strategy_tools import (
+    SnapshotDecider,
+    SnapshotStrategyProposer,
+)
+from gpt_trader.features.trade_ideas import (
+    MarketSnapshot,
+    ProductType,
+    Proposer,
+    SymbolSeries,
+    TradeDirection,
+    evaluate_eligibility,
+)
+
+AS_OF = datetime(2026, 7, 3, 0, 0, tzinfo=UTC)
+
+# Flat closes then a two-bar rise: the 5-bar average crosses above the 20-bar
+# average within the crossover lookback and the trend turns bullish, clearing
+# the baseline entry gate (crossover 0.4 + trend 0.3 >= min_confidence 0.5).
+GOLDEN_CROSS = ["100"] * 28 + ["102", "104"]
+# Mirror image: bearish crossover + bearish trend emits SELL on a flat book.
+BEARISH_BREAK = ["100"] * 28 + ["98", "96"]
+
+
+def make_series(
+    closes: list[str],
+    symbol: str = "BTC-USD",
+    as_of: datetime = AS_OF,
+) -> SymbolSeries:
+    candles = tuple(
+        Candle(
+            ts=as_of - timedelta(days=len(closes) - index),
+            open=Decimal(close),
+            high=Decimal(close),
+            low=Decimal(close),
+            close=Decimal(close),
+            volume=Decimal("1000"),
+        )
+        for index, close in enumerate(closes)
+    )
+    return SymbolSeries(symbol=symbol, granularity="1d", candles=candles)
+
+
+def snapshot_of(*series: SymbolSeries, as_of: datetime = AS_OF) -> MarketSnapshot:
+    return MarketSnapshot(as_of=as_of, source="coinbase:candles", series=series)
+
+
+def spot_proposer() -> SnapshotStrategyProposer:
+    return SnapshotStrategyProposer(SpotStrategy, strategy_name="baseline-spot")
+
+
+class SpyStrategy:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def decide(
+        self,
+        symbol: str,
+        current_mark: Decimal,
+        position_state: dict[str, Any] | None,
+        recent_marks: Any,
+        equity: Decimal,
+        product: Any,
+        market_data: Any = None,
+        candles: Any = None,
+    ) -> Decision:
+        self.calls.append(
+            {
+                "symbol": symbol,
+                "current_mark": current_mark,
+                "position_state": position_state,
+                "recent_marks": recent_marks,
+                "equity": equity,
+                "product": product,
+                "market_data": market_data,
+                "candles": candles,
+            }
+        )
+        return Decision(Action.HOLD, "spy", confidence=0.0, indicators={})
+
+
+def test_satisfies_proposer_protocol() -> None:
+    assert isinstance(spot_proposer(), Proposer)
+
+
+def test_shipped_baseline_strategies_satisfy_snapshot_decider() -> None:
+    assert isinstance(SpotStrategy(), SnapshotDecider)
+    assert isinstance(BaselinePerpsStrategy(), SnapshotDecider)
+
+
+def test_proposer_id_is_a_stable_property() -> None:
+    assert spot_proposer().proposer_id == "snapshot-strategy-baseline-spot"
+
+
+def test_buy_signal_maps_to_eligible_executable_long_idea() -> None:
+    ideas = spot_proposer().propose(snapshot_of(make_series(GOLDEN_CROSS)))
+
+    assert len(ideas) == 1
+    idea = ideas[0]
+    assert idea.instrument == "BTC-USD"
+    assert idea.direction is TradeDirection.LONG
+    assert idea.product_type is ProductType.SPOT
+    assert idea.decision_id.startswith("trade-20260703-baseline-spot-btc-usd-")
+    assert idea.data_used[0].startswith("coinbase:candles:1d:BTC-USD:")
+    assert idea.time_horizon.expires_at == AS_OF + timedelta(hours=48)
+    assert evaluate_eligibility(idea) == []
+    # Executor admission requires real sizing, not the advisory default.
+    assert idea.sizing_recommendation.quantity is not None
+    assert idea.sizing_recommendation.quantity > 0
+    assert idea.sizing_recommendation.notional is not None
+    assert idea.max_loss.amount is not None
+    assert idea.max_loss.amount > 0
+    assert any("engine=position-sizer-bridge-v1" in item for item in idea.data_used)
+
+
+def test_identical_snapshots_yield_identical_ideas() -> None:
+    snapshot = snapshot_of(make_series(GOLDEN_CROSS))
+
+    first = spot_proposer().propose(snapshot)
+    second = spot_proposer().propose(snapshot)
+
+    assert first == second
+    assert [idea.record_hash() for idea in first] == [idea.record_hash() for idea in second]
+
+
+def test_non_buy_decisions_produce_no_ideas() -> None:
+    bearish = snapshot_of(make_series(BEARISH_BREAK))
+
+    perps = SnapshotStrategyProposer(BaselinePerpsStrategy, strategy_name="baseline-perps")
+    assert perps.propose(bearish) == []
+    assert spot_proposer().propose(bearish) == []
+
+
+def test_insufficient_history_produces_no_ideas() -> None:
+    assert spot_proposer().propose(snapshot_of(make_series(["100"] * 10))) == []
+
+
+def test_empty_series_is_skipped() -> None:
+    empty = SymbolSeries(symbol="ETH-USD", granularity="1d", candles=())
+
+    ideas = spot_proposer().propose(snapshot_of(make_series(GOLDEN_CROSS), empty))
+
+    assert [idea.instrument for idea in ideas] == ["BTC-USD"]
+
+
+def test_fresh_strategy_instance_per_symbol_series() -> None:
+    built: list[SpotStrategy] = []
+
+    def factory() -> SpotStrategy:
+        strategy = SpotStrategy()
+        built.append(strategy)
+        return strategy
+
+    proposer = SnapshotStrategyProposer(factory, strategy_name="baseline-spot")
+    snapshot = snapshot_of(make_series(GOLDEN_CROSS), make_series(GOLDEN_CROSS, symbol="ETH-USD"))
+
+    ideas = proposer.propose(snapshot)
+
+    assert [idea.instrument for idea in ideas] == ["BTC-USD", "ETH-USD"]
+    assert len(built) == 2
+    proposer.propose(snapshot)
+    assert len(built) == 4
+
+
+def test_decide_inputs_come_from_snapshot_only() -> None:
+    spy = SpyStrategy()
+    series = make_series(GOLDEN_CROSS)
+
+    SnapshotStrategyProposer(lambda: spy, strategy_name="spy").propose(snapshot_of(series))
+
+    assert len(spy.calls) == 1
+    call = spy.calls[0]
+    closes = [candle.close for candle in series.candles]
+    assert call["symbol"] == "BTC-USD"
+    assert call["recent_marks"] == closes
+    assert call["current_mark"] == closes[-1]
+    assert call["candles"] == series.candles
+    # The snapshot contract carries no account or position state.
+    assert call["position_state"] is None
+    assert call["equity"] == Decimal("0")
+    assert call["product"] is None
+    assert call["market_data"] is None
+
+
+def test_naive_snapshot_as_of_is_treated_as_utc() -> None:
+    naive = AS_OF.replace(tzinfo=None)
+
+    ideas = spot_proposer().propose(
+        snapshot_of(make_series(GOLDEN_CROSS, as_of=naive), as_of=naive)
+    )
+
+    assert len(ideas) == 1
+    assert ideas[0].time_horizon.expires_at == AS_OF + timedelta(hours=48)

--- a/tests/unit/gpt_trader/features/strategy_tools/test_snapshot_proposer.py
+++ b/tests/unit/gpt_trader/features/strategy_tools/test_snapshot_proposer.py
@@ -104,6 +104,15 @@ def test_proposer_id_is_a_stable_property() -> None:
     assert spot_proposer().proposer_id == "snapshot-strategy-baseline-spot"
 
 
+def test_strategy_name_is_normalized() -> None:
+    padded = SnapshotStrategyProposer(SpotStrategy, strategy_name=" baseline-spot ")
+
+    assert padded.proposer_id == "snapshot-strategy-baseline-spot"
+
+    ideas = padded.propose(snapshot_of(make_series(GOLDEN_CROSS)))
+    assert ideas == spot_proposer().propose(snapshot_of(make_series(GOLDEN_CROSS)))
+
+
 def test_buy_signal_maps_to_eligible_executable_long_idea() -> None:
     ideas = spot_proposer().propose(snapshot_of(make_series(GOLDEN_CROSS)))
 

--- a/tests/unit/gpt_trader/features/strategy_tools/test_snapshot_proposer.py
+++ b/tests/unit/gpt_trader/features/strategy_tools/test_snapshot_proposer.py
@@ -4,7 +4,10 @@ from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from typing import Any
 
+import pytest
+
 from gpt_trader.core import Candle
+from gpt_trader.errors import ValidationError
 from gpt_trader.features.live_trade.strategies.baseline import (
     Action,
     BaselinePerpsStrategy,
@@ -142,6 +145,17 @@ def test_identical_snapshots_yield_identical_ideas() -> None:
 
     assert first == second
     assert [idea.record_hash() for idea in first] == [idea.record_hash() for idea in second]
+
+
+def test_non_spot_product_type_fails_closed() -> None:
+    perps = SnapshotStrategyProposer(
+        BaselinePerpsStrategy,
+        strategy_name="baseline-perps",
+        product_type=ProductType.FUTURES,
+    )
+
+    with pytest.raises(ValidationError, match="supports spot ideas only"):
+        perps.propose(snapshot_of(make_series(GOLDEN_CROSS)))
 
 
 def test_non_buy_decisions_produce_no_ideas() -> None:

--- a/tests/unit/gpt_trader/features/strategy_tools/test_trade_idea_adapter.py
+++ b/tests/unit/gpt_trader/features/strategy_tools/test_trade_idea_adapter.py
@@ -190,6 +190,7 @@ def test_sizing_bridge_makes_mapped_ideas_executable() -> None:
     assert idea.sizing_recommendation.quantity is not None
     assert idea.sizing_recommendation.quantity > 0
     assert idea.sizing_recommendation.notional is not None
+    assert idea.sizing_recommendation.notional > 0
     assert idea.max_loss.amount is not None
     assert idea.max_loss.amount > 0
     assert idea.max_loss.percent_of_account is not None

--- a/tests/unit/gpt_trader/features/strategy_tools/test_trade_idea_adapter.py
+++ b/tests/unit/gpt_trader/features/strategy_tools/test_trade_idea_adapter.py
@@ -21,6 +21,7 @@ from gpt_trader.features.trade_ideas import (
     ActorType,
     ProductType,
     TradeDirection,
+    TradeIdeaPositionSizingBridge,
     TradeIdeaService,
     TradeIdeaState,
     evaluate_eligibility,
@@ -175,3 +176,36 @@ def test_non_spot_context_is_rejected_before_proposal(tmp_path: Path) -> None:
         adapter.propose_decision(_buy_decision(), context, service)
 
     assert service.list_views() == []
+
+
+def test_sizing_bridge_makes_mapped_ideas_executable() -> None:
+    adapter = StrategySignalToTradeIdeaAdapter(
+        StrategySignalToTradeIdeaAdapterConfig(enabled=True),
+        sizing_bridge=TradeIdeaPositionSizingBridge(),
+    )
+
+    idea = adapter.map_decision(_buy_decision(), _context())
+
+    assert idea is not None
+    assert idea.sizing_recommendation.quantity is not None
+    assert idea.sizing_recommendation.quantity > 0
+    assert idea.sizing_recommendation.notional is not None
+    assert idea.max_loss.amount is not None
+    assert idea.max_loss.amount > 0
+    assert idea.max_loss.percent_of_account is not None
+    assert any("engine=position-sizer-bridge-v1" in item for item in idea.data_used)
+    assert any("Sized at the worst permitted entry" in item for item in idea.max_loss.assumptions)
+    assert evaluate_eligibility(idea) == []
+
+
+def test_default_adapter_sizing_stays_advisory() -> None:
+    idea = _enabled_adapter().map_decision(_buy_decision(), _context())
+
+    assert idea is not None
+    assert idea.sizing_recommendation.quantity is None
+    assert idea.sizing_recommendation.notional is None
+    assert idea.max_loss.amount is None
+    assert any(
+        "Sizing remains advisory until a human approves the idea" in item
+        for item in idea.max_loss.assumptions
+    )


### PR DESCRIPTION
## Summary
<!-- What and why. Keep it crisp. Link related issues. -->
Related issue / finding / routed package: #1164 (stage 1 of 3)

First strategy→proposer convergence step of the accepted [adopt-five-role-composition](../blob/main/docs/decisions/adopt-five-role-composition.md) decision: the stateless baseline strategy family can now run as a `Proposer` over recorder-produced `MarketSnapshot` artifacts, instead of the trade-idea lane growing a second proposer brain.

- **`SnapshotStrategyProposer`** (new, `features/strategy_tools/snapshot_proposer.py`): wraps an injected strategy factory onto the `Proposer` contract. Every `decide(...)` input is derived from the snapshot alone — mark window = candle closes, current mark = last close, flat book (`position_state=None`), zero equity (account state is not part of the snapshot contract). A fresh strategy instance is built per symbol series, so state cannot bleed across symbols or snapshots and identical snapshots yield byte-identical ideas (stable `decision_id`/`record_hash`). Strategies are injected structurally via the new `SnapshotDecider` protocol, so **no new cross-slice import edge**: `strategy_tools` still does not import `live_trade`; composition roots (tests today, the `ideas` CLI in stage 2) own strategy construction.
- **`StrategySignalToTradeIdeaAdapter`**: gains an optional injected `TradeIdeaPositionSizingBridge`. When present, mapped ideas carry executable sizing (positive `quantity`/`notional`, estimated `max_loss.amount`) computed against the same offline budget equity `BaselineProposer` uses, sized at the worst permitted entry. Without it (the default, including the existing default-off runtime gate), advisory sizing is byte-for-byte unchanged. Also adds `actor_id(strategy_name)` so a context-free stable proposer id exists; `proposer_id(context)` delegates to it.

Deliberately out of this PR, per the issue's staging: CLI wiring (`ideas propose-*`/`cycle`/`replay`, stage 2) and the stateful strategies (mean-reversion cooldown, regime-switcher detector; stage 3).

## Type of change
- [ ] Refactor
- [x] Feature
- [ ] Bug fix
- [ ] Tests only
- [ ] CI/Docs/Tooling

## Scope & Impact
- Affected areas / components: `src/gpt_trader/features/strategy_tools/` (new `snapshot_proposer.py`; `trade_idea_adapter.py`; `__init__.py` exports) + unit tests
- Any behavior changes? Additive only. The adapter without a sizing bridge produces identical output to before (pinned by `test_default_adapter_sizing_stays_advisory` and the untouched existing adapter suite); the live engine's default-off proposal gate constructs the adapter without a bridge, so runtime behavior is unchanged. New behavior exists only when a composition root opts in.

## Test Plan
- [x] Unit tests added/updated (`test_snapshot_proposer.py`: protocol conformance, eligibility, executable sizing, determinism/`record_hash` stability, non-buy/insufficient-history/empty-series, fresh-instance-per-series, snapshot-only `decide` inputs, naive-`as_of` coercion; `test_trade_idea_adapter.py`: sized vs advisory paths)
- [ ] Integration tests added/updated (n/a — unit-level slice; end-to-end exercised via CLI drive below)
- [ ] Contract tests (if applicable)
- [x] Ran locally: full `tests/unit` — 6349 passed, 10 skipped
- [x] Markers used appropriately (`unit`/`integration`/`slow`/`perf`)

## Quality Gates
- [x] `make ci-required` passes locally (lint/format, docs audits, type check, agent freshness, test guardrails, core unit tests)
- [x] `uv run mypy src/gpt_trader` clean
- [x] No `sys.path` hacks in tests; `AsyncMock` (not `MagicMock`) on `async def`
- [x] Import boundaries respected (`scripts/ci/check_import_boundaries.py` green; no new edges needed)

## Observability & Errors
- [x] Structured JSON logs for new/changed paths (n/a — the wrapper adds no I/O; failures surface as typed `ValidationError`s from the existing adapter/eligibility paths)
- [x] Errors include diagnostic context (symbol, field, value via `ValidationError`; sub-cent precision guard verified end-to-end)

## Agent Artifacts & Config (if touched)
- [x] `make ci-required` includes the agent-artifact freshness check — green
- [ ] If docs changed: `make agent-docs-links` passes (no docs changed)

## Breaking Changes
- [x] None
- [ ] Documented in PR body and the linked issue if any

## Screenshots / Logs (optional)
End-to-end drive (proposer → `TradeIdeaService` → shipped CLI), golden-cross snapshot:

```
proposer_id: snapshot-strategy-baseline-spot
{ "decision_id": "trade-20260703-baseline-spot-btc-usd-171c9ec6",
  "instrument": "BTC-USD", "direction": "long",
  "entry_zone": ["102.96", "105.04"], "invalidation": "Close below the strategy stop level 101.92",
  "quantity": "0.47600914", "notional": "50.00", "max_loss_amount": "1.49" }
workflow states: ['proposed']
$ gpt-trader ideas approve trade-20260703-... --actor rj --account attested via `ideas budget set`
✓ ideas approve OK (trade-20260703-baseline-spot-btc-usd-171c9ec6, state=approved)
✓ ideas audit verify OK (2 events)
# identical rerun over the same snapshot:
DuplicateTradeIdeaError: Trade idea decision_id 'trade-20260703-...' already exists
```

## Checklist
- [x] Acceptance criteria in linked issue(s), finding packet, or routed package met (stage-1 subset: `Proposer` conformance, eligibility, determinism, executable sizing, no look-ahead, live path unchanged; CLI selectability is stage 2)
- [x] Affected paths listed in PR description

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RqeG8W2GjNxMk2Wo6agKBa

---
_Generated by [Claude Code](https://claude.ai/code/session_01RqeG8W2GjNxMk2Wo6agKBa)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added snapshot-based strategy proposal to turn recorded market snapshots into executable trade ideas.
  * Enhanced trade-idea sizing: when sizing support is available, generated ideas include executable quantity/notional and computed max-loss; otherwise sizing remains advisory.
  * Exposed snapshot strategy proposer components publicly, including stable proposer IDs and normalized strategy naming.
* **Tests**
  * Added unit tests for snapshot proposer determinism, eligibility mapping, series skipping/insufficient history handling, per-symbol strategy instantiation, snapshot-derived decision inputs, and UTC handling for naive timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->