### PR TITLE
docs(decisions): accept event-driven execution topology

### DIFF
--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -68,7 +68,7 @@ markers. Regenerating cannot drift from the files.
 <!-- BEGIN GENERATED DECISION INDEX -->
 | Date | Decision | Status |
 |------|----------|--------|
-| 2026-07-04 | [Adopt an event-driven execution topology — rails as kernel, not workflow](adopt-event-driven-execution-topology.md) | proposed |
+| 2026-07-04 | [Adopt an event-driven execution topology — rails as kernel, not workflow](adopt-event-driven-execution-topology.md) | accepted |
 | 2026-07-04 | [Venue-neutrality posture — adapters at the edges, no speculative abstraction](venue-neutrality-posture.md) | accepted |
 | 2026-07-03 | [MIT license for the public repository](adopt-mit-license.md) | accepted |
 | 2026-07-03 | [Persistent audited autonomy-level state](persistent-autonomy-state.md) | accepted |

--- a/docs/decisions/adopt-event-driven-execution-topology.md
+++ b/docs/decisions/adopt-event-driven-execution-topology.md
@@ -1,15 +1,12 @@
 # Adopt an event-driven execution topology — rails as kernel, not workflow
 
 ---
-status: proposed
+status: accepted
 date: 2026-07-04
 deciders: rj
 supersedes:
 superseded-by:
 ---
-
-> While `status: proposed`, this is an open decision the owner has not yet made.
-> See the [decisions README](README.md) for the lifecycle.
 
 ## Context
 
@@ -97,13 +94,18 @@ closed and operating) without reopening its "no second proposer brain" rule.
 
 ## Decision
 
-*Open — fill in when the owner decides.*
+**Option A — adopt the event-driven topology.** Accepted 2026-07-04 by rj. The
+rails are a runtime risk kernel every execution path consults; the queue/sweep
+workflow is the kernel's human-review client; scheduled jobs are chores, never
+the heartbeat.
 
 ## Consequences
 
-- Kernel extraction, the in-process engine lane, the eligibility split, the
-  continuous portfolio monitors, and replay-accelerated evidence are sequenced
-  as GitHub issues; this record holds the shape, not the backlog.
+- The work is sequenced as GitHub issues: kernel extraction (#1189),
+  eligibility invariant/mode split (#1190), in-process event-driven lane
+  (#1191, blocked on #1189/#1190), continuous portfolio monitors (#1192),
+  rubric scorecard + replay-accelerated evidence (#1193). This record holds
+  the shape, not the backlog.
 - The hourly launchd cycle continues unchanged during the transition as an
   evidence harness, explicitly labeled scaffolding.
 - Any rubric scorecard built before or during the transition reads the


### PR DESCRIPTION
## Summary

Flips [adopt-event-driven-execution-topology](docs/decisions/adopt-event-driven-execution-topology.md) to `accepted` (RJ, 2026-07-04) and records the sequenced follow-up issues in Consequences:

- #1189 — runtime risk kernel extraction
- #1190 — eligibility invariant vs mode-dependent split
- #1191 — in-process event-driven lane (blocked on #1189/#1190)
- #1192 — continuous portfolio monitors (HWM / drawdown-from-peak / exposure)
- #1193 — rubric scorecard + replay-accelerated evidence (idea-level trail only)

Decision index regenerated.

## Safety boundary

Doc-only. Authorizes no broker/API call, live execution, money movement, or autonomy change.

## Testing

- `docs_link_audit.py` ✓ (81 files)
- `docs_reachability_check.py` ✓ (60 files)
- `generate_decision_index.py` ✓ (20 records)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Marked the decision as accepted and recorded its acceptance date and owner.
  * Updated the decision record with a clearer consequences section that outlines the implementation sequence and related follow-up work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->