### PR TITLE
refactor(risk): shared trading-day and percent-unit primitives (#1120 stage 1)

### DIFF
--- a/docs/agents/glossary.md
+++ b/docs/agents/glossary.md
@@ -36,6 +36,19 @@ Any abbreviation not listed here should be spelled out in full.
 | `E2E` | End-to-End | Testing | Industry standard |
 | `qty` | Quantity | Trading domain | Standard trading term for order/position size |
 
+## Domain Term Distinctions
+
+Risk-limit fields that read alike but measure different things (from the
+accepted decision `docs/decisions/canonical-risk-limit-vocabulary.md`):
+
+| Term | Measures | Not to be confused with |
+|------|----------|-------------------------|
+| `max_loss_per_idea_pct` | **Loss at invalidation** — the equity percentage lost if the idea's stop is hit | Notional exposure: a small stop distance lets a large position stay inside this cap |
+| `max_position_pct_per_symbol` | **Notional exposure** — the equity percentage a symbol's position may occupy | Loss at invalidation: exposure says nothing about how much is lost at the stop |
+
+Percentage unit suffixes (`_pct` = percent points, `_fraction` = unit
+fraction) are defined in `docs/naming.md` §2.4.
+
 ## Banned Abbreviations
 
 These abbreviations are banned and must be spelled out:

--- a/docs/naming.md
+++ b/docs/naming.md
@@ -34,6 +34,13 @@ The automated naming scan loads its banned pattern list from
 - **Format:** `snake_case` for mutable state; `UPPER_SNAKE_CASE` for constants.
 - **Rules:** Prefer full words; use domain terms that match docs (`portfolio`, `position`, `exposure`).
 - **Quantity terminology:** `qty` is approved for trading domain use (see glossary); prefer `quantity` for non-trading contexts.
+- **Percentage unit suffixes:** fields suffixed `_pct` hold **percent points**
+  (`Decimal("10")` means 10%); fields suffixed `_fraction` hold **unit
+  fractions** (`0.10` means 10%). Convert between the two only through
+  `gpt_trader.core.risk_units` (per the accepted decision
+  `docs/decisions/canonical-risk-limit-vocabulary.md`). Pre-existing `_pct`
+  fields holding fractions (e.g. `RiskConfig.daily_loss_limit_pct`) are
+  transitional exceptions scheduled for migration under issue #1120.
 - **Banned abbreviations:** `amt` (prefer `amount`), `cfg` (prefer `config`).
 
 ### 2.5 Configuration Keys & Environment Variables

--- a/src/gpt_trader/core/risk_units.py
+++ b/src/gpt_trader/core/risk_units.py
@@ -1,0 +1,55 @@
+"""Canonical unit primitives for the risk-limit vocabulary.
+
+Implements the shared primitives from the accepted decision
+``docs/decisions/canonical-risk-limit-vocabulary.md`` (Option A): one
+normalization owning the percent-points <-> fraction conversion, and one
+trading-day boundary shared by the approval gate's same-day realized-loss
+window and the runtime daily-loss breaker.
+
+Unit convention (``docs/naming.md``): fields suffixed ``_pct`` hold percent
+points (``Decimal("10")`` means 10%); fields suffixed ``_fraction`` hold unit
+fractions (``Decimal("0.10")`` means 10%). These converters are the only
+sanctioned crossing between the two.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+
+_ONE_HUNDRED = Decimal("100")
+
+
+def pct_points_to_fraction(value: Decimal) -> Decimal:
+    """Convert percent points (``Decimal("10")`` = 10%) to a unit fraction."""
+    return value / _ONE_HUNDRED
+
+
+def fraction_to_pct_points(value: Decimal) -> Decimal:
+    """Convert a unit fraction (``Decimal("0.10")`` = 10%) to percent points."""
+    return value * _ONE_HUNDRED
+
+
+def trading_day(moment: datetime) -> date:
+    """Return the trading day containing ``moment``.
+
+    The trading day is the UTC calendar date. Naive datetimes are treated as
+    UTC rather than host-local time, so the boundary never depends on the
+    machine the process happens to run on.
+    """
+    if moment.tzinfo is None:
+        return moment.date()
+    return moment.astimezone(UTC).date()
+
+
+def same_trading_day(first: datetime, second: datetime) -> bool:
+    """Return True when both datetimes fall on the same trading day."""
+    return trading_day(first) == trading_day(second)
+
+
+__all__ = [
+    "fraction_to_pct_points",
+    "pct_points_to_fraction",
+    "same_trading_day",
+    "trading_day",
+]

--- a/src/gpt_trader/features/live_trade/risk/manager/__init__.py
+++ b/src/gpt_trader/features/live_trade/risk/manager/__init__.py
@@ -21,6 +21,7 @@ from datetime import datetime
 from decimal import Decimal, InvalidOperation
 from typing import TYPE_CHECKING, Any
 
+from gpt_trader.core.risk_units import trading_day
 from gpt_trader.features.live_trade.risk.manager.models import (
     ExposureState,
     RiskWarning,
@@ -103,7 +104,7 @@ class LiveRiskManager:
                 raise ValueError("Risk state payload is not an object")
 
             saved_date = state.get("date")
-            current_date = self._now_provider().strftime("%Y-%m-%d")
+            current_date = trading_day(self._now_provider()).isoformat()
 
             if saved_date != current_date:
                 self._state_load_error = None
@@ -140,7 +141,7 @@ class LiveRiskManager:
             Path(self.state_file).parent.mkdir(parents=True, exist_ok=True)
 
             state = {
-                "date": self._now_provider().strftime("%Y-%m-%d"),
+                "date": trading_day(self._now_provider()).isoformat(),
                 "start_of_day_equity": (
                     str(self._start_of_day_equity) if self._start_of_day_equity else None
                 ),

--- a/src/gpt_trader/features/trade_ideas/service.py
+++ b/src/gpt_trader/features/trade_ideas/service.py
@@ -17,6 +17,11 @@ from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Any, cast
 
+from gpt_trader.core.risk_units import (
+    fraction_to_pct_points,
+    pct_points_to_fraction,
+    same_trading_day,
+)
 from gpt_trader.errors import ValidationError
 from gpt_trader.features.trade_ideas.audit import (
     ActorType,
@@ -148,7 +153,7 @@ def _decimal_to_str(value: Decimal | None) -> str | None:
 def _percent_of_amount(amount: Decimal, equity: Decimal) -> Decimal | None:
     if equity <= 0:
         return None
-    return amount / equity * Decimal("100")
+    return fraction_to_pct_points(amount / equity)
 
 
 def _equity_from_max_loss_amount_percent(
@@ -190,12 +195,6 @@ def _absolute_notional(idea: TradeIdea) -> Decimal | None:
     if notional is None:
         return None
     return abs(notional)
-
-
-def _same_day(timestamp: datetime, now: datetime) -> bool:
-    if now.tzinfo is None or now.utcoffset() is None:
-        return timestamp.date() == now.date()
-    return timestamp.astimezone(now.tzinfo).date() == now.date()
 
 
 def _page_items(
@@ -329,7 +328,7 @@ class TradeIdeaService:
             ):
                 open_ideas.append(idea)
                 continue
-            if closeout is not None and _same_day(closeout.timestamp, evaluation_time):
+            if closeout is not None and same_trading_day(closeout.timestamp, evaluation_time):
                 if (
                     event.after_state is TradeIdeaState.FILLED
                     or _closeout_has_realized_profit_loss(closeout)
@@ -389,7 +388,9 @@ class TradeIdeaService:
         open_notional_headroom_pct = None
         if account_equity is not None and account_equity > 0:
             open_notional_pct = _percent_of_amount(context.open_notional, account_equity)
-            max_open_notional = account_equity * budget.max_open_notional_pct / Decimal("100")
+            max_open_notional = account_equity * pct_points_to_fraction(
+                budget.max_open_notional_pct
+            )
             open_notional_headroom = max(max_open_notional - context.open_notional, Decimal("0"))
             open_notional_headroom_pct = max(
                 budget.max_open_notional_pct - (open_notional_pct or Decimal("0")),

--- a/src/gpt_trader/features/trade_ideas/sizing.py
+++ b/src/gpt_trader/features/trade_ideas/sizing.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass, field
 from decimal import Decimal
 from typing import Protocol
 
+from gpt_trader.core.risk_units import fraction_to_pct_points, pct_points_to_fraction
 from gpt_trader.features.intelligence.sizing import (
     PositionSizer,
     PositionSizingConfig,
@@ -210,9 +211,11 @@ def _budget_cap_fraction(
     stop_fraction = context.stop_loss_distance / context.current_price
     if stop_fraction <= 0:
         return None
-    max_loss_fraction = _effective_max_loss_pct(context.max_loss_pct, budget) / Decimal("100")
+    max_loss_fraction = pct_points_to_fraction(
+        _effective_max_loss_pct(context.max_loss_pct, budget)
+    )
     loss_cap_fraction = max_loss_fraction / stop_fraction
-    notional_cap_fraction = budget.max_open_notional_pct / Decimal("100")
+    notional_cap_fraction = pct_points_to_fraction(budget.max_open_notional_pct)
     return float(min(loss_cap_fraction, notional_cap_fraction))
 
 
@@ -228,7 +231,11 @@ def _estimated_risk_fraction(
 ) -> float:
     if equity <= 0 or current_price <= 0:
         return 0.0
-    return float(_estimated_loss_pct(notional * stop_loss_distance / current_price, equity) / 100)
+    return float(
+        pct_points_to_fraction(
+            _estimated_loss_pct(notional * stop_loss_distance / current_price, equity)
+        )
+    )
 
 
 def _estimated_loss_amount(
@@ -244,7 +251,7 @@ def _estimated_loss_amount(
 def _estimated_loss_pct(loss_amount: Decimal, equity: Decimal) -> Decimal:
     if equity <= 0:
         return Decimal("0")
-    return loss_amount / equity * Decimal("100")
+    return fraction_to_pct_points(loss_amount / equity)
 
 
 def _confidence_score(label: ConfidenceLabel) -> float:

--- a/tests/unit/gpt_trader/core/test_risk_units.py
+++ b/tests/unit/gpt_trader/core/test_risk_units.py
@@ -1,0 +1,75 @@
+"""Tests for the canonical risk-unit primitives.
+
+These pin the shared vocabulary from
+docs/decisions/canonical-risk-limit-vocabulary.md: one percent-points <->
+fraction conversion and one trading-day boundary.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, timedelta, timezone
+from decimal import Decimal
+
+from gpt_trader.core.risk_units import (
+    fraction_to_pct_points,
+    pct_points_to_fraction,
+    same_trading_day,
+    trading_day,
+)
+
+
+def test_pct_points_to_fraction() -> None:
+    assert pct_points_to_fraction(Decimal("10")) == Decimal("0.1")
+    assert pct_points_to_fraction(Decimal("100")) == Decimal("1")
+    assert pct_points_to_fraction(Decimal("0")) == Decimal("0")
+    assert pct_points_to_fraction(Decimal("2.5")) == Decimal("0.025")
+
+
+def test_fraction_to_pct_points() -> None:
+    assert fraction_to_pct_points(Decimal("0.05")) == Decimal("5")
+    assert fraction_to_pct_points(Decimal("1")) == Decimal("100")
+    assert fraction_to_pct_points(Decimal("0")) == Decimal("0")
+
+
+def test_conversion_round_trip() -> None:
+    for raw in ("0", "5", "10", "37.5", "100"):
+        value = Decimal(raw)
+        assert fraction_to_pct_points(pct_points_to_fraction(value)) == value
+
+
+def test_trading_day_is_the_utc_calendar_date() -> None:
+    aware_utc = datetime(2026, 7, 3, 23, 59, 59, tzinfo=UTC)
+    assert trading_day(aware_utc) == date(2026, 7, 3)
+
+
+def test_trading_day_converts_offsets_before_taking_the_date() -> None:
+    # 20:00 in UTC-5 is already 01:00 the next day in UTC.
+    late_evening_est = datetime(2026, 7, 3, 20, 0, tzinfo=timezone(timedelta(hours=-5)))
+    assert trading_day(late_evening_est) == date(2026, 7, 4)
+
+
+def test_trading_day_treats_naive_datetimes_as_utc() -> None:
+    # Naive input must not be interpreted as host-local time; the boundary
+    # cannot depend on the machine the process runs on.
+    naive = datetime(2026, 7, 3, 23, 30)
+    assert trading_day(naive) == date(2026, 7, 3)
+
+
+def test_same_trading_day_at_the_utc_boundary() -> None:
+    before_midnight = datetime(2026, 7, 3, 23, 59, 59, tzinfo=UTC)
+    after_midnight = datetime(2026, 7, 4, 0, 0, 0, tzinfo=UTC)
+    assert not same_trading_day(before_midnight, after_midnight)
+    assert same_trading_day(before_midnight, before_midnight - timedelta(hours=23))
+
+
+def test_same_trading_day_normalizes_mixed_offsets() -> None:
+    # 21:00 UTC-4 and 01:00 UTC next day are the same instant's day in UTC.
+    est_evening = datetime(2026, 7, 3, 21, 0, tzinfo=timezone(timedelta(hours=-4)))
+    utc_next_morning = datetime(2026, 7, 4, 1, 0, tzinfo=UTC)
+    assert same_trading_day(est_evening, utc_next_morning)
+
+
+def test_same_trading_day_pairs_naive_with_aware_as_utc() -> None:
+    naive = datetime(2026, 7, 4, 1, 0)
+    aware = datetime(2026, 7, 3, 21, 0, tzinfo=timezone(timedelta(hours=-4)))
+    assert same_trading_day(naive, aware)


### PR DESCRIPTION
## Summary

Stage 1 of #1120 (risk-vocabulary ADR Option A, accepted in `docs/decisions/canonical-risk-limit-vocabulary.md`): the shared primitives that Stage 2's derivation seam will consume.

- **`gpt_trader/core/risk_units.py`** — one normalization owning the percent-points ↔ fraction conversion (`pct_points_to_fraction` / `fraction_to_pct_points`) and one trading-day boundary (`trading_day` / `same_trading_day`: UTC calendar date, naive datetimes treated as UTC). Homed in `core` because `features/trade_ideas`' frozen dependency set is core + errors only (import-boundary guard verified).
- **Trading-day convergence** — the approval gate's same-day realized-loss window (`service._same_day`, deleted) and the runtime daily-loss breaker's date rollover (`strftime("%Y-%m-%d")`) previously used two subtly different day definitions; both now call `trading_day`. This also removes a host-local-time dependency: the old `_same_day` interpreted naive timestamps via `astimezone` (machine-local), the canonical primitive pins them to UTC.
- **Appetite conversions converge** — the inline `/ Decimal("100")` budget-appetite conversions in `sizing.py` and `service.py` now go through the normalization functions.
- **Naming pass** (per the ADR's Consequences): `docs/naming.md` §2.4 gains the `_pct` = percent points vs `_fraction` = unit fraction rule (with `RiskConfig`'s fraction-holding `_pct` fields noted as transitional exceptions for stages 2/3); `docs/agents/glossary.md` documents `max_loss_per_idea_pct` (loss at invalidation) vs `max_position_pct_per_symbol` (notional exposure).

Behavior-preserving on the live path: for tz-aware UTC inputs (the only inputs produced at runtime) the new day boundary is identical to both old implementations.

Stage 2 (startup derivation seam seeding RiskConfig from the active RiskBudget version) and Stage 3 (transitional-alias retirement) follow separately.

## Testing

- `make ci-required` green (includes import-boundary guard, docs link audit, stage-1 rails smoke)
- Full unit suite: 6397 passed, 10 skipped
- New `tests/unit/gpt_trader/core/test_risk_units.py` pins conversion round-trips, the UTC day boundary, offset normalization, and naive-as-UTC handling

Refs #1120

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Clarified risk-limit and percentage naming rules in the docs, including how percent-point and fraction values differ.
  * Added shared handling for percentage conversions and trading-day calculations across the app.

* **Bug Fixes**
  * Improved same-day risk and loss calculations to use trading-day boundaries instead of simple clock-based dates.
  * Standardized budget and risk estimates so percentage values are interpreted consistently.

* **Tests**
  * Added coverage for percentage conversions and UTC-based trading-day behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->