### PR TITLE
feat(web): envelope console page (#1152 phase 3)

### DIFF
--- a/src/gpt_trader/features/trade_ideas/service.py
+++ b/src/gpt_trader/features/trade_ideas/service.py
@@ -467,15 +467,47 @@ class TradeIdeaService:
         *,
         actor_type: ActorType = ActorType.HUMAN,
     ) -> list[str]:
-        """Return every current-policy reason an idea could not be approved."""
-        resolution = self.current_autonomy()
+        """Return every current-policy reason an idea could not be approved.
+
+        Decision-path variant: seeds the budget and autonomy logs on first
+        use. Render-only paths must use ``peek_approval_violations``.
+        """
+        return self._approval_violations(
+            idea,
+            actor_type=actor_type,
+            resolution=self.current_autonomy(),
+            budget=self.current_budget(),
+        )
+
+    def peek_approval_violations(
+        self,
+        idea: TradeIdea,
+        *,
+        actor_type: ActorType = ActorType.HUMAN,
+    ) -> list[str]:
+        """Return approval violations without seeding any log (read-only paths)."""
+        return self._approval_violations(
+            idea,
+            actor_type=actor_type,
+            resolution=self.peek_autonomy(),
+            budget=self.peek_budget(),
+        )
+
+    def _approval_violations(
+        self,
+        idea: TradeIdea,
+        *,
+        actor_type: ActorType,
+        resolution: AutonomyResolution,
+        budget: RiskBudget,
+    ) -> list[str]:
         policy = ApprovalPolicy(resolution.mode)
         return [
             *self._autonomy_resolution_violations(resolution),
             *policy.approval_violations(
                 idea,
                 actor_type=actor_type,
-                budget=self.current_budget(),
+                budget=budget,
                 open_approved_count=self.open_approved_count(),
                 now=self._now(),
                 review_started_at=self._review_started_at(idea.decision_id),

--- a/src/gpt_trader/web/app.py
+++ b/src/gpt_trader/web/app.py
@@ -20,12 +20,19 @@ from fastapi.templating import Jinja2Templates
 
 from gpt_trader.errors import ValidationError
 from gpt_trader.features.trade_ideas.accounting import compute_paper_accounting
-from gpt_trader.features.trade_ideas.audit import AuditAction
-from gpt_trader.features.trade_ideas.models import TradeIdea
+from gpt_trader.features.trade_ideas.audit import ActorType, AuditAction
+from gpt_trader.features.trade_ideas.autonomy import (
+    AUTONOMY_SOURCE_FAIL_CLOSED,
+    RATCHET_ACTOR_ID,
+    AutonomyIntegrityError,
+)
+from gpt_trader.features.trade_ideas.budget import RiskBudget
+from gpt_trader.features.trade_ideas.models import AutonomyMode, TradeIdea
 from gpt_trader.features.trade_ideas.review_metrics import compute_review_instrumentation
 from gpt_trader.features.trade_ideas.service import (
     TradeIdeaService,
     create_trade_idea_service,
+    resolve_auto_approval_enabled,
     resolve_trade_idea_actor_id,
 )
 from gpt_trader.features.trade_ideas.service_models import (
@@ -138,6 +145,97 @@ def _record_versions(service: TradeIdeaService, view: TradeIdeaView) -> list[dic
     return versions
 
 
+# Budget fields an operator can move through the envelope form; version and
+# reason are handled separately (sequenced / required per submission).
+_BUDGET_LEVER_FIELDS = (
+    "max_loss_per_idea_pct",
+    "max_daily_loss_pct",
+    "max_open_notional_pct",
+    "max_concurrent_approved_tickets",
+    "max_review_latency_hours",
+    "sizing_capped_by_budget",
+    "gain_retention_floor_pct",
+    "allow_futures_leverage",
+    "allow_naked_shorts",
+    "account_equity",
+)
+
+
+def _budget_changes(previous: RiskBudget, current: RiskBudget) -> list[str]:
+    """Human-readable lever diffs between two consecutive budget versions."""
+    changes: list[str] = []
+    for field in _BUDGET_LEVER_FIELDS:
+        before = getattr(previous, field)
+        after = getattr(current, field)
+        if before != after:
+            changes.append(f"{field}: {before} → {after}")
+    return changes
+
+
+def _budget_form_values(budget: RiskBudget) -> dict[str, str | bool]:
+    """Form-ready values for the lever inputs, prefilled from a budget version."""
+    values: dict[str, str | bool] = {}
+    for field in _BUDGET_LEVER_FIELDS:
+        value = getattr(budget, field)
+        if isinstance(value, bool):
+            values[field] = value
+        else:
+            values[field] = "" if value is None else str(value)
+    return values
+
+
+def _budget_from_form(
+    *,
+    base_version: int,
+    reason: str,
+    values: dict[str, str | bool],
+) -> RiskBudget:
+    """Build the candidate next budget version from submitted form values.
+
+    Conversion failures and ``RiskBudget`` invariant violations surface as
+    ``ValueError`` with a field-named message so the caller can re-render the
+    form instead of returning a bare 500.
+    """
+
+    def _decimal(field: str) -> Decimal:
+        raw = str(values[field]).strip()
+        try:
+            return Decimal(raw)
+        except ArithmeticError as error:
+            raise ValueError(f"{field} must be a decimal number, got {raw!r}") from error
+
+    def _int(field: str) -> int:
+        raw = str(values[field]).strip()
+        try:
+            return int(raw)
+        except ValueError as error:
+            raise ValueError(f"{field} must be a whole number, got {raw!r}") from error
+
+    equity_raw = str(values["account_equity"]).strip()
+    account_equity: Decimal | None = None
+    if equity_raw:
+        try:
+            account_equity = Decimal(equity_raw)
+        except ArithmeticError as error:
+            raise ValueError(
+                f"account_equity must be a decimal number or blank, got {equity_raw!r}"
+            ) from error
+    return RiskBudget(
+        version=base_version + 1,
+        max_loss_per_idea_pct=_decimal("max_loss_per_idea_pct"),
+        max_daily_loss_pct=_decimal("max_daily_loss_pct"),
+        max_open_notional_pct=_decimal("max_open_notional_pct"),
+        max_concurrent_approved_tickets=_int("max_concurrent_approved_tickets"),
+        max_review_latency_hours=_int("max_review_latency_hours"),
+        sizing_capped_by_budget=bool(values["sizing_capped_by_budget"]),
+        gain_retention_floor_pct=_decimal("gain_retention_floor_pct"),
+        allow_futures_leverage=bool(values["allow_futures_leverage"]),
+        allow_naked_shorts=bool(values["allow_naked_shorts"]),
+        reason=reason,
+        account_equity=account_equity,
+    )
+
+
 def create_app(
     *,
     ideas_root: Path | None = None,
@@ -216,9 +314,139 @@ def create_app(
             status_code=status_code,
         )
 
+    def _render_envelope(
+        request: Request,
+        *,
+        error: str | None = None,
+        form_values: dict[str, str | bool] | None = None,
+        status_code: int = 200,
+    ) -> HTMLResponse:
+        budget = resolved_service.peek_budget()
+        autonomy = resolved_service.peek_autonomy()
+        budget_history = resolved_service.budget_log.history()
+        budget_rows: list[dict[str, Any]] = []
+        for index, entry in enumerate(budget_history):
+            previous = budget_history[index - 1].budget if index else None
+            budget_rows.append(
+                {
+                    "entry": entry,
+                    "changes": (_budget_changes(previous, entry.budget) if previous else []),
+                }
+            )
+        budget_rows.reverse()
+        autonomy_error: str | None = None
+        try:
+            autonomy_rows = list(reversed(resolved_service.autonomy_history()))
+        except AutonomyIntegrityError as exc:
+            autonomy_rows = []
+            autonomy_error = str(exc)
+        # Exception-queue framing: proposed ideas that clear the envelope are
+        # what Stage 2 auto-approval would sweep; everything else needs a human.
+        inside_envelope: list[dict[str, Any]] = []
+        exceptions: list[dict[str, Any]] = []
+        awaiting_resubmission: list[dict[str, Any]] = []
+        for row in _queue_rows(resolved_service):
+            if row["state"] is TradeIdeaState.NEEDS_CHANGES:
+                awaiting_resubmission.append(row)
+            elif row["violations"]:
+                exceptions.append(row)
+            else:
+                inside_envelope.append(row)
+        auto_approval_enabled = resolve_auto_approval_enabled()
+        return templates.TemplateResponse(
+            request=request,
+            name="envelope.html",
+            context={
+                "actor_id": resolved_actor,
+                "budget": budget,
+                "autonomy": autonomy,
+                "autonomy_fail_closed": autonomy.source == AUTONOMY_SOURCE_FAIL_CLOSED,
+                "ratchet_actor_id": RATCHET_ACTOR_ID,
+                "budget_rows": budget_rows,
+                "autonomy_rows": autonomy_rows,
+                "autonomy_error": autonomy_error,
+                "inside_envelope": inside_envelope,
+                "exceptions": exceptions,
+                "awaiting_resubmission": awaiting_resubmission,
+                "auto_approval_enabled": auto_approval_enabled,
+                "stage2_active": (
+                    auto_approval_enabled and autonomy.mode is AutonomyMode.BOUNDED_AUTONOMY
+                ),
+                "form": form_values or _budget_form_values(budget),
+                "error": error,
+            },
+            status_code=status_code,
+        )
+
     @app.get("/", response_class=HTMLResponse)
     def queue(request: Request) -> HTMLResponse:
         return _render_queue(request)
+
+    @app.get("/envelope", response_class=HTMLResponse)
+    def envelope(request: Request) -> HTMLResponse:
+        return _render_envelope(request)
+
+    @app.post("/envelope/budget", response_model=None)
+    def enact_budget(
+        request: Request,
+        base_version: int = Form(...),
+        reason: str = Form(""),
+        max_loss_per_idea_pct: str = Form(""),
+        max_daily_loss_pct: str = Form(""),
+        max_open_notional_pct: str = Form(""),
+        max_concurrent_approved_tickets: str = Form(""),
+        max_review_latency_hours: str = Form(""),
+        sizing_capped_by_budget: bool = Form(False),
+        gain_retention_floor_pct: str = Form(""),
+        allow_futures_leverage: bool = Form(False),
+        allow_naked_shorts: bool = Form(False),
+        account_equity: str = Form(""),
+    ) -> HTMLResponse | RedirectResponse:
+        form_values: dict[str, str | bool] = {
+            "max_loss_per_idea_pct": max_loss_per_idea_pct,
+            "max_daily_loss_pct": max_daily_loss_pct,
+            "max_open_notional_pct": max_open_notional_pct,
+            "max_concurrent_approved_tickets": max_concurrent_approved_tickets,
+            "max_review_latency_hours": max_review_latency_hours,
+            "sizing_capped_by_budget": sizing_capped_by_budget,
+            "gain_retention_floor_pct": gain_retention_floor_pct,
+            "allow_futures_leverage": allow_futures_leverage,
+            "allow_naked_shorts": allow_naked_shorts,
+            "account_equity": account_equity,
+        }
+
+        def _form_error(message: str) -> HTMLResponse:
+            return _render_envelope(
+                request, error=message, form_values=form_values, status_code=400
+            )
+
+        cleaned_reason = reason.strip()
+        if not cleaned_reason:
+            return _form_error("A reason is required for every budget version.")
+        current_version = resolved_service.peek_budget().version
+        if base_version != current_version:
+            # Optimistic-concurrency guard: the form was rendered against a
+            # version that is no longer current (another operator, the CLI, or
+            # an agent enacted a change since). The append-side sequencing
+            # check in RiskBudgetLog remains the authority for races past this
+            # point; this just turns the common case into a clear message.
+            return _form_error(
+                f"The budget moved to v{current_version} after this form was "
+                f"loaded (v{base_version}). Review the current levers and reapply."
+            )
+        try:
+            candidate = _budget_from_form(
+                base_version=base_version,
+                reason=cleaned_reason,
+                values=form_values,
+            )
+        except ValueError as exc:
+            return _form_error(str(exc))
+        try:
+            resolved_service.update_budget(candidate, ActorType.HUMAN, resolved_actor)
+        except ValidationError as exc:
+            return _form_error(str(exc))
+        return RedirectResponse(url="/envelope", status_code=303)
 
     @app.get("/accountant", response_class=HTMLResponse)
     def accountant(request: Request) -> HTMLResponse:

--- a/src/gpt_trader/web/app.py
+++ b/src/gpt_trader/web/app.py
@@ -9,6 +9,7 @@ required reason. The console holds no state of its own.
 from __future__ import annotations
 
 import json
+import threading
 from datetime import UTC, datetime
 from decimal import Decimal
 from pathlib import Path
@@ -250,6 +251,12 @@ def create_app(
     # from the service's own root so an injected service and the feed can
     # never point at different ideas roots.
     cycle_manifest_path = resolved_service.root / "cycle" / "manifest.jsonl"
+    # Serializes the staleness pre-check + audited append for budget updates:
+    # sync route handlers run on a threadpool, so without this two forms
+    # rendered from the same version could both pass the pre-check and both
+    # append "the same" next version (RiskBudgetLog.append has no lock of its
+    # own). In-process only — console writes for one operator identity.
+    budget_update_lock = threading.Lock()
 
     app = FastAPI(title="GPT-Trader operator console", docs_url=None, redoc_url=None)
     templates = Jinja2Templates(directory=str(_TEMPLATES_DIR))
@@ -437,30 +444,33 @@ def create_app(
                 status_code=409,
             )
 
-        # The staleness guard runs before any other validation: every other
-        # error path echoes the submitted levers back under a fresh hidden
-        # base_version, which must never happen for a stale submission.
-        if base_version != resolved_service.peek_budget().version:
-            return _version_conflict()
-        cleaned_reason = reason.strip()
-        if not cleaned_reason:
-            return _form_error("A reason is required for every budget version.")
-        try:
-            candidate = _budget_from_form(
-                base_version=base_version,
-                reason=cleaned_reason,
-                values=form_values,
-            )
-        except ValueError as exc:
-            return _form_error(str(exc))
-        try:
-            resolved_service.update_budget(candidate, ActorType.HUMAN, resolved_actor)
-        except BudgetIntegrityError:
-            # The append-side sequencing check in RiskBudgetLog caught a race
-            # past the pre-check; same conflict, same fresh-lever re-render.
-            return _version_conflict()
-        except ValidationError as exc:
-            return _form_error(str(exc))
+        with budget_update_lock:
+            # The staleness guard runs before any other validation: every
+            # other error path echoes the submitted levers back under a fresh
+            # hidden base_version, which must never happen for a stale
+            # submission.
+            if base_version != resolved_service.peek_budget().version:
+                return _version_conflict()
+            cleaned_reason = reason.strip()
+            if not cleaned_reason:
+                return _form_error("A reason is required for every budget version.")
+            try:
+                candidate = _budget_from_form(
+                    base_version=base_version,
+                    reason=cleaned_reason,
+                    values=form_values,
+                )
+            except ValueError as exc:
+                return _form_error(str(exc))
+            try:
+                resolved_service.update_budget(candidate, ActorType.HUMAN, resolved_actor)
+            except BudgetIntegrityError:
+                # An out-of-process writer (CLI, agent) moved the log between
+                # the pre-check and the append; same conflict, same
+                # fresh-lever re-render.
+                return _version_conflict()
+            except ValidationError as exc:
+                return _form_error(str(exc))
         return RedirectResponse(url="/envelope", status_code=303)
 
     @app.get("/accountant", response_class=HTMLResponse)

--- a/src/gpt_trader/web/app.py
+++ b/src/gpt_trader/web/app.py
@@ -26,7 +26,7 @@ from gpt_trader.features.trade_ideas.autonomy import (
     RATCHET_ACTOR_ID,
     AutonomyIntegrityError,
 )
-from gpt_trader.features.trade_ideas.budget import RiskBudget
+from gpt_trader.features.trade_ideas.budget import BudgetIntegrityError, RiskBudget
 from gpt_trader.features.trade_ideas.models import AutonomyMode, TradeIdea
 from gpt_trader.features.trade_ideas.review_metrics import compute_review_instrumentation
 from gpt_trader.features.trade_ideas.service import (
@@ -111,7 +111,7 @@ def _queue_rows(service: TradeIdeaService) -> list[dict[str, Any]]:
                     "view": view,
                     "idea": view.idea,
                     "state": view.state,
-                    "violations": service.approval_violations(view.idea),
+                    "violations": service.peek_approval_violations(view.idea),
                     "expires_in": (
                         _format_duration(expiration.seconds_until_expiry) if expiration else None
                     ),
@@ -307,7 +307,7 @@ def create_app(
                 "can_approve": TradeIdeaState.APPROVED in allowed_targets,
                 "can_request_changes": TradeIdeaState.NEEDS_CHANGES in allowed_targets,
                 "can_reject": TradeIdeaState.REJECTED in allowed_targets,
-                "violations": resolved_service.approval_violations(view.idea),
+                "violations": resolved_service.peek_approval_violations(view.idea),
                 "versions": _record_versions(resolved_service, view),
                 "error": error,
             },
@@ -420,20 +420,28 @@ def create_app(
                 request, error=message, form_values=form_values, status_code=400
             )
 
+        def _version_conflict() -> HTMLResponse:
+            # Optimistic-concurrency guard: the form was rendered against a
+            # version that is no longer current (another operator, the CLI, or
+            # an agent enacted a change since). Render the *current* levers,
+            # not the submitted ones — echoing stale values behind a fresh
+            # base_version would let a reflexive resubmit silently revert the
+            # concurrent change.
+            return _render_envelope(
+                request,
+                error=(
+                    f"The budget moved to v{resolved_service.peek_budget().version} after "
+                    f"this form was loaded (v{base_version}). The current levers are shown "
+                    "below; reapply your change if it still holds."
+                ),
+                status_code=409,
+            )
+
         cleaned_reason = reason.strip()
         if not cleaned_reason:
             return _form_error("A reason is required for every budget version.")
-        current_version = resolved_service.peek_budget().version
-        if base_version != current_version:
-            # Optimistic-concurrency guard: the form was rendered against a
-            # version that is no longer current (another operator, the CLI, or
-            # an agent enacted a change since). The append-side sequencing
-            # check in RiskBudgetLog remains the authority for races past this
-            # point; this just turns the common case into a clear message.
-            return _form_error(
-                f"The budget moved to v{current_version} after this form was "
-                f"loaded (v{base_version}). Review the current levers and reapply."
-            )
+        if base_version != resolved_service.peek_budget().version:
+            return _version_conflict()
         try:
             candidate = _budget_from_form(
                 base_version=base_version,
@@ -444,6 +452,10 @@ def create_app(
             return _form_error(str(exc))
         try:
             resolved_service.update_budget(candidate, ActorType.HUMAN, resolved_actor)
+        except BudgetIntegrityError:
+            # The append-side sequencing check in RiskBudgetLog caught a race
+            # past the pre-check; same conflict, same fresh-lever re-render.
+            return _version_conflict()
         except ValidationError as exc:
             return _form_error(str(exc))
         return RedirectResponse(url="/envelope", status_code=303)

--- a/src/gpt_trader/web/app.py
+++ b/src/gpt_trader/web/app.py
@@ -437,11 +437,14 @@ def create_app(
                 status_code=409,
             )
 
+        # The staleness guard runs before any other validation: every other
+        # error path echoes the submitted levers back under a fresh hidden
+        # base_version, which must never happen for a stale submission.
+        if base_version != resolved_service.peek_budget().version:
+            return _version_conflict()
         cleaned_reason = reason.strip()
         if not cleaned_reason:
             return _form_error("A reason is required for every budget version.")
-        if base_version != resolved_service.peek_budget().version:
-            return _version_conflict()
         try:
             candidate = _budget_from_form(
                 base_version=base_version,

--- a/src/gpt_trader/web/templates/base.html
+++ b/src/gpt_trader/web/templates/base.html
@@ -50,6 +50,17 @@
       color: var(--bad); border-radius: 6px; padding: 0.6rem 0.9rem; margin: 0 0 1rem;
     }
     form.decision { display: flex; gap: 0.5rem; align-items: center; margin: 0.4rem 0; flex-wrap: wrap; }
+    form.levers {
+      background: var(--panel); border: 1px solid var(--line); border-radius: 6px;
+      padding: 0.9rem; display: flex; flex-direction: column; gap: 0.7rem;
+    }
+    form.levers .lever-grid {
+      display: grid; grid-template-columns: repeat(auto-fill, minmax(16rem, 1fr)); gap: 0.7rem;
+    }
+    form.levers label { display: flex; flex-direction: column; gap: 0.2rem; color: var(--muted); font-size: 0.8rem; }
+    form.levers label.check { flex-direction: row; align-items: center; gap: 0.4rem; }
+    form.levers input[type="text"] { min-width: 0; }
+    form.levers button { align-self: flex-start; border-color: var(--accent); color: var(--accent); }
     input[type="text"] {
       background: var(--bg); border: 1px solid var(--line); color: var(--text);
       border-radius: 4px; padding: 0.35rem 0.55rem; min-width: 22rem;
@@ -74,6 +85,7 @@
       <a href="/">GPT-Trader operator console</a>
       <nav>
         <a href="/">Queue</a>
+        <a href="/envelope">Envelope</a>
         <a href="/accountant">Accountant</a>
         <a href="/activity">Activity</a>
       </nav>

--- a/src/gpt_trader/web/templates/envelope.html
+++ b/src/gpt_trader/web/templates/envelope.html
@@ -1,0 +1,154 @@
+{% extends "base.html" %}
+{% block title %}Envelope — GPT-Trader console{% endblock %}
+{% block content %}
+<h1>Envelope</h1>
+
+{% if autonomy_fail_closed %}
+<div class="banner">Autonomy state failed closed to {{ autonomy.mode.value }}: {{ autonomy.error }}</div>
+{% endif %}
+{% if error %}
+<div class="banner">{{ error }}</div>
+{% endif %}
+
+<div class="cards">
+  <div class="card">
+    <div class="label">Autonomy</div>
+    <div class="value">{{ autonomy.mode.value }}</div>
+    <div class="muted">v{{ autonomy.version if autonomy.version is not none else "—" }} · {{ autonomy.source }}</div>
+  </div>
+  <div class="card">
+    <div class="label">Risk budget</div>
+    <div class="value">v{{ budget.version }}</div>
+    <div class="muted">{{ budget_rows | length }} audited version{{ "s" if budget_rows | length != 1 }}</div>
+  </div>
+  <div class="card">
+    <div class="label">Stage 2 auto-approval</div>
+    <div class="value {{ 'ok' if stage2_active else 'muted' }}">{{ "active" if stage2_active else "inactive" }}</div>
+    <div class="muted">flag {{ "on" if auto_approval_enabled else "off" }} · mode {{ autonomy.mode.value }}</div>
+  </div>
+  <div class="card">
+    <div class="label">Exceptions pending</div>
+    <div class="value {{ 'warn' if exceptions else 'ok' }}">{{ exceptions | length }}</div>
+    <div class="muted">{{ inside_envelope | length }} inside envelope · {{ awaiting_resubmission | length }} awaiting resubmission</div>
+  </div>
+</div>
+
+<h2>Exception queue</h2>
+<p class="muted">
+  Ideas inside the envelope clear every approval-policy check and are what the
+  Stage 2 sweep auto-approves; exceptions are the ones that need your judgment.
+</p>
+{% if exceptions %}
+<table>
+  <tr><th>Idea</th><th>Instrument</th><th>Direction</th><th>Max loss</th><th>Expires in</th><th>Why it needs you</th></tr>
+  {% for row in exceptions %}
+  <tr>
+    <td><a href="/ideas/{{ row.idea.decision_id }}">{{ row.idea.decision_id }}</a></td>
+    <td>{{ row.idea.instrument }}</td>
+    <td>{{ row.idea.direction.value }}</td>
+    <td>
+      {% if row.idea.max_loss.percent_of_account is not none %}{{ row.idea.max_loss.percent_of_account }}%{% endif %}
+      {% if row.idea.max_loss.amount is not none %}<span class="muted">(${{ row.idea.max_loss.amount }})</span>{% endif %}
+    </td>
+    <td>{% if row.expires_in %}<span class="warn">{{ row.expires_in }}</span>{% else %}<span class="muted">&gt; warning window</span>{% endif %}</td>
+    <td><ul class="muted">{% for violation in row.violations %}<li>{{ violation }}</li>{% endfor %}</ul></td>
+  </tr>
+  {% endfor %}
+</table>
+{% elif inside_envelope or awaiting_resubmission %}
+<p class="ok">No exceptions — every reviewable idea is inside the envelope.</p>
+{% else %}
+<p class="muted">Nothing pending.</p>
+{% endif %}
+{% if inside_envelope %}
+<p class="muted">
+  Inside the envelope:
+  {% for row in inside_envelope %}<a href="/ideas/{{ row.idea.decision_id }}">{{ row.idea.decision_id }}</a>{{ ", " if not loop.last }}{% endfor %}
+</p>
+{% endif %}
+
+<h2>Budget levers</h2>
+<form class="levers" method="post" action="/envelope/budget">
+  <input type="hidden" name="base_version" value="{{ budget.version }}">
+  <div class="lever-grid">
+    <label>Max loss per idea (%)
+      <input type="text" name="max_loss_per_idea_pct" value="{{ form.max_loss_per_idea_pct }}">
+    </label>
+    <label>Max daily loss (%)
+      <input type="text" name="max_daily_loss_pct" value="{{ form.max_daily_loss_pct }}">
+    </label>
+    <label>Max open notional (%)
+      <input type="text" name="max_open_notional_pct" value="{{ form.max_open_notional_pct }}">
+    </label>
+    <label>Gain retention floor (%)
+      <input type="text" name="gain_retention_floor_pct" value="{{ form.gain_retention_floor_pct }}">
+    </label>
+    <label>Max concurrent approved tickets
+      <input type="text" name="max_concurrent_approved_tickets" value="{{ form.max_concurrent_approved_tickets }}">
+    </label>
+    <label>Max review latency (hours)
+      <input type="text" name="max_review_latency_hours" value="{{ form.max_review_latency_hours }}">
+    </label>
+    <label>Attested account equity ($, blank = unverified)
+      <input type="text" name="account_equity" value="{{ form.account_equity }}">
+    </label>
+    <label class="check"><input type="checkbox" name="sizing_capped_by_budget" {{ "checked" if form.sizing_capped_by_budget }}> Sizing capped by budget</label>
+    <label class="check"><input type="checkbox" name="allow_futures_leverage" {{ "checked" if form.allow_futures_leverage }}> Allow futures leverage</label>
+    <label class="check"><input type="checkbox" name="allow_naked_shorts" {{ "checked" if form.allow_naked_shorts }}> Allow naked shorts</label>
+  </div>
+  <label>Reason (required, audited)
+    <input type="text" name="reason" placeholder="Why this budget version">
+  </label>
+  <button type="submit">Enact budget v{{ budget.version + 1 }}</button>
+</form>
+
+<h2>Budget history</h2>
+{% if budget_rows %}
+<table>
+  <tr><th>Version</th><th>When</th><th>Actor</th><th>Changes</th><th>Reason</th></tr>
+  {% for row in budget_rows %}
+  <tr>
+    <td>v{{ row.entry.budget.version }}</td>
+    <td>{{ row.entry.timestamp | timestamp }}</td>
+    <td>{{ row.entry.actor_type.value }}:{{ row.entry.actor_id }}</td>
+    <td>
+      {% if row.changes %}
+      <ul>{% for change in row.changes %}<li>{{ change }}</li>{% endfor %}</ul>
+      {% elif loop.last %}<span class="muted">initial version</span>
+      {% else %}<span class="muted">no lever changes</span>{% endif %}
+    </td>
+    <td class="muted">{{ row.entry.budget.reason }}</td>
+  </tr>
+  {% endfor %}
+</table>
+{% else %}
+<p class="muted">No budget versions enacted yet — the seeded defaults apply.</p>
+{% endif %}
+
+<h2>Autonomy &amp; ratchet history</h2>
+{% if autonomy_error %}
+<div class="banner">Autonomy state log is unreadable: {{ autonomy_error }}</div>
+{% endif %}
+{% if autonomy_rows %}
+<table>
+  <tr><th>Version</th><th>When</th><th>Mode</th><th>Actor</th><th>Reason &amp; evidence</th></tr>
+  {% for entry in autonomy_rows %}
+  <tr>
+    <td>v{{ entry.version }}</td>
+    <td>{{ entry.timestamp | timestamp }}</td>
+    <td>
+      {{ entry.mode.value }}
+      {% if entry.actor_id == ratchet_actor_id %}<span class="pill bad">ratchet</span>{% endif %}
+    </td>
+    <td>{{ entry.actor_type.value }}:{{ entry.actor_id }}</td>
+    <td>
+      {{ entry.reason }}
+      {% if entry.evidence %}<ul class="muted">{% for item in entry.evidence %}<li>{{ item }}</li>{% endfor %}</ul>{% endif %}
+    </td>
+  </tr>
+  {% endfor %}
+</table>
+{% elif not autonomy_error %}
+<p class="muted">No autonomy-level changes recorded — the seeded default applies.</p>
+{% endif %}
+{% endblock %}

--- a/tests/unit/gpt_trader/web/test_console_envelope.py
+++ b/tests/unit/gpt_trader/web/test_console_envelope.py
@@ -1,0 +1,204 @@
+"""Envelope page: budget lever management, audited histories, exception framing."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from gpt_trader.features.trade_ideas.audit import ActorType
+from gpt_trader.features.trade_ideas.autonomy import RATCHET_ACTOR_ID
+from gpt_trader.features.trade_ideas.models import AutonomyMode, MaxLoss
+from gpt_trader.features.trade_ideas.service import TradeIdeaService
+from gpt_trader.web import create_app
+from tests.unit.gpt_trader.features.trade_ideas.conftest import (
+    attest_account_equity,
+    build_trade_idea,
+)
+
+_NOW = datetime(2026, 6, 12, 10, 0, tzinfo=UTC)
+
+
+@pytest.fixture
+def service(tmp_path: Path) -> TradeIdeaService:
+    return TradeIdeaService(tmp_path, now_factory=lambda: _NOW)
+
+
+@pytest.fixture
+def client(service: TradeIdeaService) -> TestClient:
+    return TestClient(create_app(service=service, actor_id="rj"))
+
+
+def _lever_form(service: TradeIdeaService, **overrides: str) -> dict[str, str]:
+    """Form payload mirroring the current budget, with per-test overrides."""
+    budget = service.peek_budget()
+    payload = {
+        "base_version": str(budget.version),
+        "reason": "Operator adjustment",
+        "max_loss_per_idea_pct": str(budget.max_loss_per_idea_pct),
+        "max_daily_loss_pct": str(budget.max_daily_loss_pct),
+        "max_open_notional_pct": str(budget.max_open_notional_pct),
+        "max_concurrent_approved_tickets": str(budget.max_concurrent_approved_tickets),
+        "max_review_latency_hours": str(budget.max_review_latency_hours),
+        "gain_retention_floor_pct": str(budget.gain_retention_floor_pct),
+        "account_equity": "" if budget.account_equity is None else str(budget.account_equity),
+    }
+    if budget.sizing_capped_by_budget:
+        payload["sizing_capped_by_budget"] = "on"
+    if budget.allow_futures_leverage:
+        payload["allow_futures_leverage"] = "on"
+    if budget.allow_naked_shorts:
+        payload["allow_naked_shorts"] = "on"
+    payload.update(overrides)
+    return payload
+
+
+def test_envelope_renders_current_budget_and_autonomy(
+    service: TradeIdeaService, client: TestClient
+) -> None:
+    attest_account_equity(service, equity=Decimal("20000"))
+
+    response = client.get("/envelope")
+
+    assert response.status_code == 200
+    assert "Budget levers" in response.text
+    assert 'value="2"' in response.text  # hidden base_version after attestation bump
+    assert "human_approved_execution" in response.text
+    assert "Operator-attested equity for tests" in response.text  # budget history reason
+
+
+def test_envelope_get_does_not_seed_logs(tmp_path: Path, client: TestClient) -> None:
+    client.get("/envelope")
+
+    assert not (tmp_path / "risk_budget.jsonl").exists()
+    assert not (tmp_path / "autonomy_state.jsonl").exists()
+
+
+def test_enacting_a_lever_change_appends_an_audited_budget_version(
+    service: TradeIdeaService, client: TestClient
+) -> None:
+    response = client.post(
+        "/envelope/budget",
+        data=_lever_form(service, max_daily_loss_pct="8", reason="Tighten daily loss"),
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    entries = service.budget_log.history()
+    assert entries[-1].budget.version == 2  # seed v1 + enacted v2
+    assert entries[-1].budget.max_daily_loss_pct == Decimal("8")
+    assert entries[-1].budget.reason == "Tighten daily loss"
+    assert entries[-1].actor_type is ActorType.HUMAN
+    assert entries[-1].actor_id == "rj"
+
+
+def test_enacted_change_shows_in_budget_history_diff(
+    service: TradeIdeaService, client: TestClient
+) -> None:
+    client.post(
+        "/envelope/budget",
+        data=_lever_form(service, max_daily_loss_pct="8", reason="Tighten daily loss"),
+        follow_redirects=False,
+    )
+
+    response = client.get("/envelope")
+
+    assert response.status_code == 200
+    assert "max_daily_loss_pct: 10 → 8" in response.text
+    assert "initial version" in response.text
+
+
+def test_budget_change_requires_a_reason(service: TradeIdeaService, client: TestClient) -> None:
+    response = client.post(
+        "/envelope/budget",
+        data=_lever_form(service, max_daily_loss_pct="8", reason="  "),
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 400
+    assert "reason is required" in response.text
+    assert service.budget_log.history() == []
+
+
+def test_stale_form_version_is_refused_with_a_conflict_message(
+    service: TradeIdeaService, client: TestClient
+) -> None:
+    stale = _lever_form(service, max_daily_loss_pct="8")
+    attest_account_equity(service, equity=Decimal("20000"))  # budget moves to v2
+
+    response = client.post("/envelope/budget", data=stale, follow_redirects=False)
+
+    assert response.status_code == 400
+    assert "moved to v2" in response.text
+    assert service.budget_log.history()[-1].budget.version == 2
+
+
+def test_non_numeric_lever_re_renders_with_a_field_named_error(
+    service: TradeIdeaService, client: TestClient
+) -> None:
+    response = client.post(
+        "/envelope/budget",
+        data=_lever_form(service, max_daily_loss_pct="lots"),
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 400
+    assert "max_daily_loss_pct must be a decimal number" in response.text
+    assert service.budget_log.history() == []
+
+
+def test_ratchet_entry_renders_with_its_breach_evidence(
+    service: TradeIdeaService, client: TestClient
+) -> None:
+    service.set_autonomy_mode(
+        AutonomyMode.BOUNDED_AUTONOMY,
+        actor_type=ActorType.HUMAN,
+        actor_id="rj",
+        reason="Stage 2 graduation",
+    )
+    # Lowering is open to any actor: this is the shape the daily-loss ratchet
+    # writes at a decision boundary.
+    service.set_autonomy_mode(
+        AutonomyMode.HUMAN_APPROVED_EXECUTION,
+        actor_type=ActorType.SYSTEM,
+        actor_id=RATCHET_ACTOR_ID,
+        reason="Automatic ratchet-down: daily loss breached",
+        evidence=("same_day_realized_loss_pct=12 exceeds max_daily_loss_pct=10",),
+    )
+
+    response = client.get("/envelope")
+
+    assert response.status_code == 200
+    assert "ratchet" in response.text
+    assert "same_day_realized_loss_pct=12 exceeds max_daily_loss_pct=10" in response.text
+    assert "Stage 2 graduation" in response.text
+
+
+def test_exception_framing_separates_violations_from_inside_envelope(
+    service: TradeIdeaService, client: TestClient
+) -> None:
+    attest_account_equity(service, equity=Decimal("20000"))
+    service.propose(
+        build_trade_idea(decision_id="trade-20260612-001"),
+        actor_id="idea-generator-v1",
+    )
+    oversized = build_trade_idea(
+        decision_id="trade-20260612-002",
+        max_loss=MaxLoss(
+            amount=Decimal("2000"),
+            percent_of_account=Decimal("10"),  # above max_loss_per_idea_pct=5
+            assumptions=("Fill at zone midpoint",),
+        ),
+    )
+    service.propose(oversized, actor_id="idea-generator-v1")
+
+    response = client.get("/envelope")
+
+    assert response.status_code == 200
+    assert "trade-20260612-002" in response.text
+    assert "max_loss_per_idea_pct" in response.text  # violation text on the exception
+    assert "Inside the envelope:" in response.text
+    assert "trade-20260612-001" in response.text

--- a/tests/unit/gpt_trader/web/test_console_envelope.py
+++ b/tests/unit/gpt_trader/web/test_console_envelope.py
@@ -148,6 +148,22 @@ def test_stale_form_version_is_refused_and_re_renders_current_levers(
     assert service.budget_log.history()[-1].budget.version == 2
 
 
+def test_stale_form_with_another_validation_error_still_conflicts_first(
+    service: TradeIdeaService, client: TestClient
+) -> None:
+    # A stale submission must hit the conflict path before any other check:
+    # a reason (or parse) error would echo the stale levers back under the
+    # fresh hidden base_version, arming the very revert the guard prevents.
+    stale = _lever_form(service, max_daily_loss_pct="8", reason="  ")
+    attest_account_equity(service, equity=Decimal("20000"))  # budget moves to v2
+
+    response = client.post("/envelope/budget", data=stale, follow_redirects=False)
+
+    assert response.status_code == 409
+    assert 'name="max_daily_loss_pct" value="10"' in response.text
+    assert service.budget_log.history()[-1].budget.version == 2
+
+
 def test_non_numeric_lever_re_renders_with_a_field_named_error(
     service: TradeIdeaService, client: TestClient
 ) -> None:

--- a/tests/unit/gpt_trader/web/test_console_envelope.py
+++ b/tests/unit/gpt_trader/web/test_console_envelope.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 from datetime import UTC, datetime
 from decimal import Decimal
 from pathlib import Path
@@ -176,6 +177,36 @@ def test_non_numeric_lever_re_renders_with_a_field_named_error(
     assert response.status_code == 400
     assert "max_daily_loss_pct must be a decimal number" in response.text
     assert service.budget_log.history() == []
+
+
+def test_concurrent_submissions_from_the_same_version_have_one_winner(
+    service: TradeIdeaService, client: TestClient
+) -> None:
+    # Four forms rendered from the same budget version and submitted together:
+    # the route lock serializes check+append, so for every interleaving
+    # exactly one submission enacts v2 and the rest get the conflict page —
+    # never multiple accepted appends of "the same" next version.
+    forms = [
+        _lever_form(service, max_daily_loss_pct=str(value), reason=f"Operator {value}")
+        for value in (6, 7, 8, 9)
+    ]
+    statuses: list[int] = []
+    statuses_lock = threading.Lock()
+
+    def submit(form: dict[str, str]) -> None:
+        response = client.post("/envelope/budget", data=form, follow_redirects=False)
+        with statuses_lock:
+            statuses.append(response.status_code)
+
+    threads = [threading.Thread(target=submit, args=(form,)) for form in forms]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert sorted(statuses) == [303, 409, 409, 409]
+    entries = service.budget_log.history()
+    assert [entry.budget.version for entry in entries] == [1, 2]
 
 
 def test_ratchet_entry_renders_with_its_breach_evidence(

--- a/tests/unit/gpt_trader/web/test_console_envelope.py
+++ b/tests/unit/gpt_trader/web/test_console_envelope.py
@@ -70,8 +70,16 @@ def test_envelope_renders_current_budget_and_autonomy(
     assert "Operator-attested equity for tests" in response.text  # budget history reason
 
 
-def test_envelope_get_does_not_seed_logs(tmp_path: Path, client: TestClient) -> None:
+def test_envelope_get_does_not_seed_logs(
+    tmp_path: Path, service: TradeIdeaService, client: TestClient
+) -> None:
+    # A pending idea exercises the per-row violation check, which historically
+    # went through the seeding current_budget()/current_autonomy() reads; the
+    # console must use the peek variant so a GET never creates durable state.
+    service.propose(build_trade_idea(), actor_id="idea-generator-v1")
+
     client.get("/envelope")
+    client.get("/")
 
     assert not (tmp_path / "risk_budget.jsonl").exists()
     assert not (tmp_path / "autonomy_state.jsonl").exists()
@@ -123,7 +131,7 @@ def test_budget_change_requires_a_reason(service: TradeIdeaService, client: Test
     assert service.budget_log.history() == []
 
 
-def test_stale_form_version_is_refused_with_a_conflict_message(
+def test_stale_form_version_is_refused_and_re_renders_current_levers(
     service: TradeIdeaService, client: TestClient
 ) -> None:
     stale = _lever_form(service, max_daily_loss_pct="8")
@@ -131,8 +139,12 @@ def test_stale_form_version_is_refused_with_a_conflict_message(
 
     response = client.post("/envelope/budget", data=stale, follow_redirects=False)
 
-    assert response.status_code == 400
+    assert response.status_code == 409
     assert "moved to v2" in response.text
+    # The conflict page must show the current levers, not echo the stale
+    # submission: resubmitting stale values would silently revert v2.
+    assert 'name="max_daily_loss_pct" value="10"' in response.text
+    assert 'name="base_version" value="2"' in response.text
     assert service.budget_log.history()[-1].budget.version == 2
 
 

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -9,8 +9,8 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6030,
-    "total_files": 715,
+    "total_tests": 6039,
+    "total_files": 716,
     "markers_used": 14
   },
   "quick_commands": {

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -9,7 +9,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6039,
+    "total_tests": 6040,
     "total_files": 716,
     "markers_used": 14
   },

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -9,7 +9,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6040,
+    "total_tests": 6041,
     "total_files": 716,
     "markers_used": 14
   },

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -92,7 +92,7 @@
     ]
   },
   "counts": {
-    "unit": 5866,
+    "unit": 5875,
     "asyncio": 310,
     "parametrize": 180,
     "integration": 87,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -92,7 +92,7 @@
     ]
   },
   "counts": {
-    "unit": 5876,
+    "unit": 5877,
     "asyncio": 310,
     "parametrize": 180,
     "integration": 87,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -92,7 +92,7 @@
     ]
   },
   "counts": {
-    "unit": 5875,
+    "unit": 5876,
     "asyncio": 310,
     "parametrize": 180,
     "integration": 87,


### PR DESCRIPTION
Phase 3 of #1152: the envelope console — the durable operator core once Stage 2 turns the review queue into an exception path.

## What's here

**`/envelope`** (new page, linked in the console nav):

- **Budget lever management.** A form over the audited `TradeIdeaService.update_budget` call: every submission requires a reason, is stamped `human:<actor>`, and appends the next version to `risk_budget.jsonl`. A hidden `base_version` gives optimistic concurrency — a form rendered against a version that is no longer current re-renders with a conflict message instead of enacting on stale levers (the append-side sequencing check in `RiskBudgetLog` remains the authority for races past the pre-check).
- **Budget version history.** Every audited version, newest first, with a per-version diff of exactly which levers moved (`max_daily_loss_pct: 10 → 8`), the actor, and the reason.
- **Autonomy & ratchet history.** The full `autonomy_state.jsonl` history with breach evidence; automatic ratchet-down entries (actor `autonomy-ratchet`) are flagged. An integrity-broken log renders as a banner rather than a 500, and a fail-closed resolution banners at the top of the page.
- **Exception-queue framing.** Pending ideas split into *inside the envelope* (violation-free proposed ideas — what the Stage 2 sweep would auto-approve), *exceptions* (proposed with approval-policy violations — the ones that need human judgment, listed with their reasons), and *awaiting resubmission* (needs-changes). Cards show the Stage 2 gate status (feature flag × audited autonomy mode).

## Constraints held

- Thin adapter: every read renders durable artifacts (`risk_budget.jsonl`, `autonomy_state.jsonl`, records/audit via the service); the only mutation is the existing audited `update_budget` call. No new state stores.
- GETs stay non-mutating: rendering `/envelope` on a fresh root seeds neither the budget nor the autonomy log (covered by test).
- Imports stay inside the `web_console_frozen_dependencies` boundary (trade_ideas/core/errors only).
- Malformed form input (non-numeric levers, missing reason) re-renders with a field-named error at 400; `RiskBudget` invariant violations and `PolicyViolationError` surface the same way.

## Testing

- 9 new unit tests in `tests/unit/gpt_trader/web/test_console_envelope.py` (render, no-seed-on-GET, audited enactment, required reason, stale-version conflict, invalid input, ratchet evidence rendering, exception framing).
- Full unit suite: 6563 passed. `make ci-required` green locally.

Part of #1152.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Envelope” console page showing autonomy/budget status, budget/ratchet history, and an exception queue with an inside-envelope view.
  * Added a budget-enact workflow to submit audited lever changes with optimistic concurrency and a required, audited reason.

* **Bug Fixes**
  * Improved the exception queue to use non-mutating violation preview logic.
  * Added clearer validation and conflict handling (400 for invalid inputs; 409 when the submission is stale, re-rendering current values).

* **Tests**
  * Expanded unit coverage for lever diffs, history rendering, reason/lever validation, ratchet/evidence UI, and concurrent enactment behavior.

* **Style**
  * Refreshed Envelope page styling and added the Envelope navigation link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->