### PR TITLE
chore(agents): regenerate testing inventories after #1182

### DIFF
--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -9,7 +9,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6009,
+    "total_tests": 6010,
     "total_files": 712,
     "markers_used": 14
   },

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -92,7 +92,7 @@
     ]
   },
   "counts": {
-    "unit": 5845,
+    "unit": 5846,
     "asyncio": 310,
     "parametrize": 180,
     "integration": 87,


### PR DESCRIPTION
The #1182 cherry-pick added test_needs_changes_idea_offers_only_reject without regenerating var/agents testing inventories; this refreshes them (verified via agent-regenerate --verify).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test-related counts to reflect one additional test and one additional unit test marker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->