### PR TITLE
docs(decisions): propose persistent audited autonomy-level state

### DIFF
--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -69,6 +69,7 @@ markers. Regenerating cannot drift from the files.
 | Date | Decision | Status |
 |------|----------|--------|
 | 2026-07-03 | [MIT license for the public repository](adopt-mit-license.md) | accepted |
+| 2026-07-03 | [Persistent audited autonomy-level state](persistent-autonomy-state.md) | accepted |
 | 2026-07-02 | [Account snapshot command — wire a real provider or remove it](account-snapshot-wire-or-remove.md) | accepted |
 | 2026-07-02 | [Adopt a measured-outcome operating rubric](adopt-measured-outcome-rubric.md) | accepted |
 | 2026-07-02 | [Canonical risk-limit vocabulary — budget vs runtime limits](canonical-risk-limit-vocabulary.md) | accepted |

--- a/docs/decisions/persistent-autonomy-state.md
+++ b/docs/decisions/persistent-autonomy-state.md
@@ -1,7 +1,7 @@
 # Persistent audited autonomy-level state
 
 ---
-status: proposed
+status: accepted
 date: 2026-07-03
 deciders: RJ
 supersedes:
@@ -48,12 +48,15 @@ a truthful read surface for "what may the system do right now, and why".
   A new versioned, append-only `autonomy_state.jsonl` in the trade-ideas root,
   mirroring the `RiskBudgetLog` pattern: each entry records the mode, the
   actor type and id, the rationale, and (for automatic ratchets) the breach
-  evidence that triggered it. `TradeIdeaService` resolves the current mode at
-  construction and hands it to `ApprovalPolicy`; changes flow through the same
-  audited service path as everything else. Raising the level requires a human
-  actor; lowering is open to system actors so the breach ratchet can act
-  without a human in the loop. Trade-off: one more versioned log to operate,
-  and mode resolution must fail closed when the log is unreadable.
+  evidence that triggered it. `TradeIdeaService` resolves the current mode
+  through the audited log at each approval or budget-decision boundary before
+  applying `ApprovalPolicy`, so CLI changes and automatic ratchets affect the
+  next decision without rebuilding a long-lived service instance. Changes flow
+  through the same audited service path as everything else. Raising the level
+  requires a human actor; lowering is open to system actors so the breach
+  ratchet can act without a human in the loop. Trade-off: one more versioned
+  log to operate, and mode resolution must fail closed when the log is
+  unreadable.
 - **Option B — Autonomy mode as configuration (profile / BotConfig / env).**
   Cheapest to wire, but a config change is silent and unversioned — it
   violates the recorded-and-reversible property, and it collides with the
@@ -69,23 +72,26 @@ a truthful read surface for "what may the system do right now, and why".
 
 ## Decision
 
-Open — awaiting owner decision. Option A is recommended: it is the only shape
-that makes the autonomy level as auditable as the budget it gates, and it
-keeps authority and appetite as separately-audited concerns.
+Accepted: Option A. The autonomy level gets its own append-only, versioned
+audit log beside the risk budget log. This is the only option that makes the
+authority level as auditable as the budget it gates while keeping authority and
+appetite as separately-audited concerns.
 
 ## Consequences
 
-If Option A is accepted:
+With Option A accepted:
 
 - New `AutonomyStateLog` in `features/trade_ideas`: append-only JSONL beside
   `risk_budget.jsonl`, versioned entries with mode, actor, rationale, and
   optional trigger evidence. Integrity rules match the budget log (strict
   version sequencing; append is the only write).
-- `TradeIdeaService` resolves the active mode from the log and constructs
-  `ApprovalPolicy` with it. Fail-closed resolution: an **absent** log means
-  the seeded default `human_approved_execution` (today's behavior, no AI
-  submission); an **unreadable or integrity-broken** log resolves to
-  `research_only` and surfaces the error.
+- `TradeIdeaService` resolves the active mode from the log at each approval or
+  budget-decision boundary before applying `ApprovalPolicy`. The reload
+  boundary is the next decision through the audited service flow, not service
+  construction. Fail-closed resolution: an **absent** log means the seeded
+  default `human_approved_execution` (today's behavior, no AI submission); an
+  **unreadable or integrity-broken** log resolves to `research_only` and
+  surfaces the error.
 - Transition rules: raising the level requires `ActorType.HUMAN` with a
   rationale; lowering is permitted to any actor. The automatic ratchet-down
   appends the breach evidence it acted on. Every transition is also an
@@ -103,7 +109,8 @@ If Option A is accepted:
   this record changes where the level is *recorded*, not what the level *is*.
   Together with the budget gates, this unblocks
   [#1039](https://github.com/Solders-Girdles/GPT-Trader/issues/1039).
-- Implementation is filed as a follow-up issue once this record is accepted.
+- Implementation follows in a bounded issue after this record; ratchet triggers
+  are defined there against the unified risk vocabulary from #1120.
 
 ## Safety boundary
 

--- a/docs/decisions/persistent-autonomy-state.md
+++ b/docs/decisions/persistent-autonomy-state.md
@@ -1,0 +1,113 @@
+# Persistent audited autonomy-level state
+
+---
+status: proposed
+date: 2026-07-03
+deciders: RJ
+supersedes:
+superseded-by:
+---
+
+## Context
+
+The accepted five-role composition
+([adopt-five-role-composition](adopt-five-role-composition.md)) names
+"persistent audited autonomy-level state" as a convergence step, and the
+accepted direction ([DIRECTION](../DIRECTION.md)) requires that **every grant
+of autonomy is earned, recorded, and reversible**, with autonomy ratcheting
+**down automatically** on a breach — audited, not silent.
+
+Today the autonomy level satisfies none of that:
+
+- `AutonomyMode` exists as an enum
+  (`src/gpt_trader/features/trade_ideas/models.py`: `research_only`,
+  `human_approved_execution`, `bounded_autonomy`) and `ApprovalPolicy`
+  enforces per-mode rules (`src/gpt_trader/features/trade_ideas/policy.py`),
+  but the active mode is whatever the constructor default says in code.
+- Nothing persists the mode, no CLI surface reads or changes it, and a mode
+  change is an unaudited code edit — invisible to the append-only audit trail
+  that records every other state change in the workflow.
+- The risk budget already has the shape the direction demands: `RiskBudgetLog`
+  (`src/gpt_trader/features/trade_ideas/budget.py`) is versioned, append-only,
+  and every version carries the actor and rationale that produced it.
+
+Why decide now: Stage 2 auto-approval
+([#1039](https://github.com/Solders-Girdles/GPT-Trader/issues/1039)) is
+blocked on an explicit autonomy-mode gate, and its acceptance criteria assume
+a mode that can be verified rather than asserted. The automatic ratchet-down
+needs a well-defined "breach" to consume, which is exactly what the risk
+unification ([#1120](https://github.com/Solders-Girdles/GPT-Trader/issues/1120),
+in flight) provides: one appetite vocabulary and one trading-day boundary.
+The operator console direction
+([adopt-operator-web-console](adopt-operator-web-console.md)) will also need
+a truthful read surface for "what may the system do right now, and why".
+
+## Options
+
+- **Option A — Append-only autonomy log beside the budget log (recommended).**
+  A new versioned, append-only `autonomy_state.jsonl` in the trade-ideas root,
+  mirroring the `RiskBudgetLog` pattern: each entry records the mode, the
+  actor type and id, the rationale, and (for automatic ratchets) the breach
+  evidence that triggered it. `TradeIdeaService` resolves the current mode at
+  construction and hands it to `ApprovalPolicy`; changes flow through the same
+  audited service path as everything else. Raising the level requires a human
+  actor; lowering is open to system actors so the breach ratchet can act
+  without a human in the loop. Trade-off: one more versioned log to operate,
+  and mode resolution must fail closed when the log is unreadable.
+- **Option B — Autonomy mode as configuration (profile / BotConfig / env).**
+  Cheapest to wire, but a config change is silent and unversioned — it
+  violates the recorded-and-reversible property, and it collides with the
+  accepted rule that a profile name is never execution approval
+  ([prod-canary-profile-meaning](prod-canary-profile-meaning.md), hardening
+  tracked in [#1122](https://github.com/Solders-Girdles/GPT-Trader/issues/1122)).
+- **Option C — Fold the mode into `RiskBudget` versions.** Reuses the existing
+  log and its integrity checks, but couples risk appetite with authority: a
+  budget tweak and an autonomy grant become the same event type, muddying both
+  audit stories. It also blocks the Stage 3 meta-envelope shape, where agents
+  may renegotiate budgets inside owner limits but must never touch their own
+  autonomy level.
+
+## Decision
+
+Open — awaiting owner decision. Option A is recommended: it is the only shape
+that makes the autonomy level as auditable as the budget it gates, and it
+keeps authority and appetite as separately-audited concerns.
+
+## Consequences
+
+If Option A is accepted:
+
+- New `AutonomyStateLog` in `features/trade_ideas`: append-only JSONL beside
+  `risk_budget.jsonl`, versioned entries with mode, actor, rationale, and
+  optional trigger evidence. Integrity rules match the budget log (strict
+  version sequencing; append is the only write).
+- `TradeIdeaService` resolves the active mode from the log and constructs
+  `ApprovalPolicy` with it. Fail-closed resolution: an **absent** log means
+  the seeded default `human_approved_execution` (today's behavior, no AI
+  submission); an **unreadable or integrity-broken** log resolves to
+  `research_only` and surfaces the error.
+- Transition rules: raising the level requires `ActorType.HUMAN` with a
+  rationale; lowering is permitted to any actor. The automatic ratchet-down
+  appends the breach evidence it acted on. Every transition is also an
+  audited workflow event.
+- Ratchet triggers are defined against the unified risk vocabulary from
+  [#1120](https://github.com/Solders-Girdles/GPT-Trader/issues/1120) (one
+  appetite source, one trading-day boundary) so "breach" is a single
+  well-defined event, not two dialects. The trigger set ships with the
+  implementation issue, not this record.
+- CLI gains a read surface (current mode + history) and a change command that
+  goes through the audited service path. The kill switch stays orthogonal:
+  it halts execution immediately; the autonomy log records level changes. A
+  kill-switch trip may be a ratchet trigger, but the mechanisms stay separate.
+- Entering `bounded_autonomy` remains gated by [DIRECTION](../DIRECTION.md):
+  this record changes where the level is *recorded*, not what the level *is*.
+  Together with the budget gates, this unblocks
+  [#1039](https://github.com/Solders-Girdles/GPT-Trader/issues/1039).
+- Implementation is filed as a follow-up issue once this record is accepted.
+
+## Safety boundary
+
+This decision authorizes no broker/API call, no live execution, no money
+movement, and **no autonomy change**. It decides how the autonomy level is
+persisted and audited; the level itself stays `human_approved_execution`
+until the DIRECTION gates and a recorded human approval say otherwise.


### PR DESCRIPTION
## Summary

**Open decision record — `status: proposed`, awaiting RJ's call. Not for merge until accepted or explicitly parked as a tracked open decision.**

Adds `docs/decisions/persistent-autonomy-state.md`, the decision the five-role composition record names as the convergence step after #1120: where the autonomy level (`research_only` / `human_approved_execution` / `bounded_autonomy`) is persisted and audited.

Today the mode is an unaudited constructor default in `ApprovalPolicy` — no persistence, no CLI surface, no audit of changes, which fails DIRECTION's "every grant of autonomy is earned, recorded, and reversible."

Options drafted:
- **A (recommended)** — append-only `autonomy_state.jsonl` mirroring `RiskBudgetLog`: versioned entries with actor + rationale, human-only raises, system ratchet-down on breach with recorded evidence, fail-closed resolution (absent log → `human_approved_execution`; corrupt log → `research_only`).
- **B** — mode as configuration: rejected-shaped; silent/unversioned, collides with "profile is never execution approval" (prod-canary record, #1122).
- **C** — fold mode into `RiskBudget` versions: couples authority with appetite, blocks the Stage 3 meta-envelope shape.

Ratchet triggers are deliberately deferred to the implementation issue and defined against #1120's unified vocabulary so "breach" is one event, not two dialects. Accepting Option A (plus #1120's budget gates) unblocks #1039.

## Safety boundary

The record authorizes no broker/API call, no live execution, no money movement, and no autonomy change — it decides where the level is recorded, not what it is.

## Verification

- `docs_link_audit` passed (81 files)
- `docs_currency_scan --fail-on missing,stale` passed

Refs #1039, #1120

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new decision record describing how autonomy level state is persistently tracked, audited, and made reversible.
  * Defined an append-only, versioned autonomy audit trail as the preferred approach, with fail-closed behavior when records are missing or invalid.
  * Documented rules for when autonomy can be increased or lowered, including automatic ratcheting down on breach with traceable workflow evidence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->