### PR TITLE
fix(web): offer only workflow-permitted decisions per idea state

### DIFF
--- a/src/gpt_trader/web/app.py
+++ b/src/gpt_trader/web/app.py
@@ -29,7 +29,7 @@ from gpt_trader.features.trade_ideas.service_models import (
     TradeIdeaView,
     UnknownTradeIdeaError,
 )
-from gpt_trader.features.trade_ideas.workflow import TradeIdeaState
+from gpt_trader.features.trade_ideas.workflow import ALLOWED_TRANSITIONS, TradeIdeaState
 
 _TEMPLATES_DIR = Path(__file__).parent / "templates"
 
@@ -165,6 +165,10 @@ def create_app(
                 context={"decision_id": decision_id, "actor_id": resolved_actor},
                 status_code=404,
             )
+        # Offer only the decisions the workflow permits from this state:
+        # e.g. a needs-changes idea can be rejected, but must be resubmitted
+        # by its proposer before it can be approved again.
+        allowed_targets = ALLOWED_TRANSITIONS.get(view.state, frozenset())
         return templates.TemplateResponse(
             request=request,
             name="idea_detail.html",
@@ -173,7 +177,9 @@ def create_app(
                 "view": view,
                 "idea": view.idea,
                 "record": view.idea.to_dict(),
-                "actionable": view.state in _PENDING_STATES,
+                "can_approve": TradeIdeaState.APPROVED in allowed_targets,
+                "can_request_changes": TradeIdeaState.NEEDS_CHANGES in allowed_targets,
+                "can_reject": TradeIdeaState.REJECTED in allowed_targets,
                 "violations": resolved_service.approval_violations(view.idea),
                 "versions": _record_versions(resolved_service, view),
                 "error": error,

--- a/src/gpt_trader/web/templates/idea_detail.html
+++ b/src/gpt_trader/web/templates/idea_detail.html
@@ -36,20 +36,29 @@
 <ul>{% for violation in violations %}<li class="bad">{{ violation }}</li>{% endfor %}</ul>
 {% endif %}
 
-{% if actionable %}
+{% if can_approve or can_request_changes or can_reject %}
 <h2>Decide</h2>
+{% if can_approve %}
 <form class="decision" method="post" action="/ideas/{{ idea.decision_id }}/approve">
   <input type="text" name="reason" placeholder="Reason (required, audited)" required>
   <button class="approve" type="submit">Approve</button>
 </form>
+{% endif %}
+{% if can_request_changes %}
 <form class="decision" method="post" action="/ideas/{{ idea.decision_id }}/request-changes">
   <input type="text" name="reason" placeholder="What must change (required, audited)" required>
   <button class="changes" type="submit">Request changes</button>
 </form>
+{% endif %}
+{% if can_reject %}
 <form class="decision" method="post" action="/ideas/{{ idea.decision_id }}/reject">
   <input type="text" name="reason" placeholder="Reason (required, audited)" required>
   <button class="reject" type="submit">Reject</button>
 </form>
+{% endif %}
+{% if view.state.value == "needs_changes" %}
+<p class="muted">Awaiting resubmission by the proposer before it can be approved.</p>
+{% endif %}
 {% endif %}
 
 <h2>Thesis</h2>

--- a/src/gpt_trader/web/templates/queue.html
+++ b/src/gpt_trader/web/templates/queue.html
@@ -46,7 +46,9 @@
     </td>
     <td>{% if row.expires_in %}<span class="warn">{{ row.expires_in }}</span>{% else %}<span class="muted">&gt; warning window</span>{% endif %}</td>
     <td>
-      {% if row.violations %}
+      {% if row.state.value == "needs_changes" %}
+      <span class="warn">awaiting resubmission</span>
+      {% elif row.violations %}
       <span class="bad">{{ row.violations | length }} violation{{ "s" if row.violations | length != 1 }}</span>
       <ul class="muted">{% for violation in row.violations %}<li>{{ violation }}</li>{% endfor %}</ul>
       {% else %}<span class="ok">eligible</span>{% endif %}

--- a/tests/unit/gpt_trader/web/test_console_app.py
+++ b/tests/unit/gpt_trader/web/test_console_app.py
@@ -152,3 +152,22 @@ def test_decision_on_unknown_idea_returns_404(client: TestClient) -> None:
     response = client.post("/ideas/no-such-idea/approve", data={"reason": "x"})
 
     assert response.status_code == 404
+
+
+def test_needs_changes_idea_offers_only_reject(
+    service: TradeIdeaService, client: TestClient
+) -> None:
+    _propose_default(service)
+    service.request_changes(_DECISION_ID, actor_id="rj", reason="Tighten invalidation")
+
+    detail = client.get(f"/ideas/{_DECISION_ID}")
+    assert detail.status_code == 200
+    assert f"/ideas/{_DECISION_ID}/reject" in detail.text
+    assert f"/ideas/{_DECISION_ID}/approve" not in detail.text
+    assert f"/ideas/{_DECISION_ID}/request-changes" not in detail.text
+    assert "Awaiting resubmission" in detail.text
+
+    # The endpoint still refuses even if the form is bypassed.
+    approve = client.post(f"/ideas/{_DECISION_ID}/approve", data={"reason": "Trying anyway"})
+    assert approve.status_code == 400
+    assert service.get(_DECISION_ID).state is TradeIdeaState.NEEDS_CHANGES


### PR DESCRIPTION
Follow-up to #1181: the review fix for the codex finding (needs-changes ideas offered Approve / Request-changes buttons that can only 400) raced the auto-merge — #1181 merged on the pre-fix head, so this lands the already-reviewed commit separately.

- Decision buttons on idea detail are derived from `ALLOWED_TRANSITIONS`: a needs-changes idea offers Reject only, with an awaiting-resubmission note.
- Queue eligibility column shows "awaiting resubmission" for needs-changes rows instead of a misleading "eligible".
- Regression test: `test_needs_changes_idea_offers_only_reject` (detail buttons + endpoint still refuses a bypassed POST).

Cherry-pick of 149d2760 from the original branch; web test suite green (10 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Review actions now match the current workflow state, so only valid options appear for each idea.
  * Ideas waiting for resubmission now show a clear “Awaiting resubmission” message in the detail view and queue.
  * The decision panel is hidden when no review action is available, reducing confusion.
* **Tests**
  * Added coverage for the resubmission flow and the restricted action buttons shown in that state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->