### PR TITLE
feat(strategy tools + ideas cli): run stateful strategies as snapshot proposers (#1164 stage 3)

### DIFF
--- a/docs/paper_trading.md
+++ b/docs/paper_trading.md
@@ -194,10 +194,15 @@ only in the scheduler entry.
 Strategy-backed proposers — the live strategy library running over the turn's
 snapshot through the `Proposer` contract — are opt-in until replay parity is
 demonstrated: pass `--proposer strategy-baseline-spot` (or
-`strategy-baseline-perps`; both emit long-only spot ideas), or set
-`CYCLE_PROPOSERS="baseline regime-aware strategy-baseline-spot"`. For
-sub-cent symbols the proposal price levels quantize to zero at the default
-precision and fail closed; pass a finer `--price-precision` for the turn.
+`strategy-baseline-perps`, `strategy-mean-reversion`,
+`strategy-regime-switcher`; all emit long-only spot ideas), or set
+`CYCLE_PROPOSERS="baseline regime-aware strategy-baseline-spot"`. Each
+strategy proposes only past its own live warm-up floor: the baseline family
+and mean reversion need 20 candles, while the regime switcher holds until its
+detector confirms a regime at 54 candles — keep `--lookback` comfortably
+above that (the default 200 is). For sub-cent symbols the proposal price
+levels quantize to zero at the default precision and fail closed; pass a
+finer `--price-precision` for the turn.
 
 ### launchd (macOS)
 

--- a/src/gpt_trader/cli/commands/ideas.py
+++ b/src/gpt_trader/cli/commands/ideas.py
@@ -21,7 +21,7 @@ from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Any, cast
 
-from gpt_trader.app.config import BotConfig
+from gpt_trader.app.config import BotConfig, MeanReversionConfig
 from gpt_trader.app.runtime import resolve_runtime_paths
 from gpt_trader.cli import options
 from gpt_trader.cli.commands.ideas_input import (
@@ -49,6 +49,8 @@ from gpt_trader.features.live_trade.strategies.baseline import (
     BaseStrategyConfig,
     SpotStrategy,
 )
+from gpt_trader.features.live_trade.strategies.mean_reversion import MeanReversionStrategy
+from gpt_trader.features.live_trade.strategies.regime_switcher import RegimeSwitchingStrategy
 from gpt_trader.features.recorder import (
     DEFAULT_COINBASE_BASE_URL,
     DEFAULT_SNAPSHOT_SOURCE_LABEL,
@@ -58,6 +60,7 @@ from gpt_trader.features.recorder import (
 )
 from gpt_trader.features.strategy_tools import (
     SNAPSHOT_STRATEGY_PROPOSER_PREFIX,
+    SnapshotDecideDrive,
     SnapshotStrategyProposer,
     StrategyFactory,
     StrategySignalToTradeIdeaAdapter,
@@ -131,7 +134,11 @@ VENUE_CHOICES = ("coinbase", "manual")
 # --strategy flag values: live-trade strategies runnable as snapshot proposers.
 # The CLI is the composition root — it constructs the strategy so the
 # strategy_tools slice never imports live_trade (SnapshotDecider is structural).
-STRATEGY_PROPOSER_CHOICES = ("baseline-spot", "baseline-perps")
+# "ensemble" is deliberately absent (#1164 stage 3 deferral): its combiner
+# mutates hysteresis state inside combine() and decide() swallows signal
+# failures with a bare print, so its decisions are not yet explainable from
+# recorded data alone; it joins this list once that surface is audited.
+STRATEGY_PROPOSER_CHOICES = ("baseline-spot", "baseline-perps", "mean-reversion", "regime-switcher")
 # cycle --proposer / replay tournament ids for the same strategies.
 STRATEGY_BACKED_PROPOSER_IDS = tuple(f"strategy-{name}" for name in STRATEGY_PROPOSER_CHOICES)
 DEFAULT_CYCLE_PROPOSERS = ("baseline", "regime-aware")
@@ -704,7 +711,7 @@ def register(subparsers: Any) -> None:
         type=_positive_int_value,
         help=(
             "Minimum historical candles before evaluating snapshots "
-            "(default: the strategy's warm-up floor, max(long-MA period, RSI period + 1))"
+            "(default: the selected strategy's own warm-up floor)"
         ),
     )
     strategy_replay.add_argument(
@@ -1436,31 +1443,50 @@ def _resolve_replay_min_history(
     return requested_min_history
 
 
-def _default_strategy_replay_min_history() -> int:
-    """The strategy's own warm-up floor: ``decide`` holds below this history.
+def _strategy_replay_floor(strategy_name: str) -> tuple[int, str]:
+    """One strategy's warm-up floor and why: ``decide`` holds below it.
 
-    Matches the live insufficient-data gate exactly (windows are not
+    Matches the live insufficient-data gate exactly (configurations are not
     CLI-tunable because the parity lane replays the live configuration
     as-is); anything stricter would silently skip early snapshots the live
     strategy would have evaluated.
     """
-    config = BaseStrategyConfig()
-    return max(config.long_ma_period, config.rsi_period + 1)
+    if strategy_name in ("baseline-spot", "baseline-perps"):
+        config = BaseStrategyConfig()
+        floor = max(config.long_ma_period, config.rsi_period + 1)
+        reason = (
+            f"decide() holds below max(long-MA {config.long_ma_period}, "
+            f"RSI {config.rsi_period} + 1) candles"
+        )
+        return floor, reason
+    if strategy_name == "mean-reversion":
+        mean_reversion_config = MeanReversionConfig()
+        floor = mean_reversion_config.lookback_window
+        reason = f"decide() holds below the {floor}-candle Z-Score lookback window"
+        return floor, reason
+    # regime-switcher: the regime stays UNKNOWN (decide() holds) until the
+    # detector's long EMA initializes and min_regime_ticks consecutive
+    # classifications confirm the first regime; that always exceeds the
+    # delegate strategies' own 20-candle floors at live defaults.
+    regime_config = RegimeConfig()
+    floor = regime_config.long_ema_period + regime_config.min_regime_ticks - 1
+    reason = (
+        f"the regime stays UNKNOWN below long-EMA {regime_config.long_ema_period} "
+        f"+ min-regime-ticks {regime_config.min_regime_ticks} - 1 candles"
+    )
+    return floor, reason
 
 
 def _resolve_strategy_replay_min_history(args: Namespace) -> int:
-    required_min_history = _default_strategy_replay_min_history()
+    required_min_history, floor_reason = _strategy_replay_floor(args.strategy)
     requested_min_history = cast(int | None, args.min_history)
     if requested_min_history is None:
         return required_min_history
     if requested_min_history < required_min_history:
-        config = BaseStrategyConfig()
         raise CandleInputError(
             (
-                f"--min-history must be at least {required_min_history} for the "
-                f"baseline strategy family: decide() holds below "
-                f"max(long-MA {config.long_ma_period}, "
-                f"RSI {config.rsi_period} + 1) candles"
+                f"--min-history must be at least {required_min_history} for "
+                f"{args.strategy}: {floor_reason}"
             ),
             field="min_history",
         )
@@ -1534,13 +1560,14 @@ def _tournament_entries(args: Namespace) -> list[tuple[Proposer, int]]:
             )
         seen.add(proposer_id)
         if proposer_id in STRATEGY_BACKED_PROPOSER_IDS:
+            strategy_name = proposer_id.removeprefix("strategy-")
             entries.append(
                 (
                     _snapshot_strategy_proposer(
-                        proposer_id.removeprefix("strategy-"),
+                        strategy_name,
                         price_precision=args.price_precision,
                     ),
-                    _default_strategy_replay_min_history(),
+                    _strategy_replay_floor(strategy_name)[0],
                 )
             )
         else:
@@ -1663,9 +1690,32 @@ def _handle_propose_regime_aware(args: Namespace) -> CliResponse:
     )
 
 
-_STRATEGY_FACTORIES: dict[str, StrategyFactory] = {
-    "baseline-spot": SpotStrategy,
-    "baseline-perps": BaselinePerpsStrategy,
+def _mean_reversion_snapshot_strategy() -> MeanReversionStrategy:
+    """Fresh live-default strategy; the caller-owned CooldownState starts clear."""
+    return MeanReversionStrategy(MeanReversionConfig())
+
+
+def _regime_switcher_snapshot_strategy() -> RegimeSwitchingStrategy:
+    """Fresh switcher with a fresh MarketRegimeDetector, spot-lane delegates."""
+    return RegimeSwitchingStrategy(
+        trend_strategy_factory=SpotStrategy,
+        mean_reversion_strategy_factory=_mean_reversion_snapshot_strategy,
+        enable_shorts=False,
+    )
+
+
+# Composition-root recipe per --strategy choice. The baseline family and mean
+# reversion decide from the mark window alone (mean reversion's cooldown is a
+# caller-owned CooldownState that stays inert on the lane's flat book), so one
+# final-bar decide reproduces the live decision. The regime switcher's
+# MarketRegimeDetector accumulates state per decide call, so it is driven per
+# candle: a fresh detector warmed from the snapshot's own closes (#1164
+# stage 3).
+_STRATEGY_PROPOSER_SPECS: dict[str, tuple[StrategyFactory, SnapshotDecideDrive]] = {
+    "baseline-spot": (SpotStrategy, "final-bar"),
+    "baseline-perps": (BaselinePerpsStrategy, "final-bar"),
+    "mean-reversion": (_mean_reversion_snapshot_strategy, "final-bar"),
+    "regime-switcher": (_regime_switcher_snapshot_strategy, "per-candle"),
 }
 
 
@@ -1684,10 +1734,12 @@ def _snapshot_strategy_proposer(
         ),
         sizing_bridge=sizing_bridge or TradeIdeaPositionSizingBridge(),
     )
+    strategy_factory, drive = _STRATEGY_PROPOSER_SPECS[strategy_name]
     return SnapshotStrategyProposer(
-        _STRATEGY_FACTORIES[strategy_name],
+        strategy_factory,
         strategy_name=strategy_name,
         adapter=adapter,
+        drive=drive,
     )
 
 

--- a/src/gpt_trader/features/live_trade/strategies/mean_reversion/__init__.py
+++ b/src/gpt_trader/features/live_trade/strategies/mean_reversion/__init__.py
@@ -1,7 +1,8 @@
 """Mean Reversion Strategy using Z-Score and volatility targeting."""
 
 from gpt_trader.features.live_trade.strategies.mean_reversion.strategy import (
+    CooldownState,
     MeanReversionStrategy,
 )
 
-__all__ = ["MeanReversionStrategy"]
+__all__ = ["CooldownState", "MeanReversionStrategy"]

--- a/src/gpt_trader/features/live_trade/strategies/mean_reversion/strategy.py
+++ b/src/gpt_trader/features/live_trade/strategies/mean_reversion/strategy.py
@@ -27,6 +27,20 @@ logger = get_logger(__name__, component="mean_reversion")
 
 
 @dataclass
+class CooldownState:
+    """Re-entry cooldown counter, externalized from the strategy (#1164 stage 3).
+
+    ``decide`` mutates only this object; every other input is passed per call.
+    The live engine keeps today's behavior through the default per-instance
+    state, while replay callers (the snapshot-proposer lane) construct a fresh
+    ``CooldownState`` per replay window so decisions are a pure function of
+    recorded inputs plus caller-owned state.
+    """
+
+    remaining: int = 0
+
+
+@dataclass
 class ZScoreState:
     """Current Z-Score indicator state."""
 
@@ -54,9 +68,9 @@ class MeanReversionStrategy:
     - Volatility targeting: size = (target_vol / current_vol) * equity * max_position_pct
     """
 
-    def __init__(self, config: MeanReversionConfig) -> None:
+    def __init__(self, config: MeanReversionConfig, cooldown: CooldownState | None = None) -> None:
         self.config = config
-        self._cooldown_remaining = 0
+        self._cooldown = cooldown if cooldown is not None else CooldownState()
         logger.info(
             f"MeanReversionStrategy initialized: "
             f"z_entry={config.z_score_entry_threshold}, "
@@ -197,12 +211,12 @@ class MeanReversionStrategy:
         """Decide on entry when no position exists."""
         indicators = self._build_indicators(state)
 
-        if self._cooldown_remaining > 0:
-            self._cooldown_remaining -= 1
-            indicators["cooldown_remaining"] = self._cooldown_remaining
+        if self._cooldown.remaining > 0:
+            self._cooldown.remaining -= 1
+            indicators["cooldown_remaining"] = self._cooldown.remaining
             return Decision(
                 Action.HOLD,
-                f"Cooldown active ({self._cooldown_remaining} bars remaining)",
+                f"Cooldown active ({self._cooldown.remaining} bars remaining)",
                 confidence=0.0,
                 indicators=indicators,
             )
@@ -268,8 +282,8 @@ class MeanReversionStrategy:
         # Check for mean reversion exit (price returned to fair value)
         if state.signal == "exit":
             if self.config.cooldown_bars > 0:
-                self._cooldown_remaining = max(self._cooldown_remaining, self.config.cooldown_bars)
-                indicators["cooldown_remaining"] = self._cooldown_remaining
+                self._cooldown.remaining = max(self._cooldown.remaining, self.config.cooldown_bars)
+                indicators["cooldown_remaining"] = self._cooldown.remaining
             return Decision(
                 Action.CLOSE,
                 f"Z-Score={z:.2f} near zero (mean reversion complete)",
@@ -292,10 +306,10 @@ class MeanReversionStrategy:
                 # Stop loss
                 if pnl_pct < -self.config.stop_loss_pct:
                     if self.config.cooldown_bars > 0:
-                        self._cooldown_remaining = max(
-                            self._cooldown_remaining, self.config.cooldown_bars
+                        self._cooldown.remaining = max(
+                            self._cooldown.remaining, self.config.cooldown_bars
                         )
-                        indicators["cooldown_remaining"] = self._cooldown_remaining
+                        indicators["cooldown_remaining"] = self._cooldown.remaining
                     return Decision(
                         Action.CLOSE,
                         f"Stop loss triggered: {pnl_pct:.2%} loss",
@@ -306,10 +320,10 @@ class MeanReversionStrategy:
                 # Take profit
                 if pnl_pct > self.config.take_profit_pct:
                     if self.config.cooldown_bars > 0:
-                        self._cooldown_remaining = max(
-                            self._cooldown_remaining, self.config.cooldown_bars
+                        self._cooldown.remaining = max(
+                            self._cooldown.remaining, self.config.cooldown_bars
                         )
-                        indicators["cooldown_remaining"] = self._cooldown_remaining
+                        indicators["cooldown_remaining"] = self._cooldown.remaining
                     return Decision(
                         Action.CLOSE,
                         f"Take profit triggered: {pnl_pct:.2%} gain",
@@ -320,8 +334,8 @@ class MeanReversionStrategy:
         # Check for signal reversal (optional: close on opposite signal)
         if position_side == "long" and state.signal == "short":
             if self.config.cooldown_bars > 0:
-                self._cooldown_remaining = max(self._cooldown_remaining, self.config.cooldown_bars)
-                indicators["cooldown_remaining"] = self._cooldown_remaining
+                self._cooldown.remaining = max(self._cooldown.remaining, self.config.cooldown_bars)
+                indicators["cooldown_remaining"] = self._cooldown.remaining
             return Decision(
                 Action.CLOSE,
                 f"Signal reversal: Z-Score={z:.2f} now indicates short",
@@ -330,8 +344,8 @@ class MeanReversionStrategy:
             )
         if position_side == "short" and state.signal == "long":
             if self.config.cooldown_bars > 0:
-                self._cooldown_remaining = max(self._cooldown_remaining, self.config.cooldown_bars)
-                indicators["cooldown_remaining"] = self._cooldown_remaining
+                self._cooldown.remaining = max(self._cooldown.remaining, self.config.cooldown_bars)
+                indicators["cooldown_remaining"] = self._cooldown.remaining
             return Decision(
                 Action.CLOSE,
                 f"Signal reversal: Z-Score={z:.2f} now indicates long",
@@ -433,9 +447,9 @@ class MeanReversionStrategy:
     def rehydrate(self, events: Sequence[dict[str, Any]]) -> int:
         """Restore strategy state from historical events.
 
-        MeanReversionStrategy is stateless - it calculates Z-Score fresh
-        from the recent_marks passed to decide(). No internal state
-        needs restoration.
+        Z-Score state is calculated fresh from the recent_marks passed to
+        decide(), and the re-entry cooldown lives in a caller-owned
+        ``CooldownState``, so no internal state needs restoration from events.
 
         Args:
             events: Historical events from EventStore

--- a/src/gpt_trader/features/strategy_tools/__init__.py
+++ b/src/gpt_trader/features/strategy_tools/__init__.py
@@ -9,6 +9,7 @@ from gpt_trader.features.strategy_tools.filters import (
 from gpt_trader.features.strategy_tools.guards import RiskGuards, create_standard_risk_guards
 from gpt_trader.features.strategy_tools.snapshot_proposer import (
     SNAPSHOT_STRATEGY_PROPOSER_PREFIX,
+    SnapshotDecideDrive,
     SnapshotDecider,
     SnapshotStrategyProposer,
     StrategyFactory,
@@ -24,6 +25,7 @@ __all__ = [
     "SNAPSHOT_STRATEGY_PROPOSER_PREFIX",
     "MarketConditionFilters",
     "RiskGuards",
+    "SnapshotDecideDrive",
     "SnapshotDecider",
     "SnapshotStrategyProposer",
     "StrategyDecisionSignal",

--- a/src/gpt_trader/features/strategy_tools/snapshot_proposer.py
+++ b/src/gpt_trader/features/strategy_tools/snapshot_proposer.py
@@ -17,6 +17,16 @@ ideas. Strategies are injected structurally (:class:`SnapshotDecider`), which
 keeps this slice free of ``features.live_trade`` imports; composition roots
 own strategy construction.
 
+Two drive modes cover the strategy library (#1164 stage 3). ``"final-bar"``
+calls ``decide`` once over the full mark window — correct for strategies whose
+decision is a pure function of that window (the baseline family; mean
+reversion once its cooldown is caller-owned and inert on a flat book).
+``"per-candle"`` replays ``decide`` over every candle prefix and keeps only
+the final decision, so strategies that accumulate per-call state (the regime
+switcher's ``MarketRegimeDetector``) warm that state from recorded closes
+alone; the fresh instance per series makes the replay deterministic, and
+discarded warm-up decisions can never become ideas.
+
 The lane is long-only and spot-only today: non-buy decisions (including a
 perps strategy's short entries) are dropped by the adapter, and a non-spot
 ``product_type`` fails closed through the adapter's spot-only validation
@@ -29,7 +39,7 @@ from __future__ import annotations
 from collections.abc import Callable, Sequence
 from datetime import UTC, datetime
 from decimal import Decimal
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, Literal, Protocol, get_args, runtime_checkable
 
 from gpt_trader.errors import ValidationError
 from gpt_trader.features.strategy_tools.trade_idea_adapter import (
@@ -48,15 +58,23 @@ from gpt_trader.features.trade_ideas import (
 
 SNAPSHOT_STRATEGY_PROPOSER_PREFIX = "snapshot-strategy"
 
+# How the wrapper feeds a strategy's decide() from a symbol series: one call
+# over the full mark window, or one call per candle prefix (only the final
+# decision can become an idea). Per-candle exists for strategies whose decide
+# accumulates state per call, so that state is fed from recorded closes alone.
+SnapshotDecideDrive = Literal["final-bar", "per-candle"]
+
 
 @runtime_checkable
 class SnapshotDecider(Protocol):
     """Structural slice of the live ``TradingStrategy`` surface the wrapper drives.
 
     Mirrors ``features.live_trade.interfaces.TradingStrategy.decide`` without
-    importing the live-trade slice. Only strategies whose ``decide`` is a pure
-    function of these arguments are replay-safe here; strategies that mutate
-    internal state per call need fresh-state-per-snapshot handling first.
+    importing the live-trade slice. Strategies whose ``decide`` is a pure
+    function of these arguments are replay-safe under the ``"final-bar"``
+    drive; strategies that accumulate internal state per call need the
+    ``"per-candle"`` drive, which rebuilds that state from the snapshot's own
+    closes on a fresh instance.
     """
 
     def decide(
@@ -85,12 +103,18 @@ class SnapshotStrategyProposer:
         strategy_name: str,
         product_type: ProductType = ProductType.SPOT,
         adapter: StrategySignalToTradeIdeaAdapter | None = None,
+        drive: SnapshotDecideDrive = "final-bar",
     ) -> None:
         if not strategy_name.strip():
             raise ValidationError("strategy_name must be non-empty", field="strategy_name")
+        if drive not in get_args(SnapshotDecideDrive):
+            raise ValidationError(
+                f"drive must be one of {get_args(SnapshotDecideDrive)}", field="drive"
+            )
         self._strategy_factory = strategy_factory
         self._strategy_name = strategy_name.strip()
         self._product_type = product_type
+        self._drive: SnapshotDecideDrive = drive
         if adapter is None:
             adapter = StrategySignalToTradeIdeaAdapter(
                 StrategySignalToTradeIdeaAdapterConfig(
@@ -120,15 +144,29 @@ class SnapshotStrategyProposer:
             return None
         closes = [candle.close for candle in series.candles]
         strategy = self._strategy_factory()
-        decision = strategy.decide(
-            symbol=series.symbol,
-            current_mark=closes[-1],
-            position_state=None,
-            recent_marks=closes,
-            equity=Decimal("0"),
-            product=None,
-            candles=series.candles,
-        )
+        if self._drive == "per-candle":
+            # Warm per-call strategy state from the recorded closes; every
+            # decision before the final bar is warm-up only and is discarded.
+            for end in range(1, len(series.candles) + 1):
+                decision = strategy.decide(
+                    symbol=series.symbol,
+                    current_mark=closes[end - 1],
+                    position_state=None,
+                    recent_marks=closes[:end],
+                    equity=Decimal("0"),
+                    product=None,
+                    candles=series.candles[:end],
+                )
+        else:
+            decision = strategy.decide(
+                symbol=series.symbol,
+                current_mark=closes[-1],
+                position_state=None,
+                recent_marks=closes,
+                equity=Decimal("0"),
+                product=None,
+                candles=series.candles,
+            )
         context = StrategySignalContext(
             symbol=series.symbol,
             current_mark=closes[-1],
@@ -148,6 +186,7 @@ def _utc_aware(value: datetime) -> datetime:
 
 __all__ = [
     "SNAPSHOT_STRATEGY_PROPOSER_PREFIX",
+    "SnapshotDecideDrive",
     "SnapshotDecider",
     "SnapshotStrategyProposer",
     "StrategyFactory",

--- a/tests/unit/gpt_trader/cli/commands/test_ideas_cycle.py
+++ b/tests/unit/gpt_trader/cli/commands/test_ideas_cycle.py
@@ -195,6 +195,63 @@ def test_cycle_strategy_backed_proposer_is_opt_in_configuration(
     assert only_turn["proposal_count"] == 1
 
 
+def _mean_reversion_dip_snapshot_payload() -> dict[str, Any]:
+    """Flat closes then a final-bar dip far below the -2.0 Z-Score threshold."""
+    closes = [Decimal("100")] * 29 + [Decimal("96")]
+    start = _AS_OF - timedelta(hours=len(closes))
+    series = SymbolSeries(
+        symbol="BTC-USD",
+        granularity="ONE_HOUR",
+        candles=tuple(
+            Candle(
+                ts=start + timedelta(hours=index),
+                open=close,
+                high=close,
+                low=close,
+                close=close,
+                volume=Decimal("1000"),
+            )
+            for index, close in enumerate(closes)
+        ),
+    )
+    return market_snapshot_to_payload(
+        MarketSnapshot(as_of=_AS_OF, source="test:fixture", series=(series,))
+    )
+
+
+def test_cycle_stateful_strategy_proposers_are_selectable(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    root = tmp_path / "ideas"
+    attest_ideas_root(root)
+    dip_snapshot_path = tmp_path / "dip-snapshot.json"
+    dip_snapshot_path.write_text(
+        json.dumps(_mean_reversion_dip_snapshot_payload()), encoding="utf-8"
+    )
+    exit_code, response = _run_json(
+        capsys,
+        [
+            "ideas",
+            "cycle",
+            "--snapshot",
+            str(dip_snapshot_path),
+            "--proposer",
+            "strategy-mean-reversion",
+            "--proposer",
+            "strategy-regime-switcher",
+            *_root_args(root),
+        ],
+    )
+    assert exit_code == 0
+    turns = {turn["proposer_id"]: turn["proposal_count"] for turn in response["data"]["proposers"]}
+    # Mean reversion buys the dip; the switcher holds because 30 candles are
+    # below its detector's regime-confirmation floor.
+    assert turns == {
+        "snapshot-strategy-mean-reversion": 1,
+        "snapshot-strategy-regime-switcher": 0,
+    }
+
+
 def test_cycle_from_coinbase_requires_market_parameters(
     capsys: pytest.CaptureFixture[str], tmp_path: Path
 ) -> None:

--- a/tests/unit/gpt_trader/cli/commands/test_ideas_propose_strategy.py
+++ b/tests/unit/gpt_trader/cli/commands/test_ideas_propose_strategy.py
@@ -32,6 +32,16 @@ AS_OF = datetime(2035, 6, 12, 0, 0, tzinfo=UTC)
 GOLDEN_CROSS = ["100"] * 28 + ["102", "104"]
 FLAT = ["100"] * 30
 SUB_CENT_GOLDEN_CROSS = ["0.004"] * 28 + ["0.0041", "0.0042"]
+# Flat closes then a sharp final-bar dip: Z-Score over the 20-candle window
+# drops far below the -2.0 entry threshold (mean reversion long).
+MEAN_REVERSION_DIP = ["100"] * 29 + ["96"]
+# Ultra-quiet damped oscillation, then the same dip: strictly shrinking moves
+# keep the regime detector's classification stable so the first regime
+# confirms at candle 54 (long-EMA 50 + min-regime-ticks 5 - 1) as
+# SIDEWAYS_QUIET, routing the final-bar dip to the mean-reversion delegate.
+REGIME_SWITCHER_DIP = [
+    f"{100 + (1 if i % 2 == 0 else -1) * 0.05 * (0.995 ** i):.4f}" for i in range(59)
+] + ["96"]
 
 
 def _run_json(capsys: pytest.CaptureFixture[str], argv: list[str]) -> tuple[int, dict[str, Any]]:
@@ -143,6 +153,67 @@ def test_propose_strategy_baseline_perps_choice_emits_spot_ideas(
         (root / "records" / proposal["decision_id"] / "latest.json").read_text(encoding="utf-8")
     )
     assert latest["product_type"] == "spot"
+
+
+def test_propose_strategy_mean_reversion_choice_buys_the_dip(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = tmp_path / "ideas"
+    snapshot_path = _write_snapshot(tmp_path / "dip.json", _snapshot_payload(MEAN_REVERSION_DIP))
+
+    exit_code, response = _propose_strategy(capsys, root, snapshot_path, strategy="mean-reversion")
+
+    assert exit_code == 0
+    assert response["data"]["proposer_id"] == "snapshot-strategy-mean-reversion"
+    assert response["data"]["proposal_count"] == 1
+    proposal = response["data"]["proposed"][0]
+    assert proposal["decision_id"].startswith("trade-20350612-mean-reversion-btc-usd-")
+    latest = json.loads(
+        (root / "records" / proposal["decision_id"] / "latest.json").read_text(encoding="utf-8")
+    )
+    assert latest["product_type"] == "spot"
+    assert latest["direction"] == "long"
+    assert latest["sizing_recommendation"]["quantity"] is not None
+    assert latest["max_loss"]["amount"] is not None
+
+
+def test_propose_strategy_regime_switcher_choice_buys_the_sideways_dip(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = tmp_path / "ideas"
+    snapshot_path = _write_snapshot(
+        tmp_path / "sideways-dip.json", _snapshot_payload(REGIME_SWITCHER_DIP)
+    )
+
+    exit_code, response = _propose_strategy(capsys, root, snapshot_path, strategy="regime-switcher")
+
+    assert exit_code == 0
+    assert response["data"]["proposer_id"] == "snapshot-strategy-regime-switcher"
+    assert response["data"]["proposal_count"] == 1
+    proposal = response["data"]["proposed"][0]
+    latest = json.loads(
+        (root / "records" / proposal["decision_id"] / "latest.json").read_text(encoding="utf-8")
+    )
+    assert latest["product_type"] == "spot"
+    assert latest["direction"] == "long"
+    assert latest["sizing_recommendation"]["quantity"] is not None
+
+
+def test_propose_strategy_regime_switcher_holds_below_detector_warmup(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = tmp_path / "ideas"
+    # The dip is present, but only 30 candles precede it: the regime detector
+    # cannot confirm a regime, so the switcher holds and nothing is proposed.
+    snapshot_path = _write_snapshot(
+        tmp_path / "short-dip.json", _snapshot_payload(MEAN_REVERSION_DIP)
+    )
+
+    exit_code, response = _propose_strategy(capsys, root, snapshot_path, strategy="regime-switcher")
+
+    assert exit_code == 0
+    assert response["data"]["proposal_count"] == 0
+    assert response["metadata"]["was_noop"] is True
 
 
 def test_propose_strategy_sizes_with_attested_account_equity(

--- a/tests/unit/gpt_trader/cli/commands/test_ideas_replay_strategy.py
+++ b/tests/unit/gpt_trader/cli/commands/test_ideas_replay_strategy.py
@@ -23,6 +23,15 @@ AS_OF = datetime(2026, 6, 12, 12, 0, tzinfo=UTC)
 # snapshots evaluated after the default 20-candle warm-up floor.
 RISING_CLOSES = ["100"] * 26 + ["102", "104", "106", "108"]
 FLAT_CLOSES = ["100"] * 30
+# The dip sits one bar before the end so the replay window ending at the dip
+# is evaluated (windows never include the fixture's final candle).
+MEAN_REVERSION_DIP_CLOSES = ["100"] * 28 + ["96", "100"]
+# Ultra-quiet damped oscillation, then the same dip: the regime detector
+# confirms SIDEWAYS_QUIET at candle 54 (long-EMA 50 + min-regime-ticks 5 - 1)
+# and the window ending at the dip routes to the mean-reversion delegate.
+REGIME_SWITCHER_DIP_CLOSES = [
+    f"{100 + (1 if i % 2 == 0 else -1) * 0.05 * (0.995 ** i):.4f}" for i in range(58)
+] + ["96", "100"]
 
 
 def _fixture_payload(closes: list[str]) -> dict[str, Any]:
@@ -46,7 +55,12 @@ def _write_fixture(path: Path, payload: dict[str, Any]) -> Path:
     return path
 
 
-def _strategy_args(path: Path, *, extra: list[str] | None = None) -> list[str]:
+def _strategy_args(
+    path: Path,
+    *,
+    strategy: str = "baseline-spot",
+    extra: list[str] | None = None,
+) -> list[str]:
     return [
         "ideas",
         "replay",
@@ -58,7 +72,7 @@ def _strategy_args(path: Path, *, extra: list[str] | None = None) -> list[str]:
         "--granularity",
         "ONE_HOUR",
         "--strategy",
-        "baseline-spot",
+        strategy,
         "--format",
         "json",
         *(extra or []),
@@ -112,6 +126,59 @@ def test_replay_strategy_rejects_min_history_below_strategy_requirements(
     assert response["errors"][0]["code"] == CliErrorCode.INVALID_ARGUMENT.value
     assert response["errors"][0]["details"]["field"] == "min_history"
     assert "--min-history must be at least 20" in response["errors"][0]["message"]
+
+
+def test_replay_strategy_mean_reversion_uses_its_own_warmup_floor(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    fixture = _write_fixture(tmp_path / "dip.json", _fixture_payload(MEAN_REVERSION_DIP_CLOSES))
+
+    exit_code, response = _run_json(capsys, _strategy_args(fixture, strategy="mean-reversion"))
+
+    assert exit_code == 0
+    data = response["data"]
+    assert data["proposer_id"] == "snapshot-strategy-mean-reversion"
+    # Default min-history is the Z-Score lookback window (20).
+    assert data["snapshots_evaluated"] == len(MEAN_REVERSION_DIP_CLOSES) - 20
+    assert data["ideas_proposed"] >= 1
+
+
+def test_replay_strategy_regime_switcher_uses_the_detector_floor(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    fixture = _write_fixture(
+        tmp_path / "sideways-dip.json", _fixture_payload(REGIME_SWITCHER_DIP_CLOSES)
+    )
+
+    exit_code, response = _run_json(capsys, _strategy_args(fixture, strategy="regime-switcher"))
+
+    assert exit_code == 0
+    data = response["data"]
+    assert data["proposer_id"] == "snapshot-strategy-regime-switcher"
+    # Default min-history is the detector's regime-confirmation floor
+    # (long-EMA 50 + min-regime-ticks 5 - 1 = 54).
+    assert data["snapshots_evaluated"] == len(REGIME_SWITCHER_DIP_CLOSES) - 54
+    assert data["ideas_proposed"] >= 1
+
+
+def test_replay_strategy_rejects_min_history_below_regime_switcher_floor(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    fixture = _write_fixture(
+        tmp_path / "sideways-dip.json", _fixture_payload(REGIME_SWITCHER_DIP_CLOSES)
+    )
+
+    exit_code, response = _run_json(
+        capsys,
+        _strategy_args(fixture, strategy="regime-switcher", extra=["--min-history", "30"]),
+    )
+
+    assert exit_code == 1
+    assert response["errors"][0]["code"] == CliErrorCode.INVALID_ARGUMENT.value
+    assert response["errors"][0]["details"]["field"] == "min_history"
+    assert "--min-history must be at least 54 for regime-switcher" in (
+        response["errors"][0]["message"]
+    )
 
 
 def test_replay_strategy_help_documents_read_only_contract(

--- a/tests/unit/gpt_trader/cli/commands/test_ideas_replay_tournament.py
+++ b/tests/unit/gpt_trader/cli/commands/test_ideas_replay_tournament.py
@@ -180,6 +180,57 @@ def test_replay_tournament_rejects_min_history_below_strategy_floor(
     assert "--min-history must be at least 20" in response["errors"][0]["message"]
 
 
+def test_replay_tournament_ranks_mean_reversion_strategy_beside_baseline(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # The dip sits one bar before the end so the shared replay window ending
+    # at the dip is evaluated for the mean-reversion strategy proposer.
+    closes = ["100"] * 28 + ["96", "100"]
+    fixture = _write_fixture(
+        tmp_path / "dip-candles.json",
+        {
+            "candles": [
+                _candle(index - len(closes), open_=close, high=close, low=close, close=close)
+                for index, close in enumerate(closes)
+            ]
+        },
+    )
+    argv = _tournament_args(fixture)
+    argv[argv.index("--proposers") + 1] = "baseline-ma-2-4,strategy-mean-reversion"
+
+    exit_code, response = _run_json(capsys, argv)
+
+    assert exit_code == 0
+    data = response["data"]
+    proposer_ids = {report["proposer_id"] for report in data["reports"]}
+    assert proposer_ids == {"baseline-ma-2-4", "snapshot-strategy-mean-reversion"}
+    mean_reversion_report = next(
+        report
+        for report in data["reports"]
+        if report["proposer_id"] == "snapshot-strategy-mean-reversion"
+    )
+    assert mean_reversion_report["ideas_proposed"] >= 1
+
+
+def test_replay_tournament_regime_switcher_floor_dominates_min_history(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    fixture = _write_fixture(tmp_path / "long-candles.json", _long_history_fixture())
+    argv = _tournament_args(fixture)
+    argv[argv.index("--proposers") + 1] = "baseline-ma-2-4,strategy-regime-switcher"
+    argv.extend(["--min-history", "30"])
+
+    exit_code, response = _run_json(capsys, argv)
+
+    assert exit_code == 1
+    assert response["errors"][0]["code"] == CliErrorCode.INVALID_ARGUMENT.value
+    # The shared window floor is the regime switcher's regime-confirmation
+    # floor (long-EMA 50 + min-regime-ticks 5 - 1 = 54), not the baseline's.
+    assert "--min-history must be at least 54" in response["errors"][0]["message"]
+
+
 def test_replay_tournament_rejects_unknown_proposer_id(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],

--- a/tests/unit/gpt_trader/features/live_trade/strategies/mean_reversion/test_cooldown_state.py
+++ b/tests/unit/gpt_trader/features/live_trade/strategies/mean_reversion/test_cooldown_state.py
@@ -1,0 +1,83 @@
+"""Caller-owned cooldown state for MeanReversionStrategy (#1164 stage 3).
+
+Default per-instance cooldown behavior is pinned by
+test_strategy_exit_logic_and_cooldown.py; these tests pin the externalized
+surface: an injected ``CooldownState`` is the only cooldown truth, so a caller
+that owns the state can observe it, share it across instances, or hand a
+fresh one to a replay window.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from gpt_trader.app.config import MeanReversionConfig
+from gpt_trader.features.live_trade.strategies.baseline import Action
+from gpt_trader.features.live_trade.strategies.mean_reversion import (
+    CooldownState,
+    MeanReversionStrategy,
+)
+
+FLAT_MARKS = [Decimal("100")] * 20
+DIP_MARKS = [Decimal("100")] * 19 + [Decimal("85")]
+LONG_POSITION = {
+    "quantity": Decimal("0.1"),
+    "side": "long",
+    "entry_price": Decimal("95"),
+}
+
+
+def _config() -> MeanReversionConfig:
+    return MeanReversionConfig(
+        z_score_entry_threshold=2.0,
+        z_score_exit_threshold=0.5,
+        lookback_window=20,
+        cooldown_bars=2,
+    )
+
+
+def _decide(strategy: MeanReversionStrategy, marks, position_state=None):
+    return strategy.decide(
+        symbol="BTC-USD",
+        current_mark=marks[-1],
+        position_state=position_state,
+        recent_marks=marks,
+        equity=Decimal("10000"),
+        product=None,
+    )
+
+
+def test_injected_cooldown_state_blocks_entry_and_is_caller_visible() -> None:
+    state = CooldownState(remaining=2)
+    strategy = MeanReversionStrategy(_config(), cooldown=state)
+
+    decision = _decide(strategy, DIP_MARKS)
+
+    assert decision.action == Action.HOLD
+    assert "cooldown" in decision.reason.lower()
+    assert state.remaining == 1
+
+
+def test_exit_writes_cooldown_into_the_caller_owned_state() -> None:
+    state = CooldownState()
+    strategy = MeanReversionStrategy(_config(), cooldown=state)
+
+    decision = _decide(strategy, FLAT_MARKS, position_state=LONG_POSITION)
+
+    assert decision.action == Action.CLOSE
+    assert state.remaining == 2
+    # A fresh instance handed the same state keeps honoring it: the strategy
+    # carries no hidden cooldown of its own.
+    successor = MeanReversionStrategy(_config(), cooldown=state)
+    assert _decide(successor, DIP_MARKS).action == Action.HOLD
+    assert state.remaining == 1
+
+
+def test_default_cooldown_state_is_per_instance() -> None:
+    first = MeanReversionStrategy(_config())
+    assert _decide(first, FLAT_MARKS, position_state=LONG_POSITION).action == Action.CLOSE
+
+    # The CLOSE above armed first's own cooldown; a separately constructed
+    # instance starts clear and may enter immediately (today's live behavior).
+    second = MeanReversionStrategy(_config())
+    assert _decide(second, DIP_MARKS).action == Action.BUY

--- a/tests/unit/gpt_trader/features/strategy_tools/test_snapshot_proposer.py
+++ b/tests/unit/gpt_trader/features/strategy_tools/test_snapshot_proposer.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import pytest
 
+from gpt_trader.app.config import MeanReversionConfig
 from gpt_trader.core import Candle
 from gpt_trader.errors import ValidationError
 from gpt_trader.features.live_trade.strategies.baseline import (
@@ -14,6 +15,8 @@ from gpt_trader.features.live_trade.strategies.baseline import (
     Decision,
     SpotStrategy,
 )
+from gpt_trader.features.live_trade.strategies.mean_reversion import MeanReversionStrategy
+from gpt_trader.features.live_trade.strategies.regime_switcher import RegimeSwitchingStrategy
 from gpt_trader.features.strategy_tools import (
     SnapshotDecider,
     SnapshotStrategyProposer,
@@ -35,6 +38,24 @@ AS_OF = datetime(2026, 7, 3, 0, 0, tzinfo=UTC)
 GOLDEN_CROSS = ["100"] * 28 + ["102", "104"]
 # Mirror image: bearish crossover + bearish trend emits SELL on a flat book.
 BEARISH_BREAK = ["100"] * 28 + ["98", "96"]
+# Flat closes then a sharp final-bar dip: the Z-Score over the 20-candle
+# window drops far below the -2.0 entry threshold (mean reversion long).
+MEAN_REVERSION_DIP = ["100"] * 29 + ["96"]
+
+
+def damped_sideways_closes(count: int) -> list[str]:
+    """Ultra-quiet damped oscillation around 100.
+
+    Strictly shrinking moves keep the regime detector's classification stable
+    (SIDEWAYS_QUIET) once its 50-candle long EMA warms, so the first regime
+    confirms at candle 54 (long-EMA 50 + min-regime-ticks 5 - 1). Appending a
+    sharp dip as the final bar hands the switcher's mean-reversion delegate a
+    deep negative Z-Score without flipping the confirmed regime.
+    """
+    return [f"{100 + (1 if i % 2 == 0 else -1) * 0.05 * (0.995 ** i):.4f}" for i in range(count)]
+
+
+REGIME_SWITCHER_DIP = damped_sideways_closes(59) + ["96"]
 
 
 def make_series(
@@ -62,6 +83,26 @@ def snapshot_of(*series: SymbolSeries, as_of: datetime = AS_OF) -> MarketSnapsho
 
 def spot_proposer() -> SnapshotStrategyProposer:
     return SnapshotStrategyProposer(SpotStrategy, strategy_name="baseline-spot")
+
+
+def _mean_reversion_strategy() -> MeanReversionStrategy:
+    return MeanReversionStrategy(MeanReversionConfig())
+
+
+def mean_reversion_proposer() -> SnapshotStrategyProposer:
+    return SnapshotStrategyProposer(_mean_reversion_strategy, strategy_name="mean-reversion")
+
+
+def regime_switcher_proposer() -> SnapshotStrategyProposer:
+    return SnapshotStrategyProposer(
+        lambda: RegimeSwitchingStrategy(
+            trend_strategy_factory=SpotStrategy,
+            mean_reversion_strategy_factory=_mean_reversion_strategy,
+            enable_shorts=False,
+        ),
+        strategy_name="regime-switcher",
+        drive="per-candle",
+    )
 
 
 class SpyStrategy:
@@ -226,3 +267,113 @@ def test_naive_snapshot_as_of_is_treated_as_utc() -> None:
 
     assert len(ideas) == 1
     assert ideas[0].time_horizon.expires_at == AS_OF + timedelta(hours=48)
+
+
+def test_unknown_drive_fails_closed() -> None:
+    with pytest.raises(ValidationError, match="drive"):
+        SnapshotStrategyProposer(
+            SpotStrategy,
+            strategy_name="baseline-spot",
+            drive="warp",  # type: ignore[arg-type]
+        )
+
+
+def test_per_candle_drive_feeds_growing_prefixes_from_the_snapshot() -> None:
+    spy = SpyStrategy()
+    series = make_series(GOLDEN_CROSS)
+
+    SnapshotStrategyProposer(lambda: spy, strategy_name="spy", drive="per-candle").propose(
+        snapshot_of(series)
+    )
+
+    closes = [candle.close for candle in series.candles]
+    assert len(spy.calls) == len(closes)
+    for index, call in enumerate(spy.calls):
+        assert call["recent_marks"] == closes[: index + 1]
+        assert call["current_mark"] == closes[index]
+        assert call["candles"] == series.candles[: index + 1]
+        assert call["position_state"] is None
+        assert call["equity"] == Decimal("0")
+
+
+def test_per_candle_warmup_decisions_never_become_ideas() -> None:
+    class EarlyBuyStrategy:
+        def decide(
+            self,
+            symbol: str,
+            current_mark: Decimal,
+            position_state: dict[str, Any] | None,
+            recent_marks: Any,
+            equity: Decimal,
+            product: Any,
+            market_data: Any = None,
+            candles: Any = None,
+        ) -> Decision:
+            if len(recent_marks) == 5:
+                return Decision(Action.BUY, "warm-up buy", confidence=0.9, indicators={})
+            return Decision(Action.HOLD, "hold", confidence=0.0, indicators={})
+
+    proposer = SnapshotStrategyProposer(
+        EarlyBuyStrategy, strategy_name="early-buy", drive="per-candle"
+    )
+
+    assert proposer.propose(snapshot_of(make_series(GOLDEN_CROSS))) == []
+
+
+def test_drives_agree_for_pure_strategies() -> None:
+    snapshot = snapshot_of(make_series(GOLDEN_CROSS))
+
+    final_bar = spot_proposer().propose(snapshot)
+    per_candle = SnapshotStrategyProposer(
+        SpotStrategy, strategy_name="baseline-spot", drive="per-candle"
+    ).propose(snapshot)
+
+    assert final_bar == per_candle
+
+
+def test_mean_reversion_dip_maps_to_eligible_executable_long_idea() -> None:
+    snapshot = snapshot_of(make_series(MEAN_REVERSION_DIP))
+
+    first = mean_reversion_proposer().propose(snapshot)
+    second = mean_reversion_proposer().propose(snapshot)
+
+    assert len(first) == 1
+    assert first == second
+    idea = first[0]
+    assert idea.direction is TradeDirection.LONG
+    assert idea.product_type is ProductType.SPOT
+    assert evaluate_eligibility(idea) == []
+    assert idea.sizing_recommendation.quantity is not None
+    assert idea.sizing_recommendation.quantity > 0
+    assert idea.max_loss.amount is not None
+
+
+def test_mean_reversion_holds_below_its_lookback_window() -> None:
+    below_floor = make_series(["100"] * 15 + ["96"])
+
+    assert mean_reversion_proposer().propose(snapshot_of(below_floor)) == []
+
+
+def test_regime_switcher_emits_deterministic_eligible_idea() -> None:
+    snapshot = snapshot_of(make_series(REGIME_SWITCHER_DIP))
+
+    first = regime_switcher_proposer().propose(snapshot)
+    second = regime_switcher_proposer().propose(snapshot)
+
+    assert len(first) == 1
+    assert first == second
+    assert [idea.record_hash() for idea in first] == [idea.record_hash() for idea in second]
+    idea = first[0]
+    assert idea.direction is TradeDirection.LONG
+    assert evaluate_eligibility(idea) == []
+    assert idea.sizing_recommendation.quantity is not None
+    assert idea.sizing_recommendation.quantity > 0
+
+
+def test_regime_switcher_holds_until_detector_confirms_a_regime() -> None:
+    # 53 candles: the detector's 50-candle long EMA has warmed, but the first
+    # regime cannot confirm before candle 54 (min-regime-ticks 5), so the
+    # switcher still holds on the dip the mean-reversion delegate would buy.
+    below_floor = make_series(damped_sideways_closes(52) + ["96"])
+
+    assert regime_switcher_proposer().propose(snapshot_of(below_floor)) == []

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -9,8 +9,8 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 5873,
-    "total_files": 699,
+    "total_tests": 5893,
+    "total_files": 700,
     "markers_used": 14
   },
   "quick_commands": {

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -92,7 +92,7 @@
     ]
   },
   "counts": {
-    "unit": 5716,
+    "unit": 5736,
     "asyncio": 310,
     "parametrize": 173,
     "integration": 80,


### PR DESCRIPTION
## Summary

Stage 3 of #1164 — the last implementation stage of the strategy→proposer convergence: the stateful live strategies (mean reversion, regime switcher) now run as deterministic proposers over Recorder-produced `MarketSnapshot` artifacts, entering the workflow only through `TradeIdeaService.propose`.

- **Mean-reversion cooldown externalized** (`features/live_trade/strategies/mean_reversion/`): the `_cooldown_remaining` counter moves into a caller-owned `CooldownState` injected at construction (default: fresh per-instance state, live behavior pinned by the existing suite plus new externalization tests). `decide()` is now a pure function of its arguments plus explicit caller-owned state; on the proposer lane's flat book the cooldown is structurally inert, so the strategy runs under the existing final-bar drive.
- **Per-candle drive** (`features/strategy_tools/snapshot_proposer.py`): `SnapshotStrategyProposer` gains `drive="final-bar" | "per-candle"`. Per-candle replays `decide()` over every candle prefix and keeps only the final decision, so per-call strategy state (the regime switcher's `MarketRegimeDetector`, its per-symbol caches) is warmed from the snapshot's own closes on a fresh instance per series — deterministic, and discarded warm-up decisions can never become ideas. For pure strategies the two drives agree (pinned by test). No new import edges; strategies stay structurally injected.
- **CLI composition root** (`cli/commands/ideas.py`): `mean-reversion` and `regime-switcher` join `--strategy` for `propose-strategy`/`replay strategy`, and `strategy-mean-reversion`/`strategy-regime-switcher` join `cycle --proposer` and `replay tournament`. The switcher is composed as live: `SpotStrategy` trend delegate, mean-reversion delegate, fresh detector per instance, `enable_shorts=False` for the spot lane. Replay min-history floors are per-strategy warm-up gates: 20 (Z-Score lookback) for mean reversion, **54** (long-EMA 50 + min-regime-ticks 5 − 1: the regime stays UNKNOWN below it, verified empirically) for the switcher — the parity lane evaluates every snapshot the live strategy would have evaluated.
- **Ensemble deferred with rationale** (recorded beside the choices tuple and on the issue): `RegimeAwareCombiner` mutates hysteresis state inside `combine()` and `EnsembleStrategy.decide()` swallows signal failures with a bare `print`, so its decisions are not yet explainable from recorded data alone; auditing that surface exceeds this slice.

Cycle defaults are unchanged (`baseline`, `regime-aware`); strategy-backed proposers remain opt-in until replay parity is demonstrated. Runbook updated with the new ids and warm-up floors.

## Verification

- `uv run pytest tests/unit -n auto -q` — 6388 passed
- `make ci-required` green (includes import-boundary guard, docs audits, stage1-smoke)
- `MOCK_BROKER=1 uv run gpt-trader run --profile dev --dev-fast` — clean lifecycle, zero errors (live-path regression for the strategy-module change)
- Offline end-to-end: `budget set` (attested equity) → `propose-strategy --strategy mean-reversion` (0 approval violations) → `approve` → `execute-paper` filled at the snapshot mark → duplicate rerun refused on identical `decision_id` → `audit verify` chain intact

Closes #1164 acceptance for stage 3; the issue's remaining follow-ups (retiring the direct decide→submit path, WS telemetry convergence) stay out of scope per the decision record.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for additional strategy-based idea generation and replay options.
  * Expanded strategy handling to cover more live-trade scenarios and adaptable decision modes.

* **Bug Fixes**
  * Improved history validation so each strategy uses its own required warm-up window.
  * Cooldown behavior now persists correctly across decisions and stays visible to the caller.

* **Tests**
  * Added coverage for new strategy paths, replay limits, proposal selection, and drive-mode behavior.
  * Updated test totals and marker counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->