### PR TITLE
feat(risk): seed runtime risk limits from the active RiskBudget (#1120 stage 2)

### DIFF
--- a/docs/architecture/SEAMS.md
+++ b/docs/architecture/SEAMS.md
@@ -99,6 +99,20 @@ Config is the shared input surface that defines:
 ### Notes
 - `app/config` is used across layers as a shared input surface.
 - Avoid importing `app.container` or CLI modules from lower layers.
+- The risk-appetite derivation seam (stage 2 of
+  [canonical risk-limit vocabulary](../decisions/canonical-risk-limit-vocabulary.md),
+  #1120) lives in `src/gpt_trader/app/risk_budget_seed.py` and is wired behind
+  the default-off `risk_budget_runtime_seed_enabled` gate. When set, the
+  composition root (`src/gpt_trader/app/container.py`) resolves the active
+  `RiskBudget` version once at startup: the runtime risk manager's
+  `daily_loss_limit_pct` / `max_exposure_pct` are seeded from the budget
+  (`src/gpt_trader/app/containers/risk_validation.py`, which records the
+  seeded budget version in startup telemetry), `allow_futures_leverage=false`
+  clamps the effective CFM leverage cap to 1x, and `allow_naked_shorts=false`
+  forces shorts off. When unset (the default), runtime limits come from
+  `BotConfig.risk` exactly as before. The default stays off until a
+  MOCK_BROKER regression covers the loosened breaker (the budget defaults —
+  10% daily loss / 100% exposure — are looser than the runtime 5% / 80%).
 
 ---
 

--- a/src/gpt_trader/app/config/bot_config.py
+++ b/src/gpt_trader/app/config/bot_config.py
@@ -199,6 +199,15 @@ class BotConfig:
     # engine enters proposal-only mode and never places orders while the gate is
     # on. See docs/DIRECTION.md, docs/STATUS.md, docs/architecture/SEAMS.md.
     strategy_signal_proposals_enabled: bool = False
+    # Stage 2 derivation seam (default OFF). When enabled, the runtime risk
+    # manager's appetite fields (daily_loss_limit_pct, max_exposure_pct) are
+    # seeded from the active RiskBudget version at engine startup, and the
+    # budget's permissions gate shorts and CFM leverage. Default-off because
+    # the budget defaults are LOOSER than the runtime defaults (10% daily loss
+    # / 100% exposure vs 5% / 80%); flipping the default is held until a
+    # MOCK_BROKER regression covers the loosened breaker. See
+    # docs/decisions/canonical-risk-limit-vocabulary.md (#1120).
+    risk_budget_runtime_seed_enabled: bool = False
     market_order_fallback: bool = True
     # Enabled by default for resiliency; disable only for controlled troubleshooting.
     order_submission_retries_enabled: bool = True
@@ -565,6 +574,7 @@ class BotConfig:
                 "dry_run": schema.execution.dry_run,
                 "mock_broker": schema.execution.mock_broker,
                 "strategy_signal_proposals_enabled": schema.execution.strategy_signal_proposals,
+                "risk_budget_runtime_seed_enabled": schema.execution.risk_budget_runtime_seed,
                 "log_level": schema.monitoring.log_level,
                 "status_interval": schema.monitoring.update_interval,
                 "status_enabled": schema.monitoring.status_enabled,

--- a/src/gpt_trader/app/config/profile_loader.py
+++ b/src/gpt_trader/app/config/profile_loader.py
@@ -518,6 +518,7 @@ class ProfileLoader:
             "use_limit_orders": schema.execution.use_limit_orders,
             "market_order_fallback": schema.execution.market_order_fallback,
             "strategy_signal_proposals_enabled": schema.execution.strategy_signal_proposals,
+            "risk_budget_runtime_seed_enabled": schema.execution.risk_budget_runtime_seed,
             # Monitoring
             "log_level": schema.monitoring.log_level,
             "status_interval": schema.monitoring.update_interval,
@@ -626,6 +627,7 @@ def _schema_to_bot_config(
         "dry_run": schema.execution.dry_run,
         "mock_broker": schema.execution.mock_broker,
         "strategy_signal_proposals_enabled": schema.execution.strategy_signal_proposals,
+        "risk_budget_runtime_seed_enabled": schema.execution.risk_budget_runtime_seed,
         "log_level": schema.monitoring.log_level,
         "status_interval": schema.monitoring.update_interval,
         "status_enabled": schema.monitoring.status_enabled,

--- a/src/gpt_trader/app/config/profile_schema.py
+++ b/src/gpt_trader/app/config/profile_schema.py
@@ -71,6 +71,9 @@ class ExecutionConfig:
     # Stage 1 human-approved loop (default OFF): route live strategy decisions
     # into the approval-gated trade-idea workflow instead of submitting orders.
     strategy_signal_proposals: bool = False
+    # Stage 2 derivation seam (default OFF): seed runtime risk limits from the
+    # active RiskBudget version at engine startup (#1120).
+    risk_budget_runtime_seed: bool = False
 
 
 @dataclass
@@ -189,6 +192,7 @@ class ProfileSchema:
             use_limit_orders=execution_data.get("use_limit_orders", False),
             market_order_fallback=execution_data.get("market_order_fallback", True),
             strategy_signal_proposals=execution_data.get("strategy_signal_proposals", False),
+            risk_budget_runtime_seed=execution_data.get("risk_budget_runtime_seed", False),
         )
 
         # Parse session config

--- a/src/gpt_trader/app/container.py
+++ b/src/gpt_trader/app/container.py
@@ -33,6 +33,7 @@ from gpt_trader.utilities.logging_patterns import get_logger
 
 if TYPE_CHECKING:
     from gpt_trader.app.config.profile_loader import ProfileLoader
+    from gpt_trader.app.risk_budget_seed import RiskBudgetRuntimeSeed
     from gpt_trader.features.live_trade.bot import TradingBot
     from gpt_trader.features.live_trade.execution.validation import ValidationFailureTracker
     from gpt_trader.features.live_trade.risk.manager import LiveRiskManager
@@ -58,6 +59,25 @@ class ApplicationContainer:
 
     def __init__(self, config: BotConfig):
         self.config = config
+        # Stage 2 derivation seam (default OFF): resolve the active RiskBudget
+        # version once at startup so the shorts gate and the runtime risk
+        # limits are seeded from the same version, before the settings
+        # snapshot/fingerprint capture the effective config. See
+        # docs/decisions/canonical-risk-limit-vocabulary.md (#1120).
+        self._risk_budget_seed: RiskBudgetRuntimeSeed | None = None
+        if config.risk_budget_runtime_seed_enabled:
+            from gpt_trader.app.risk_budget_seed import (
+                apply_shorts_permission,
+                resolve_risk_budget_runtime_seed,
+            )
+
+            self._risk_budget_seed = resolve_risk_budget_runtime_seed()
+            apply_shorts_permission(config, self._risk_budget_seed)
+            logger.info(
+                "Runtime risk limits seeded from risk budget",
+                budget_version=self._risk_budget_seed.budget_version,
+                budget_source=self._risk_budget_seed.budget_source,
+            )
         self._runtime_settings_snapshot = create_runtime_settings_snapshot(config)
         self._startup_config_fingerprint = compute_startup_config_fingerprint(
             self._runtime_settings_snapshot
@@ -79,6 +99,7 @@ class ApplicationContainer:
         self._risk_validation = RiskValidationContainer(
             config=config,
             event_store_provider=lambda: self.event_store,
+            risk_budget_seed=self._risk_budget_seed,
         )
 
     @property

--- a/src/gpt_trader/app/containers/risk_validation.py
+++ b/src/gpt_trader/app/containers/risk_validation.py
@@ -9,11 +9,12 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from gpt_trader.app.config import BotConfig
 
 if TYPE_CHECKING:
+    from gpt_trader.app.risk_budget_seed import RiskBudgetRuntimeSeed
     from gpt_trader.features.live_trade.execution.validation import ValidationFailureTracker
     from gpt_trader.features.live_trade.risk.manager import LiveRiskManager
     from gpt_trader.persistence.event_store import EventStore
@@ -29,15 +30,21 @@ class RiskValidationContainer:
         event_store_provider: Callable returning the EventStore instance.
             This is a callable (not the instance) to support lazy resolution
             and avoid initialization order issues.
+        risk_budget_seed: Runtime risk-appetite values derived from the active
+            RiskBudget version at startup (docs/decisions/
+            canonical-risk-limit-vocabulary.md). None (the default) keeps the
+            pre-seam behavior: appetite fields come from BotConfig.risk.
     """
 
     def __init__(
         self,
         config: BotConfig,
         event_store_provider: Callable[[], EventStore],
+        risk_budget_seed: RiskBudgetRuntimeSeed | None = None,
     ):
         self._config = config
         self._event_store_provider = event_store_provider
+        self._risk_budget_seed = risk_budget_seed
 
         self._risk_manager: LiveRiskManager | None = None
         self._validation_failure_tracker: ValidationFailureTracker | None = None
@@ -64,14 +71,23 @@ class RiskValidationContainer:
                 # baseline, ensemble, or any other type uses strategy config
                 kill_switch = getattr(self._config.strategy, "kill_switch_enabled", False)
 
-            risk_config = RiskConfig(
-                max_leverage=bot_risk.max_leverage,
-                daily_loss_limit_pct=bot_risk.daily_loss_limit_pct,
-                max_position_pct_per_symbol=float(bot_risk.position_fraction),
+            risk_config_kwargs: dict[str, Any] = {
+                "max_leverage": bot_risk.max_leverage,
+                "daily_loss_limit_pct": bot_risk.daily_loss_limit_pct,
+                "max_position_pct_per_symbol": float(bot_risk.position_fraction),
                 # Map other relevant fields
-                kill_switch_enabled=kill_switch,
-                reduce_only_mode=self._config.reduce_only_mode,
-            )
+                "kill_switch_enabled": kill_switch,
+                "reduce_only_mode": self._config.reduce_only_mode,
+            }
+            seed = self._risk_budget_seed
+            if seed is not None:
+                risk_config_kwargs["daily_loss_limit_pct"] = seed.daily_loss_limit_pct
+                risk_config_kwargs["max_exposure_pct"] = seed.max_exposure_pct
+                if not seed.allow_futures_leverage:
+                    # Permission gates magnitude: without futures leverage the
+                    # effective CFM cap is 1x regardless of configured caps.
+                    risk_config_kwargs["cfm_max_leverage"] = 1
+            risk_config = RiskConfig(**risk_config_kwargs)
 
             profile = getattr(self._config, "profile", None)
             profile_value = (
@@ -85,11 +101,19 @@ class RiskValidationContainer:
                 )
                 state_file = str(state_file_path)
 
+            event_store = self._event_store_provider()
             self._risk_manager = LiveRiskManager(
                 config=risk_config,
-                event_store=self._event_store_provider(),
+                event_store=event_store,
                 state_file=state_file,
             )
+            if seed is not None:
+                from gpt_trader.app.risk_budget_seed import RISK_BUDGET_SEED_EVENT_TYPE
+
+                # Startup telemetry: record which budget version seeded the
+                # runtime breaker so the restart-bounded drift window between
+                # approval-time and runtime limits stays visible.
+                event_store.append(RISK_BUDGET_SEED_EVENT_TYPE, seed.telemetry_payload())
         return self._risk_manager
 
     @property

--- a/src/gpt_trader/app/risk_budget_seed.py
+++ b/src/gpt_trader/app/risk_budget_seed.py
@@ -1,0 +1,104 @@
+"""Startup derivation seam: seed runtime risk limits from the active RiskBudget.
+
+Implements the derivation stage of the accepted decision
+``docs/decisions/canonical-risk-limit-vocabulary.md`` (Option A): the
+versioned ``RiskBudget`` is canonical for risk appetite, and the live
+``RiskConfig`` derives its appetite fields from the budget version current at
+engine startup. A budget change mid-run takes effect at approval time
+immediately but at runtime only after restart; the seeded version is recorded
+in startup telemetry so that drift window stays visible.
+
+The seam is default-off behind ``BotConfig.risk_budget_runtime_seed_enabled``
+because the seeded budget defaults are LOOSER than the runtime defaults (10%
+daily loss / 100% open notional vs 5% / 80%): enabling it is a live-path
+behavior change, held until a MOCK_BROKER regression covers the loosened
+breaker (#1120).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from gpt_trader.core.risk_units import pct_points_to_fraction
+from gpt_trader.features.trade_ideas.budget import DEFAULT_RISK_BUDGET, RiskBudgetLog
+from gpt_trader.features.trade_ideas.service import resolve_ideas_root
+
+if TYPE_CHECKING:
+    from gpt_trader.app.config import BotConfig
+
+RISK_BUDGET_SEED_EVENT_TYPE = "risk_budget_runtime_seed"
+
+
+@dataclass(frozen=True, slots=True)
+class RiskBudgetRuntimeSeed:
+    """Runtime risk-appetite values derived from one RiskBudget version.
+
+    ``daily_loss_limit_pct`` and ``max_exposure_pct`` are unit fractions
+    (``RiskConfig`` convention), already normalized from the budget's
+    percent-point fields through the canonical converter.
+    """
+
+    budget_version: int
+    budget_source: str  # "risk_budget_log" | "default"
+    daily_loss_limit_pct: float
+    max_exposure_pct: float
+    allow_futures_leverage: bool
+    allow_naked_shorts: bool
+
+    def telemetry_payload(self) -> dict[str, Any]:
+        return {
+            "budget_version": self.budget_version,
+            "budget_source": self.budget_source,
+            "daily_loss_limit_pct": self.daily_loss_limit_pct,
+            "max_exposure_pct": self.max_exposure_pct,
+            "allow_futures_leverage": self.allow_futures_leverage,
+            "allow_naked_shorts": self.allow_naked_shorts,
+        }
+
+
+def resolve_risk_budget_runtime_seed(ideas_root: Path | None = None) -> RiskBudgetRuntimeSeed:
+    """Resolve the active budget version into runtime seed values.
+
+    Reads the same ``risk_budget.jsonl`` the approval gate uses. A missing log
+    falls back to ``DEFAULT_RISK_BUDGET`` (matching ``TradeIdeaService``); a
+    corrupt log raises so startup fails closed instead of trading on limits
+    that cannot be attributed to a budget version.
+    """
+    root = resolve_ideas_root(ideas_root).expanduser()
+    logged = RiskBudgetLog(root / "risk_budget.jsonl").current()
+    budget = logged if logged is not None else DEFAULT_RISK_BUDGET
+    return RiskBudgetRuntimeSeed(
+        budget_version=budget.version,
+        budget_source="risk_budget_log" if logged is not None else "default",
+        daily_loss_limit_pct=float(pct_points_to_fraction(budget.max_daily_loss_pct)),
+        max_exposure_pct=float(pct_points_to_fraction(budget.max_open_notional_pct)),
+        allow_futures_leverage=budget.allow_futures_leverage,
+        allow_naked_shorts=budget.allow_naked_shorts,
+    )
+
+
+def apply_shorts_permission(config: BotConfig, seed: RiskBudgetRuntimeSeed) -> None:
+    """Gate shorts by the budget's ``allow_naked_shorts`` permission.
+
+    The permission only restricts: when the budget forbids naked shorts, the
+    top-level flag and the per-strategy flags (the canonical source behind
+    ``BotConfig.active_enable_shorts``) are all forced off so the factory and
+    the runtime agree. When the budget allows shorts, strategy preferences are
+    left untouched — a permission is not a mandate.
+    """
+    if seed.allow_naked_shorts:
+        return
+    config.enable_shorts = False
+    if hasattr(config.strategy, "enable_shorts"):
+        config.strategy.enable_shorts = False
+    config.mean_reversion.enable_shorts = False
+
+
+__all__ = [
+    "RISK_BUDGET_SEED_EVENT_TYPE",
+    "RiskBudgetRuntimeSeed",
+    "apply_shorts_permission",
+    "resolve_risk_budget_runtime_seed",
+]

--- a/src/gpt_trader/cli/services.py
+++ b/src/gpt_trader/cli/services.py
@@ -189,6 +189,8 @@ def _apply_profile_kwargs(config: BotConfig, profile_kwargs: dict[str, Any]) -> 
         config.strategy_signal_proposals_enabled = profile_kwargs[
             "strategy_signal_proposals_enabled"
         ]
+    if "risk_budget_runtime_seed_enabled" in profile_kwargs:
+        config.risk_budget_runtime_seed_enabled = profile_kwargs["risk_budget_runtime_seed_enabled"]
 
     if "enable_shorts" in profile_kwargs:
         config.enable_shorts = profile_kwargs["enable_shorts"]

--- a/tests/unit/gpt_trader/app/config/test_bot_config.py
+++ b/tests/unit/gpt_trader/app/config/test_bot_config.py
@@ -189,6 +189,17 @@ class TestFromDictLegacyProfileMapping:
 
         assert config.strategy_signal_proposals_enabled is True
 
+    def test_profile_style_maps_risk_budget_runtime_seed_gate(self) -> None:
+        with pytest.warns(DeprecationWarning, match=r"Legacy profile-style YAML mapping"):
+            config = BotConfig.from_dict(
+                {
+                    "profile_name": "seed-profile",
+                    "execution": {"risk_budget_runtime_seed": True},
+                }
+            )
+
+        assert config.risk_budget_runtime_seed_enabled is True
+
 
 class TestHealthThresholdsConfig:
     """Tests for health threshold model conversion."""

--- a/tests/unit/gpt_trader/app/config/test_profile_loader.py
+++ b/tests/unit/gpt_trader/app/config/test_profile_loader.py
@@ -342,3 +342,21 @@ class TestProfileOverridePrecedence:
         monkeypatch.setenv("BOT_PROFILE", " paper ")
 
         assert get_env_profile_override() == "paper"
+
+
+class TestRiskBudgetRuntimeSeedMapping:
+    """Stage 2 derivation seam gate (#1120): schema parse and kwargs mapping."""
+
+    def test_from_yaml_defaults_off(self) -> None:
+        schema = ProfileSchema.from_yaml({}, "empty")
+
+        assert schema.execution.risk_budget_runtime_seed is False
+
+    def test_to_bot_config_kwargs_maps_gate(self) -> None:
+        schema = ProfileSchema.from_yaml(
+            {"execution": {"risk_budget_runtime_seed": True}}, "seed-profile"
+        )
+
+        kwargs = ProfileLoader().to_bot_config_kwargs(schema, Profile.DEV)
+
+        assert kwargs["risk_budget_runtime_seed_enabled"] is True

--- a/tests/unit/gpt_trader/app/containers/test_risk_validation.py
+++ b/tests/unit/gpt_trader/app/containers/test_risk_validation.py
@@ -178,3 +178,81 @@ class TestRiskValidationContainer:
         risk_manager = container.risk_manager
         expected = str(Path(config.runtime_root) / "runtime_data" / "canary" / "risk_state.json")
         assert risk_manager.state_file == expected
+
+
+def _runtime_seed(*, allow_futures_leverage: bool = False) -> object:
+    from gpt_trader.app.risk_budget_seed import RiskBudgetRuntimeSeed
+
+    return RiskBudgetRuntimeSeed(
+        budget_version=1,
+        budget_source="default",
+        daily_loss_limit_pct=0.10,
+        max_exposure_pct=1.0,
+        allow_futures_leverage=allow_futures_leverage,
+        allow_naked_shorts=False,
+    )
+
+
+class TestRiskBudgetSeedApplication:
+    """Stage 2 derivation seam (#1120): budget-seeded runtime limits."""
+
+    def test_no_seed_keeps_bot_risk_defaults(self, mock_event_store: MagicMock) -> None:
+        container = RiskValidationContainer(
+            config=BotConfig(symbols=["BTC-USD"]),
+            event_store_provider=lambda: mock_event_store,
+        )
+
+        risk_manager = container.risk_manager
+
+        assert risk_manager.config.daily_loss_limit_pct == 0.05
+        assert risk_manager.config.max_exposure_pct == 0.8
+        assert risk_manager.config.cfm_max_leverage == 5
+        mock_event_store.append.assert_not_called()
+
+    def test_seed_overrides_appetite_fields_and_clamps_cfm(
+        self, mock_event_store: MagicMock
+    ) -> None:
+        container = RiskValidationContainer(
+            config=BotConfig(symbols=["BTC-USD"]),
+            event_store_provider=lambda: mock_event_store,
+            risk_budget_seed=_runtime_seed(),
+        )
+
+        risk_manager = container.risk_manager
+
+        assert risk_manager.config.daily_loss_limit_pct == 0.10
+        assert risk_manager.config.max_exposure_pct == 1.0
+        assert risk_manager.config.cfm_max_leverage == 1
+
+    def test_futures_permission_keeps_cfm_caps(self, mock_event_store: MagicMock) -> None:
+        container = RiskValidationContainer(
+            config=BotConfig(symbols=["BTC-USD"]),
+            event_store_provider=lambda: mock_event_store,
+            risk_budget_seed=_runtime_seed(allow_futures_leverage=True),
+        )
+
+        assert container.risk_manager.config.cfm_max_leverage == 5
+
+    def test_seed_emits_startup_telemetry_once(self, mock_event_store: MagicMock) -> None:
+        from gpt_trader.app.risk_budget_seed import RISK_BUDGET_SEED_EVENT_TYPE
+
+        container = RiskValidationContainer(
+            config=BotConfig(symbols=["BTC-USD"]),
+            event_store_provider=lambda: mock_event_store,
+            risk_budget_seed=_runtime_seed(),
+        )
+
+        container.risk_manager
+        container.risk_manager  # cached access must not re-emit
+
+        mock_event_store.append.assert_called_once_with(
+            RISK_BUDGET_SEED_EVENT_TYPE,
+            {
+                "budget_version": 1,
+                "budget_source": "default",
+                "daily_loss_limit_pct": 0.10,
+                "max_exposure_pct": 1.0,
+                "allow_futures_leverage": False,
+                "allow_naked_shorts": False,
+            },
+        )

--- a/tests/unit/gpt_trader/app/test_application_container.py
+++ b/tests/unit/gpt_trader/app/test_application_container.py
@@ -216,3 +216,36 @@ class TestApplicationContainerSecondaryServices:
 
         secrets_manager2 = container.secrets_manager
         assert secrets_manager is secrets_manager2
+
+
+class TestRiskBudgetRuntimeSeedGate:
+    """Stage 2 derivation seam (#1120): default-off startup seeding."""
+
+    def test_gate_off_resolves_no_seed(self, mock_config: BotConfig) -> None:
+        container = ApplicationContainer(mock_config)
+
+        assert container._risk_budget_seed is None
+        assert container._risk_validation._risk_budget_seed is None
+
+    def test_gate_on_seeds_and_gates_shorts(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("GPT_TRADER_IDEAS_ROOT", str(tmp_path))
+        config = BotConfig(
+            symbols=["BTC-USD"],
+            enable_shorts=True,
+            risk_budget_runtime_seed_enabled=True,
+        )
+        config.strategy.enable_shorts = True
+
+        container = ApplicationContainer(config)
+
+        seed = container._risk_budget_seed
+        assert seed is not None
+        # Missing budget log falls back to the default budget (version 1),
+        # whose permissions forbid naked shorts.
+        assert seed.budget_version == 1
+        assert seed.budget_source == "default"
+        assert config.enable_shorts is False
+        assert config.strategy.enable_shorts is False
+        assert container._risk_validation._risk_budget_seed is seed

--- a/tests/unit/gpt_trader/app/test_risk_budget_seed.py
+++ b/tests/unit/gpt_trader/app/test_risk_budget_seed.py
@@ -1,0 +1,144 @@
+"""Tests for the risk-budget -> runtime-limit derivation seam (#1120 stage 2)."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from datetime import UTC, datetime
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from gpt_trader.app.config import BotConfig
+from gpt_trader.app.risk_budget_seed import (
+    RiskBudgetRuntimeSeed,
+    apply_shorts_permission,
+    resolve_risk_budget_runtime_seed,
+)
+from gpt_trader.features.trade_ideas.audit import ActorType
+from gpt_trader.features.trade_ideas.budget import (
+    DEFAULT_RISK_BUDGET,
+    BudgetLogEntry,
+    RiskBudgetLog,
+)
+
+
+def _append_budget_version(ideas_root: Path, **overrides: object) -> None:
+    log = RiskBudgetLog(ideas_root / "risk_budget.jsonl")
+    current = log.current()
+    version = 1 if current is None else current.version + 1
+    budget = replace(DEFAULT_RISK_BUDGET, version=version, **overrides)  # type: ignore[arg-type]
+    log.append(
+        BudgetLogEntry(
+            timestamp=datetime(2026, 7, 3, tzinfo=UTC),
+            actor_type=ActorType.HUMAN,
+            actor_id="rj",
+            budget=budget,
+        )
+    )
+
+
+class TestResolveRiskBudgetRuntimeSeed:
+    def test_missing_log_falls_back_to_default_budget(self, tmp_path: Path) -> None:
+        seed = resolve_risk_budget_runtime_seed(tmp_path)
+
+        assert seed.budget_version == DEFAULT_RISK_BUDGET.version
+        assert seed.budget_source == "default"
+        # DEFAULT budget: 10% daily loss, 100% open notional (percent points)
+        # normalized to the RiskConfig fraction convention.
+        assert seed.daily_loss_limit_pct == pytest.approx(0.10)
+        assert seed.max_exposure_pct == pytest.approx(1.0)
+        assert seed.allow_futures_leverage is False
+        assert seed.allow_naked_shorts is False
+
+    def test_seeded_log_uses_current_version(self, tmp_path: Path) -> None:
+        _append_budget_version(tmp_path)
+        _append_budget_version(
+            tmp_path,
+            max_daily_loss_pct=Decimal("7"),
+            max_open_notional_pct=Decimal("60"),
+            allow_futures_leverage=True,
+            allow_naked_shorts=True,
+        )
+
+        seed = resolve_risk_budget_runtime_seed(tmp_path)
+
+        assert seed.budget_version == 2
+        assert seed.budget_source == "risk_budget_log"
+        assert seed.daily_loss_limit_pct == pytest.approx(0.07)
+        assert seed.max_exposure_pct == pytest.approx(0.60)
+        assert seed.allow_futures_leverage is True
+        assert seed.allow_naked_shorts is True
+
+    def test_corrupt_log_fails_closed(self, tmp_path: Path) -> None:
+        (tmp_path / "risk_budget.jsonl").write_text("not json\n", encoding="utf-8")
+
+        with pytest.raises(json.JSONDecodeError):
+            resolve_risk_budget_runtime_seed(tmp_path)
+
+    def test_env_root_resolution(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _append_budget_version(tmp_path, max_daily_loss_pct=Decimal("3"))
+        monkeypatch.setenv("GPT_TRADER_IDEAS_ROOT", str(tmp_path))
+
+        seed = resolve_risk_budget_runtime_seed()
+
+        assert seed.budget_version == 1
+        assert seed.daily_loss_limit_pct == pytest.approx(0.03)
+
+    def test_telemetry_payload_round_trips_fields(self) -> None:
+        seed = RiskBudgetRuntimeSeed(
+            budget_version=3,
+            budget_source="risk_budget_log",
+            daily_loss_limit_pct=0.07,
+            max_exposure_pct=0.6,
+            allow_futures_leverage=True,
+            allow_naked_shorts=False,
+        )
+
+        assert seed.telemetry_payload() == {
+            "budget_version": 3,
+            "budget_source": "risk_budget_log",
+            "daily_loss_limit_pct": 0.07,
+            "max_exposure_pct": 0.6,
+            "allow_futures_leverage": True,
+            "allow_naked_shorts": False,
+        }
+
+
+def _seed(allow_naked_shorts: bool) -> RiskBudgetRuntimeSeed:
+    return RiskBudgetRuntimeSeed(
+        budget_version=1,
+        budget_source="default",
+        daily_loss_limit_pct=0.10,
+        max_exposure_pct=1.0,
+        allow_futures_leverage=False,
+        allow_naked_shorts=allow_naked_shorts,
+    )
+
+
+class TestApplyShortsPermission:
+    def test_forbidden_shorts_forces_all_flags_off(self) -> None:
+        config = BotConfig(enable_shorts=True)
+        config.strategy.enable_shorts = True
+        config.mean_reversion.enable_shorts = True
+
+        apply_shorts_permission(config, _seed(allow_naked_shorts=False))
+
+        assert config.enable_shorts is False
+        assert config.strategy.enable_shorts is False
+        assert config.mean_reversion.enable_shorts is False
+        # active_enable_shorts derives from strategy config; the gate must
+        # leave no mismatch for it to warn about.
+        assert config.active_enable_shorts is False
+
+    def test_permission_is_not_a_mandate(self) -> None:
+        config = BotConfig(enable_shorts=False)
+        config.strategy.enable_shorts = False
+        config.mean_reversion.enable_shorts = True
+
+        apply_shorts_permission(config, _seed(allow_naked_shorts=True))
+
+        assert config.enable_shorts is False
+        assert config.strategy.enable_shorts is False
+        assert config.mean_reversion.enable_shorts is True

--- a/tests/unit/gpt_trader/cli/test_services_build_config.py
+++ b/tests/unit/gpt_trader/cli/test_services_build_config.py
@@ -117,3 +117,11 @@ def test_apply_profile_kwargs_maps_strategy_signal_proposals_gate() -> None:
     services._apply_profile_kwargs(config, {"strategy_signal_proposals_enabled": True})
 
     assert config.strategy_signal_proposals_enabled is True
+
+
+def test_apply_profile_kwargs_maps_risk_budget_runtime_seed_gate() -> None:
+    config = BotConfig(risk_budget_runtime_seed_enabled=False)
+
+    services._apply_profile_kwargs(config, {"risk_budget_runtime_seed_enabled": True})
+
+    assert config.risk_budget_runtime_seed_enabled is True

--- a/var/agents/configuration/environment_variables.json
+++ b/var/agents/configuration/environment_variables.json
@@ -28,7 +28,7 @@
       ],
       "code_references": [
         {
-          "line": 459,
+          "line": 468,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "os.getenv"
         }
@@ -51,7 +51,7 @@
       ],
       "code_references": [
         {
-          "line": 447,
+          "line": 456,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_bool_env"
         }
@@ -67,7 +67,7 @@
       ],
       "code_references": [
         {
-          "line": 383,
+          "line": 392,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_bool_env"
         }
@@ -90,7 +90,7 @@
       ],
       "code_references": [
         {
-          "line": 465,
+          "line": 474,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "os.getenv"
         }
@@ -123,7 +123,7 @@
       ],
       "code_references": [
         {
-          "line": 463,
+          "line": 472,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_int_env"
         },
@@ -176,7 +176,7 @@
       ],
       "code_references": [
         {
-          "line": 464,
+          "line": 473,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_list_env"
         }
@@ -208,7 +208,7 @@
       ],
       "code_references": [
         {
-          "line": 458,
+          "line": 467,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "os.getenv"
         }
@@ -318,7 +318,7 @@
       ],
       "code_references": [
         {
-          "line": 452,
+          "line": 461,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "os.getenv"
         }
@@ -341,7 +341,7 @@
       ],
       "code_references": [
         {
-          "line": 456,
+          "line": 465,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "os.getenv"
         }
@@ -357,12 +357,12 @@
       ],
       "code_references": [
         {
-          "line": 384,
+          "line": 393,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "os.getenv"
         },
         {
-          "line": 384,
+          "line": 393,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_bool_env"
         }
@@ -457,7 +457,7 @@
       ],
       "code_references": [
         {
-          "line": 457,
+          "line": 466,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_bool_env"
         },
@@ -616,7 +616,7 @@
       ],
       "code_references": [
         {
-          "line": 453,
+          "line": 462,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_bool_env"
         }
@@ -680,7 +680,7 @@
       ],
       "code_references": [
         {
-          "line": 442,
+          "line": 451,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_bool_env"
         }
@@ -726,7 +726,7 @@
       ],
       "code_references": [
         {
-          "line": 476,
+          "line": 485,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "os.getenv"
         }
@@ -744,7 +744,7 @@
       ],
       "code_references": [
         {
-          "line": 474,
+          "line": 483,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "os.getenv"
         },
@@ -777,7 +777,7 @@
       ],
       "code_references": [
         {
-          "line": 234,
+          "line": 233,
           "path": "src/gpt_trader/features/trade_ideas/service.py",
           "reader": "os.environ.get"
         }
@@ -1189,7 +1189,7 @@
       ],
       "code_references": [
         {
-          "line": 224,
+          "line": 223,
           "path": "src/gpt_trader/features/trade_ideas/service.py",
           "reader": "os.environ.get"
         }
@@ -1553,7 +1553,7 @@
       ],
       "code_references": [
         {
-          "line": 473,
+          "line": 482,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "os.getenv"
         },
@@ -1778,7 +1778,7 @@
       ],
       "code_references": [
         {
-          "line": 414,
+          "line": 423,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "_health_float"
         }
@@ -1794,7 +1794,7 @@
       ],
       "code_references": [
         {
-          "line": 413,
+          "line": 422,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "_health_float"
         }
@@ -1810,7 +1810,7 @@
       ],
       "code_references": [
         {
-          "line": 424,
+          "line": 433,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "_health_int"
         }
@@ -1826,7 +1826,7 @@
       ],
       "code_references": [
         {
-          "line": 423,
+          "line": 432,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "_health_int"
         }
@@ -1842,7 +1842,7 @@
       ],
       "code_references": [
         {
-          "line": 420,
+          "line": 429,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "_health_float"
         }
@@ -1858,7 +1858,7 @@
       ],
       "code_references": [
         {
-          "line": 417,
+          "line": 426,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "_health_float"
         }
@@ -1874,7 +1874,7 @@
       ],
       "code_references": [
         {
-          "line": 426,
+          "line": 435,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "_health_int"
         }
@@ -1890,7 +1890,7 @@
       ],
       "code_references": [
         {
-          "line": 425,
+          "line": 434,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "_health_int"
         }
@@ -1906,7 +1906,7 @@
       ],
       "code_references": [
         {
-          "line": 410,
+          "line": 419,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "_health_float"
         }
@@ -1922,7 +1922,7 @@
       ],
       "code_references": [
         {
-          "line": 409,
+          "line": 418,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "_health_float"
         }
@@ -1938,7 +1938,7 @@
       ],
       "code_references": [
         {
-          "line": 412,
+          "line": 421,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "_health_float"
         }
@@ -1954,7 +1954,7 @@
       ],
       "code_references": [
         {
-          "line": 411,
+          "line": 420,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "_health_float"
         }
@@ -1970,7 +1970,7 @@
       ],
       "code_references": [
         {
-          "line": 416,
+          "line": 425,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "_health_float"
         }
@@ -1986,7 +1986,7 @@
       ],
       "code_references": [
         {
-          "line": 415,
+          "line": 424,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "_health_float"
         }
@@ -2018,7 +2018,7 @@
       ],
       "code_references": [
         {
-          "line": 439,
+          "line": 448,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_int_env"
         }
@@ -2057,7 +2057,7 @@
       ],
       "code_references": [
         {
-          "line": 441,
+          "line": 450,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "os.getenv"
         }
@@ -2080,7 +2080,7 @@
       ],
       "code_references": [
         {
-          "line": 346,
+          "line": 355,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_int_env"
         }
@@ -2096,7 +2096,7 @@
       ],
       "code_references": [
         {
-          "line": 484,
+          "line": 493,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_bool_env"
         }
@@ -2119,7 +2119,7 @@
       ],
       "code_references": [
         {
-          "line": 478,
+          "line": 487,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_bool_env"
         }
@@ -2142,7 +2142,7 @@
       ],
       "code_references": [
         {
-          "line": 479,
+          "line": 488,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_bool_env"
         }
@@ -2190,7 +2190,7 @@
       ],
       "code_references": [
         {
-          "line": 485,
+          "line": 494,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_bool_env"
         }
@@ -2206,7 +2206,7 @@
       ],
       "code_references": [
         {
-          "line": 486,
+          "line": 495,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_bool_env"
         }
@@ -2292,7 +2292,7 @@
       ],
       "code_references": [
         {
-          "line": 466,
+          "line": 475,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_bool_env"
         }
@@ -2356,7 +2356,7 @@
       ],
       "code_references": [
         {
-          "line": 468,
+          "line": 477,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_bool_env"
         }
@@ -2379,7 +2379,7 @@
       ],
       "code_references": [
         {
-          "line": 471,
+          "line": 480,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_decimal_env"
         }
@@ -2395,7 +2395,7 @@
       ],
       "code_references": [
         {
-          "line": 469,
+          "line": 478,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_bool_env"
         }
@@ -2427,7 +2427,7 @@
       ],
       "code_references": [
         {
-          "line": 467,
+          "line": 476,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_int_env"
         }
@@ -2558,7 +2558,7 @@
       ],
       "code_references": [
         {
-          "line": 475,
+          "line": 484,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "os.getenv"
         }
@@ -2575,7 +2575,7 @@
       ],
       "code_references": [
         {
-          "line": 377,
+          "line": 386,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "_risk_float"
         },
@@ -2719,7 +2719,7 @@
       ],
       "code_references": [
         {
-          "line": 371,
+          "line": 380,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "_risk_int"
         },
@@ -2748,7 +2748,7 @@
       ],
       "code_references": [
         {
-          "line": 367,
+          "line": 376,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "os.getenv"
         },
@@ -2776,7 +2776,7 @@
       ],
       "code_references": [
         {
-          "line": 370,
+          "line": 379,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "_risk_decimal"
         }
@@ -2832,7 +2832,7 @@
       ],
       "code_references": [
         {
-          "line": 483,
+          "line": 492,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_bool_env"
         },
@@ -2922,7 +2922,7 @@
       ],
       "code_references": [
         {
-          "line": 373,
+          "line": 382,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "_risk_decimal"
         }
@@ -2938,7 +2938,7 @@
       ],
       "code_references": [
         {
-          "line": 374,
+          "line": 383,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "_risk_decimal"
         }
@@ -2954,7 +2954,7 @@
       ],
       "code_references": [
         {
-          "line": 372,
+          "line": 381,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "_risk_int"
         }
@@ -3079,7 +3079,7 @@
       ],
       "code_references": [
         {
-          "line": 345,
+          "line": 354,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_int_env"
         }
@@ -3095,7 +3095,7 @@
       ],
       "code_references": [
         {
-          "line": 477,
+          "line": 486,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_bool_env"
         }
@@ -3111,7 +3111,7 @@
       ],
       "code_references": [
         {
-          "line": 446,
+          "line": 455,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_bool_env"
         }
@@ -3134,7 +3134,7 @@
       ],
       "code_references": [
         {
-          "line": 444,
+          "line": 453,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "os.getenv"
         }
@@ -3157,7 +3157,7 @@
       ],
       "code_references": [
         {
-          "line": 445,
+          "line": 454,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_int_env"
         }
@@ -3182,7 +3182,7 @@
       ],
       "code_references": [
         {
-          "line": 461,
+          "line": 470,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_list_env"
         },
@@ -3216,7 +3216,7 @@
       ],
       "code_references": [
         {
-          "line": 429,
+          "line": 438,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "os.getenv"
         },
@@ -3290,7 +3290,7 @@
       ],
       "code_references": [
         {
-          "line": 443,
+          "line": 452,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "os.getenv"
         }

--- a/var/agents/reasoning/config_code_map.md
+++ b/var/agents/reasoning/config_code_map.md
@@ -40,6 +40,7 @@ Scan root: `src/gpt_trader`
 | profile | 0 | — |
 | reduce_only_mode | 0 | — |
 | regime_switcher_trend_mode | 0 | — |
+| risk_budget_runtime_seed_enabled | 0 | — |
 | risk_config_path | 0 | — |
 | runtime_root | 0 | — |
 | spot_force_live | 0 | — |

--- a/var/agents/schemas/bot_config_schema.json
+++ b/var/agents/schemas/bot_config_schema.json
@@ -86,6 +86,10 @@
       "type": "boolean",
       "default": false
     },
+    "risk_budget_runtime_seed_enabled": {
+      "type": "boolean",
+      "default": false
+    },
     "market_order_fallback": {
       "type": "boolean",
       "default": true

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -9,8 +9,8 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 5893,
-    "total_files": 700,
+    "total_tests": 5919,
+    "total_files": 702,
     "markers_used": 14
   },
   "quick_commands": {

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -92,7 +92,7 @@
     ]
   },
   "counts": {
-    "unit": 5736,
+    "unit": 5762,
     "asyncio": 310,
     "parametrize": 173,
     "integration": 80,


### PR DESCRIPTION
## Summary

Stage 2 of #1120 (canonical risk-limit vocabulary, Option A): the startup derivation seam that seeds the live risk manager's appetite fields from the active `RiskBudget` version — **default-off**.

- **Derivation module** `src/gpt_trader/app/risk_budget_seed.py`: resolves the same `risk_budget.jsonl` the approval gate uses (missing log → `DEFAULT_RISK_BUDGET`, matching `TradeIdeaService`; corrupt log → raises, fail closed) and normalizes percent points → fractions through the stage-1 `core.risk_units` converter.
- **Composition root** (`app/container.py`): when `risk_budget_runtime_seed_enabled` is set, resolves the seed once before the settings snapshot/fingerprint, applies the `allow_naked_shorts` permission (restrict-only — forced through the strategy configs so `active_enable_shorts` agrees; a permission is not a mandate), and hands the seed to `RiskValidationContainer`.
- **Risk container**: seeds `daily_loss_limit_pct` (from `max_daily_loss_pct`) and `max_exposure_pct` (from `max_open_notional_pct`); `allow_futures_leverage=false` clamps the effective CFM leverage cap to 1x. Emits a `risk_budget_runtime_seed` event recording the seeded budget version/source so the restart-bounded drift window between approval-time and runtime limits stays visible.
- **Gate wiring** mirrors `strategy_signal_proposals_enabled`: profile schema + loader (both kwargs sites), legacy `BotConfig.from_dict`, CLI `_apply_profile_kwargs`.
- **Refresh semantics** per the decision record: seeded at engine startup only; mid-run budget changes take effect at approval time immediately, at runtime after restart. Live re-seeding is explicitly out of scope.

## Why default-off

Budget defaults **loosen** the runtime breaker (10% daily loss / 100% open notional vs the runtime 5% / 80%). Flipping the gate is a real live-path behavior change; the flip is held until a MOCK_BROKER regression exercises the loosened breaker (or the budget is renegotiated first). With the gate off, behavior is byte-identical to before.

## Testing

- New: derivation unit tests (default/seeded/corrupt log, env-root resolution, telemetry payload, shorts gate both directions), container seeding tests (off = unchanged 5%/80%/CFM 5 + no event; on = 10%/100%/CFM 1 + one event; futures permission keeps caps), composition-root gate tests, profile/legacy/CLI mapping tests.
- `make ci-required` green locally (6414 unit tests passed, stage1 rails smoke OK); ruff/black/mypy/agent-naming clean.

## Safety boundary

No broker/API call, no live execution, no autonomy change. Default-off; runtime limits are unchanged unless the gate is explicitly enabled.

Refs #1120, docs/decisions/canonical-risk-limit-vocabulary.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a gated option (`risk_budget_runtime_seed_enabled`) to seed runtime risk limits from the active risk budget at startup.
  * When enabled, leverage/short permissions are tightened as needed and startup telemetry records the seeded budget version/source.
* **Bug Fixes**
  * Runtime risk behavior now stays aligned with the seeded budget values when the feature is enabled.
* **Documentation**
  * Updated the SEAMS “Notes” documentation for the risk-appetite derivation seam.
* **Tests**
  * Added unit tests covering config/profile mapping, startup gating, seed resolution, runtime risk overrides, and seed telemetry emission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->