### PR TITLE
feat(risk): flip RiskBudget runtime seeding on by default (#1120)

### DIFF
--- a/docs/architecture/SEAMS.md
+++ b/docs/architecture/SEAMS.md
@@ -102,17 +102,18 @@ Config is the shared input surface that defines:
 - The risk-appetite derivation seam (stage 2 of
   [canonical risk-limit vocabulary](../decisions/canonical-risk-limit-vocabulary.md),
   #1120) lives in `src/gpt_trader/app/risk_budget_seed.py` and is wired behind
-  the default-off `risk_budget_runtime_seed_enabled` gate. When set, the
-  composition root (`src/gpt_trader/app/container.py`) resolves the active
-  `RiskBudget` version once at startup: the runtime risk manager's
+  the default-on `risk_budget_runtime_seed_enabled` gate. When set (the
+  default), the composition root (`src/gpt_trader/app/container.py`) resolves
+  the active `RiskBudget` version once at startup: the runtime risk manager's
   `daily_loss_limit_pct` / `max_exposure_pct` are seeded from the budget
   (`src/gpt_trader/app/containers/risk_validation.py`, which records the
   seeded budget version in startup telemetry), `allow_futures_leverage=false`
   clamps the effective CFM leverage cap to 1x, and `allow_naked_shorts=false`
-  forces shorts off. When unset (the default), runtime limits come from
-  `BotConfig.risk` exactly as before. The default stays off until a
-  MOCK_BROKER regression covers the loosened breaker (the budget defaults —
-  10% daily loss / 100% exposure — are looser than the runtime 5% / 80%).
+  forces shorts off. When unset, runtime limits come from `BotConfig.risk`
+  exactly as before. The budget defaults — 10% daily loss / 100% exposure —
+  are looser than the legacy runtime 5% / 80%; the loosened breaker band is
+  pinned by the MOCK_BROKER regression in
+  `tests/integration/test_risk_budget_seeded_breaker.py`.
 
 ---
 

--- a/src/gpt_trader/app/config/bot_config.py
+++ b/src/gpt_trader/app/config/bot_config.py
@@ -199,15 +199,16 @@ class BotConfig:
     # engine enters proposal-only mode and never places orders while the gate is
     # on. See docs/DIRECTION.md, docs/STATUS.md, docs/architecture/SEAMS.md.
     strategy_signal_proposals_enabled: bool = False
-    # Stage 2 derivation seam (default OFF). When enabled, the runtime risk
+    # Stage 2 derivation seam (default ON). When enabled, the runtime risk
     # manager's appetite fields (daily_loss_limit_pct, max_exposure_pct) are
     # seeded from the active RiskBudget version at engine startup, and the
-    # budget's permissions gate shorts and CFM leverage. Default-off because
-    # the budget defaults are LOOSER than the runtime defaults (10% daily loss
-    # / 100% exposure vs 5% / 80%); flipping the default is held until a
-    # MOCK_BROKER regression covers the loosened breaker. See
+    # budget's permissions gate shorts and CFM leverage. The budget defaults
+    # are LOOSER than the legacy runtime defaults (10% daily loss / 100%
+    # exposure vs 5% / 80%); the loosened breaker band is pinned by the
+    # MOCK_BROKER regression in
+    # tests/integration/test_risk_budget_seeded_breaker.py. See
     # docs/decisions/canonical-risk-limit-vocabulary.md (#1120).
-    risk_budget_runtime_seed_enabled: bool = False
+    risk_budget_runtime_seed_enabled: bool = True
     market_order_fallback: bool = True
     # Enabled by default for resiliency; disable only for controlled troubleshooting.
     order_submission_retries_enabled: bool = True

--- a/src/gpt_trader/app/config/profile_schema.py
+++ b/src/gpt_trader/app/config/profile_schema.py
@@ -71,9 +71,9 @@ class ExecutionConfig:
     # Stage 1 human-approved loop (default OFF): route live strategy decisions
     # into the approval-gated trade-idea workflow instead of submitting orders.
     strategy_signal_proposals: bool = False
-    # Stage 2 derivation seam (default OFF): seed runtime risk limits from the
+    # Stage 2 derivation seam (default ON): seed runtime risk limits from the
     # active RiskBudget version at engine startup (#1120).
-    risk_budget_runtime_seed: bool = False
+    risk_budget_runtime_seed: bool = True
 
 
 @dataclass
@@ -192,7 +192,7 @@ class ProfileSchema:
             use_limit_orders=execution_data.get("use_limit_orders", False),
             market_order_fallback=execution_data.get("market_order_fallback", True),
             strategy_signal_proposals=execution_data.get("strategy_signal_proposals", False),
-            risk_budget_runtime_seed=execution_data.get("risk_budget_runtime_seed", False),
+            risk_budget_runtime_seed=execution_data.get("risk_budget_runtime_seed", True),
         )
 
         # Parse session config

--- a/src/gpt_trader/app/container.py
+++ b/src/gpt_trader/app/container.py
@@ -59,7 +59,7 @@ class ApplicationContainer:
 
     def __init__(self, config: BotConfig):
         self.config = config
-        # Stage 2 derivation seam (default OFF): resolve the active RiskBudget
+        # Stage 2 derivation seam (default ON): resolve the active RiskBudget
         # version once at startup so the shorts gate and the runtime risk
         # limits are seeded from the same version, before the settings
         # snapshot/fingerprint capture the effective config. See

--- a/src/gpt_trader/app/risk_budget_seed.py
+++ b/src/gpt_trader/app/risk_budget_seed.py
@@ -8,11 +8,11 @@ engine startup. A budget change mid-run takes effect at approval time
 immediately but at runtime only after restart; the seeded version is recorded
 in startup telemetry so that drift window stays visible.
 
-The seam is default-off behind ``BotConfig.risk_budget_runtime_seed_enabled``
-because the seeded budget defaults are LOOSER than the runtime defaults (10%
-daily loss / 100% open notional vs 5% / 80%): enabling it is a live-path
-behavior change, held until a MOCK_BROKER regression covers the loosened
-breaker (#1120).
+The seam is default-on behind ``BotConfig.risk_budget_runtime_seed_enabled``.
+The seeded budget defaults are LOOSER than the legacy runtime defaults (10%
+daily loss / 100% open notional vs 5% / 80%); the loosened breaker band is
+pinned by the MOCK_BROKER regression in
+``tests/integration/test_risk_budget_seeded_breaker.py`` (#1120).
 """
 
 from __future__ import annotations

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,20 @@ def strict_container_mode(monkeypatch):
     monkeypatch.setenv("GPT_TRADER_STRICT_CONTAINER", "1")
 
 
+@pytest.fixture(autouse=True)
+def isolated_ideas_root(tmp_path_factory, monkeypatch):
+    """Pin the trade-ideas root away from any real on-disk state.
+
+    With risk_budget_runtime_seed_enabled on by default (#1120), every
+    ApplicationContainer startup resolves the active RiskBudget from the
+    ideas root. Without this pin, tests that build a container would read
+    whatever risk_budget.jsonl exists under the developer's CWD. Tests that
+    care about specific budget contents set GPT_TRADER_IDEAS_ROOT (or pass
+    an explicit root) themselves, which overrides this fixture.
+    """
+    monkeypatch.setenv("GPT_TRADER_IDEAS_ROOT", str(tmp_path_factory.mktemp("isolated-ideas-root")))
+
+
 @pytest.fixture
 def application_container(mock_config):
     """Provide an ApplicationContainer for tests that need it.

--- a/tests/integration/test_risk_budget_seeded_breaker.py
+++ b/tests/integration/test_risk_budget_seeded_breaker.py
@@ -1,0 +1,169 @@
+"""MOCK_BROKER regression for the budget-seeded (loosened) runtime breaker.
+
+The RiskBudget derivation seam (#1120) seeds the runtime breaker from the
+active budget version, and the default budget is LOOSER than the legacy
+RiskConfig defaults: 10% daily loss / 100% open notional vs 5% / 80%.
+Enabling ``risk_budget_runtime_seed_enabled`` is therefore a live-path
+behavior change. These tests pin the changed band through the real container
+wiring with the deterministic broker: values between the legacy and seeded
+limits no longer trip the breaker, values beyond the seeded limits still do,
+and the restrict-side permissions (CFM 1x clamp, shorts off) land.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from gpt_trader.app.config import BotConfig
+from gpt_trader.app.container import (
+    ApplicationContainer,
+    clear_application_container,
+    set_application_container,
+)
+from gpt_trader.app.risk_budget_seed import RISK_BUDGET_SEED_EVENT_TYPE
+from gpt_trader.features.live_trade.risk.manager import ValidationError
+
+pytestmark = pytest.mark.integration
+
+_MARK_PRICE = Decimal("50000")
+
+
+def _build_container(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    seed_enabled: bool,
+) -> ApplicationContainer:
+    # Point the seam at an empty ideas root: a missing budget log resolves to
+    # DEFAULT_RISK_BUDGET (10% daily loss / 100% open notional, futures
+    # leverage and naked shorts forbidden) — the exact budget the default
+    # flip would put on the live path.
+    monkeypatch.setenv("GPT_TRADER_IDEAS_ROOT", str(tmp_path / "ideas"))
+    config = BotConfig(
+        symbols=["BTC-USD"],
+        mock_broker=True,
+        risk_budget_runtime_seed_enabled=seed_enabled,
+        runtime_root=str(tmp_path),
+    )
+    container = ApplicationContainer(config)
+    set_application_container(container)
+    return container
+
+
+@pytest.fixture
+def seeded_container(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Generator[ApplicationContainer]:
+    yield _build_container(tmp_path, monkeypatch, seed_enabled=True)
+    clear_application_container()
+
+
+@pytest.fixture
+def legacy_container(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Generator[ApplicationContainer]:
+    yield _build_container(tmp_path, monkeypatch, seed_enabled=False)
+    clear_application_container()
+
+
+def _broker_equity(container: ApplicationContainer) -> Decimal:
+    balances = container.broker.list_balances()
+    return sum((balance.total for balance in balances), Decimal("0"))
+
+
+class TestSeededBreakerLoosenedBand:
+    """Seed enabled: the breaker runs at the budget's 10% / 100% limits."""
+
+    def test_runtime_limits_seeded_from_default_budget(
+        self, seeded_container: ApplicationContainer
+    ) -> None:
+        risk = seeded_container.risk_manager
+
+        assert risk.config is not None
+        assert risk.config.daily_loss_limit_pct == pytest.approx(0.10)
+        assert risk.config.max_exposure_pct == pytest.approx(1.0)
+        # allow_futures_leverage=False clamps the effective CFM cap to 1x.
+        assert risk.config.cfm_max_leverage == 1
+        # allow_naked_shorts=False forces shorts off end to end.
+        assert seeded_container.config.enable_shorts is False
+        assert seeded_container.config.active_enable_shorts is False
+        # The seeded budget version is attributable in startup telemetry.
+        events = seeded_container.event_store.get_recent_by_type(RISK_BUDGET_SEED_EVENT_TYPE)
+        assert len(events) == 1
+
+    def test_daily_loss_between_legacy_and_seeded_limits_does_not_trip(
+        self, seeded_container: ApplicationContainer
+    ) -> None:
+        risk = seeded_container.risk_manager
+        start_equity = _broker_equity(seeded_container)
+        risk.track_daily_pnl(start_equity, {})
+
+        # 7% down: inside the loosened band (would trip the legacy 5% limit).
+        tripped = risk.track_daily_pnl(start_equity * Decimal("0.93"), {})
+
+        assert tripped is False
+        assert risk.is_reduce_only_mode() is False
+
+    def test_daily_loss_beyond_seeded_limit_still_trips(
+        self, seeded_container: ApplicationContainer
+    ) -> None:
+        risk = seeded_container.risk_manager
+        start_equity = _broker_equity(seeded_container)
+        risk.track_daily_pnl(start_equity, {})
+
+        # 11% down: beyond the seeded 10% limit.
+        tripped = risk.track_daily_pnl(start_equity * Decimal("0.89"), {})
+
+        assert tripped is True
+        assert risk.is_reduce_only_mode() is True
+
+    def test_exposure_between_legacy_and_seeded_caps_is_accepted(
+        self, seeded_container: ApplicationContainer
+    ) -> None:
+        risk = seeded_container.risk_manager
+        equity = _broker_equity(seeded_container)
+
+        # 90% of equity: inside the loosened band (legacy cap was 80%).
+        qty = equity * Decimal("0.90") / _MARK_PRICE
+        risk.pre_trade_validate("BTC-USD", "buy", qty, _MARK_PRICE, None, equity, {})
+
+    def test_exposure_beyond_seeded_cap_is_still_rejected(
+        self, seeded_container: ApplicationContainer
+    ) -> None:
+        risk = seeded_container.risk_manager
+        equity = _broker_equity(seeded_container)
+
+        qty = equity * Decimal("1.05") / _MARK_PRICE
+        with pytest.raises(ValidationError, match="exceed cap"):
+            risk.pre_trade_validate("BTC-USD", "buy", qty, _MARK_PRICE, None, equity, {})
+
+
+class TestLegacyBreakerContrast:
+    """Seed disabled: the same inputs trip the legacy 5% / 80% limits.
+
+    This is the other half of the regression pin — if these start passing,
+    the loosened band no longer describes a behavior change and the seeded
+    tests above lose their meaning.
+    """
+
+    def test_daily_loss_trips_at_legacy_limit(self, legacy_container: ApplicationContainer) -> None:
+        risk = legacy_container.risk_manager
+        start_equity = _broker_equity(legacy_container)
+        risk.track_daily_pnl(start_equity, {})
+
+        tripped = risk.track_daily_pnl(start_equity * Decimal("0.93"), {})
+
+        assert tripped is True
+        assert risk.is_reduce_only_mode() is True
+
+    def test_exposure_rejected_at_legacy_cap(self, legacy_container: ApplicationContainer) -> None:
+        risk = legacy_container.risk_manager
+        equity = _broker_equity(legacy_container)
+
+        qty = equity * Decimal("0.90") / _MARK_PRICE
+        with pytest.raises(ValidationError, match="exceed cap"):
+            risk.pre_trade_validate("BTC-USD", "buy", qty, _MARK_PRICE, None, equity, {})

--- a/tests/unit/gpt_trader/app/config/test_profile_loader.py
+++ b/tests/unit/gpt_trader/app/config/test_profile_loader.py
@@ -347,16 +347,16 @@ class TestProfileOverridePrecedence:
 class TestRiskBudgetRuntimeSeedMapping:
     """Stage 2 derivation seam gate (#1120): schema parse and kwargs mapping."""
 
-    def test_from_yaml_defaults_off(self) -> None:
+    def test_from_yaml_defaults_on(self) -> None:
         schema = ProfileSchema.from_yaml({}, "empty")
 
-        assert schema.execution.risk_budget_runtime_seed is False
+        assert schema.execution.risk_budget_runtime_seed is True
 
     def test_to_bot_config_kwargs_maps_gate(self) -> None:
         schema = ProfileSchema.from_yaml(
-            {"execution": {"risk_budget_runtime_seed": True}}, "seed-profile"
+            {"execution": {"risk_budget_runtime_seed": False}}, "seed-profile"
         )
 
         kwargs = ProfileLoader().to_bot_config_kwargs(schema, Profile.DEV)
 
-        assert kwargs["risk_budget_runtime_seed_enabled"] is True
+        assert kwargs["risk_budget_runtime_seed_enabled"] is False

--- a/tests/unit/gpt_trader/app/test_application_container.py
+++ b/tests/unit/gpt_trader/app/test_application_container.py
@@ -219,22 +219,24 @@ class TestApplicationContainerSecondaryServices:
 
 
 class TestRiskBudgetRuntimeSeedGate:
-    """Stage 2 derivation seam (#1120): default-off startup seeding."""
+    """Stage 2 derivation seam (#1120): default-on startup seeding."""
 
-    def test_gate_off_resolves_no_seed(self, mock_config: BotConfig) -> None:
+    def test_gate_disabled_resolves_no_seed(self, mock_config: BotConfig) -> None:
+        mock_config.risk_budget_runtime_seed_enabled = False
+
         container = ApplicationContainer(mock_config)
 
         assert container._risk_budget_seed is None
         assert container._risk_validation._risk_budget_seed is None
 
-    def test_gate_on_seeds_and_gates_shorts(
+    def test_default_gate_seeds_and_gates_shorts(
         self, tmp_path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setenv("GPT_TRADER_IDEAS_ROOT", str(tmp_path))
+        # No explicit gate value: seeding must engage by default.
         config = BotConfig(
             symbols=["BTC-USD"],
             enable_shorts=True,
-            risk_budget_runtime_seed_enabled=True,
         )
         config.strategy.enable_shorts = True
 

--- a/var/agents/configuration/environment_variables.json
+++ b/var/agents/configuration/environment_variables.json
@@ -28,7 +28,7 @@
       ],
       "code_references": [
         {
-          "line": 468,
+          "line": 469,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "os.getenv"
         }
@@ -51,7 +51,7 @@
       ],
       "code_references": [
         {
-          "line": 456,
+          "line": 457,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_bool_env"
         }
@@ -67,7 +67,7 @@
       ],
       "code_references": [
         {
-          "line": 392,
+          "line": 393,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_bool_env"
         }
@@ -90,7 +90,7 @@
       ],
       "code_references": [
         {
-          "line": 474,
+          "line": 475,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "os.getenv"
         }
@@ -123,7 +123,7 @@
       ],
       "code_references": [
         {
-          "line": 472,
+          "line": 473,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_int_env"
         },
@@ -176,7 +176,7 @@
       ],
       "code_references": [
         {
-          "line": 473,
+          "line": 474,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_list_env"
         }
@@ -208,7 +208,7 @@
       ],
       "code_references": [
         {
-          "line": 467,
+          "line": 468,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "os.getenv"
         }
@@ -318,7 +318,7 @@
       ],
       "code_references": [
         {
-          "line": 461,
+          "line": 462,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "os.getenv"
         }
@@ -341,7 +341,7 @@
       ],
       "code_references": [
         {
-          "line": 465,
+          "line": 466,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "os.getenv"
         }
@@ -357,12 +357,12 @@
       ],
       "code_references": [
         {
-          "line": 393,
+          "line": 394,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "os.getenv"
         },
         {
-          "line": 393,
+          "line": 394,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_bool_env"
         }
@@ -457,7 +457,7 @@
       ],
       "code_references": [
         {
-          "line": 466,
+          "line": 467,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_bool_env"
         },
@@ -616,7 +616,7 @@
       ],
       "code_references": [
         {
-          "line": 462,
+          "line": 463,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_bool_env"
         }
@@ -680,7 +680,7 @@
       ],
       "code_references": [
         {
-          "line": 451,
+          "line": 452,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_bool_env"
         }
@@ -726,7 +726,7 @@
       ],
       "code_references": [
         {
-          "line": 485,
+          "line": 486,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "os.getenv"
         }
@@ -744,7 +744,7 @@
       ],
       "code_references": [
         {
-          "line": 483,
+          "line": 484,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "os.getenv"
         },
@@ -1553,7 +1553,7 @@
       ],
       "code_references": [
         {
-          "line": 482,
+          "line": 483,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "os.getenv"
         },
@@ -1778,7 +1778,7 @@
       ],
       "code_references": [
         {
-          "line": 423,
+          "line": 424,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "_health_float"
         }
@@ -1794,7 +1794,7 @@
       ],
       "code_references": [
         {
-          "line": 422,
+          "line": 423,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "_health_float"
         }
@@ -1810,7 +1810,7 @@
       ],
       "code_references": [
         {
-          "line": 433,
+          "line": 434,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "_health_int"
         }
@@ -1826,7 +1826,7 @@
       ],
       "code_references": [
         {
-          "line": 432,
+          "line": 433,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "_health_int"
         }
@@ -1842,7 +1842,7 @@
       ],
       "code_references": [
         {
-          "line": 429,
+          "line": 430,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "_health_float"
         }
@@ -1858,7 +1858,7 @@
       ],
       "code_references": [
         {
-          "line": 426,
+          "line": 427,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "_health_float"
         }
@@ -1874,7 +1874,7 @@
       ],
       "code_references": [
         {
-          "line": 435,
+          "line": 436,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "_health_int"
         }
@@ -1890,7 +1890,7 @@
       ],
       "code_references": [
         {
-          "line": 434,
+          "line": 435,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "_health_int"
         }
@@ -1906,7 +1906,7 @@
       ],
       "code_references": [
         {
-          "line": 419,
+          "line": 420,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "_health_float"
         }
@@ -1922,7 +1922,7 @@
       ],
       "code_references": [
         {
-          "line": 418,
+          "line": 419,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "_health_float"
         }
@@ -1938,7 +1938,7 @@
       ],
       "code_references": [
         {
-          "line": 421,
+          "line": 422,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "_health_float"
         }
@@ -1954,7 +1954,7 @@
       ],
       "code_references": [
         {
-          "line": 420,
+          "line": 421,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "_health_float"
         }
@@ -1970,7 +1970,7 @@
       ],
       "code_references": [
         {
-          "line": 425,
+          "line": 426,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "_health_float"
         }
@@ -1986,7 +1986,7 @@
       ],
       "code_references": [
         {
-          "line": 424,
+          "line": 425,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "_health_float"
         }
@@ -2018,7 +2018,7 @@
       ],
       "code_references": [
         {
-          "line": 448,
+          "line": 449,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_int_env"
         }
@@ -2057,7 +2057,7 @@
       ],
       "code_references": [
         {
-          "line": 450,
+          "line": 451,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "os.getenv"
         }
@@ -2080,7 +2080,7 @@
       ],
       "code_references": [
         {
-          "line": 355,
+          "line": 356,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_int_env"
         }
@@ -2096,7 +2096,7 @@
       ],
       "code_references": [
         {
-          "line": 493,
+          "line": 494,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_bool_env"
         }
@@ -2119,7 +2119,7 @@
       ],
       "code_references": [
         {
-          "line": 487,
+          "line": 488,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_bool_env"
         }
@@ -2142,7 +2142,7 @@
       ],
       "code_references": [
         {
-          "line": 488,
+          "line": 489,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_bool_env"
         }
@@ -2190,7 +2190,7 @@
       ],
       "code_references": [
         {
-          "line": 494,
+          "line": 495,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_bool_env"
         }
@@ -2206,7 +2206,7 @@
       ],
       "code_references": [
         {
-          "line": 495,
+          "line": 496,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_bool_env"
         }
@@ -2292,7 +2292,7 @@
       ],
       "code_references": [
         {
-          "line": 475,
+          "line": 476,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_bool_env"
         }
@@ -2356,7 +2356,7 @@
       ],
       "code_references": [
         {
-          "line": 477,
+          "line": 478,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_bool_env"
         }
@@ -2379,7 +2379,7 @@
       ],
       "code_references": [
         {
-          "line": 480,
+          "line": 481,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_decimal_env"
         }
@@ -2395,7 +2395,7 @@
       ],
       "code_references": [
         {
-          "line": 478,
+          "line": 479,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_bool_env"
         }
@@ -2427,7 +2427,7 @@
       ],
       "code_references": [
         {
-          "line": 476,
+          "line": 477,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_int_env"
         }
@@ -2558,7 +2558,7 @@
       ],
       "code_references": [
         {
-          "line": 484,
+          "line": 485,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "os.getenv"
         }
@@ -2575,7 +2575,7 @@
       ],
       "code_references": [
         {
-          "line": 386,
+          "line": 387,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "_risk_float"
         },
@@ -2719,7 +2719,7 @@
       ],
       "code_references": [
         {
-          "line": 380,
+          "line": 381,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "_risk_int"
         },
@@ -2748,7 +2748,7 @@
       ],
       "code_references": [
         {
-          "line": 376,
+          "line": 377,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "os.getenv"
         },
@@ -2776,7 +2776,7 @@
       ],
       "code_references": [
         {
-          "line": 379,
+          "line": 380,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "_risk_decimal"
         }
@@ -2832,7 +2832,7 @@
       ],
       "code_references": [
         {
-          "line": 492,
+          "line": 493,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_bool_env"
         },
@@ -2922,7 +2922,7 @@
       ],
       "code_references": [
         {
-          "line": 382,
+          "line": 383,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "_risk_decimal"
         }
@@ -2938,7 +2938,7 @@
       ],
       "code_references": [
         {
-          "line": 383,
+          "line": 384,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "_risk_decimal"
         }
@@ -2954,7 +2954,7 @@
       ],
       "code_references": [
         {
-          "line": 381,
+          "line": 382,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "_risk_int"
         }
@@ -3079,7 +3079,7 @@
       ],
       "code_references": [
         {
-          "line": 354,
+          "line": 355,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_int_env"
         }
@@ -3095,7 +3095,7 @@
       ],
       "code_references": [
         {
-          "line": 486,
+          "line": 487,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_bool_env"
         }
@@ -3111,7 +3111,7 @@
       ],
       "code_references": [
         {
-          "line": 455,
+          "line": 456,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_bool_env"
         }
@@ -3134,7 +3134,7 @@
       ],
       "code_references": [
         {
-          "line": 453,
+          "line": 454,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "os.getenv"
         }
@@ -3157,7 +3157,7 @@
       ],
       "code_references": [
         {
-          "line": 454,
+          "line": 455,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_int_env"
         }
@@ -3182,7 +3182,7 @@
       ],
       "code_references": [
         {
-          "line": 470,
+          "line": 471,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "parse_list_env"
         },
@@ -3216,7 +3216,7 @@
       ],
       "code_references": [
         {
-          "line": 438,
+          "line": 439,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "os.getenv"
         },
@@ -3290,7 +3290,7 @@
       ],
       "code_references": [
         {
-          "line": 452,
+          "line": 453,
           "path": "src/gpt_trader/app/config/bot_config.py",
           "reader": "os.getenv"
         }

--- a/var/agents/schemas/bot_config_schema.json
+++ b/var/agents/schemas/bot_config_schema.json
@@ -88,7 +88,7 @@
     },
     "risk_budget_runtime_seed_enabled": {
       "type": "boolean",
-      "default": false
+      "default": true
     },
     "market_order_fallback": {
       "type": "boolean",

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -9,8 +9,8 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 5919,
-    "total_files": 702,
+    "total_tests": 5926,
+    "total_files": 703,
     "markers_used": 14
   },
   "quick_commands": {

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -95,7 +95,7 @@
     "unit": 5762,
     "asyncio": 310,
     "parametrize": 173,
-    "integration": 80,
+    "integration": 87,
     "endpoints": 64,
     "property": 63,
     "usefixtures": 17,


### PR DESCRIPTION
Closes out remaining item 1 of #1120 (the default flip, held until a MOCK_BROKER regression exercised the loosened breaker).

## What

- **MOCK_BROKER regression** (`tests/integration/test_risk_budget_seeded_breaker.py`): pins the loosened breaker band through real `ApplicationContainer` wiring with the deterministic broker. With the seam enabled and the default budget active (10% daily loss / 100% open notional):
  - a 7% daily loss and a 90% exposure — both breaches under the legacy 5% / 80% defaults — no longer trip the breaker,
  - an 11% loss and a 105% exposure still trip it,
  - the restrict-side permissions land (CFM leverage clamped to 1x, shorts forced off end to end, seeded budget version recorded in startup telemetry).
  - A legacy-contrast class proves the same inputs trip the unseeded 5% / 80% breaker, so the pin stays meaningful.
- **Default flip**: `BotConfig.risk_budget_runtime_seed_enabled` and the profile-schema `execution.risk_budget_runtime_seed` default to `True`. Profiles can opt out with `execution.risk_budget_runtime_seed: false`.
- Docs/comments updated to default-on (seam docstring, composition-root comment, `docs/architecture/SEAMS.md`).

## Why now

Per the decision record (`docs/decisions/canonical-risk-limit-vocabulary.md`, Option A) the RiskBudget is canonical for risk appetite; the flip was explicitly gated on this regression because seeding is a live-path behavior change toward looser limits. With the band pinned in both directions, the runtime breaker and the approval gate now derive from the same budget version by default.

## Safety boundary

No broker/API change, no live execution, no autonomy change. The seam still fails closed on a corrupt budget log and only restricts permissions (shorts off, CFM 1x) relative to strategy preferences.

## Verification

- `uv run pytest tests/integration -m integration -q` — 83 passed
- `make ci-required` — green (lint, docs audit, typecheck, guardrails, 6414 unit tests, stage1 smoke)

Remaining on #1120 after this: stage 3 transitional-alias retirement (follow-up PR).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Risk-budget “runtime seeding” is now enabled by default, applying a newer seeded baseline for initial risk limits unless explicitly disabled.

* **Bug Fixes**
  * Added an integration regression test validating seeded vs legacy “runtime breaker” behavior, including daily loss/exposure thresholds and ValidationError when exceeding seeded caps.

* **Documentation**
  * Updated architecture and module documentation to reflect the default-on runtime seeding behavior.

* **Chores**
  * Updated configuration/schema defaults, refreshed related unit test expectations, and refreshed test/environment metadata and counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->