### PR TITLE
fix(trade-ideas): lock budget-log appends and fail closed on broken history

### DIFF
--- a/src/gpt_trader/features/trade_ideas/autonomy.py
+++ b/src/gpt_trader/features/trade_ideas/autonomy.py
@@ -111,7 +111,7 @@ class AutonomyResolution:
 class AutonomyStateLog:
     """Append-only JSONL log of autonomy-level versions; the last entry is current.
 
-    Unlike the budget log, reads validate version sequencing so a tampered or
+    Like the budget log, reads validate version sequencing so a tampered or
     truncated log is detected at resolution time and can fail closed.
     """
 

--- a/src/gpt_trader/features/trade_ideas/budget.py
+++ b/src/gpt_trader/features/trade_ideas/budget.py
@@ -274,7 +274,7 @@ class RiskBudgetLog:
                             value=entry.budget.version,
                         )
                     entries.append(entry)
-        except OSError as error:
+        except (OSError, UnicodeDecodeError) as error:
             raise BudgetIntegrityError(
                 f"Budget log is unreadable: {error}",
                 field="path",

--- a/src/gpt_trader/features/trade_ideas/budget.py
+++ b/src/gpt_trader/features/trade_ideas/budget.py
@@ -17,9 +17,11 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from datetime import datetime
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Any
+
+from filelock import FileLock, Timeout
 
 from gpt_trader.errors import ValidationError
 from gpt_trader.features.trade_ideas.audit import ActorType
@@ -41,7 +43,7 @@ def _require_non_negative_int(value: int, field: str) -> None:
 
 
 class BudgetIntegrityError(ValidationError):
-    """Raised when a budget append would break version sequencing."""
+    """Raised when the budget log is malformed, contended, or an append breaks sequencing."""
 
 
 def _require_boolean(value: Any, field: str) -> bool:
@@ -184,38 +186,94 @@ class BudgetLogEntry:
 
 
 class RiskBudgetLog:
-    """Append-only JSONL log of budget versions; the last entry is current."""
+    """Append-only JSONL log of budget versions; the last entry is current.
+
+    Appends hold an OS-level file lock while re-reading the current version,
+    so two processes (e.g. the CLI and the web console) cannot both append
+    the same next version; the loser gets a ``BudgetIntegrityError`` and must
+    re-read the budget it is renegotiating against.
+
+    Reads validate version sequencing and fail closed by raising
+    ``BudgetIntegrityError``: the budget powers approval decisions, and the
+    seeded defaults may be wider (and lack the operator-attested equity) than
+    the operator's current version, so a tampered or duplicated log must stop
+    budget resolution rather than fall back.
+    """
+
+    _LOCK_TIMEOUT_SECONDS = 10.0
 
     def __init__(self, path: Path) -> None:
         self._path = path
+        self._lock = FileLock(str(path) + ".lock")
 
     @property
     def path(self) -> Path:
         return self._path
 
     def append(self, entry: BudgetLogEntry) -> None:
-        current = self.current()
-        expected_version = 1 if current is None else current.version + 1
-        if entry.budget.version != expected_version:
-            raise BudgetIntegrityError(
-                f"Budget version must be {expected_version}, got {entry.budget.version}",
-                field="version",
-                value=entry.budget.version,
-            )
         self._path.parent.mkdir(parents=True, exist_ok=True)
-        line = json.dumps(entry.to_dict(), sort_keys=True, separators=(",", ":"))
-        with self._path.open("a", encoding="utf-8") as handle:
-            handle.write(line + "\n")
+        try:
+            self._lock.acquire(timeout=self._LOCK_TIMEOUT_SECONDS)
+        except Timeout as error:
+            raise BudgetIntegrityError(
+                f"Timed out waiting for the budget log lock: {self._lock.lock_file}",
+                field="path",
+                value=str(self._path),
+            ) from error
+        try:
+            current = self.current()
+            expected_version = 1 if current is None else current.version + 1
+            if entry.budget.version != expected_version:
+                raise BudgetIntegrityError(
+                    f"Budget version must be {expected_version}, got {entry.budget.version}",
+                    field="version",
+                    value=entry.budget.version,
+                )
+            line = json.dumps(entry.to_dict(), sort_keys=True, separators=(",", ":"))
+            with self._path.open("a", encoding="utf-8") as handle:
+                handle.write(line + "\n")
+        finally:
+            self._lock.release()
 
     def history(self) -> list[BudgetLogEntry]:
         if not self._path.exists():
             return []
         entries: list[BudgetLogEntry] = []
-        with self._path.open("r", encoding="utf-8") as handle:
-            for line in handle:
-                line = line.strip()
-                if line:
-                    entries.append(BudgetLogEntry.from_dict(json.loads(line)))
+        try:
+            with self._path.open("r", encoding="utf-8") as handle:
+                for line_number, raw_line in enumerate(handle, start=1):
+                    line = raw_line.strip()
+                    if not line:
+                        continue
+                    try:
+                        entry = BudgetLogEntry.from_dict(json.loads(line))
+                    except (
+                        KeyError,
+                        TypeError,
+                        ValueError,
+                        InvalidOperation,
+                        json.JSONDecodeError,
+                    ) as error:
+                        raise BudgetIntegrityError(
+                            f"Budget log line {line_number} is malformed: {error}",
+                            field="line",
+                            value=line_number,
+                        ) from error
+                    expected_version = len(entries) + 1
+                    if entry.budget.version != expected_version:
+                        raise BudgetIntegrityError(
+                            f"Budget log line {line_number} has version "
+                            f"{entry.budget.version}; expected {expected_version}",
+                            field="version",
+                            value=entry.budget.version,
+                        )
+                    entries.append(entry)
+        except OSError as error:
+            raise BudgetIntegrityError(
+                f"Budget log is unreadable: {error}",
+                field="path",
+                value=str(self._path),
+            ) from error
         return entries
 
     def current(self) -> RiskBudget | None:

--- a/src/gpt_trader/features/trade_ideas/budget.py
+++ b/src/gpt_trader/features/trade_ideas/budget.py
@@ -220,6 +220,12 @@ class RiskBudgetLog:
                 field="path",
                 value=str(self._path),
             ) from error
+        except OSError as error:
+            raise BudgetIntegrityError(
+                f"Budget log lock is unusable: {error}",
+                field="path",
+                value=str(self._path),
+            ) from error
         try:
             current = self.current()
             expected_version = 1 if current is None else current.version + 1

--- a/src/gpt_trader/features/trade_ideas/service.py
+++ b/src/gpt_trader/features/trade_ideas/service.py
@@ -52,6 +52,7 @@ from gpt_trader.features.trade_ideas.broker_payloads import (
 )
 from gpt_trader.features.trade_ideas.budget import (
     DEFAULT_RISK_BUDGET,
+    BudgetIntegrityError,
     BudgetLogEntry,
     RiskBudget,
     RiskBudgetLog,
@@ -312,14 +313,22 @@ class TradeIdeaService:
         budget = self._budget_log.current()
         if budget is not None:
             return budget
-        self._budget_log.append(
-            BudgetLogEntry(
-                timestamp=self._now(),
-                actor_type=ActorType.SYSTEM,
-                actor_id="seed-defaults",
-                budget=DEFAULT_RISK_BUDGET,
+        try:
+            self._budget_log.append(
+                BudgetLogEntry(
+                    timestamp=self._now(),
+                    actor_type=ActorType.SYSTEM,
+                    actor_id="seed-defaults",
+                    budget=DEFAULT_RISK_BUDGET,
+                )
             )
-        )
+        except BudgetIntegrityError:
+            # Another process won the seed race under the log lock; adopt
+            # whatever it appended instead of failing this read path.
+            budget = self._budget_log.current()
+            if budget is None:
+                raise
+            return budget
         return DEFAULT_RISK_BUDGET
 
     # -- autonomy ----------------------------------------------------------

--- a/src/gpt_trader/preflight/checks/trade_ideas.py
+++ b/src/gpt_trader/preflight/checks/trade_ideas.py
@@ -146,6 +146,12 @@ def check_trade_ideas_readiness(checker: PreflightCheck) -> bool:
     for append_error in (
         _existing_log_append_error(audit_path, label="audit log"),
         _existing_log_append_error(budget_path, label="risk budget log"),
+        # Every budget append acquires this sidecar lock, so an unusable
+        # lock path fails seeding/renegotiation even when the log is fine.
+        _existing_log_append_error(
+            budget_path.with_name(budget_path.name + ".lock"),
+            label="risk budget lock",
+        ),
     ):
         if append_error is not None:
             checker.log_error(append_error, details=details)

--- a/src/gpt_trader/preflight/checks/trade_ideas.py
+++ b/src/gpt_trader/preflight/checks/trade_ideas.py
@@ -57,19 +57,11 @@ def _latest_state_counts(events: list[AuditEvent]) -> Counter[TradeIdeaState]:
 
 
 def _validate_budget_history(budget_log: RiskBudgetLog) -> tuple[int, int] | None:
+    # history() raises BudgetIntegrityError on malformed lines or
+    # non-contiguous versions, so reading it is the validation.
     entries = budget_log.history()
     if not entries:
         return None
-    for expected_version, entry in enumerate(entries, start=1):
-        if entry.budget.version != expected_version:
-            raise ValidationError(
-                (
-                    "Risk budget versions must be contiguous; "
-                    f"expected {expected_version}, got {entry.budget.version}"
-                ),
-                field="version",
-                value=entry.budget.version,
-            )
     return len(entries), entries[-1].budget.version
 
 

--- a/tests/unit/gpt_trader/app/test_risk_budget_seed.py
+++ b/tests/unit/gpt_trader/app/test_risk_budget_seed.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from dataclasses import replace
 from datetime import UTC, datetime
 from decimal import Decimal
@@ -19,6 +18,7 @@ from gpt_trader.app.risk_budget_seed import (
 from gpt_trader.features.trade_ideas.audit import ActorType
 from gpt_trader.features.trade_ideas.budget import (
     DEFAULT_RISK_BUDGET,
+    BudgetIntegrityError,
     BudgetLogEntry,
     RiskBudgetLog,
 )
@@ -74,7 +74,7 @@ class TestResolveRiskBudgetRuntimeSeed:
     def test_corrupt_log_fails_closed(self, tmp_path: Path) -> None:
         (tmp_path / "risk_budget.jsonl").write_text("not json\n", encoding="utf-8")
 
-        with pytest.raises(json.JSONDecodeError):
+        with pytest.raises(BudgetIntegrityError, match="line 1 is malformed"):
             resolve_risk_budget_runtime_seed(tmp_path)
 
     def test_env_root_resolution(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/gpt_trader/features/trade_ideas/test_budget.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_budget.py
@@ -156,6 +156,17 @@ def test_append_times_out_when_lock_is_held(
     assert budget_log.current() is None
 
 
+def test_unusable_lock_file_raises_integrity_error(budget_log: RiskBudgetLog) -> None:
+    lock_path = Path(str(budget_log.path) + ".lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path.mkdir()
+
+    with pytest.raises(BudgetIntegrityError, match="lock is unusable"):
+        budget_log.append(build_entry(DEFAULT_RISK_BUDGET))
+
+    assert budget_log.current() is None
+
+
 def test_append_succeeds_after_lock_is_released(budget_log: RiskBudgetLog) -> None:
     budget_log.path.parent.mkdir(parents=True, exist_ok=True)
     foreign_lock = FileLock(str(budget_log.path) + ".lock")

--- a/tests/unit/gpt_trader/features/trade_ideas/test_budget.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_budget.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
 from decimal import Decimal
 from pathlib import Path
 
 import pytest
+from filelock import FileLock
 
 from gpt_trader.features.trade_ideas import (
     DEFAULT_RISK_BUDGET,
@@ -94,6 +96,75 @@ def test_versions_must_be_contiguous(budget_log: RiskBudgetLog) -> None:
 
     with pytest.raises(BudgetIntegrityError):
         budget_log.append(build_entry(skipped, minute=1))
+
+
+def test_malformed_line_raises_integrity_error(budget_log: RiskBudgetLog) -> None:
+    budget_log.append(build_entry(DEFAULT_RISK_BUDGET))
+    with budget_log.path.open("a", encoding="utf-8") as handle:
+        handle.write("not json\n")
+
+    with pytest.raises(BudgetIntegrityError, match="line 2 is malformed"):
+        budget_log.history()
+
+
+def test_malformed_decimal_raises_integrity_error(budget_log: RiskBudgetLog) -> None:
+    budget_log.append(build_entry(DEFAULT_RISK_BUDGET))
+    corrupted = budget_log.path.read_text(encoding="utf-8").replace(
+        '"max_loss_per_idea_pct":"5"',
+        '"max_loss_per_idea_pct":"bad"',
+    )
+    budget_log.path.write_text(corrupted, encoding="utf-8")
+
+    with pytest.raises(BudgetIntegrityError, match="line 1 is malformed"):
+        budget_log.history()
+
+
+def test_version_gap_in_file_raises_integrity_error(budget_log: RiskBudgetLog) -> None:
+    budget_log.append(build_entry(DEFAULT_RISK_BUDGET))
+    skipped = RiskBudget.from_dict({**DEFAULT_RISK_BUDGET.to_dict(), "version": 5})
+    with budget_log.path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(build_entry(skipped, minute=1).to_dict()) + "\n")
+
+    with pytest.raises(BudgetIntegrityError, match="version 5; expected 2"):
+        budget_log.history()
+
+
+def test_duplicated_version_in_file_raises_integrity_error(budget_log: RiskBudgetLog) -> None:
+    # The artifact an unlocked concurrent append would have left behind:
+    # two entries both claiming the same next version.
+    budget_log.append(build_entry(DEFAULT_RISK_BUDGET))
+    line = budget_log.path.read_text(encoding="utf-8")
+    budget_log.path.write_text(line + line, encoding="utf-8")
+
+    with pytest.raises(BudgetIntegrityError, match="version 1; expected 2"):
+        budget_log.history()
+
+    with pytest.raises(BudgetIntegrityError):
+        budget_log.current()
+
+
+def test_append_times_out_when_lock_is_held(
+    budget_log: RiskBudgetLog, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(RiskBudgetLog, "_LOCK_TIMEOUT_SECONDS", 0.05)
+    budget_log.path.parent.mkdir(parents=True, exist_ok=True)
+    foreign_lock = FileLock(str(budget_log.path) + ".lock")
+    with foreign_lock.acquire(timeout=1):
+        with pytest.raises(BudgetIntegrityError, match="budget log lock"):
+            budget_log.append(build_entry(DEFAULT_RISK_BUDGET))
+
+    assert budget_log.current() is None
+
+
+def test_append_succeeds_after_lock_is_released(budget_log: RiskBudgetLog) -> None:
+    budget_log.path.parent.mkdir(parents=True, exist_ok=True)
+    foreign_lock = FileLock(str(budget_log.path) + ".lock")
+    with foreign_lock.acquire(timeout=1):
+        pass
+
+    budget_log.append(build_entry(DEFAULT_RISK_BUDGET))
+
+    assert budget_log.current() == DEFAULT_RISK_BUDGET
 
 
 def test_renegotiated_budget_becomes_current(budget_log: RiskBudgetLog) -> None:

--- a/tests/unit/gpt_trader/features/trade_ideas/test_budget.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_budget.py
@@ -119,6 +119,14 @@ def test_malformed_decimal_raises_integrity_error(budget_log: RiskBudgetLog) -> 
         budget_log.history()
 
 
+def test_invalid_utf8_raises_integrity_error(budget_log: RiskBudgetLog) -> None:
+    budget_log.path.parent.mkdir(parents=True, exist_ok=True)
+    budget_log.path.write_bytes(b"\xff\xfe\x00")
+
+    with pytest.raises(BudgetIntegrityError, match="unreadable"):
+        budget_log.history()
+
+
 def test_version_gap_in_file_raises_integrity_error(budget_log: RiskBudgetLog) -> None:
     budget_log.append(build_entry(DEFAULT_RISK_BUDGET))
     skipped = RiskBudget.from_dict({**DEFAULT_RISK_BUDGET.to_dict(), "version": 5})

--- a/tests/unit/gpt_trader/features/trade_ideas/test_service_budget_versions.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_service_budget_versions.py
@@ -10,8 +10,11 @@ from gpt_trader.features.trade_ideas import (
     DEFAULT_RISK_BUDGET,
     ActorType,
     AutonomyMode,
+    BudgetIntegrityError,
+    BudgetLogEntry,
     PolicyViolationError,
     RiskBudget,
+    RiskBudgetLog,
 )
 from gpt_trader.features.trade_ideas.service import TradeIdeaService
 
@@ -26,6 +29,49 @@ def service(tmp_path: Path) -> TradeIdeaService:
 
 def test_budget_seeds_defaults_on_first_use(service: TradeIdeaService) -> None:
     assert service.current_budget() == DEFAULT_RISK_BUDGET
+
+
+def test_current_budget_adopts_concurrent_seed(
+    service: TradeIdeaService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    real_append = RiskBudgetLog.append
+
+    def racing_append(self: RiskBudgetLog, entry: BudgetLogEntry) -> None:
+        # A concurrent process seeds first, so this append loses the version
+        # race under the log lock instead of duplicating version 1.
+        winner = RiskBudgetLog(self.path)
+        real_append(
+            winner,
+            BudgetLogEntry(
+                timestamp=datetime(2026, 6, 12, 10, 0, tzinfo=UTC),
+                actor_type=ActorType.SYSTEM,
+                actor_id="other-process",
+                budget=DEFAULT_RISK_BUDGET,
+            ),
+        )
+        real_append(self, entry)
+
+    monkeypatch.setattr(RiskBudgetLog, "append", racing_append)
+
+    assert service.current_budget() == DEFAULT_RISK_BUDGET
+
+    history = service.budget_log.history()
+    assert [entry.budget.version for entry in history] == [1]
+    assert history[0].actor_id == "other-process"
+
+
+def test_budget_resolution_fails_closed_on_corrupt_log(service: TradeIdeaService) -> None:
+    # A duplicated version (the unlocked-race artifact) must stop budget
+    # resolution rather than fall back to the seeded defaults.
+    service.current_budget()
+    path = service.budget_log.path
+    line = path.read_text(encoding="utf-8")
+    path.write_text(line + line, encoding="utf-8")
+
+    with pytest.raises(BudgetIntegrityError):
+        service.peek_budget()
+    with pytest.raises(BudgetIntegrityError):
+        service.current_budget()
 
 
 def test_human_can_renegotiate_budget(service: TradeIdeaService) -> None:

--- a/tests/unit/gpt_trader/preflight/test_checks_trade_ideas.py
+++ b/tests/unit/gpt_trader/preflight/test_checks_trade_ideas.py
@@ -257,6 +257,24 @@ def test_trade_ideas_readiness_fails_when_latest_record_id_mismatches(
     assert result["details"]["ideas_root"] == str(ideas_root)
 
 
+def test_trade_ideas_readiness_fails_when_budget_lock_is_unusable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ideas_root = tmp_path / "trade_ideas"
+    _seed_budget(ideas_root)
+    lock_path = ideas_root / "risk_budget.jsonl.lock"
+    if lock_path.exists():
+        lock_path.unlink()
+    lock_path.mkdir()
+    monkeypatch.setenv("GPT_TRADER_IDEAS_ROOT", str(ideas_root))
+
+    checker = PreflightCheck(profile="dev")
+
+    assert check_trade_ideas_readiness(checker) is False
+    result = _failed_result(checker, "risk budget lock is not a file")
+    assert result["details"]["ideas_root"] == str(ideas_root)
+
+
 def test_trade_ideas_readiness_fails_when_budget_is_missing(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/var/agents/configuration/environment_variables.json
+++ b/var/agents/configuration/environment_variables.json
@@ -777,7 +777,7 @@
       ],
       "code_references": [
         {
-          "line": 255,
+          "line": 256,
           "path": "src/gpt_trader/features/trade_ideas/service.py",
           "reader": "os.environ.get"
         }
@@ -1189,7 +1189,7 @@
       ],
       "code_references": [
         {
-          "line": 268,
+          "line": 269,
           "path": "src/gpt_trader/features/trade_ideas/service.py",
           "reader": "os.environ.get"
         }
@@ -1221,7 +1221,7 @@
       ],
       "code_references": [
         {
-          "line": 245,
+          "line": 246,
           "path": "src/gpt_trader/features/trade_ideas/service.py",
           "reader": "os.environ.get"
         }

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -9,7 +9,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6049,
+    "total_tests": 6050,
     "total_files": 716,
     "markers_used": 14
   },

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -9,7 +9,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6050,
+    "total_tests": 6051,
     "total_files": 716,
     "markers_used": 14
   },

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -9,7 +9,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6041,
+    "total_tests": 6049,
     "total_files": 716,
     "markers_used": 14
   },

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -9,7 +9,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6051,
+    "total_tests": 6052,
     "total_files": 716,
     "markers_used": 14
   },

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -92,7 +92,7 @@
     ]
   },
   "counts": {
-    "unit": 5885,
+    "unit": 5886,
     "asyncio": 310,
     "parametrize": 180,
     "integration": 87,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -92,7 +92,7 @@
     ]
   },
   "counts": {
-    "unit": 5877,
+    "unit": 5885,
     "asyncio": 310,
     "parametrize": 180,
     "integration": 87,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -92,7 +92,7 @@
     ]
   },
   "counts": {
-    "unit": 5887,
+    "unit": 5888,
     "asyncio": 310,
     "parametrize": 180,
     "integration": 87,

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -92,7 +92,7 @@
     ]
   },
   "counts": {
-    "unit": 5886,
+    "unit": 5887,
     "asyncio": 310,
     "parametrize": 180,
     "integration": 87,


### PR DESCRIPTION
## Summary

Hardens `RiskBudgetLog` against the two gaps it had versus its sibling `AutonomyStateLog` (raised in the PR #1185 review discussion: the CLI `ideas budget set` can race the web console's budget POST, which only holds an in-process lock).

- **Locked appends.** `append()` did an unlocked read-then-append, so two processes could both append the same next version. It now holds an OS-level `FileLock` (`risk_budget.jsonl.lock`, same `filelock` dependency the paper cycle already uses) around the version check + write. The losing writer gets a clean `BudgetIntegrityError` and must re-read the budget it is renegotiating against; a lock timeout (10s) also surfaces as `BudgetIntegrityError`.
- **Validated reads.** `history()` now raises `BudgetIntegrityError` on malformed lines, non-contiguous (including duplicated) versions, and unreadable files, mirroring `AutonomyStateLog.history()`.

## Fail-closed decision

The autonomy log fails closed to `research_only`; the budget log has no safe analog because the seeded `DEFAULT_RISK_BUDGET` may be *wider* than the operator's current version and lacks the operator-attested `account_equity`. So budget resolution fails closed by **propagating** the integrity error: `peek_budget()` / `current_budget()` / gate paths refuse to resolve a budget from a broken log rather than silently falling back to defaults. The CLI already maps `BudgetIntegrityError` to `OPERATION_FAILED`, preflight reports "risk budget unreadable", and the Stage-2 cycle records a failed manifest row.

One behavioral consequence handled: `TradeIdeaService.current_budget()` seeding on first use can now lose the seed race cleanly (previously it would have silently duplicated version 1); it adopts the concurrent winner's entry instead of erroring.

Also folds in two small consistency fixes: preflight's `_validate_budget_history` contiguity loop was made redundant by the read-side validation, and the "unlike the budget log" note in `autonomy.py` is now stale.

## Testing

- New unit tests: malformed line / malformed decimal / version gap / duplicated version (the unlocked-race artifact) all raise `BudgetIntegrityError`; append times out with a foreign lock held and succeeds after release; service adopts a concurrent seed; service budget resolution fails closed on a corrupt log.
- `uv run pytest tests/unit -n auto -q` — 6572 passed.
- `uv run ruff check . --fix`, `uv run black .`, `uv run mypy src/gpt_trader`, `uv run agent-naming`, `uv run agent-regenerate` — all clean (regenerated var/agents artifacts are line-number shifts only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Strengthened trade-idea risk budget log integrity checks for malformed, unreadable, corrupt numeric fields, truncated/tampered, and non-sequential/duplicate entries.
  - Improved concurrency-safe risk budget seeding so only the winning version is adopted after contention.
  - Hardened lock contention and unusable lock-file handling to fail safely instead of masking corruption.
  - Updated preflight “readiness” to validate both the budget log and its sidecar lock.
- **Tests**
  - Expanded unit coverage for corrupted logs, version gaps/duplicates, concurrency/race scenarios, and lock edge cases.
- **Chores**
  - Updated environment-variable and test metadata counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->