### PR TITLE
fix(trade-ideas): lock autonomy-log appends and adopt concurrent seeds

### DIFF
--- a/src/gpt_trader/features/trade_ideas/autonomy.py
+++ b/src/gpt_trader/features/trade_ideas/autonomy.py
@@ -24,6 +24,8 @@ from decimal import Decimal
 from pathlib import Path
 from typing import Any
 
+from filelock import FileLock, Timeout
+
 from gpt_trader.core.risk_units import trading_day
 from gpt_trader.errors import ValidationError
 from gpt_trader.features.trade_ideas.audit import ActorType
@@ -45,7 +47,7 @@ AUTONOMY_SOURCE_FAIL_CLOSED = "fail_closed"
 
 
 class AutonomyIntegrityError(ValidationError):
-    """Raised when the autonomy log is malformed or an append breaks sequencing."""
+    """Raised when the autonomy log is malformed, contended, or an append breaks sequencing."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -111,30 +113,54 @@ class AutonomyResolution:
 class AutonomyStateLog:
     """Append-only JSONL log of autonomy-level versions; the last entry is current.
 
-    Like the budget log, reads validate version sequencing so a tampered or
-    truncated log is detected at resolution time and can fail closed.
+    Like the budget log, appends hold an OS-level file lock while re-reading
+    the current version, so two processes (e.g. the CLI and the web console)
+    cannot both append the same next version; the loser gets an
+    ``AutonomyIntegrityError`` and must re-read the state it is acting on.
+    Reads validate version sequencing so a tampered or truncated log is
+    detected at resolution time and can fail closed.
     """
+
+    _LOCK_TIMEOUT_SECONDS = 10.0
 
     def __init__(self, path: Path) -> None:
         self._path = path
+        self._lock = FileLock(str(path) + ".lock")
 
     @property
     def path(self) -> Path:
         return self._path
 
     def append(self, entry: AutonomyStateEntry) -> None:
-        current = self.current()
-        expected_version = 1 if current is None else current.version + 1
-        if entry.version != expected_version:
-            raise AutonomyIntegrityError(
-                f"Autonomy state version must be {expected_version}, got {entry.version}",
-                field="version",
-                value=entry.version,
-            )
         self._path.parent.mkdir(parents=True, exist_ok=True)
-        line = json.dumps(entry.to_dict(), sort_keys=True, separators=(",", ":"))
-        with self._path.open("a", encoding="utf-8") as handle:
-            handle.write(line + "\n")
+        try:
+            self._lock.acquire(timeout=self._LOCK_TIMEOUT_SECONDS)
+        except Timeout as error:
+            raise AutonomyIntegrityError(
+                f"Timed out waiting for the autonomy state log lock: {self._lock.lock_file}",
+                field="path",
+                value=str(self._path),
+            ) from error
+        except OSError as error:
+            raise AutonomyIntegrityError(
+                f"Autonomy state log lock is unusable: {error}",
+                field="path",
+                value=str(self._path),
+            ) from error
+        try:
+            current = self.current()
+            expected_version = 1 if current is None else current.version + 1
+            if entry.version != expected_version:
+                raise AutonomyIntegrityError(
+                    f"Autonomy state version must be {expected_version}, got {entry.version}",
+                    field="version",
+                    value=entry.version,
+                )
+            line = json.dumps(entry.to_dict(), sort_keys=True, separators=(",", ":"))
+            with self._path.open("a", encoding="utf-8") as handle:
+                handle.write(line + "\n")
+        finally:
+            self._lock.release()
 
     def history(self) -> list[AutonomyStateEntry]:
         if not self._path.exists():
@@ -163,7 +189,7 @@ class AutonomyStateLog:
                             value=entry.version,
                         )
                     entries.append(entry)
-        except OSError as error:
+        except (OSError, UnicodeDecodeError) as error:
             raise AutonomyIntegrityError(
                 f"Autonomy state log is unreadable: {error}",
                 field="path",

--- a/src/gpt_trader/features/trade_ideas/service.py
+++ b/src/gpt_trader/features/trade_ideas/service.py
@@ -342,19 +342,27 @@ class TradeIdeaService:
         resolution = self.peek_autonomy()
         if resolution.source != AUTONOMY_SOURCE_SEEDED_DEFAULT:
             return resolution
-        self._autonomy_log.append(
-            AutonomyStateEntry(
-                version=1,
-                timestamp=self._now(),
-                mode=DEFAULT_AUTONOMY_MODE,
-                actor_type=ActorType.SYSTEM,
-                actor_id="seed-defaults",
-                reason=(
-                    "Seeded default accepted in docs/decisions/persistent-autonomy-state.md: "
-                    "human approval required for every execution"
-                ),
+        try:
+            self._autonomy_log.append(
+                AutonomyStateEntry(
+                    version=1,
+                    timestamp=self._now(),
+                    mode=DEFAULT_AUTONOMY_MODE,
+                    actor_type=ActorType.SYSTEM,
+                    actor_id="seed-defaults",
+                    reason=(
+                        "Seeded default accepted in docs/decisions/persistent-autonomy-state.md: "
+                        "human approval required for every execution"
+                    ),
+                )
             )
-        )
+        except AutonomyIntegrityError:
+            # Another process won the seed race under the log lock; adopt
+            # whatever it appended instead of failing this decision path.
+            resolution = self.peek_autonomy()
+            if resolution.source != AUTONOMY_SOURCE_LOG:
+                raise
+            return resolution
         return AutonomyResolution(
             mode=DEFAULT_AUTONOMY_MODE,
             version=1,

--- a/tests/unit/gpt_trader/features/trade_ideas/test_autonomy.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_autonomy.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 from pathlib import Path
 
 import pytest
+from filelock import FileLock
 
 from gpt_trader.features.trade_ideas import (
     DEFAULT_AUTONOMY_MODE,
@@ -120,6 +121,70 @@ def test_version_gap_in_file_raises_integrity_error(autonomy_log: AutonomyStateL
 
     with pytest.raises(AutonomyIntegrityError, match="version 5; expected 2"):
         autonomy_log.history()
+
+
+def test_invalid_utf8_raises_integrity_error(autonomy_log: AutonomyStateLog) -> None:
+    autonomy_log.path.parent.mkdir(parents=True, exist_ok=True)
+    autonomy_log.path.write_bytes(b"\xff\xfe not utf-8\n")
+
+    with pytest.raises(AutonomyIntegrityError, match="unreadable"):
+        autonomy_log.history()
+
+    resolution = resolve_autonomy(autonomy_log)
+    assert resolution.mode is FAIL_CLOSED_AUTONOMY_MODE
+
+
+def test_duplicated_version_in_file_raises_integrity_error(
+    autonomy_log: AutonomyStateLog,
+) -> None:
+    # The artifact an unlocked concurrent append would have left behind:
+    # two entries both claiming the same next version.
+    autonomy_log.append(build_entry())
+    line = autonomy_log.path.read_text(encoding="utf-8")
+    autonomy_log.path.write_text(line + line, encoding="utf-8")
+
+    with pytest.raises(AutonomyIntegrityError, match="version 1; expected 2"):
+        autonomy_log.history()
+
+    with pytest.raises(AutonomyIntegrityError):
+        autonomy_log.current()
+
+
+def test_append_times_out_when_lock_is_held(
+    autonomy_log: AutonomyStateLog, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(AutonomyStateLog, "_LOCK_TIMEOUT_SECONDS", 0.05)
+    autonomy_log.path.parent.mkdir(parents=True, exist_ok=True)
+    foreign_lock = FileLock(str(autonomy_log.path) + ".lock")
+    with foreign_lock.acquire(timeout=1):
+        with pytest.raises(AutonomyIntegrityError, match="autonomy state log lock"):
+            autonomy_log.append(build_entry())
+
+    assert autonomy_log.current() is None
+
+
+def test_unusable_lock_file_raises_integrity_error(autonomy_log: AutonomyStateLog) -> None:
+    lock_path = Path(str(autonomy_log.path) + ".lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path.mkdir()
+
+    with pytest.raises(AutonomyIntegrityError, match="lock is unusable"):
+        autonomy_log.append(build_entry())
+
+    assert autonomy_log.current() is None
+
+
+def test_append_succeeds_after_lock_is_released(autonomy_log: AutonomyStateLog) -> None:
+    autonomy_log.path.parent.mkdir(parents=True, exist_ok=True)
+    foreign_lock = FileLock(str(autonomy_log.path) + ".lock")
+    with foreign_lock.acquire(timeout=1):
+        pass
+
+    autonomy_log.append(build_entry())
+
+    current = autonomy_log.current()
+    assert current is not None
+    assert current.version == 1
 
 
 def test_resolve_absent_log_is_seeded_default(autonomy_log: AutonomyStateLog) -> None:

--- a/tests/unit/gpt_trader/features/trade_ideas/test_service_autonomy.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_service_autonomy.py
@@ -15,6 +15,8 @@ from gpt_trader.features.trade_ideas import (
     ActorType,
     AutonomyIntegrityError,
     AutonomyMode,
+    AutonomyStateEntry,
+    AutonomyStateLog,
     CloseoutResolution,
     PolicyViolationError,
     RiskBudget,
@@ -94,6 +96,40 @@ def test_current_autonomy_seeds_default_on_first_use(
     assert len(history) == 1
     assert history[0].actor_type is ActorType.SYSTEM
     assert history[0].actor_id == "seed-defaults"
+
+
+def test_current_autonomy_adopts_concurrent_seed(
+    service: TradeIdeaService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    real_append = AutonomyStateLog.append
+
+    def racing_append(self: AutonomyStateLog, entry: AutonomyStateEntry) -> None:
+        # A concurrent process seeds first, so this append loses the version
+        # race under the log lock instead of duplicating version 1.
+        winner = AutonomyStateLog(self.path)
+        real_append(
+            winner,
+            AutonomyStateEntry(
+                version=1,
+                timestamp=datetime(2026, 6, 12, 10, 0, tzinfo=UTC),
+                mode=AutonomyMode.HUMAN_APPROVED_EXECUTION,
+                actor_type=ActorType.SYSTEM,
+                actor_id="other-process",
+                reason="Seeded default from a concurrent process",
+            ),
+        )
+        real_append(self, entry)
+
+    monkeypatch.setattr(AutonomyStateLog, "append", racing_append)
+
+    resolution = service.current_autonomy()
+
+    assert resolution.mode is AutonomyMode.HUMAN_APPROVED_EXECUTION
+    assert resolution.version == 1
+    assert resolution.source == AUTONOMY_SOURCE_LOG
+    history = service.autonomy_history()
+    assert [entry.version for entry in history] == [1]
+    assert history[0].actor_id == "other-process"
 
 
 def test_human_raise_is_audited_and_becomes_current(service: TradeIdeaService) -> None:

--- a/var/agents/testing/index.json
+++ b/var/agents/testing/index.json
@@ -9,7 +9,7 @@
     "source_test_map": "source_test_map.json"
   },
   "summary": {
-    "total_tests": 6052,
+    "total_tests": 6058,
     "total_files": 716,
     "markers_used": 14
   },

--- a/var/agents/testing/markers.json
+++ b/var/agents/testing/markers.json
@@ -92,7 +92,7 @@
     ]
   },
   "counts": {
-    "unit": 5888,
+    "unit": 5894,
     "asyncio": 310,
     "parametrize": 180,
     "integration": 87,


### PR DESCRIPTION
## Summary

`AutonomyStateLog.append()` had the same unlocked read-then-append race that #1186 just closed for `RiskBudgetLog`: two processes (e.g. the hourly Stage-2 cycle and the web console) could both read the current version and append the same next version. The read side already detects the resulting duplicate and fails closed to `research_only`, but the write should not be able to corrupt the log in the first place.

- **`AutonomyStateLog.append()` now holds an OS-level `<path>.lock`** (`filelock.FileLock`, already a runtime dep) around the version check + write, mirroring `RiskBudgetLog`. A lock timeout or unusable lock file surfaces as `AutonomyIntegrityError`.
- **`TradeIdeaService.current_autonomy()` adopts a concurrent seed**: with locking, the loser of the first-use seed race gets an integrity error instead of duplicating version 1; it now re-reads and adopts the winner's entry the way `current_budget()` does (#1186). Any other integrity failure still re-raises.
- **`history()` wraps `UnicodeDecodeError` as `AutonomyIntegrityError`**: the file iterator raises it before the per-line handler runs, so an invalid-UTF-8 log leaked a raw decode error instead of failing closed — the autonomy-side twin of the review finding fixed on #1186.

## Testing

Mirrors the #1186 test additions in `test_autonomy.py` / `test_service_autonomy.py`:
- append times out with `AutonomyIntegrityError` while a foreign process holds the lock (and appends nothing)
- unusable lock file (directory in its place) surfaces as `AutonomyIntegrityError`
- append succeeds after the lock is released
- duplicated version in the file (the unlocked-race artifact) breaks `history()`/`current()`
- invalid UTF-8 raises `AutonomyIntegrityError` and `resolve_autonomy` fails closed to `research_only`
- `current_autonomy()` adopts the concurrent winner's seed entry instead of raising

`uv run pytest tests/unit -n auto -q` (6582 passed), ruff, black, mypy, agent-naming, `uv run agent-regenerate` all clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when multiple processes update autonomy data at the same time.
  * Added safer handling for unreadable or corrupted log entries, including invalid text and lock-related failures.
  * Seeding autonomy now recovers gracefully if another process writes first.

* **Tests**
  * Expanded test coverage for concurrency, lock timeouts, duplicate entries, and unreadable log scenarios.
  * Updated test counts to reflect the added coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->