### PR TITLE
feat(web): accountant and agent-activity console pages (#1152 phase 2)

### DIFF
--- a/src/gpt_trader/features/trade_ideas/accounting.py
+++ b/src/gpt_trader/features/trade_ideas/accounting.py
@@ -14,12 +14,15 @@ The equity ledger folds two kinds of events in timestamp order:
   carries the same equity forward is not an attestation and does not reset
   the ledger.
 - A closeout with a realized profit/loss amount adjusts the level. It folds at
-  its *terminal event* time (when the trade actually ended, resolved through
-  ``terminal_event_id`` by the caller), not at the time the attribution was
-  entered: an attestation made after a trade closed already includes that
-  trade's P&L, so a later-entered attribution must sort before it rather than
-  double-count. Closeouts whose amount is unavailable are counted but cannot
-  move the ledger, and closeouts that ended before the first attestation
+  the time the trade actually resolved, as best the artifacts can say: the
+  caller maps ``terminal_event_id`` to the audit timestamp for terminal events
+  that *are* the resolution (expiry / cancellation / rejection), so a
+  late-entered attribution sorts before an attestation that already reflects
+  it. A ``FILLED`` audit event is the entry fill, not the later market close,
+  so filled trades deliberately keep their attribution timestamp — record
+  attributions promptly, and before re-attesting equity, to keep the ledger
+  exact. Closeouts whose amount is unavailable are counted but cannot move
+  the ledger, and closeouts that resolved before the first attestation
   contribute to the realized total only — there is no level for them to
   adjust yet.
 

--- a/src/gpt_trader/features/trade_ideas/accounting.py
+++ b/src/gpt_trader/features/trade_ideas/accounting.py
@@ -13,10 +13,15 @@ The equity ledger folds two kinds of events in timestamp order:
   measured the account, superseding anything derived. A lever change that
   carries the same equity forward is not an attestation and does not reset
   the ledger.
-- A closeout with a realized profit/loss amount adjusts the level. Closeouts
-  whose amount is unavailable are counted but cannot move the ledger, and
-  closeouts recorded before the first attestation contribute to the realized
-  total only — there is no level for them to adjust yet.
+- A closeout with a realized profit/loss amount adjusts the level. It folds at
+  its *terminal event* time (when the trade actually ended, resolved through
+  ``terminal_event_id`` by the caller), not at the time the attribution was
+  entered: an attestation made after a trade closed already includes that
+  trade's P&L, so a later-entered attribution must sort before it rather than
+  double-count. Closeouts whose amount is unavailable are counted but cannot
+  move the ledger, and closeouts that ended before the first attestation
+  contribute to the realized total only — there is no level for them to
+  adjust yet.
 
 The high-water mark is the peak of the whole ledger: a re-attestation moves
 the level but never erases the historical peak, so drawdown-from-peak stays
@@ -25,7 +30,7 @@ honest across resets.
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal
@@ -80,16 +85,26 @@ def _attestations(entries: Iterable[BudgetLogEntry]) -> list[EquityAttestation]:
 def compute_paper_accounting(
     budget_entries: Iterable[BudgetLogEntry],
     closeouts: Iterable[CloseoutAttribution],
+    *,
+    terminal_times: Mapping[str, datetime] | None = None,
 ) -> PaperAccountingSummary:
-    """Fold attestations and closeout amounts into the paper equity ledger."""
+    """Fold attestations and closeout amounts into the paper equity ledger.
+
+    ``terminal_times`` maps a closeout's ``terminal_event_id`` to the audit
+    timestamp of that terminal event; a closeout without a mapping falls back
+    to its attribution timestamp.
+    """
     attestations = _attestations(budget_entries)
-    ordered_closeouts = sorted(closeouts, key=lambda record: record.timestamp)
+    resolved_terminal_times = terminal_times or {}
+
+    def _closeout_time(record: CloseoutAttribution) -> datetime:
+        return resolved_terminal_times.get(record.terminal_event_id, record.timestamp)
 
     # Merge in timestamp order; on a tie the attestation applies first, so a
     # closeout stamped at the same instant adjusts the freshly attested level.
     events: list[tuple[datetime, int, EquityAttestation | CloseoutAttribution]] = [
         (attestation.timestamp, 0, attestation) for attestation in attestations
-    ] + [(record.timestamp, 1, record) for record in ordered_closeouts]
+    ] + [(_closeout_time(record), 1, record) for record in closeouts]
     events.sort(key=lambda event: (event[0], event[1]))
 
     equity: Decimal | None = None

--- a/src/gpt_trader/features/trade_ideas/accounting.py
+++ b/src/gpt_trader/features/trade_ideas/accounting.py
@@ -1,0 +1,138 @@
+"""Read-only paper accounting derived from the budget log and closeouts.
+
+Paper equity, the high-water mark, and drawdown-from-peak are the accountant
+view named in docs/decisions/adopt-operator-web-console.md. Everything here is
+a pure computation over two durable artifacts — budget-log entries and
+closeout attribution records — so the numbers are reproducible from evidence
+alone and nothing mutates storage.
+
+The equity ledger folds two kinds of events in timestamp order:
+
+- An *attestation* is a budget-log entry whose ``account_equity`` differs from
+  the previous entry's value. It sets the equity level outright — the operator
+  measured the account, superseding anything derived. A lever change that
+  carries the same equity forward is not an attestation and does not reset
+  the ledger.
+- A closeout with a realized profit/loss amount adjusts the level. Closeouts
+  whose amount is unavailable are counted but cannot move the ledger, and
+  closeouts recorded before the first attestation contribute to the realized
+  total only — there is no level for them to adjust yet.
+
+The high-water mark is the peak of the whole ledger: a re-attestation moves
+the level but never erases the historical peak, so drawdown-from-peak stays
+honest across resets.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+
+from gpt_trader.features.trade_ideas.budget import BudgetLogEntry
+from gpt_trader.features.trade_ideas.closeout import CloseoutAttribution
+
+
+@dataclass(frozen=True, slots=True)
+class EquityAttestation:
+    """One operator-attested equity level from the budget log."""
+
+    timestamp: datetime
+    actor_id: str
+    equity: Decimal
+    budget_version: int
+
+
+@dataclass(frozen=True, slots=True)
+class PaperAccountingSummary:
+    """Paper equity ledger totals; ``None`` means no attested basis exists."""
+
+    attestation: EquityAttestation | None
+    current_equity: Decimal | None
+    high_water_mark: Decimal | None
+    drawdown_amount: Decimal | None
+    drawdown_percent: Decimal | None
+    realized_profit_loss_total: Decimal
+    realized_profit_loss_since_attestation: Decimal | None
+    closeout_count: int
+    closeout_amount_unavailable_count: int
+
+
+def _attestations(entries: Iterable[BudgetLogEntry]) -> list[EquityAttestation]:
+    attestations: list[EquityAttestation] = []
+    previous_equity: Decimal | None = None
+    for entry in entries:
+        equity = entry.budget.account_equity
+        if equity is not None and equity != previous_equity:
+            attestations.append(
+                EquityAttestation(
+                    timestamp=entry.timestamp,
+                    actor_id=entry.actor_id,
+                    equity=equity,
+                    budget_version=entry.budget.version,
+                )
+            )
+        previous_equity = equity
+    return attestations
+
+
+def compute_paper_accounting(
+    budget_entries: Iterable[BudgetLogEntry],
+    closeouts: Iterable[CloseoutAttribution],
+) -> PaperAccountingSummary:
+    """Fold attestations and closeout amounts into the paper equity ledger."""
+    attestations = _attestations(budget_entries)
+    ordered_closeouts = sorted(closeouts, key=lambda record: record.timestamp)
+
+    # Merge in timestamp order; on a tie the attestation applies first, so a
+    # closeout stamped at the same instant adjusts the freshly attested level.
+    events: list[tuple[datetime, int, EquityAttestation | CloseoutAttribution]] = [
+        (attestation.timestamp, 0, attestation) for attestation in attestations
+    ] + [(record.timestamp, 1, record) for record in ordered_closeouts]
+    events.sort(key=lambda event: (event[0], event[1]))
+
+    equity: Decimal | None = None
+    high_water_mark: Decimal | None = None
+    realized_total = Decimal("0")
+    realized_since_attestation: Decimal | None = None
+    closeout_count = 0
+    unavailable_count = 0
+
+    for _timestamp, _order, event in events:
+        if isinstance(event, EquityAttestation):
+            equity = event.equity
+            high_water_mark = equity if high_water_mark is None else max(high_water_mark, equity)
+            realized_since_attestation = Decimal("0")
+            continue
+        closeout_count += 1
+        amount = event.realized_profit_loss_amount
+        if amount is None:
+            unavailable_count += 1
+            continue
+        realized_total += amount
+        if equity is None:
+            continue
+        equity += amount
+        if realized_since_attestation is not None:
+            realized_since_attestation += amount
+        if high_water_mark is not None:
+            high_water_mark = max(high_water_mark, equity)
+
+    drawdown_amount: Decimal | None = None
+    drawdown_percent: Decimal | None = None
+    if equity is not None and high_water_mark is not None and high_water_mark > 0:
+        drawdown_amount = max(high_water_mark - equity, Decimal("0"))
+        drawdown_percent = drawdown_amount / high_water_mark * Decimal("100")
+
+    return PaperAccountingSummary(
+        attestation=attestations[-1] if attestations else None,
+        current_equity=equity,
+        high_water_mark=high_water_mark,
+        drawdown_amount=drawdown_amount,
+        drawdown_percent=drawdown_percent,
+        realized_profit_loss_total=realized_total,
+        realized_profit_loss_since_attestation=realized_since_attestation,
+        closeout_count=closeout_count,
+        closeout_amount_unavailable_count=unavailable_count,
+    )

--- a/src/gpt_trader/features/trade_ideas/service.py
+++ b/src/gpt_trader/features/trade_ideas/service.py
@@ -561,7 +561,9 @@ class TradeIdeaService:
     def budget_headroom(self, *, now: datetime | None = None) -> dict[str, object]:
         """Return read-only aggregate budget headroom for operators and agents."""
         evaluation_time = now or self._now()
-        budget = self.current_budget()
+        # Non-mutating read: rendering headroom (console pages, budget show)
+        # must not seed risk_budget.jsonl; decision paths seed on first use.
+        budget = self.peek_budget()
         context = self.approval_budget_context(now=evaluation_time)
         account_equity = context.account_equity_snapshot
         daily_loss_used_pct = context.same_day_realized_loss_pct + context.open_approved_at_risk_pct

--- a/src/gpt_trader/features/trade_ideas/service.py
+++ b/src/gpt_trader/features/trade_ideas/service.py
@@ -276,12 +276,18 @@ class TradeIdeaService:
         *,
         now_factory: Callable[[], datetime] = _utc_now,
     ) -> None:
+        self._root = root
         self._store = TradeIdeaStore(root / "records")
         self._audit = TradeIdeaAuditLog(root / "audit.jsonl")
         self._closeouts = CloseoutAttributionLog(root / "closeout_attributions.jsonl")
         self._budget_log = RiskBudgetLog(root / "risk_budget.jsonl")
         self._autonomy_log = AutonomyStateLog(root / "autonomy_state.jsonl")
         self._now = now_factory
+
+    @property
+    def root(self) -> Path:
+        """Storage root all of this service's durable artifacts live under."""
+        return self._root
 
     @property
     def audit_log(self) -> TradeIdeaAuditLog:

--- a/src/gpt_trader/features/trade_ideas/service.py
+++ b/src/gpt_trader/features/trade_ideas/service.py
@@ -291,6 +291,10 @@ class TradeIdeaService:
     def closeout_log(self) -> CloseoutAttributionLog:
         return self._closeouts
 
+    @property
+    def budget_log(self) -> RiskBudgetLog:
+        return self._budget_log
+
     # -- budget ----------------------------------------------------------
 
     def peek_budget(self) -> RiskBudget:

--- a/src/gpt_trader/web/app.py
+++ b/src/gpt_trader/web/app.py
@@ -25,7 +25,6 @@ from gpt_trader.features.trade_ideas.review_metrics import compute_review_instru
 from gpt_trader.features.trade_ideas.service import (
     TradeIdeaService,
     create_trade_idea_service,
-    resolve_ideas_root,
     resolve_trade_idea_actor_id,
 )
 from gpt_trader.features.trade_ideas.service_models import (
@@ -148,8 +147,10 @@ def create_app(
     resolved_service = service or create_trade_idea_service(ideas_root)
     resolved_actor = resolve_trade_idea_actor_id(actor_id)
     # The cycle manifest lives beside the trade-idea stores; the CLI runner
-    # writes it under <ideas_root>/cycle (gpt-trader ideas cycle).
-    cycle_manifest_path = resolve_ideas_root(ideas_root) / "cycle" / "manifest.jsonl"
+    # writes it under <ideas_root>/cycle (gpt-trader ideas cycle). Derive it
+    # from the service's own root so an injected service and the feed can
+    # never point at different ideas roots.
+    cycle_manifest_path = resolved_service.root / "cycle" / "manifest.jsonl"
 
     app = FastAPI(title="GPT-Trader operator console", docs_url=None, redoc_url=None)
     templates = Jinja2Templates(directory=str(_TEMPLATES_DIR))
@@ -220,9 +221,16 @@ def create_app(
 
     @app.get("/accountant", response_class=HTMLResponse)
     def accountant(request: Request) -> HTMLResponse:
+        # Closeouts fold at their terminal event's audit time, not the time
+        # the attribution was entered — a delayed attribution must not
+        # re-apply P&L an intervening attestation already includes.
+        terminal_times = {
+            event.event_id: event.timestamp for event in resolved_service.list_audit_events().items
+        }
         summary = compute_paper_accounting(
             resolved_service.budget_log.history(),
             resolved_service.query_closeout_records().items,
+            terminal_times=terminal_times,
         )
         return templates.TemplateResponse(
             request=request,

--- a/src/gpt_trader/web/app.py
+++ b/src/gpt_trader/web/app.py
@@ -20,6 +20,7 @@ from fastapi.templating import Jinja2Templates
 
 from gpt_trader.errors import ValidationError
 from gpt_trader.features.trade_ideas.accounting import compute_paper_accounting
+from gpt_trader.features.trade_ideas.audit import AuditAction
 from gpt_trader.features.trade_ideas.models import TradeIdea
 from gpt_trader.features.trade_ideas.review_metrics import compute_review_instrumentation
 from gpt_trader.features.trade_ideas.service import (
@@ -221,11 +222,15 @@ def create_app(
 
     @app.get("/accountant", response_class=HTMLResponse)
     def accountant(request: Request) -> HTMLResponse:
-        # Closeouts fold at their terminal event's audit time, not the time
-        # the attribution was entered — a delayed attribution must not
-        # re-apply P&L an intervening attestation already includes.
+        # Closeouts fold at their resolution time so a delayed attribution
+        # cannot re-apply P&L an intervening attestation already includes.
+        # Only non-FILLED terminal events are mapped: a FILLED audit event is
+        # the entry fill, not the later market close, so filled trades keep
+        # their attribution timestamp (the closest available evidence).
         terminal_times = {
-            event.event_id: event.timestamp for event in resolved_service.list_audit_events().items
+            event.event_id: event.timestamp
+            for event in resolved_service.list_audit_events().items
+            if event.action is not AuditAction.FILLED
         }
         summary = compute_paper_accounting(
             resolved_service.budget_log.history(),

--- a/src/gpt_trader/web/app.py
+++ b/src/gpt_trader/web/app.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 from datetime import UTC, datetime
+from decimal import Decimal
 from pathlib import Path
 from typing import Any
 
@@ -18,11 +19,13 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 
 from gpt_trader.errors import ValidationError
+from gpt_trader.features.trade_ideas.accounting import compute_paper_accounting
 from gpt_trader.features.trade_ideas.models import TradeIdea
 from gpt_trader.features.trade_ideas.review_metrics import compute_review_instrumentation
 from gpt_trader.features.trade_ideas.service import (
     TradeIdeaService,
     create_trade_idea_service,
+    resolve_ideas_root,
     resolve_trade_idea_actor_id,
 )
 from gpt_trader.features.trade_ideas.service_models import (
@@ -30,8 +33,12 @@ from gpt_trader.features.trade_ideas.service_models import (
     UnknownTradeIdeaError,
 )
 from gpt_trader.features.trade_ideas.workflow import ALLOWED_TRANSITIONS, TradeIdeaState
+from gpt_trader.web.cycle_feed import load_cycle_feed
 
 _TEMPLATES_DIR = Path(__file__).parent / "templates"
+
+# Newest audit events shown on the activity page.
+_ACTIVITY_EVENT_LIMIT = 50
 
 # States an operator can still act on from the console review queue.
 _PENDING_STATES = (TradeIdeaState.PROPOSED, TradeIdeaState.NEEDS_CHANGES)
@@ -64,6 +71,21 @@ def _format_rate(value: float | None) -> str:
     if value is None:
         return "—"
     return f"{value * 100:.0f}%"
+
+
+def _format_money(value: Decimal | str | None) -> str:
+    if value is None:
+        return "—"
+    amount = Decimal(str(value))
+    sign = "-" if amount < 0 else ""
+    return f"{sign}${abs(amount):,.2f}"
+
+
+def _format_percent(value: Decimal | str | None) -> str:
+    if value is None:
+        return "—"
+    amount = Decimal(str(value))
+    return f"{amount.quantize(Decimal('0.01')):f}%"
 
 
 def _pretty_json(value: object) -> str:
@@ -125,12 +147,17 @@ def create_app(
     """Build the console app over one TradeIdeaService and one operator identity."""
     resolved_service = service or create_trade_idea_service(ideas_root)
     resolved_actor = resolve_trade_idea_actor_id(actor_id)
+    # The cycle manifest lives beside the trade-idea stores; the CLI runner
+    # writes it under <ideas_root>/cycle (gpt-trader ideas cycle).
+    cycle_manifest_path = resolve_ideas_root(ideas_root) / "cycle" / "manifest.jsonl"
 
     app = FastAPI(title="GPT-Trader operator console", docs_url=None, redoc_url=None)
     templates = Jinja2Templates(directory=str(_TEMPLATES_DIR))
     templates.env.filters["duration"] = _format_duration
     templates.env.filters["timestamp"] = _format_timestamp
     templates.env.filters["rate"] = _format_rate
+    templates.env.filters["money"] = _format_money
+    templates.env.filters["percent"] = _format_percent
     templates.env.filters["pretty_json"] = _pretty_json
 
     def _render_queue(request: Request, status_code: int = 200) -> HTMLResponse:
@@ -190,6 +217,38 @@ def create_app(
     @app.get("/", response_class=HTMLResponse)
     def queue(request: Request) -> HTMLResponse:
         return _render_queue(request)
+
+    @app.get("/accountant", response_class=HTMLResponse)
+    def accountant(request: Request) -> HTMLResponse:
+        summary = compute_paper_accounting(
+            resolved_service.budget_log.history(),
+            resolved_service.query_closeout_records().items,
+        )
+        return templates.TemplateResponse(
+            request=request,
+            name="accountant.html",
+            context={
+                "actor_id": resolved_actor,
+                "summary": summary,
+                "budget": resolved_service.peek_budget(),
+                "headroom": resolved_service.budget_headroom(),
+                "open_approved_count": resolved_service.open_approved_count(),
+            },
+        )
+
+    @app.get("/activity", response_class=HTMLResponse)
+    def activity(request: Request) -> HTMLResponse:
+        audit_events = resolved_service.list_audit_events().items
+        return templates.TemplateResponse(
+            request=request,
+            name="activity.html",
+            context={
+                "actor_id": resolved_actor,
+                "feed": load_cycle_feed(cycle_manifest_path),
+                "manifest_path": str(cycle_manifest_path),
+                "events": tuple(reversed(audit_events[-_ACTIVITY_EVENT_LIMIT:])),
+            },
+        )
 
     @app.get("/ideas/{decision_id}", response_class=HTMLResponse)
     def idea_detail(request: Request, decision_id: str) -> HTMLResponse:

--- a/src/gpt_trader/web/cycle_feed.py
+++ b/src/gpt_trader/web/cycle_feed.py
@@ -62,6 +62,10 @@ class CycleFeed:
     completed_count: int
     failed_count: int
     unreadable_line_count: int
+    # Set when the manifest exists but cannot be read at all (permissions,
+    # a directory left at the path, undecodable bytes); a missing manifest
+    # is the normal pre-first-turn state, not an error.
+    manifest_error: str | None = None
 
 
 def _parse_timestamp(value: Any) -> datetime | None:
@@ -146,10 +150,14 @@ def load_cycle_feed(manifest_path: Path, *, limit: int = 50) -> CycleFeed:
     """Load the manifest newest-first; a missing file is an empty feed."""
     turns: list[CycleTurn] = []
     unreadable_line_count = 0
+    manifest_error: str | None = None
     try:
         lines = manifest_path.read_text(encoding="utf-8").splitlines()
     except FileNotFoundError:
         lines = []
+    except (OSError, UnicodeDecodeError) as error:
+        lines = []
+        manifest_error = f"{type(error).__name__}: {error}"
     for line in lines:
         if not line.strip():
             continue
@@ -174,4 +182,5 @@ def load_cycle_feed(manifest_path: Path, *, limit: int = 50) -> CycleFeed:
         completed_count=completed_count,
         failed_count=len(turns) - completed_count,
         unreadable_line_count=unreadable_line_count,
+        manifest_error=manifest_error,
     )

--- a/src/gpt_trader/web/cycle_feed.py
+++ b/src/gpt_trader/web/cycle_feed.py
@@ -161,7 +161,12 @@ def load_cycle_feed(manifest_path: Path, *, limit: int = 50) -> CycleFeed:
         if not isinstance(row, dict):
             unreadable_line_count += 1
             continue
-        turns.append(_parse_turn(row))
+        try:
+            turns.append(_parse_turn(row))
+        except (TypeError, ValueError):
+            # Valid JSON with a corrupt field (schema drift, manual repair)
+            # is still an unreadable row, never a 500 on the activity page.
+            unreadable_line_count += 1
     completed_count = sum(1 for turn in turns if turn.outcome == "completed")
     return CycleFeed(
         turns=tuple(reversed(turns[-limit:])),

--- a/src/gpt_trader/web/cycle_feed.py
+++ b/src/gpt_trader/web/cycle_feed.py
@@ -1,0 +1,172 @@
+"""Read-only view over the paper-cycle manifest for the activity page.
+
+``<ideas_root>/cycle/manifest.jsonl`` is the cycle runner's evidence contract
+(``gpt_trader.features.idea_execution.cycle``): exactly one JSON line per
+turn, including failed turns. The console renders that file as the durable
+artifact it is rather than importing the runner — the runner's module pulls
+in the paper execution lane, which the web console's frozen dependency set
+forbids by decision (docs/decisions/adopt-operator-web-console.md).
+
+Parsing is deliberately tolerant: a truncated or corrupt line is counted and
+skipped, never fatal, because the feed must stay readable while a turn is
+mid-append or after a crashed writer.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class ProposerActivity:
+    """One proposer's leg of a turn, as recorded in the manifest row."""
+
+    proposer_id: str
+    proposal_count: int
+    skipped_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class CycleTurn:
+    """One manifest row; failed turns carry an error and partial fields."""
+
+    run_id: str
+    started_at: datetime | None
+    finished_at: datetime | None
+    duration_seconds: float | None
+    outcome: str
+    error: str | None
+    snapshot_source: str | None
+    snapshot_symbols: tuple[str, ...]
+    proposers: tuple[ProposerActivity, ...]
+    execution_enabled: bool
+    executed_count: int
+    execution_skipped_count: int
+    queue_pending_total: int | None
+
+    @property
+    def proposal_count(self) -> int:
+        return sum(activity.proposal_count for activity in self.proposers)
+
+
+@dataclass(frozen=True, slots=True)
+class CycleFeed:
+    """Newest-first window of turns plus whole-manifest counts."""
+
+    turns: tuple[CycleTurn, ...]
+    turn_count: int
+    completed_count: int
+    failed_count: int
+    unreadable_line_count: int
+
+
+def _parse_timestamp(value: Any) -> datetime | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def _parse_proposers(value: Any) -> tuple[ProposerActivity, ...]:
+    if not isinstance(value, list):
+        return ()
+    activities: list[ProposerActivity] = []
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        skipped = item.get("skipped_open_instruments")
+        activities.append(
+            ProposerActivity(
+                proposer_id=str(item.get("proposer_id", "—")),
+                proposal_count=int(item.get("proposal_count", 0) or 0),
+                skipped_count=len(skipped) if isinstance(skipped, list) else 0,
+            )
+        )
+    return tuple(activities)
+
+
+def _parse_turn(row: dict[str, Any]) -> CycleTurn:
+    started_at = _parse_timestamp(row.get("started_at"))
+    finished_at = _parse_timestamp(row.get("finished_at"))
+    duration_seconds: float | None = None
+    if started_at is not None and finished_at is not None:
+        duration_seconds = (finished_at - started_at).total_seconds()
+
+    snapshot = row.get("snapshot")
+    snapshot_source: str | None = None
+    snapshot_symbols: tuple[str, ...] = ()
+    if isinstance(snapshot, dict):
+        source = snapshot.get("source")
+        snapshot_source = str(source) if source is not None else None
+        symbols = snapshot.get("symbols")
+        if isinstance(symbols, list):
+            snapshot_symbols = tuple(str(symbol) for symbol in symbols)
+
+    execution = row.get("execution")
+    execution_enabled = False
+    executed_count = 0
+    execution_skipped_count = 0
+    if isinstance(execution, dict):
+        execution_enabled = bool(execution.get("enabled"))
+        executed = execution.get("executed")
+        executed_count = len(executed) if isinstance(executed, list) else 0
+        skipped = execution.get("skipped")
+        execution_skipped_count = len(skipped) if isinstance(skipped, list) else 0
+
+    queue = row.get("queue")
+    queue_pending_total: int | None = None
+    if isinstance(queue, dict) and isinstance(queue.get("pending_total"), int):
+        queue_pending_total = queue["pending_total"]
+
+    error = row.get("error")
+    return CycleTurn(
+        run_id=str(row.get("run_id", "—")),
+        started_at=started_at,
+        finished_at=finished_at,
+        duration_seconds=duration_seconds,
+        outcome=str(row.get("outcome", "unknown")),
+        error=str(error) if error is not None else None,
+        snapshot_source=snapshot_source,
+        snapshot_symbols=snapshot_symbols,
+        proposers=_parse_proposers(row.get("proposers")),
+        execution_enabled=execution_enabled,
+        executed_count=executed_count,
+        execution_skipped_count=execution_skipped_count,
+        queue_pending_total=queue_pending_total,
+    )
+
+
+def load_cycle_feed(manifest_path: Path, *, limit: int = 50) -> CycleFeed:
+    """Load the manifest newest-first; a missing file is an empty feed."""
+    turns: list[CycleTurn] = []
+    unreadable_line_count = 0
+    try:
+        lines = manifest_path.read_text(encoding="utf-8").splitlines()
+    except FileNotFoundError:
+        lines = []
+    for line in lines:
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            unreadable_line_count += 1
+            continue
+        if not isinstance(row, dict):
+            unreadable_line_count += 1
+            continue
+        turns.append(_parse_turn(row))
+    completed_count = sum(1 for turn in turns if turn.outcome == "completed")
+    return CycleFeed(
+        turns=tuple(reversed(turns[-limit:])),
+        turn_count=len(turns),
+        completed_count=completed_count,
+        failed_count=len(turns) - completed_count,
+        unreadable_line_count=unreadable_line_count,
+    )

--- a/src/gpt_trader/web/templates/accountant.html
+++ b/src/gpt_trader/web/templates/accountant.html
@@ -1,0 +1,86 @@
+{% extends "base.html" %}
+{% block title %}Accountant — GPT-Trader console{% endblock %}
+{% block content %}
+<h1>Accountant</h1>
+
+<div class="cards">
+  <div class="card">
+    <div class="label">Paper equity</div>
+    <div class="value">{{ summary.current_equity | money }}</div>
+    {% if summary.attestation %}
+    <div class="muted">attested {{ summary.attestation.equity | money }} by {{ summary.attestation.actor_id }} · {{ summary.attestation.timestamp | timestamp }}</div>
+    {% else %}
+    <div class="muted">no attested equity yet</div>
+    {% endif %}
+  </div>
+  <div class="card">
+    <div class="label">High-water mark</div>
+    <div class="value">{{ summary.high_water_mark | money }}</div>
+    <div class="muted">
+      {% if summary.drawdown_amount is not none %}
+      drawdown {{ summary.drawdown_amount | money }} ({{ summary.drawdown_percent | percent }})
+      {% else %}—{% endif %}
+    </div>
+  </div>
+  <div class="card">
+    <div class="label">Realized P&amp;L since attestation</div>
+    {% if summary.realized_profit_loss_since_attestation is not none %}
+    <div class="value {{ 'ok' if summary.realized_profit_loss_since_attestation >= 0 else 'bad' }}">{{ summary.realized_profit_loss_since_attestation | money }}</div>
+    {% else %}
+    <div class="value">—</div>
+    {% endif %}
+    <div class="muted">{{ summary.realized_profit_loss_total | money }} all time</div>
+  </div>
+  <div class="card">
+    <div class="label">Closeouts recorded</div>
+    <div class="value">{{ summary.closeout_count }}</div>
+    <div class="muted">
+      {% if summary.closeout_amount_unavailable_count %}
+      <span class="warn">{{ summary.closeout_amount_unavailable_count }} without a P&amp;L amount</span>
+      {% else %}all with P&amp;L amounts{% endif %}
+    </div>
+  </div>
+</div>
+
+<h2>Budget levers vs usage</h2>
+<table>
+  <tr><th>Lever</th><th>Budget</th><th>In use</th><th>Headroom</th></tr>
+  <tr>
+    <td>Daily loss</td>
+    <td>{{ budget.max_daily_loss_pct | percent }}</td>
+    <td>{{ headroom.daily_loss_used_pct | percent }}</td>
+    <td>{{ headroom.daily_loss_headroom_pct | percent }}</td>
+  </tr>
+  <tr>
+    <td>Open notional</td>
+    <td>{{ budget.max_open_notional_pct | percent }}</td>
+    <td>{{ headroom.open_notional_pct | percent }} <span class="muted">({{ headroom.open_notional | money }})</span></td>
+    <td>{{ headroom.open_notional_headroom_pct | percent }} <span class="muted">({{ headroom.open_notional_headroom | money }})</span></td>
+  </tr>
+  <tr>
+    <td>Concurrent approved tickets</td>
+    <td>{{ budget.max_concurrent_approved_tickets }}</td>
+    <td>{{ open_approved_count }}</td>
+    <td>{{ budget.max_concurrent_approved_tickets - open_approved_count }}</td>
+  </tr>
+  <tr>
+    <td>Max loss per idea</td>
+    <td>{{ budget.max_loss_per_idea_pct | percent }}</td>
+    <td class="muted" colspan="2">enforced per idea at approval</td>
+  </tr>
+</table>
+
+<h2>Budget provenance</h2>
+<table>
+  <tr><th>Version</th><th>Attested equity</th><th>Gain retention floor</th><th>Futures leverage</th><th>Naked shorts</th><th>Sizing capped</th></tr>
+  <tr>
+    <td>v{{ budget.version }}</td>
+    <td>{{ budget.account_equity | money }}</td>
+    <td>{{ budget.gain_retention_floor_pct | percent }}</td>
+    <td>{{ "allowed" if budget.allow_futures_leverage else "blocked" }}</td>
+    <td>{{ "allowed" if budget.allow_naked_shorts else "blocked" }}</td>
+    <td>{{ "yes" if budget.sizing_capped_by_budget else "no" }}</td>
+  </tr>
+</table>
+<p class="muted">{{ budget.reason }}</p>
+{% endblock %}

--- a/src/gpt_trader/web/templates/accountant.html
+++ b/src/gpt_trader/web/templates/accountant.html
@@ -45,16 +45,23 @@
 <h2>Budget levers vs usage</h2>
 <table>
   <tr><th>Lever</th><th>Budget</th><th>In use</th><th>Headroom</th></tr>
+  {% set daily_loss_unavailable = headroom.same_day_realized_loss_unavailable_count + headroom.open_at_risk_unavailable_count %}
   <tr>
     <td>Daily loss</td>
     <td>{{ budget.max_daily_loss_pct | percent }}</td>
-    <td>{{ headroom.daily_loss_used_pct | percent }}</td>
+    <td>
+      {{ headroom.daily_loss_used_pct | percent }}
+      {% if daily_loss_unavailable %}<div class="warn">incomplete: {{ daily_loss_unavailable }} record{{ "s" if daily_loss_unavailable != 1 }} without loss evidence</div>{% endif %}
+    </td>
     <td>{{ headroom.daily_loss_headroom_pct | percent }}</td>
   </tr>
   <tr>
     <td>Open notional</td>
     <td>{{ budget.max_open_notional_pct | percent }}</td>
-    <td>{{ headroom.open_notional_pct | percent }} <span class="muted">({{ headroom.open_notional | money }})</span></td>
+    <td>
+      {{ headroom.open_notional_pct | percent }} <span class="muted">({{ headroom.open_notional | money }})</span>
+      {% if headroom.open_notional_unavailable_count %}<div class="warn">incomplete: {{ headroom.open_notional_unavailable_count }} idea{{ "s" if headroom.open_notional_unavailable_count != 1 }} without a notional</div>{% endif %}
+    </td>
     <td>{{ headroom.open_notional_headroom_pct | percent }} <span class="muted">({{ headroom.open_notional_headroom | money }})</span></td>
   </tr>
   <tr>

--- a/src/gpt_trader/web/templates/activity.html
+++ b/src/gpt_trader/web/templates/activity.html
@@ -1,0 +1,91 @@
+{% extends "base.html" %}
+{% block title %}Agent activity — GPT-Trader console{% endblock %}
+{% block content %}
+<h1>Agent activity</h1>
+
+<div class="cards">
+  <div class="card">
+    <div class="label">Last turn</div>
+    {% if feed.turns %}
+    <div class="value {{ 'ok' if feed.turns[0].outcome == 'completed' else 'bad' }}">{{ feed.turns[0].outcome }}</div>
+    <div class="muted">{{ feed.turns[0].started_at | timestamp }}</div>
+    {% else %}
+    <div class="value">—</div>
+    <div class="muted">no turns recorded</div>
+    {% endif %}
+  </div>
+  <div class="card">
+    <div class="label">Turns recorded</div>
+    <div class="value">{{ feed.turn_count }}</div>
+    <div class="muted">{{ feed.completed_count }} completed · {{ feed.failed_count }} failed</div>
+  </div>
+  {% if feed.unreadable_line_count %}
+  <div class="card">
+    <div class="label">Manifest health</div>
+    <div class="value warn">{{ feed.unreadable_line_count }}</div>
+    <div class="muted">unreadable manifest line{{ "s" if feed.unreadable_line_count != 1 }}</div>
+  </div>
+  {% endif %}
+</div>
+
+<h2>Cycle turns</h2>
+{% if feed.turns %}
+<table>
+  <tr>
+    <th>Turn</th><th>Started</th><th>Duration</th><th>Outcome</th>
+    <th>Snapshot</th><th>Proposals</th><th>Executed</th><th>Queue after</th>
+  </tr>
+  {% for turn in feed.turns %}
+  <tr>
+    <td>{{ turn.run_id }}</td>
+    <td>{{ turn.started_at | timestamp }}</td>
+    <td>{{ turn.duration_seconds | duration }}</td>
+    <td>
+      <span class="pill {{ 'ok' if turn.outcome == 'completed' else 'bad' }}">{{ turn.outcome }}</span>
+      {% if turn.error %}<div class="bad">{{ turn.error }}</div>{% endif %}
+    </td>
+    <td>
+      {% if turn.snapshot_source %}{{ turn.snapshot_source }}{% else %}<span class="muted">—</span>{% endif %}
+      {% if turn.snapshot_symbols %}<div class="muted">{{ turn.snapshot_symbols | join(", ") }}</div>{% endif %}
+    </td>
+    <td>
+      {{ turn.proposal_count }}
+      {% if turn.proposers %}
+      <ul class="muted">
+        {% for proposer in turn.proposers %}
+        <li>{{ proposer.proposer_id }}: {{ proposer.proposal_count }}{% if proposer.skipped_count %} ({{ proposer.skipped_count }} skipped){% endif %}</li>
+        {% endfor %}
+      </ul>
+      {% endif %}
+    </td>
+    <td>
+      {% if turn.execution_enabled %}
+      {{ turn.executed_count }}{% if turn.execution_skipped_count %} <span class="muted">({{ turn.execution_skipped_count }} skipped)</span>{% endif %}
+      {% else %}<span class="muted">off</span>{% endif %}
+    </td>
+    <td>{{ turn.queue_pending_total if turn.queue_pending_total is not none else "—" }}</td>
+  </tr>
+  {% endfor %}
+</table>
+{% else %}
+<p class="muted">No cycle turns recorded yet ({{ manifest_path }}).</p>
+{% endif %}
+
+<h2>Recent audit events</h2>
+{% if events %}
+<table>
+  <tr><th>Time</th><th>Action</th><th>Idea</th><th>Actor</th><th>Reason</th></tr>
+  {% for event in events %}
+  <tr>
+    <td>{{ event.timestamp | timestamp }}</td>
+    <td><span class="pill">{{ event.action.value }}</span></td>
+    <td><a href="/ideas/{{ event.decision_id }}">{{ event.decision_id }}</a></td>
+    <td>{{ event.actor_id }} <span class="muted">({{ event.actor_type.value }})</span></td>
+    <td>{{ event.reason }}</td>
+  </tr>
+  {% endfor %}
+</table>
+{% else %}
+<p class="muted">No audit events recorded yet.</p>
+{% endif %}
+{% endblock %}

--- a/src/gpt_trader/web/templates/activity.html
+++ b/src/gpt_trader/web/templates/activity.html
@@ -19,7 +19,13 @@
     <div class="value">{{ feed.turn_count }}</div>
     <div class="muted">{{ feed.completed_count }} completed · {{ feed.failed_count }} failed</div>
   </div>
-  {% if feed.unreadable_line_count %}
+  {% if feed.manifest_error %}
+  <div class="card">
+    <div class="label">Manifest health</div>
+    <div class="value bad">unreadable</div>
+    <div class="muted">{{ feed.manifest_error }}</div>
+  </div>
+  {% elif feed.unreadable_line_count %}
   <div class="card">
     <div class="label">Manifest health</div>
     <div class="value warn">{{ feed.unreadable_line_count }}</div>

--- a/src/gpt_trader/web/templates/base.html
+++ b/src/gpt_trader/web/templates/base.html
@@ -20,6 +20,8 @@
       padding: 0.8rem 1.2rem; border-bottom: 1px solid var(--line);
     }
     header a { color: var(--text); text-decoration: none; font-weight: 600; }
+    header nav { display: inline; margin-left: 1rem; }
+    header nav a { color: var(--muted); font-weight: 400; margin-right: 0.8rem; font-size: 0.9rem; }
     header .actor { color: var(--muted); font-size: 0.85rem; }
     main { max-width: 72rem; margin: 0 auto; padding: 1.2rem; }
     h1 { font-size: 1.15rem; margin: 0 0 0.8rem; }
@@ -68,7 +70,14 @@
 </head>
 <body>
   <header>
-    <a href="/">GPT-Trader operator console</a>
+    <div>
+      <a href="/">GPT-Trader operator console</a>
+      <nav>
+        <a href="/">Queue</a>
+        <a href="/accountant">Accountant</a>
+        <a href="/activity">Activity</a>
+      </nav>
+    </div>
     <span class="actor">acting as <strong>{{ actor_id }}</strong></span>
   </header>
   <main>

--- a/tests/unit/gpt_trader/features/trade_ideas/test_accounting.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_accounting.py
@@ -44,13 +44,14 @@ def _closeout(
     *,
     at: datetime,
     amount: Decimal | None,
+    terminal_event_id: str = "event-1",
 ) -> CloseoutAttribution:
     return CloseoutAttribution(
         decision_id=decision_id,
         timestamp=at,
         actor_type="human",
         actor_id="rj",
-        terminal_event_id="event-1",
+        terminal_event_id=terminal_event_id,
         record_hash="hash-1",
         resolution=CloseoutResolution.THESIS_TARGET,
         max_loss=MaxLossSnapshot(amount=Decimal("50")),
@@ -139,6 +140,36 @@ def test_unavailable_amounts_are_counted_but_do_not_move_the_ledger() -> None:
     assert summary.current_equity == Decimal("1010")
     assert summary.closeout_count == 2
     assert summary.closeout_amount_unavailable_count == 1
+
+
+def test_delayed_attribution_folds_at_terminal_time_not_entry_time() -> None:
+    # Trade ends at T1, operator attests equity at T2 (which already includes
+    # that trade's P&L), attribution is entered at T3. Folding at terminal
+    # time puts the closeout before the attestation instead of re-applying
+    # its P&L on top of the attested level.
+    entries = [
+        _budget_entry(1, at=_START, equity=Decimal("1000")),
+        _budget_entry(2, at=_START + timedelta(hours=2), equity=Decimal("1200")),
+    ]
+    closeouts = [
+        _closeout(
+            "trade-1",
+            at=_START + timedelta(hours=3),  # attribution entered after the attestation
+            amount=Decimal("200"),
+            terminal_event_id="terminal-1",
+        )
+    ]
+
+    summary = compute_paper_accounting(
+        entries,
+        closeouts,
+        terminal_times={"terminal-1": _START + timedelta(hours=1)},
+    )
+
+    assert summary.current_equity == Decimal("1200")  # not double-counted to 1400
+    assert summary.high_water_mark == Decimal("1200")
+    assert summary.realized_profit_loss_since_attestation == Decimal("0")
+    assert summary.realized_profit_loss_total == Decimal("200")
 
 
 def test_closeout_before_first_attestation_counts_toward_total_only() -> None:

--- a/tests/unit/gpt_trader/features/trade_ideas/test_accounting.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_accounting.py
@@ -1,0 +1,152 @@
+"""Paper accounting ledger: attestations set the level, closeouts move it."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+from gpt_trader.features.trade_ideas.accounting import compute_paper_accounting
+from gpt_trader.features.trade_ideas.audit import ActorType
+from gpt_trader.features.trade_ideas.budget import DEFAULT_RISK_BUDGET, BudgetLogEntry
+from gpt_trader.features.trade_ideas.closeout import (
+    CloseoutAttribution,
+    CloseoutResolution,
+    MaxLossSnapshot,
+)
+
+_START = datetime(2026, 7, 1, 12, 0, tzinfo=UTC)
+
+
+def _budget_entry(
+    version: int,
+    *,
+    at: datetime,
+    equity: Decimal | None,
+    actor_id: str = "rj",
+) -> BudgetLogEntry:
+    budget = replace(
+        DEFAULT_RISK_BUDGET,
+        version=version,
+        account_equity=equity,
+        reason="test budget version",
+    )
+    return BudgetLogEntry(
+        timestamp=at,
+        actor_type=ActorType.HUMAN,
+        actor_id=actor_id,
+        budget=budget,
+    )
+
+
+def _closeout(
+    decision_id: str,
+    *,
+    at: datetime,
+    amount: Decimal | None,
+) -> CloseoutAttribution:
+    return CloseoutAttribution(
+        decision_id=decision_id,
+        timestamp=at,
+        actor_type="human",
+        actor_id="rj",
+        terminal_event_id="event-1",
+        record_hash="hash-1",
+        resolution=CloseoutResolution.THESIS_TARGET,
+        max_loss=MaxLossSnapshot(amount=Decimal("50")),
+        realized_profit_loss_amount=amount,
+        realized_profit_loss_unavailable_reason=(
+            "" if amount is not None else "fill evidence missing"
+        ),
+    )
+
+
+def test_empty_inputs_yield_no_basis() -> None:
+    summary = compute_paper_accounting([], [])
+
+    assert summary.attestation is None
+    assert summary.current_equity is None
+    assert summary.high_water_mark is None
+    assert summary.drawdown_amount is None
+    assert summary.realized_profit_loss_total == Decimal("0")
+    assert summary.realized_profit_loss_since_attestation is None
+    assert summary.closeout_count == 0
+
+
+def test_closeouts_accrue_onto_attested_equity() -> None:
+    entries = [_budget_entry(1, at=_START, equity=Decimal("1000"))]
+    closeouts = [
+        _closeout("trade-1", at=_START + timedelta(hours=1), amount=Decimal("150")),
+        _closeout("trade-2", at=_START + timedelta(hours=2), amount=Decimal("-90")),
+    ]
+
+    summary = compute_paper_accounting(entries, closeouts)
+
+    assert summary.current_equity == Decimal("1060")
+    assert summary.high_water_mark == Decimal("1150")
+    assert summary.drawdown_amount == Decimal("90")
+    assert summary.drawdown_percent is not None
+    assert summary.drawdown_percent.quantize(Decimal("0.01")) == Decimal("7.83")
+    assert summary.realized_profit_loss_total == Decimal("60")
+    assert summary.realized_profit_loss_since_attestation == Decimal("60")
+    assert summary.closeout_count == 2
+    assert summary.closeout_amount_unavailable_count == 0
+
+
+def test_lever_change_carrying_equity_forward_is_not_an_attestation() -> None:
+    entries = [
+        _budget_entry(1, at=_START, equity=Decimal("1000")),
+        # A later version with the same equity is a lever change, not a fresh
+        # measurement; the ledger and P&L accumulator must not reset.
+        _budget_entry(2, at=_START + timedelta(hours=3), equity=Decimal("1000")),
+    ]
+    closeouts = [_closeout("trade-1", at=_START + timedelta(hours=1), amount=Decimal("-40"))]
+
+    summary = compute_paper_accounting(entries, closeouts)
+
+    assert summary.attestation is not None
+    assert summary.attestation.budget_version == 1
+    assert summary.current_equity == Decimal("960")
+    assert summary.realized_profit_loss_since_attestation == Decimal("-40")
+
+
+def test_reattestation_resets_level_but_keeps_historical_peak() -> None:
+    entries = [
+        _budget_entry(1, at=_START, equity=Decimal("2000")),
+        _budget_entry(2, at=_START + timedelta(days=1), equity=Decimal("1000")),
+    ]
+    closeouts = [_closeout("trade-1", at=_START + timedelta(days=1, hours=1), amount=Decimal("25"))]
+
+    summary = compute_paper_accounting(entries, closeouts)
+
+    assert summary.attestation is not None
+    assert summary.attestation.equity == Decimal("1000")
+    assert summary.current_equity == Decimal("1025")
+    assert summary.high_water_mark == Decimal("2000")
+    assert summary.drawdown_amount == Decimal("975")
+    assert summary.realized_profit_loss_since_attestation == Decimal("25")
+
+
+def test_unavailable_amounts_are_counted_but_do_not_move_the_ledger() -> None:
+    entries = [_budget_entry(1, at=_START, equity=Decimal("1000"))]
+    closeouts = [
+        _closeout("trade-1", at=_START + timedelta(hours=1), amount=None),
+        _closeout("trade-2", at=_START + timedelta(hours=2), amount=Decimal("10")),
+    ]
+
+    summary = compute_paper_accounting(entries, closeouts)
+
+    assert summary.current_equity == Decimal("1010")
+    assert summary.closeout_count == 2
+    assert summary.closeout_amount_unavailable_count == 1
+
+
+def test_closeout_before_first_attestation_counts_toward_total_only() -> None:
+    entries = [_budget_entry(1, at=_START + timedelta(days=1), equity=Decimal("1000"))]
+    closeouts = [_closeout("trade-1", at=_START, amount=Decimal("75"))]
+
+    summary = compute_paper_accounting(entries, closeouts)
+
+    assert summary.current_equity == Decimal("1000")
+    assert summary.realized_profit_loss_total == Decimal("75")
+    assert summary.realized_profit_loss_since_attestation == Decimal("0")

--- a/tests/unit/gpt_trader/web/test_console_accountant.py
+++ b/tests/unit/gpt_trader/web/test_console_accountant.py
@@ -1,0 +1,87 @@
+"""Accountant page: paper equity ledger and budget levers vs usage."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from gpt_trader.features.trade_ideas.closeout import CloseoutResolution
+from gpt_trader.features.trade_ideas.service import TradeIdeaService
+from gpt_trader.web import create_app
+from tests.unit.gpt_trader.features.trade_ideas.conftest import (
+    attest_account_equity,
+    build_trade_idea,
+)
+
+_NOW = datetime(2026, 6, 12, 10, 0, tzinfo=UTC)
+_DECISION_ID = "trade-20260612-001"
+
+
+@pytest.fixture
+def service(tmp_path: Path) -> TradeIdeaService:
+    return TradeIdeaService(tmp_path, now_factory=lambda: _NOW)
+
+
+@pytest.fixture
+def client(service: TradeIdeaService, tmp_path: Path) -> TestClient:
+    return TestClient(create_app(service=service, ideas_root=tmp_path, actor_id="rj"))
+
+
+def _record_closed_trade(service: TradeIdeaService, amount: Decimal) -> None:
+    attest_account_equity(service, equity=Decimal("20000"))
+    service.propose(build_trade_idea(), actor_id="idea-generator-v1")
+    service.approve(_DECISION_ID, actor_id="rj", reason="Risk verified")
+    service.record_submission(_DECISION_ID, actor_id="paper-cycle", venue="paper")
+    service.record_fill(_DECISION_ID, actor_id="paper-broker", venue="paper")
+    service.record_closeout_attribution(
+        _DECISION_ID,
+        actor_id="rj",
+        resolution=CloseoutResolution.THESIS_TARGET,
+        realized_profit_loss_amount=amount,
+    )
+
+
+def test_accountant_renders_equity_ledger_from_closeouts(
+    service: TradeIdeaService, client: TestClient
+) -> None:
+    _record_closed_trade(service, Decimal("150"))
+
+    response = client.get("/accountant")
+
+    assert response.status_code == 200
+    assert "$20,150.00" in response.text  # attested 20000 + realized 150
+    assert "attested $20,000.00 by rj" in response.text
+    assert "High-water mark" in response.text
+
+
+def test_accountant_shows_drawdown_from_peak(service: TradeIdeaService, client: TestClient) -> None:
+    _record_closed_trade(service, Decimal("-400"))
+
+    response = client.get("/accountant")
+
+    assert response.status_code == 200
+    assert "$19,600.00" in response.text
+    assert "drawdown $400.00 (2.00%)" in response.text
+    assert "-$400.00" in response.text  # realized P&L since attestation
+
+
+def test_accountant_renders_levers_vs_usage(service: TradeIdeaService, client: TestClient) -> None:
+    attest_account_equity(service, equity=Decimal("20000"))
+
+    response = client.get("/accountant")
+
+    assert response.status_code == 200
+    assert "Budget levers vs usage" in response.text
+    assert "Daily loss" in response.text
+    assert "Concurrent approved tickets" in response.text
+
+
+def test_accountant_renders_without_any_attestation(client: TestClient) -> None:
+    response = client.get("/accountant")
+
+    assert response.status_code == 200
+    assert "no attested equity yet" in response.text

--- a/tests/unit/gpt_trader/web/test_console_accountant.py
+++ b/tests/unit/gpt_trader/web/test_console_accountant.py
@@ -90,6 +90,15 @@ def test_accountant_renders_without_any_attestation(client: TestClient) -> None:
     assert "incomplete:" not in response.text
 
 
+def test_console_reads_do_not_seed_the_budget_log(tmp_path: Path, client: TestClient) -> None:
+    # Rendering any console page on a fresh root must not create durable
+    # artifacts; the budget log is seeded by decision paths, never by a GET.
+    client.get("/accountant")
+    client.get("/")
+
+    assert not (tmp_path / "risk_budget.jsonl").exists()
+
+
 def test_filled_trade_spanning_a_reattestation_keeps_its_realized_pnl(tmp_path: Path) -> None:
     # Fill at T1, re-attest while the position is still open at T2, close and
     # attribute at T3: the FILLED audit event is the entry fill, not the

--- a/tests/unit/gpt_trader/web/test_console_accountant.py
+++ b/tests/unit/gpt_trader/web/test_console_accountant.py
@@ -27,8 +27,8 @@ def service(tmp_path: Path) -> TradeIdeaService:
 
 
 @pytest.fixture
-def client(service: TradeIdeaService, tmp_path: Path) -> TestClient:
-    return TestClient(create_app(service=service, ideas_root=tmp_path, actor_id="rj"))
+def client(service: TradeIdeaService) -> TestClient:
+    return TestClient(create_app(service=service, actor_id="rj"))
 
 
 def _record_closed_trade(service: TradeIdeaService, amount: Decimal) -> None:

--- a/tests/unit/gpt_trader/web/test_console_accountant.py
+++ b/tests/unit/gpt_trader/web/test_console_accountant.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
 
+from gpt_trader.features.trade_ideas.audit import ActorType
 from gpt_trader.features.trade_ideas.closeout import CloseoutResolution
 from gpt_trader.features.trade_ideas.service import TradeIdeaService
 from gpt_trader.web import create_app
@@ -86,6 +88,47 @@ def test_accountant_renders_without_any_attestation(client: TestClient) -> None:
     assert response.status_code == 200
     assert "no attested equity yet" in response.text
     assert "incomplete:" not in response.text
+
+
+def test_filled_trade_spanning_a_reattestation_keeps_its_realized_pnl(tmp_path: Path) -> None:
+    # Fill at T1, re-attest while the position is still open at T2, close and
+    # attribute at T3: the FILLED audit event is the entry fill, not the
+    # close, so the closeout must fold at attribution time (after the
+    # re-attestation), never get sorted before it and dropped.
+    clock = {"now": _NOW}
+    service = TradeIdeaService(tmp_path, now_factory=lambda: clock["now"])
+    client = TestClient(create_app(service=service, actor_id="rj"))
+
+    attest_account_equity(service, equity=Decimal("20000"))
+    service.propose(build_trade_idea(), actor_id="idea-generator-v1")
+    service.approve(_DECISION_ID, actor_id="rj", reason="Risk verified")
+    clock["now"] = _NOW + timedelta(hours=1)
+    service.record_submission(_DECISION_ID, actor_id="paper-cycle", venue="paper")
+    service.record_fill(_DECISION_ID, actor_id="paper-broker", venue="paper")
+    clock["now"] = _NOW + timedelta(hours=2)
+    current = service.current_budget()
+    service.update_budget(
+        replace(
+            current,
+            version=current.version + 1,
+            account_equity=Decimal("19000"),
+            reason="Re-attested while position open",
+        ),
+        ActorType.HUMAN,
+        "rj",
+    )
+    clock["now"] = _NOW + timedelta(hours=3)
+    service.record_closeout_attribution(
+        _DECISION_ID,
+        actor_id="rj",
+        resolution=CloseoutResolution.THESIS_TARGET,
+        realized_profit_loss_amount=Decimal("500"),
+    )
+
+    response = client.get("/accountant")
+
+    assert response.status_code == 200
+    assert "$19,500.00" in response.text  # 19000 re-attested + 500 realized after
 
 
 def test_accountant_marks_daily_loss_usage_incomplete_when_evidence_is_missing(

--- a/tests/unit/gpt_trader/web/test_console_accountant.py
+++ b/tests/unit/gpt_trader/web/test_console_accountant.py
@@ -85,3 +85,27 @@ def test_accountant_renders_without_any_attestation(client: TestClient) -> None:
 
     assert response.status_code == 200
     assert "no attested equity yet" in response.text
+    assert "incomplete:" not in response.text
+
+
+def test_accountant_marks_daily_loss_usage_incomplete_when_evidence_is_missing(
+    service: TradeIdeaService, client: TestClient
+) -> None:
+    # A same-day closeout without any P&L evidence cannot be priced into
+    # daily-loss usage; the subset total must be marked incomplete, not exact.
+    attest_account_equity(service, equity=Decimal("20000"))
+    service.propose(build_trade_idea(), actor_id="idea-generator-v1")
+    service.approve(_DECISION_ID, actor_id="rj", reason="Risk verified")
+    service.record_submission(_DECISION_ID, actor_id="paper-cycle", venue="paper")
+    service.record_fill(_DECISION_ID, actor_id="paper-broker", venue="paper")
+    service.record_closeout_attribution(
+        _DECISION_ID,
+        actor_id="rj",
+        resolution=CloseoutResolution.THESIS_TARGET,
+        realized_profit_loss_unavailable_reason="fill evidence missing",
+    )
+
+    response = client.get("/accountant")
+
+    assert response.status_code == 200
+    assert "incomplete: 1 record without loss evidence" in response.text

--- a/tests/unit/gpt_trader/web/test_console_activity.py
+++ b/tests/unit/gpt_trader/web/test_console_activity.py
@@ -55,8 +55,10 @@ def service(tmp_path: Path) -> TradeIdeaService:
 
 
 @pytest.fixture
-def client(service: TradeIdeaService, tmp_path: Path) -> TestClient:
-    return TestClient(create_app(service=service, ideas_root=tmp_path, actor_id="rj"))
+def client(service: TradeIdeaService) -> TestClient:
+    # No ideas_root on purpose: the cycle manifest must be found under the
+    # injected service's own root, never independently re-resolved.
+    return TestClient(create_app(service=service, actor_id="rj"))
 
 
 def _write_manifest(ideas_root: Path, *rows: object) -> None:
@@ -118,6 +120,20 @@ def test_activity_renders_empty_state_without_manifest(client: TestClient) -> No
 
     assert response.status_code == 200
     assert "No cycle turns recorded yet" in response.text
+
+
+def test_activity_surfaces_unreadable_manifest_file_instead_of_crashing(
+    tmp_path: Path, client: TestClient
+) -> None:
+    # A directory left at the manifest path (e.g. after a failed append) must
+    # surface as a manifest-health error, not a 500.
+    (tmp_path / "cycle" / "manifest.jsonl").mkdir(parents=True)
+
+    response = client.get("/activity")
+
+    assert response.status_code == 200
+    assert "Manifest health" in response.text
+    assert "unreadable" in response.text
 
 
 def test_activity_lists_recent_audit_events(service: TradeIdeaService, client: TestClient) -> None:

--- a/tests/unit/gpt_trader/web/test_console_activity.py
+++ b/tests/unit/gpt_trader/web/test_console_activity.py
@@ -93,6 +93,26 @@ def test_activity_tolerates_unreadable_manifest_lines(tmp_path: Path, client: Te
     assert "unreadable manifest line" in response.text
 
 
+def test_activity_treats_corrupt_row_fields_as_unreadable(
+    tmp_path: Path, client: TestClient
+) -> None:
+    # Valid JSON with a corrupt field (schema drift, manual repair) must be
+    # counted as unreadable, not turn the page into a 500.
+    corrupt_row = {
+        "run_id": "cycle-20260704T110000Z-bad999",
+        "outcome": "completed",
+        "proposers": [{"proposer_id": "baseline-v1", "proposal_count": "not-a-number"}],
+    }
+    _write_manifest(tmp_path, _COMPLETED_ROW, corrupt_row)
+
+    response = client.get("/activity")
+
+    assert response.status_code == 200
+    assert "cycle-20260704T090000Z-abc123" in response.text
+    assert "cycle-20260704T110000Z-bad999" not in response.text
+    assert "unreadable manifest line" in response.text
+
+
 def test_activity_renders_empty_state_without_manifest(client: TestClient) -> None:
     response = client.get("/activity")
 

--- a/tests/unit/gpt_trader/web/test_console_activity.py
+++ b/tests/unit/gpt_trader/web/test_console_activity.py
@@ -1,0 +1,114 @@
+"""Activity page: cycle-turn feed from the manifest plus recent audit events."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from gpt_trader.features.trade_ideas.service import TradeIdeaService
+from gpt_trader.web import create_app
+from tests.unit.gpt_trader.features.trade_ideas.conftest import (
+    attest_account_equity,
+    build_trade_idea,
+)
+
+_NOW = datetime(2026, 6, 12, 10, 0, tzinfo=UTC)
+
+_COMPLETED_ROW = {
+    "run_id": "cycle-20260704T090000Z-abc123",
+    "started_at": "2026-07-04T09:00:00+00:00",
+    "finished_at": "2026-07-04T09:00:42+00:00",
+    "outcome": "completed",
+    "error": None,
+    "snapshot": {
+        "source": "coinbase",
+        "symbols": ["BTC-USD", "ETH-USD"],
+    },
+    "proposers": [
+        {
+            "proposer_id": "baseline-v1",
+            "proposal_count": 2,
+            "proposed_decision_ids": ["trade-a", "trade-b"],
+            "skipped_open_instruments": [{"instrument": "SOL-USD", "reason": "open idea"}],
+        }
+    ],
+    "execution": {"enabled": True, "executed": [{"decision_id": "trade-c"}], "skipped": []},
+    "queue": {"pending_total": 3},
+}
+
+_FAILED_ROW = {
+    "run_id": "cycle-20260704T100000Z-def456",
+    "started_at": "2026-07-04T10:00:00+00:00",
+    "finished_at": "2026-07-04T10:00:05+00:00",
+    "outcome": "failed",
+    "error": "ValidationError: snapshot fetch failed",
+}
+
+
+@pytest.fixture
+def service(tmp_path: Path) -> TradeIdeaService:
+    return TradeIdeaService(tmp_path, now_factory=lambda: _NOW)
+
+
+@pytest.fixture
+def client(service: TradeIdeaService, tmp_path: Path) -> TestClient:
+    return TestClient(create_app(service=service, ideas_root=tmp_path, actor_id="rj"))
+
+
+def _write_manifest(ideas_root: Path, *rows: object) -> None:
+    cycle_root = ideas_root / "cycle"
+    cycle_root.mkdir(parents=True, exist_ok=True)
+    lines = [row if isinstance(row, str) else json.dumps(row) for row in rows]
+    (cycle_root / "manifest.jsonl").write_text(
+        "".join(f"{line}\n" for line in lines), encoding="utf-8"
+    )
+
+
+def test_activity_renders_cycle_turns_newest_first(tmp_path: Path, client: TestClient) -> None:
+    _write_manifest(tmp_path, _COMPLETED_ROW, _FAILED_ROW)
+
+    response = client.get("/activity")
+
+    assert response.status_code == 200
+    assert "cycle-20260704T090000Z-abc123" in response.text
+    assert "cycle-20260704T100000Z-def456" in response.text
+    assert response.text.index("def456") < response.text.index("abc123")
+    assert "ValidationError: snapshot fetch failed" in response.text
+    assert "baseline-v1: 2 (1 skipped)" in response.text
+    assert "BTC-USD, ETH-USD" in response.text
+    assert "1 completed · 1 failed" in response.text
+
+
+def test_activity_tolerates_unreadable_manifest_lines(tmp_path: Path, client: TestClient) -> None:
+    _write_manifest(tmp_path, _COMPLETED_ROW, "{truncated")
+
+    response = client.get("/activity")
+
+    assert response.status_code == 200
+    assert "cycle-20260704T090000Z-abc123" in response.text
+    assert "unreadable manifest line" in response.text
+
+
+def test_activity_renders_empty_state_without_manifest(client: TestClient) -> None:
+    response = client.get("/activity")
+
+    assert response.status_code == 200
+    assert "No cycle turns recorded yet" in response.text
+
+
+def test_activity_lists_recent_audit_events(service: TradeIdeaService, client: TestClient) -> None:
+    attest_account_equity(service)
+    service.propose(build_trade_idea(), actor_id="idea-generator-v1")
+    service.approve("trade-20260612-001", actor_id="rj", reason="Risk verified")
+
+    response = client.get("/activity")
+
+    assert response.status_code == 200
+    assert "Recent audit events" in response.text
+    assert "idea-generator-v1" in response.text
+    assert "Risk verified" in response.text
+    assert '/ideas/trade-20260612-001"' in response.text

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -9,7 +9,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6029,
+    "total_tests": 6030,
     "total_files": 715,
     "markers_used": 14
   },

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -9,7 +9,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6028,
+    "total_tests": 6029,
     "total_files": 715,
     "markers_used": 14
   },

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -9,7 +9,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6024,
+    "total_tests": 6028,
     "total_files": 715,
     "markers_used": 14
   },

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -9,8 +9,8 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6010,
-    "total_files": 712,
+    "total_tests": 6024,
+    "total_files": 715,
     "markers_used": 14
   },
   "quick_commands": {

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -92,7 +92,7 @@
     ]
   },
   "counts": {
-    "unit": 5864,
+    "unit": 5865,
     "asyncio": 310,
     "parametrize": 180,
     "integration": 87,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -92,7 +92,7 @@
     ]
   },
   "counts": {
-    "unit": 5865,
+    "unit": 5866,
     "asyncio": 310,
     "parametrize": 180,
     "integration": 87,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -92,7 +92,7 @@
     ]
   },
   "counts": {
-    "unit": 5860,
+    "unit": 5864,
     "asyncio": 310,
     "parametrize": 180,
     "integration": 87,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -92,7 +92,7 @@
     ]
   },
   "counts": {
-    "unit": 5846,
+    "unit": 5860,
     "asyncio": 310,
     "parametrize": 180,
     "integration": 87,


### PR DESCRIPTION
Phase 2 of the operator console umbrella (#1152): the accountant view and the agent-activity feed, both read-only over durable artifacts.

## Accountant (`/accountant`)
- **Paper equity ledger** (`features/trade_ideas/accounting.py`, pure computation mirroring `review_metrics.py`): budget-log *attestations* set the equity level, closeout realized-P&L amounts move it. A lever change that carries the same `account_equity` forward is not an attestation and does not reset the ledger; a re-attestation moves the level but keeps the historical peak, so drawdown-from-peak stays honest across resets.
- Cards: paper equity, high-water mark + drawdown-from-peak, realized P&L since attestation / all time, closeout coverage (amount-unavailable counts surfaced, never hidden).
- **Budget levers vs usage**: each lever from `peek_budget()` next to its usage/headroom from the existing `budget_headroom()` read, plus concurrent-ticket usage from `open_approved_count()`.

## Agent activity (`/activity`)
- **Cycle-turn feed** rendered directly from `<ideas_root>/cycle/manifest.jsonl` — the cycle runner's evidence contract. The console deliberately does **not** import `gpt_trader.features.idea_execution`: that module pulls in the paper execution lane, which the web console's frozen dependency set forbids (`web_console_frozen_dependencies` guard, unchanged). Parsing is tolerant: corrupt/truncated lines are counted and surfaced as a manifest-health warning, never fatal.
- Per turn: outcome (failed turns show their error), snapshot source/symbols, per-proposer proposal + skip counts, executed/skipped execution leg, queue depth after the turn.
- **Recent audit events** (newest 50) with actor identity and reasons, linking into idea detail.

## Constraints held
- Thin adapter: no new state stores, no new mutation routes; every read is a service call or a durable artifact. Only service change is a `budget_log` accessor mirroring `audit_log`/`closeout_log`.
- Import-boundary allowlists untouched.

## Evidence
- 14 new tests (accounting ledger semantics; both pages over a real `TradeIdeaService` + manifest fixtures, including malformed-line tolerance and empty states); full `make ci-required` green (6548 passed).
- Both pages manually rendered over a seeded root: equity math, drawdown, manifest row, and audit feed all present.

Closes nothing; phase 3 (envelope console) remains on #1152.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **Accountant** page showing paper equity, high-water mark/drawdown, realized P&L, closeout counts, and budget levers/provenance.
  * Added an **Activity** page with newest-first cycle turns, manifest health, and recent audit events.
  * Added cycle manifest parsing for tolerant, read-only feed generation and console template money/percent formatting.
* **Bug Fixes**
  * Accountant calculations now correctly handle delayed closeout attribution and equity re-attestations without double-counting.
  * Web console no longer fails when cycle manifests are missing, unreadable, or malformed (shows health/empty states).
* **Tests**
  * Expanded unit tests for paper accounting and new/updated page tests for **Accountant** and **Activity** rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->