### PR TITLE
fix(agents): tolerate absent optional-only artifact dir in freshness verify

### DIFF
--- a/scripts/agents/regenerate_all.py
+++ b/scripts/agents/regenerate_all.py
@@ -244,6 +244,13 @@ def _diff_directories(committed_dir: Path, generated_dir: Path) -> str | None:
             f"{committed_dir.as_posix()})."
         )
     if not committed_dir.exists():
+        # A resource whose committed surface is entirely gitignored
+        # optional_files (e.g. testing, #1130) has no directory on a fresh
+        # checkout; regenerated files that are all ignored are not staleness.
+        generated_relatives = _relative_files(generated_dir)
+        ignored_relatives = _git_ignored_relatives(committed_dir, generated_relatives)
+        if generated_relatives and generated_relatives == ignored_relatives:
+            return None
         return (
             f"Committed output missing at {committed_dir.as_posix()} (generator wrote to "
             f"{generated_dir.as_posix()})."

--- a/tests/unit/scripts/test_regenerate_all_verify.py
+++ b/tests/unit/scripts/test_regenerate_all_verify.py
@@ -269,3 +269,43 @@ def test_diff_directories_ignores_git_ignored_generated_output_absent_from_commi
     monkeypatch.setattr(regenerate_all, "PROJECT_ROOT", repo_root)
 
     assert regenerate_all._diff_directories(committed_dir, generated_dir) is None
+
+
+def test_diff_directories_tolerates_absent_committed_dir_when_all_generated_ignored(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A resource whose committed surface is entirely gitignored optional_files
+    # (testing, after #1130) has NO directory on a fresh checkout. Regenerated
+    # files that are all git-ignored must not read as staleness; an unignored
+    # generated file still must.
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    _init_git_repo(repo_root)
+    (repo_root / ".gitignore").write_text(
+        "var/agents/testing/index.json\nvar/agents/testing/markers.json\n",
+        encoding="utf-8",
+    )
+    subprocess.run(
+        ["git", "add", ".gitignore"],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    committed_dir = repo_root / "var" / "agents" / "testing"
+    generated_dir = tmp_path / "generated" / "testing"
+    generated_dir.mkdir(parents=True)
+    (generated_dir / "index.json").write_text('{"summary": 1}\n', encoding="utf-8")
+    (generated_dir / "markers.json").write_text('{"markers": {}}\n', encoding="utf-8")
+
+    monkeypatch.setattr(regenerate_all, "PROJECT_ROOT", repo_root)
+
+    assert regenerate_all._diff_directories(committed_dir, generated_dir) is None
+
+    # An unignored generated file keeps the missing-committed-dir failure.
+    (generated_dir / "new_report.json").write_text("{}\n", encoding="utf-8")
+    diff_text = regenerate_all._diff_directories(committed_dir, generated_dir)
+    assert diff_text is not None
+    assert "Committed output missing" in diff_text


### PR DESCRIPTION
## Summary
Regression fix following #1195 (#1130 execution). On a fresh checkout, `var/agents/testing/` no longer exists — its entire committed surface became gitignored `optional_files` — and `_diff_directories` failed closed with `Committed output missing` **before** the git-ignore filtering could apply. This failed the Agent Artifacts Freshness lane where it blocks (pushes to main: the post-merge main run is red). The original PR worktree masked it because `git rm --cached` left the untracked files on disk.

Fix: when the committed directory is absent, regeneration counts as fresh iff every generated file is git-ignored by rule (`git check-ignore`, the same rule-based mechanism the existing filter uses). Any unignored generated file still reports the missing committed directory.

## Verification
- Fresh checkout of current main reproduces the failure; with this fix `uv run agent-regenerate --verify` reports 'All context files are up-to-date.'
- New regression test covers both branches (all-ignored tolerated; unignored file still fails): `uv run pytest tests/unit/scripts/test_regenerate_all_verify.py -q` — 7 passed.
- Diff is additive only (+47).

Touches trading execution: false

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved freshness checks so missing committed output is no longer treated as stale when all generated files are ignored by version control.
  * This avoids false alarms on fresh checkouts where only ignored generated files exist.

* **Tests**
  * Added coverage for the missing-output case with fully ignored generated files.
  * Added coverage to confirm stale output is still reported when a non-ignored generated file is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->