### PR TITLE
chore(workflow): org-transfer follow-up — queue contract, slug migration (#1127)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,8 +84,9 @@ checks, and merge only when it reports ready.
 git switch -c <branch>
 git push -u origin HEAD
 gh pr create --fill
-# Merge once agent-pr-ready reports ready and all threads are resolved:
-gh pr merge --squash --delete-branch
+# Once agent-pr-ready reports ready and all threads are resolved, enqueue;
+# the merge queue validates against latest main and merges when green:
+gh pr merge --squash --auto
 ```
 
 Standing approval covers PR merges only — live order submission and execution
@@ -98,9 +99,11 @@ Merge mechanics that repeatedly bite agents (`agent-pr-ready` detects all three)
   a child PR whose base branch just vanished. Recovery: restore the deleted
   branch from the merge SHA, reopen the child, retarget it. If you must stack,
   merge base-first.
-- **Strict up-to-date serializes batch merges.** Every merge to `main` flips
-  other green PRs to BEHIND; run `gh pr update-branch <pr>` and let CI re-run
-  rather than treating stale green as mergeable.
+- **Merges go through the merge queue** (#1127, 2026-07-04). Strict up-to-date
+  is off: the queue re-validates each entry against the latest `main` via a
+  `merge_group` CI run, so green PRs no longer invalidate each other. GitHub
+  reports `mergeStateStatus: BLOCKED` for direct merges even on ready PRs;
+  `gh pr merge --squash --auto` enqueues instead of merging directly.
 - **The protection contract is machine-checked.** `scripts/ci/check_branch_protection.py`
   owns the expected required checks/settings; drift between it and live GitHub
   settings surfaces as an `agent-pr-ready` warning.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An agent-developed, Coinbase-oriented trading system on a staged path toward bounded autonomy.
 
-[![CI](https://github.com/Solders-Girdles/GPT-Trader/actions/workflows/ci.yml/badge.svg)](https://github.com/Solders-Girdles/GPT-Trader/actions/workflows/ci.yml)
+[![CI](https://github.com/Solders-Girdles-Org/GPT-Trader/actions/workflows/ci.yml/badge.svg)](https://github.com/Solders-Girdles-Org/GPT-Trader/actions/workflows/ci.yml)
 [![Python 3.12](https://img.shields.io/badge/python-3.12-blue.svg)](https://www.python.org/downloads/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)

--- a/config/agents/docs_currency_suppressions.yaml
+++ b/config/agents/docs_currency_suppressions.yaml
@@ -51,9 +51,6 @@ suppressions:
     item: "--squash"
     reason: gh pr merge flag quoted in prose
   - doc: AGENTS.md
-    item: "--delete-branch"
-    reason: gh pr merge flag quoted in prose
-  - doc: AGENTS.md
     item: "--fill"
     reason: gh pr create flag quoted in prose
   - doc: README.md

--- a/docs/DEVELOPMENT_GUIDELINES.md
+++ b/docs/DEVELOPMENT_GUIDELINES.md
@@ -105,8 +105,9 @@ bypass guards:
 This section is the compact contributor-facing CI contract. The executable
 source of truth remains `.github/workflows/*.yml` plus GitHub branch protection.
 Current `main` branch protection requires only the named `CI` contexts listed in
-the first row below, with strict up-to-date checks and conversation resolution
-enabled. Selected context-specific lanes self-skip by changed path while keeping
+the first row below, with conversation resolution enabled and a required merge
+queue (#1127; strict up-to-date is off — the queue validates entries against the
+latest `main` via `merge_group` runs). Selected context-specific lanes self-skip by changed path while keeping
 those check names stable. The expected protection settings are machine-checked:
 `uv run python scripts/ci/check_branch_protection.py` (also surfaced as an
 `agent-pr-ready` advisory) fails when live GitHub settings drift from the

--- a/docs/decisions/account-snapshot-wire-or-remove.md
+++ b/docs/decisions/account-snapshot-wire-or-remove.md
@@ -57,7 +57,7 @@ command is transparency infrastructure.
 ## Consequences
 
 The spec issue is filed:
-[#1121](https://github.com/Solders-Girdles/GPT-Trader/issues/1121) (provider
+[#1121](https://github.com/Solders-Girdles-Org/GPT-Trader/issues/1121) (provider
 protocol, container wiring, CLI adaptation, unit tests over the real service
 with a boundary-double broker), and the "not available" fallback is dropped
 once wired.

--- a/docs/decisions/adopt-operator-web-console.md
+++ b/docs/decisions/adopt-operator-web-console.md
@@ -84,7 +84,7 @@ Stage-2 graduation evidence.
 
 Accepted: Option A — a local, server-rendered web console as a thin adapter
 over `TradeIdeaService`, built in three phases tracked in issue
-[#1152](https://github.com/Solders-Girdles/GPT-Trader/issues/1152): review
+[#1152](https://github.com/Solders-Girdles-Org/GPT-Trader/issues/1152): review
 queue + idea detail first, accountant + agent activity second, the envelope
 console third. Queue self-instrumentation (approval latency, agreement rate)
 ships in phase 1, not later — it is the evidence a Stage-2 promotion case
@@ -112,7 +112,7 @@ console's agreement-rate instrumentation.
   ideas; the envelope console becomes the primary operator seat. This is a
   re-weighting of existing screens, not a rebuild.
 - Follow-up work is tracked in
-  [#1152](https://github.com/Solders-Girdles/GPT-Trader/issues/1152), phased
+  [#1152](https://github.com/Solders-Girdles-Org/GPT-Trader/issues/1152), phased
   as separate reviewed PRs.
 
 ## Safety boundary

--- a/docs/decisions/canonical-risk-limit-vocabulary.md
+++ b/docs/decisions/canonical-risk-limit-vocabulary.md
@@ -78,7 +78,7 @@ re-homing these fields later.
 ## Decision
 
 **Option A, phased.** Accepted 2026-07-02 by RJ; implementation is tracked in
-[#1120](https://github.com/Solders-Girdles/GPT-Trader/issues/1120).
+[#1120](https://github.com/Solders-Girdles-Org/GPT-Trader/issues/1120).
 
 The rationale: it matches the accepted direction — the
 budget is *the* lever-handover mechanism, and autonomy stage 2 explicitly pairs
@@ -116,7 +116,7 @@ side deriving from it rather than carrying its own numbers.
   `max_position_pct_per_symbol` semantics documented in the glossary so
   loss-at-invalidation and notional exposure are never conflated.
 - Follow-up work is filed:
-  [#1120](https://github.com/Solders-Girdles/GPT-Trader/issues/1120) tracks the
+  [#1120](https://github.com/Solders-Girdles-Org/GPT-Trader/issues/1120) tracks the
   implementation; the seven open trade-ideas PRs do **not** need rework under
   this option.
 

--- a/docs/decisions/persistent-autonomy-state.md
+++ b/docs/decisions/persistent-autonomy-state.md
@@ -32,11 +32,11 @@ Today the autonomy level satisfies none of that:
   and every version carries the actor and rationale that produced it.
 
 Why decide now: Stage 2 auto-approval
-([#1039](https://github.com/Solders-Girdles/GPT-Trader/issues/1039)) is
+([#1039](https://github.com/Solders-Girdles-Org/GPT-Trader/issues/1039)) is
 blocked on an explicit autonomy-mode gate, and its acceptance criteria assume
 a mode that can be verified rather than asserted. The automatic ratchet-down
 needs a well-defined "breach" to consume, which is exactly what the risk
-unification ([#1120](https://github.com/Solders-Girdles/GPT-Trader/issues/1120),
+unification ([#1120](https://github.com/Solders-Girdles-Org/GPT-Trader/issues/1120),
 in flight) provides: one appetite vocabulary and one trading-day boundary.
 The operator console direction
 ([adopt-operator-web-console](adopt-operator-web-console.md)) will also need
@@ -62,7 +62,7 @@ a truthful read surface for "what may the system do right now, and why".
   violates the recorded-and-reversible property, and it collides with the
   accepted rule that a profile name is never execution approval
   ([prod-canary-profile-meaning](prod-canary-profile-meaning.md), hardening
-  tracked in [#1122](https://github.com/Solders-Girdles/GPT-Trader/issues/1122)).
+  tracked in [#1122](https://github.com/Solders-Girdles-Org/GPT-Trader/issues/1122)).
 - **Option C — Fold the mode into `RiskBudget` versions.** Reuses the existing
   log and its integrity checks, but couples risk appetite with authority: a
   budget tweak and an autonomy grant become the same event type, muddying both
@@ -97,7 +97,7 @@ With Option A accepted:
   appends the breach evidence it acted on. Every transition is also an
   audited workflow event.
 - Ratchet triggers are defined against the unified risk vocabulary from
-  [#1120](https://github.com/Solders-Girdles/GPT-Trader/issues/1120) (one
+  [#1120](https://github.com/Solders-Girdles-Org/GPT-Trader/issues/1120) (one
   appetite source, one trading-day boundary) so "breach" is a single
   well-defined event, not two dialects. The trigger set ships with the
   implementation issue, not this record.
@@ -108,7 +108,7 @@ With Option A accepted:
 - Entering `bounded_autonomy` remains gated by [DIRECTION](../DIRECTION.md):
   this record changes where the level is *recorded*, not what the level *is*.
   Together with the budget gates, this unblocks
-  [#1039](https://github.com/Solders-Girdles/GPT-Trader/issues/1039).
+  [#1039](https://github.com/Solders-Girdles-Org/GPT-Trader/issues/1039).
 - Implementation follows in a bounded issue after this record; ratchet triggers
   are defined there against the unified risk vocabulary from #1120.
 

--- a/docs/decisions/prod-canary-profile-meaning.md
+++ b/docs/decisions/prod-canary-profile-meaning.md
@@ -39,7 +39,7 @@ authorization path.
 
 `ProfileLoader` semantics are unchanged. Docs and tests are hardened so no
 profile value is ever treated as execution approval — tracked in
-[#1122](https://github.com/Solders-Girdles/GPT-Trader/issues/1122).
+[#1122](https://github.com/Solders-Girdles-Org/GPT-Trader/issues/1122).
 
 ## Safety boundary
 

--- a/docs/decisions/stage2-auto-approval-workflow.md
+++ b/docs/decisions/stage2-auto-approval-workflow.md
@@ -12,7 +12,7 @@ superseded-by:
 
 The accepted rubric ([adopt-measured-outcome-rubric](adopt-measured-outcome-rubric.md))
 names Stage 2 as "auto-approval within budget", and
-[#1039](https://github.com/Solders-Girdles/GPT-Trader/issues/1039) specifies the
+[#1039](https://github.com/Solders-Girdles-Org/GPT-Trader/issues/1039) specifies the
 workflow: ideas that pass **every** approval-policy check auto-approve with a
 system actor; ideas with any violation stay `proposed` for human review; both
 paths are audited.
@@ -26,15 +26,15 @@ waited on now exist:
 
 - Budget gates are explicit and enforced at approval time — per-idea max loss,
   projected daily loss, open-notional cap, concurrency, review latency
-  ([#1036](https://github.com/Solders-Girdles/GPT-Trader/issues/1036),
-  [#1120](https://github.com/Solders-Girdles/GPT-Trader/issues/1120)).
+  ([#1036](https://github.com/Solders-Girdles-Org/GPT-Trader/issues/1036),
+  [#1120](https://github.com/Solders-Girdles-Org/GPT-Trader/issues/1120)).
 - The autonomy level is persistent, audited, and human-raised-only, with an
   automatic breach ratchet
   ([persistent-autonomy-state](persistent-autonomy-state.md),
-  [#1170](https://github.com/Solders-Girdles/GPT-Trader/issues/1170)); that
+  [#1170](https://github.com/Solders-Girdles-Org/GPT-Trader/issues/1170)); that
   record states it "unblocks #1039" together with the budget gates.
 - Paper fills reconcile to the audit trail, so envelope exposure is measured,
-  not asserted ([#1035](https://github.com/Solders-Girdles/GPT-Trader/issues/1035)).
+  not asserted ([#1035](https://github.com/Solders-Girdles-Org/GPT-Trader/issues/1035)).
 
 ## Options
 
@@ -97,4 +97,4 @@ This decision authorizes no broker/API call, no live execution, and no money
 movement. It does not change the autonomy level: the seeded default stays
 `human_approved_execution`, raising it still requires an audited human action,
 and the feature flag defaults off. Order submission remains out of scope
-([#1039](https://github.com/Solders-Girdles/GPT-Trader/issues/1039) non-goals).
+([#1039](https://github.com/Solders-Girdles-Org/GPT-Trader/issues/1039) non-goals).

--- a/scripts/agents/pr_readiness.py
+++ b/scripts/agents/pr_readiness.py
@@ -76,8 +76,9 @@ _DEFAULT_BASE_BRANCH = "main"
 _BLOCKING_MERGE_STATES = {
     "BEHIND": (
         "Branch is behind the base; run `gh pr update-branch <pr>` (or rebase onto the "
-        "base) and let CI re-run. Strict up-to-date serializes batch merges, so this is "
-        "expected after every merge to the base."
+        "base) and let CI re-run. With the merge queue active (strict up-to-date off, "
+        "#1127) this should be rare: the queue validates entries against the latest "
+        "base itself."
     ),
     "DIRTY": "Branch has merge conflicts with the base.",
     "BLOCKED": "Branch protection is blocking the merge (see findings below).",
@@ -292,6 +293,7 @@ def assess_readiness(
     state: PullRequestState,
     *,
     require_current_head_review_signal: bool = False,
+    merge_queue_active: bool = False,
 ) -> ReadinessReport:
     """Reconcile checks + protection + threads into a non-blocking verdict."""
     findings: list[Finding] = []
@@ -340,7 +342,19 @@ def assess_readiness(
         if state.merge_state_status == "BLOCKED":
             has_specific_blocker = any(finding.severity == "blocker" for finding in findings)
             if not has_specific_blocker:
-                findings.append(Finding("blocker", guidance))
+                if merge_queue_active:
+                    # With a required merge queue, GitHub reports BLOCKED for
+                    # direct merges even when the PR is ready to enqueue.
+                    findings.append(
+                        Finding(
+                            "info",
+                            "Merge queue is active on the base branch; BLOCKED here "
+                            "means direct merge is disallowed, not that the PR is "
+                            "unready. Enqueue with `gh pr merge --squash --auto`.",
+                        )
+                    )
+                else:
+                    findings.append(Finding("blocker", guidance))
         else:
             findings.append(Finding("blocker", guidance))
 
@@ -752,6 +766,39 @@ def fetch_branch_protection(repo: str, branch: str = "main") -> dict[str, Any] |
 def _is_missing_branch_protection(error: RuntimeError) -> bool:
     message = str(error).lower()
     return "http 404" in message or "branch not protected" in message
+
+
+def fetch_merge_queue_active(repo: str, branch: str) -> bool:
+    """True when a merge queue is configured for ``branch`` (advisory; False on error)."""
+    if repo.count("/") != 1:
+        return False
+    owner, name = repo.split("/", 1)
+    query = """
+query($owner: String!, $name: String!, $branch: String!) {
+  repository(owner: $owner, name: $name) {
+    mergeQueue(branch: $branch) { id }
+  }
+}
+"""
+    try:
+        data = _gh_json(
+            [
+                "api",
+                "graphql",
+                "-f",
+                f"query={query}",
+                "-F",
+                f"owner={owner}",
+                "-F",
+                f"name={name}",
+                "-F",
+                f"branch={branch}",
+            ]
+        )
+    except (RuntimeError, json.JSONDecodeError):
+        return False
+    repository = (data.get("data") or {}).get("repository") or {}
+    return repository.get("mergeQueue") is not None
 
 
 def fetch_pr_payload(repo: str, pr: int) -> dict[str, Any]:
@@ -1283,6 +1330,7 @@ def main(argv: list[str] | None = None) -> int:
         )
         protection_raw = fetch_branch_protection(repo, base_ref_name)
         protection = parse_branch_protection(protection_raw)
+        merge_queue_active = fetch_merge_queue_active(repo, base_ref_name)
         head_committed_at, head_pushed_at = fetch_head_commit_timestamps(repo, pr)
         state = parse_pr_state(
             pr_payload,
@@ -1301,6 +1349,7 @@ def main(argv: list[str] | None = None) -> int:
     report = assess_readiness(
         state,
         require_current_head_review_signal=args.require_current_head_review_signal,
+        merge_queue_active=merge_queue_active,
     )
     apply_artifact_freshness(report, freshness)
     apply_protection_drift(report, protection_raw, base_ref_name)

--- a/scripts/ci/check_branch_protection.py
+++ b/scripts/ci/check_branch_protection.py
@@ -8,8 +8,9 @@ Usage:
 The EXPECTED_* constants below are the machine-checkable source of truth for
 what `main` branch protection must require; the prose CI contract table in
 docs/DEVELOPMENT_GUIDELINES.md points here. Update them deliberately, in the
-same change that updates the GitHub setting. The merge-queue migration (#1127)
-will flip EXPECTED_STRICT to False when it lands.
+same change that updates the GitHub setting. The merge-queue migration (#1127,
+2026-07-04) flipped EXPECTED_STRICT to False: the queue validates each entry
+against the latest main via merge_group CI, superseding strict up-to-date.
 
 Requires `gh` auth with admin read on the repository (the protection API is
 admin-scoped), so this runs locally and in `agent-pr-ready` — not in the
@@ -24,7 +25,7 @@ import subprocess
 from typing import Any
 from urllib.parse import quote
 
-DEFAULT_REPOSITORY = "Solders-Girdles/GPT-Trader"
+DEFAULT_REPOSITORY = "Solders-Girdles-Org/GPT-Trader"
 DEFAULT_BRANCH = "main"
 
 EXPECTED_REQUIRED_CHECKS = frozenset(
@@ -39,7 +40,7 @@ EXPECTED_REQUIRED_CHECKS = frozenset(
         "Integration Tests",
     }
 )
-EXPECTED_STRICT = True
+EXPECTED_STRICT = False
 EXPECTED_ENFORCE_ADMINS = True
 EXPECTED_CONVERSATION_RESOLUTION = True
 EXPECTED_REQUIRED_APPROVING_REVIEWS = 0

--- a/scripts/maintenance/project_review_issue_promoter.py
+++ b/scripts/maintenance/project_review_issue_promoter.py
@@ -11,7 +11,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
-DEFAULT_REPOSITORY = "Solders-Girdles/GPT-Trader"
+DEFAULT_REPOSITORY = "Solders-Girdles-Org/GPT-Trader"
 SCHEMA_VERSION = "gpt-trader.agent-finding.v1"
 
 SEVERITIES = {"low", "medium", "high", "critical"}

--- a/tests/_triage/dedupe_candidates.yaml
+++ b/tests/_triage/dedupe_candidates.yaml
@@ -1493,7 +1493,7 @@ clusters:
     rationale: Consolidated base build payload coverage into single module
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/344
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/344
     added: '2026-01-20'
   180648193b98:
     type: similar_names
@@ -1510,7 +1510,7 @@ clusters:
     rationale: Consolidated 3 -> 1 file
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/336
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/336
     added: '2026-01-21'
   1aceb62afe0f:
     type: similar_names
@@ -1527,7 +1527,7 @@ clusters:
     rationale: Consolidated payload and preview coverage into shared orders module
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/405
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/405
     added: '2026-01-22'
   1d1e7ae0630a:
     type: similar_names
@@ -1759,7 +1759,7 @@ clusters:
       into existing suites
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/348
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/348
     added: '2026-01-21'
   033123dabd72:
     type: similar_names
@@ -1778,7 +1778,7 @@ clusters:
       helpers
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/342
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/342
     added: '2026-01-21'
   07116d624c54:
     type: similar_names
@@ -1803,7 +1803,7 @@ clusters:
     rationale: Consolidated 11 → 4 files (<=240 lines each)
     status: done
     owner: claude
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/328
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/328
     added: '2026-01-20'
   07ed801b7538:
     type: source_fanout
@@ -1825,7 +1825,7 @@ clusters:
     rationale: Consolidated 11 → 7 files (validation + leverage/exposure tests)
     status: done
     owner: claude
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/305
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/305
     added: '2026-01-20'
   089327cc89b0:
     type: source_fanout
@@ -1856,7 +1856,7 @@ clusters:
     rationale: Consolidated 16 -> 8 files (core, flows, snapshots, widgets)
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/335
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/335
     added: '2026-01-20'
   0e3fd1462c0c:
     type: similar_names
@@ -1876,7 +1876,7 @@ clusters:
       helpers
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/341
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/341
     added: '2026-01-21'
   10f0d3fb855f:
     type: similar_names
@@ -1901,7 +1901,7 @@ clusters:
     rationale: Consolidated 11 -> 5 files (core, results, flows, observability, metrics)
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/337
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/337
     added: '2026-01-21'
   12305b4c7689:
     type: similar_names
@@ -1918,7 +1918,7 @@ clusters:
     rationale: Consolidated 3 -> 1 file
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/336
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/336
     added: '2026-01-21'
   12c5eff80c09:
     type: similar_names
@@ -1936,7 +1936,7 @@ clusters:
     rationale: Consolidated 4 -> 1 file
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/336
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/336
     added: '2026-01-20'
   13570f162254:
     type: similar_names
@@ -1955,7 +1955,7 @@ clusters:
     rationale: Consolidated broker executor retry coverage into fewer cohesive modules
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/345
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/345
     added: '2026-01-21'
   14389b2ace72:
     type: similar_names
@@ -1980,7 +1980,7 @@ clusters:
     rationale: Consolidated 17 → 11 files (core + flows + observability)
     status: done
     owner: claude
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/305
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/305
     added: '2026-01-20'
   15d57b23ad6f:
     type: similar_names
@@ -1999,7 +1999,7 @@ clusters:
     rationale: Consolidate 6 test files into 5 files (<=240 lines each)
     status: done
     owner: claude
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/303
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/303
     added: '2026-01-20'
   17fece0a22bc:
     type: similar_names
@@ -2017,7 +2017,7 @@ clusters:
     rationale: Consolidated 4 -> 1 file
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/336
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/336
     added: '2026-01-20'
   1828c35d1207:
     type: similar_names
@@ -2036,7 +2036,7 @@ clusters:
     rationale: Consolidated alert manager shards into fewer cohesive modules
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/349
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/349
     added: '2026-01-21'
   19f1bd3c33d4:
     type: similar_names
@@ -2054,7 +2054,7 @@ clusters:
       under hygiene cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/389
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/389
     added: '2026-01-21'
   1b083f952ad7:
     type: similar_names
@@ -2072,7 +2072,7 @@ clusters:
     rationale: Consolidate 6 test files into 4 files (<=240 lines each)
     status: done
     owner: claude
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/303
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/303
     added: '2026-01-20'
   1b522be5396a:
     type: source_fanout
@@ -2098,7 +2098,7 @@ clusters:
     rationale: Consolidated 17 → 11 files (core + flows + observability)
     status: done
     owner: claude
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/305
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/305
     added: '2026-01-20'
   1ba93042953b:
     type: similar_names
@@ -2116,7 +2116,7 @@ clusters:
     rationale: Consolidate 6 test files into 4 files (<=240 lines each)
     status: done
     owner: claude
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/304
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/304
     added: '2026-01-20'
   1c5a28867cce:
     type: similar_names
@@ -2135,7 +2135,7 @@ clusters:
     rationale: Consolidated 5 → 4 files (broker_ping + degradation_state merged)
     status: done
     owner: claude
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/308
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/308
     added: '2026-01-20'
   1cf535f58810:
     type: similar_names
@@ -2154,7 +2154,7 @@ clusters:
       under hygiene cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/359
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/359
     added: '2026-01-20'
   1ddeaae0a707:
     type: similar_names
@@ -2173,7 +2173,7 @@ clusters:
     rationale: Consolidated hybrid paper broker shards into fewer cohesive modules
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/350
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/350
     added: '2026-01-21'
   21a3b31c1fec:
     type: source_fanout
@@ -2193,7 +2193,7 @@ clusters:
     rationale: Consolidated 11 → 5 files (<=240 lines each)
     status: done
     owner: claude
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/305
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/305
     added: '2026-01-20'
   224e07597e52:
     type: similar_names
@@ -2211,7 +2211,7 @@ clusters:
       hygiene cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/390
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/390
     added: '2026-01-20'
   24df30e9af97:
     type: similar_names
@@ -2229,7 +2229,7 @@ clusters:
       hygiene cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/391
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/391
     added: '2026-01-21'
   2702cc2b5190:
     type: similar_names
@@ -2247,7 +2247,7 @@ clusters:
       cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/392
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/392
     added: '2026-01-21'
   2793420ff8e6:
     type: similar_names
@@ -2265,7 +2265,7 @@ clusters:
     rationale: Consolidate 6 test files into 4 files (<=240 lines each)
     status: done
     owner: claude
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/304
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/304
     added: '2026-01-20'
   2a2b4d1c902b:
     type: similar_names
@@ -2284,7 +2284,7 @@ clusters:
     rationale: Consolidated 5 → 3 files (init+health, orderbook+filtering, trades)
     status: done
     owner: claude
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/309
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/309
     added: '2026-01-20'
   2a4de4bad229:
     type: similar_names
@@ -2303,7 +2303,7 @@ clusters:
       hygiene cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/360
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/360
     added: '2026-01-20'
   2a83957b1884:
     type: similar_names
@@ -2320,7 +2320,7 @@ clusters:
     rationale: Consolidate 8 test files into 3 files (<=240 lines each)
     status: done
     owner: claude
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/302
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/302
     added: '2026-01-20'
   2d3176c22d80:
     type: similar_names
@@ -2338,7 +2338,7 @@ clusters:
     rationale: Consolidated portfolio service suites into one module via shared helpers
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/343
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/343
     added: '2026-01-21'
   '310214e39620':
     type: similar_names
@@ -2357,7 +2357,7 @@ clusters:
     rationale: Consolidated 5 → 3 files (init+supports+publish, collect, run)
     status: done
     owner: claude
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/310
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/310
     added: '2026-01-20'
   36c3dda34a26:
     type: similar_names
@@ -2375,7 +2375,7 @@ clusters:
       cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/393
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/393
     added: '2026-01-20'
   3ae819db86ca:
     type: similar_names
@@ -2399,7 +2399,7 @@ clusters:
       lines)
     status: done
     owner: rj
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/297
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/297
     added: '2026-01-20'
   417047edd7b5:
     type: similar_names
@@ -2417,7 +2417,7 @@ clusters:
       separate for hygiene cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/394
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/394
     added: '2026-01-20'
   43a48985bb6e:
     type: similar_names
@@ -2436,7 +2436,7 @@ clusters:
     rationale: Consolidate 7 test files into 5 files (<=240 lines each)
     status: done
     owner: claude
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/303
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/303
     added: '2026-01-20'
   43ad7dc90d18:
     type: similar_names
@@ -2454,7 +2454,7 @@ clusters:
       cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/395
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/395
     added: '2026-01-21'
   448f0a961f38:
     type: similar_names
@@ -2472,7 +2472,7 @@ clusters:
       hygiene cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/392
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/392
     added: '2026-01-20'
   45c19aff861e:
     type: similar_names
@@ -2490,7 +2490,7 @@ clusters:
       separate for hygiene cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/396
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/396
     added: '2026-01-21'
   4ad11115861b:
     type: similar_names
@@ -2509,7 +2509,7 @@ clusters:
       hygiene cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/361
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/361
     added: '2026-01-22'
   4d20aae790b1:
     type: similar_names
@@ -2528,7 +2528,7 @@ clusters:
       cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/362
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/362
     added: '2026-01-20'
   4d680f449c31:
     type: similar_names
@@ -2547,7 +2547,7 @@ clusters:
     rationale: Consolidate 5 test files into single parametrized file
     status: done
     owner: claude
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/311
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/311
     added: '2026-01-20'
   4e52c9b8ac2b:
     type: similar_names
@@ -2566,7 +2566,7 @@ clusters:
       stay under hygiene cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/363
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/363
     added: '2026-01-20'
   4ed82d18a683:
     type: source_fanout
@@ -2588,7 +2588,7 @@ clusters:
     rationale: Consolidated 9 test files into 7 focused modules (each <=240 lines)
     status: done
     owner: rj
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/298
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/298
     added: '2026-01-20'
   4fd6a8824efa:
     type: similar_names
@@ -2605,7 +2605,7 @@ clusters:
     rationale: Consolidate 6 test files into 3 files (<=240 lines each)
     status: done
     owner: claude
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/303
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/303
     added: '2026-01-20'
   52946e567f9f:
     type: similar_names
@@ -2625,7 +2625,7 @@ clusters:
       hygiene cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/356
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/356
     added: '2026-01-21'
   5382ed5f2cfa:
     type: similar_names
@@ -2643,7 +2643,7 @@ clusters:
       separate
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/397
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/397
     added: '2026-01-20'
   54256db34e4d:
     type: similar_names
@@ -2662,7 +2662,7 @@ clusters:
       modules to stay under hygiene cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/364
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/364
     added: '2026-01-21'
   542f5c64c1b6:
     type: similar_names
@@ -2680,7 +2680,7 @@ clusters:
       cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/398
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/398
     added: '2026-01-20'
   55e8e1dee506:
     type: similar_names
@@ -2699,7 +2699,7 @@ clusters:
     rationale: Consolidate 7 test files into 5 files (<=240 lines each)
     status: done
     owner: claude
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/303
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/303
     added: '2026-01-20'
   57a66f3200c9:
     type: similar_names
@@ -2717,7 +2717,7 @@ clusters:
       cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/389
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/389
     added: '2026-01-21'
   58908d14a224:
     type: similar_names
@@ -2736,7 +2736,7 @@ clusters:
       and edge cases split to stay under hygiene cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/365
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/365
     added: '2026-01-21'
   5a06e25609fe:
     type: similar_names
@@ -2755,7 +2755,7 @@ clusters:
       modules to stay under hygiene cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/366
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/366
     added: '2026-01-20'
   5a62074b66a1:
     type: similar_names
@@ -2774,7 +2774,7 @@ clusters:
       loop modules to stay under hygiene cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/367
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/367
     added: '2026-01-21'
   5a8749976a2e:
     type: similar_names
@@ -2793,7 +2793,7 @@ clusters:
     rationale: Consolidated market data shards into fewer cohesive modules
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/353
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/353
     added: '2026-01-21'
   5b3d06876e1e:
     type: similar_names
@@ -2812,7 +2812,7 @@ clusters:
     rationale: Consolidate 5 test files into single parametrized file
     status: done
     owner: claude
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/312
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/312
     added: '2026-01-20'
   5e74c94a6070:
     type: similar_names
@@ -2830,7 +2830,7 @@ clusters:
       for hygiene cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/399
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/399
     added: '2026-01-20'
   60bf455b111f:
     type: similar_names
@@ -2848,7 +2848,7 @@ clusters:
     rationale: Consolidated bot config suites into single module under hygiene cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/368
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/368
     added: '2026-01-20'
   678535a285b3:
     type: source_fanout
@@ -2869,7 +2869,7 @@ clusters:
     rationale: Consolidated 6 → 4 files (guard_errors + symbols split)
     status: done
     owner: claude
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/307
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/307
     added: '2026-01-20'
   68f5edc7f33a:
     type: similar_names
@@ -2888,7 +2888,7 @@ clusters:
     rationale: Consolidate 5 test files into single parametrized file
     status: done
     owner: claude
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/313
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/313
     added: '2026-01-20'
   6b3334007ca5:
     type: source_fanout
@@ -2908,7 +2908,7 @@ clusters:
     rationale: Consolidate 7 test files into 5 files (<=240 lines each)
     status: done
     owner: claude
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/303
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/303
     added: '2026-01-20'
   7088ef34973a:
     type: source_fanout
@@ -2927,7 +2927,7 @@ clusters:
     rationale: Consolidate 8 test files into 4 files (<=240 lines each)
     status: done
     owner: claude
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/302
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/302
     added: '2026-01-20'
   725609b987f2:
     type: similar_names
@@ -2946,7 +2946,7 @@ clusters:
       market data modules under hygiene cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/369
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/369
     added: '2026-01-20'
   72ef294be830:
     type: similar_names
@@ -2964,7 +2964,7 @@ clusters:
       separate
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/400
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/400
     added: '2026-01-21'
   76566dd4cf49:
     type: source_fanout
@@ -2997,7 +2997,7 @@ clusters:
     rationale: Consolidated 18 → 13 files (core + checks, <=240 lines each)
     status: done
     owner: claude
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/331
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/331
     added: '2026-01-20'
   76d0b4f00ad6:
     type: similar_names
@@ -3014,7 +3014,7 @@ clusters:
     rationale: Consolidated diagnostics checks into single suite under hygiene cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/401
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/401
     added: '2026-01-21'
   7a4b57745cc0:
     type: source_fanout
@@ -3034,7 +3034,7 @@ clusters:
     rationale: Consolidate 9 test files into 5 focused modules (each <=240 lines)
     status: done
     owner: rj
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/299
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/299
     added: '2026-01-20'
   7ae3ae24a668:
     type: similar_names
@@ -3053,7 +3053,7 @@ clusters:
     rationale: Consolidate 5 test files into single parametrized file
     status: done
     owner: claude
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/314
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/314
     added: '2026-01-20'
   7dd7f1b90ccb:
     type: similar_names
@@ -3073,7 +3073,7 @@ clusters:
       cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/357
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/357
     added: '2026-01-21'
   8073d799fbaa:
     type: similar_names
@@ -3091,7 +3091,7 @@ clusters:
       hygiene cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/402
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/402
     added: '2026-01-20'
   80b88b7e58c0:
     type: similar_names
@@ -3109,7 +3109,7 @@ clusters:
       tests separate
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/403
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/403
     added: '2026-01-21'
   81985ca6ed6b:
     type: similar_names
@@ -3128,7 +3128,7 @@ clusters:
       separate to stay under hygiene cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/370
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/370
     added: '2026-01-20'
   829ec182749c:
     type: source_fanout
@@ -3153,7 +3153,7 @@ clusters:
     rationale: Consolidate 10 test files into 5 focused modules (each <=240 lines)
     status: done
     owner: rj
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/295
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/295
     added: '2026-01-20'
   85496ba5cfab:
     type: similar_names
@@ -3172,7 +3172,7 @@ clusters:
       under hygiene cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/371
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/371
     added: '2026-01-21'
   8731f83b6ab5:
     type: similar_names
@@ -3190,7 +3190,7 @@ clusters:
     rationale: Consolidated into three modules to stay under hygiene cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/372
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/372
     added: '2026-01-21'
   8883d635b021:
     type: similar_names
@@ -3208,7 +3208,7 @@ clusters:
     rationale: Consolidated into single module under hygiene cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/373
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/373
     added: '2026-01-20'
   89ace0d7c06c:
     type: similar_names
@@ -3226,7 +3226,7 @@ clusters:
     rationale: Consolidate 6 test files into 4 files (<=240 lines each)
     status: done
     owner: claude
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/304
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/304
     added: '2026-01-20'
   8a1e11aeca85:
     type: similar_names
@@ -3244,7 +3244,7 @@ clusters:
       cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/392
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/392
     added: '2026-01-20'
   8a5666f3b255:
     type: similar_names
@@ -3262,7 +3262,7 @@ clusters:
       separate to stay under hygiene cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/397
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/397
     added: '2026-01-20'
   8bf0f5840b82:
     type: similar_names
@@ -3280,7 +3280,7 @@ clusters:
     rationale: Consolidated into three modules to stay under hygiene cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/374
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/374
     added: '2026-01-21'
   8d74e0251ecf:
     type: similar_names
@@ -3298,7 +3298,7 @@ clusters:
       signal-detail content separate to stay under hygiene cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/404
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/404
     added: '2026-01-20'
   8e54fe31d1b2:
     type: similar_names
@@ -3316,7 +3316,7 @@ clusters:
     rationale: Consolidated into two modules to stay under hygiene cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/375
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/375
     added: '2026-01-20'
   8e99233214a1:
     type: similar_names
@@ -3338,7 +3338,7 @@ clusters:
     rationale: Consolidate 8 test files into single parametrized file
     status: done
     owner: claude
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/302
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/302
     added: '2026-01-20'
   8fc986b459a0:
     type: similar_names
@@ -3356,7 +3356,7 @@ clusters:
     rationale: Consolidated into three modules to stay under hygiene cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/376
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/376
     added: '2026-01-20'
   9016ba13cca0:
     type: similar_names
@@ -3374,7 +3374,7 @@ clusters:
     rationale: Consolidated into three modules to stay under hygiene cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/377
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/377
     added: '2026-01-21'
   93fa26f42678:
     type: similar_names
@@ -3392,7 +3392,7 @@ clusters:
       editing coverage separate to stay under hygiene cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/405
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/405
     added: '2026-01-20'
   94e71330160f:
     type: similar_names
@@ -3410,7 +3410,7 @@ clusters:
     rationale: Consolidated into three modules to stay under hygiene cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/378
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/378
     added: '2026-01-21'
   95eb387c57c5:
     type: source_fanout
@@ -3433,7 +3433,7 @@ clusters:
     rationale: Consolidated websocket + reconnection suites; kept ws_events separate
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/340
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/340
     added: '2026-01-22'
   97978043d552:
     type: source_fanout
@@ -3453,7 +3453,7 @@ clusters:
     rationale: Consolidate 9 test files into 5 files (<=240 lines each)
     status: done
     owner: claude
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/304
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/304
     added: '2026-01-20'
   982957ce2656:
     type: similar_names
@@ -3470,7 +3470,7 @@ clusters:
     rationale: Consolidated coverage and cache edges into shared historical data module
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/406
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/406
     added: '2026-01-20'
   9ac4e3c819d5:
     type: similar_names
@@ -3487,7 +3487,7 @@ clusters:
     rationale: Consolidated control flow and error handling into shared process modules
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/407
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/407
     added: '2026-01-20'
   9b09ad62333d:
     type: similar_names
@@ -3505,7 +3505,7 @@ clusters:
     rationale: Consolidated into three modules to stay under hygiene cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/379
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/379
     added: '2026-01-21'
   9ec1738d6db7:
     type: similar_names
@@ -3523,7 +3523,7 @@ clusters:
     rationale: Consolidated into two modules to stay under hygiene cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/380
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/380
     added: '2026-01-20'
   a0feb5e13a69:
     type: similar_names
@@ -3542,7 +3542,7 @@ clusters:
       cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/382
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/382
     added: '2026-01-20'
   a1a9bea8c6ac:
     type: similar_names
@@ -3560,7 +3560,7 @@ clusters:
     rationale: Consolidated into two modules to stay under hygiene cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/383
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/383
     added: '2026-01-20'
   a8b68bb428de:
     type: similar_names
@@ -3578,7 +3578,7 @@ clusters:
     rationale: Consolidated into three modules to stay under hygiene cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/384
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/384
     added: '2026-01-22'
   ac7d20d54ee8:
     type: similar_names
@@ -3596,7 +3596,7 @@ clusters:
     rationale: Consolidate 6 test files into 4 files (<=240 lines each)
     status: done
     owner: claude
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/303
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/303
     added: '2026-01-20'
   acb92ca7c206:
     type: source_fanout
@@ -3617,7 +3617,7 @@ clusters:
     rationale: Consolidate 6 test files into single parametrized file
     status: done
     owner: claude
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/304
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/304
     added: '2026-01-20'
   b072a5007bf1:
     type: similar_names
@@ -3635,7 +3635,7 @@ clusters:
       cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/389
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/389
     added: '2026-01-20'
   b878f1ecbfcf:
     type: similar_names
@@ -3653,7 +3653,7 @@ clusters:
       cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/391
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/391
     added: '2026-01-21'
   b89b9f506607:
     type: similar_names
@@ -3671,7 +3671,7 @@ clusters:
       separate
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/397
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/397
     added: '2026-01-21'
   ba5346200fdc:
     type: similar_names
@@ -3690,7 +3690,7 @@ clusters:
     rationale: Consolidate 5 test files into single parametrized file
     status: done
     owner: claude
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/315
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/315
     added: '2026-01-20'
   bcf5f1feb7e9:
     type: similar_names
@@ -3709,7 +3709,7 @@ clusters:
     rationale: Consolidate 5 test files into single parametrized file
     status: done
     owner: claude
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/316
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/316
     added: '2026-01-20'
   bef8933bbed5:
     type: similar_names
@@ -3727,7 +3727,7 @@ clusters:
       score suite separate to stay under hygiene cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/391
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/391
     added: '2026-01-20'
   bf1037e6cb7f:
     type: similar_names
@@ -3745,7 +3745,7 @@ clusters:
       separate
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/398
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/398
     added: '2026-01-20'
   c00dd1e7c53c:
     type: similar_names
@@ -3764,7 +3764,7 @@ clusters:
     rationale: Consolidate 5 test files into single parametrized file
     status: done
     owner: claude
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/317
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/317
     added: '2026-01-20'
   c1e4c1ed0ffb:
     type: similar_names
@@ -3783,7 +3783,7 @@ clusters:
     rationale: Consolidate 5 test files into single parametrized file
     status: done
     owner: claude
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/318
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/318
     added: '2026-01-20'
   c4731752fc43:
     type: source_fanout
@@ -3802,7 +3802,7 @@ clusters:
     rationale: Consolidate 6 test files into 4 files (<=240 lines each)
     status: done
     owner: claude
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/304
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/304
     added: '2026-01-20'
   c545b86c64bd:
     type: source_fanout
@@ -3825,7 +3825,7 @@ clusters:
     rationale: Consolidate 8 test files into single parametrized file
     status: done
     owner: claude
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/302
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/302
     added: '2026-01-20'
   c6bbc52b8b23:
     type: similar_names
@@ -3844,7 +3844,7 @@ clusters:
     rationale: Consolidated 11 → 5 files (<=240 lines each)
     status: done
     owner: claude
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/305
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/305
     added: '2026-01-20'
   c6fbd4c62f0a:
     type: similar_names
@@ -3861,7 +3861,7 @@ clusters:
     rationale: Consolidated 3 -> 1 file
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/336
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/336
     added: '2026-01-21'
   c94a37d62ba6:
     type: similar_names
@@ -3879,7 +3879,7 @@ clusters:
     rationale: Consolidated 4 -> 1 file
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/336
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/336
     added: '2026-01-20'
   cc5aea60ee1b:
     type: similar_names
@@ -3898,7 +3898,7 @@ clusters:
     rationale: Consolidated fill model coverage into fewer cohesive modules
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/346
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/346
     added: '2026-01-21'
   cd320529fca2:
     type: similar_names
@@ -3916,7 +3916,7 @@ clusters:
     rationale: Consolidated into two modules to stay under hygiene cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/385
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/385
     added: '2026-01-20'
   cd648425ded4:
     type: source_fanout
@@ -3934,7 +3934,7 @@ clusters:
     rationale: Consolidate 6 test files into 3 files (<=240 lines each)
     status: done
     owner: claude
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/303
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/303
     added: '2026-01-20'
   cdb4985dff87:
     type: similar_names
@@ -3952,7 +3952,7 @@ clusters:
       hygiene cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/391
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/391
     added: '2026-01-21'
   cebae704e17e:
     type: similar_names
@@ -3978,7 +3978,7 @@ clusters:
     rationale: Consolidate 12 test files into single parametrized file
     status: done
     owner: claude
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/325
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/325
     added: '2026-01-20'
   d120b9cb7c95:
     type: similar_names
@@ -3997,7 +3997,7 @@ clusters:
     rationale: Consolidate 7 test files into 5 files (<=240 lines each)
     status: done
     owner: claude
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/303
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/303
     added: '2026-01-20'
   d2e226ef4410:
     type: source_fanout
@@ -4016,7 +4016,7 @@ clusters:
     rationale: Consolidate 6 test files into 4 files (<=240 lines each)
     status: done
     owner: claude
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/303
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/303
     added: '2026-01-20'
   d461eb374bb2:
     type: similar_names
@@ -4034,7 +4034,7 @@ clusters:
     rationale: Consolidated into two modules to stay under hygiene cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/386
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/386
     added: '2026-01-20'
   d47c4f77bb07:
     type: similar_names
@@ -4053,7 +4053,7 @@ clusters:
     rationale: Consolidate 5 test files into single parametrized file
     status: done
     owner: claude
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/319
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/319
     added: '2026-01-20'
   d622238858da:
     type: similar_names
@@ -4071,7 +4071,7 @@ clusters:
     rationale: Consolidated into three modules to stay under hygiene cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/387
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/387
     added: '2026-01-22'
   d732e7cd3e8a:
     type: source_fanout
@@ -4091,7 +4091,7 @@ clusters:
     rationale: Consolidate 7 test files into 5 files (<=240 lines each)
     status: done
     owner: claude
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/303
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/303
     added: '2026-01-20'
   da0ea2376a4d:
     type: similar_names
@@ -4110,7 +4110,7 @@ clusters:
     rationale: Consolidate 5 test files into single parametrized file
     status: done
     owner: claude
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/320
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/320
     added: '2026-01-20'
   de08eabdc085:
     type: similar_names
@@ -4128,7 +4128,7 @@ clusters:
     rationale: Consolidated 4 test files into two modules to stay under hygiene cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/388
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/388
     added: '2026-01-20'
   e130faa60249:
     type: similar_names
@@ -4154,7 +4154,7 @@ clusters:
     rationale: Consolidate 12 test files into single parametrized file
     status: done
     owner: claude
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/326
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/326
     added: '2026-01-20'
   e15ea682e8fa:
     type: similar_names
@@ -4171,7 +4171,7 @@ clusters:
     rationale: Consolidated 3 -> 1 file
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/338
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/338
     added: '2026-01-21'
   ecb76d4271aa:
     type: similar_names
@@ -4190,7 +4190,7 @@ clusters:
     rationale: Consolidate 5 test files into single parametrized file
     status: done
     owner: claude
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/321
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/321
     added: '2026-01-20'
   f08c1e19e6ef:
     type: similar_names
@@ -4209,7 +4209,7 @@ clusters:
     rationale: Consolidate 5 test files into single parametrized file
     status: done
     owner: claude
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/322
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/322
     added: '2026-01-20'
   f2c6cc4f883e:
     type: similar_names
@@ -4227,7 +4227,7 @@ clusters:
       cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/390
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/390
     added: '2026-01-20'
   f9cf9481c6bd:
     type: similar_names
@@ -4245,7 +4245,7 @@ clusters:
       hygiene cap
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/394
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/394
     added: '2026-01-21'
   fb5cae8b4c58:
     type: source_fanout
@@ -4266,7 +4266,7 @@ clusters:
     rationale: Consolidate 6 test files into single parametrized file
     status: done
     owner: claude
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/304
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/304
     added: '2026-01-20'
   feca38fe83aa:
     type: similar_names
@@ -4283,5 +4283,5 @@ clusters:
     rationale: Consolidated basic/unavailable coverage into core module
     status: done
     owner: codex
-    pr_url: https://github.com/Solders-Girdles/GPT-Trader/pull/391
+    pr_url: https://github.com/Solders-Girdles-Org/GPT-Trader/pull/391
     added: '2026-01-20'

--- a/tests/unit/scripts/test_check_branch_protection.py
+++ b/tests/unit/scripts/test_check_branch_protection.py
@@ -11,7 +11,7 @@ from scripts.ci import check_branch_protection as checker
 def _matching_payload() -> dict[str, Any]:
     return {
         "required_status_checks": {
-            "strict": True,
+            "strict": False,
             "contexts": sorted(checker.EXPECTED_REQUIRED_CHECKS),
         },
         "enforce_admins": {"enabled": True},
@@ -27,7 +27,7 @@ def test_matching_payload_has_no_drift() -> None:
 def test_matching_payload_modern_checks_shape() -> None:
     payload = _matching_payload()
     payload["required_status_checks"] = {
-        "strict": True,
+        "strict": False,
         "checks": [{"context": name} for name in checker.EXPECTED_REQUIRED_CHECKS],
     }
     assert checker.assess_protection_drift(payload) == []
@@ -56,7 +56,7 @@ def test_missing_and_extra_required_checks_are_drift() -> None:
 @pytest.mark.parametrize(
     ("mutation", "expected_fragment"),
     [
-        (lambda p: p["required_status_checks"].update(strict=False), "strict up-to-date is False"),
+        (lambda p: p["required_status_checks"].update(strict=True), "strict up-to-date is True"),
         (lambda p: p.update(enforce_admins={"enabled": False}), "enforce_admins is False"),
         (
             lambda p: p.update(required_conversation_resolution={"enabled": False}),
@@ -91,13 +91,13 @@ def test_main_reports_success(monkeypatch: pytest.MonkeyPatch, capsys) -> None:
 
 def test_main_reports_drift_and_fails(monkeypatch: pytest.MonkeyPatch, capsys) -> None:
     payload = _matching_payload()
-    payload["required_status_checks"]["strict"] = False
+    payload["required_status_checks"]["strict"] = True
     monkeypatch.setattr(checker, "fetch_protection", lambda repo, branch: payload)
 
     exit_code = checker.main([])
 
     assert exit_code == 1
-    assert "✗ Branch protection drift: strict up-to-date is False" in capsys.readouterr().out
+    assert "✗ Branch protection drift: strict up-to-date is True" in capsys.readouterr().out
 
 
 def test_main_reports_fetch_failure(monkeypatch: pytest.MonkeyPatch, capsys) -> None:
@@ -130,7 +130,7 @@ def test_fetch_protection_rejects_non_mapping(monkeypatch: pytest.MonkeyPatch) -
 def test_apply_protection_drift_adds_warnings_on_main() -> None:
     report = ReadinessReport(ready=True)
     payload = _matching_payload()
-    payload["required_status_checks"]["strict"] = False
+    payload["required_status_checks"]["strict"] = True
 
     apply_protection_drift(report, payload, "main")
 

--- a/tests/unit/scripts/test_pr_readiness_merge_queue.py
+++ b/tests/unit/scripts/test_pr_readiness_merge_queue.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from scripts.agents.pr_readiness import (
+    BranchProtection,
+    CheckStatus,
+    PullRequestState,
+    ReviewSignal,
+    assess_readiness,
+)
+
+
+def _protection() -> BranchProtection:
+    return BranchProtection(
+        strict=False,
+        conversation_resolution=False,
+        required_review_count=0,
+        required_checks=("Unit Tests (Core)",),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# assess_readiness: merge-queue semantics (#1127)
+# --------------------------------------------------------------------------- #
+def _green_blocked_state() -> PullRequestState:
+    return PullRequestState(
+        number=1,
+        head_oid="a367f3c6deadbeef",
+        merge_state_status="BLOCKED",
+        review_decision="",
+        checks=(CheckStatus(name="Unit Tests (Core)", state="SUCCESS", required=True),),
+        threads=(),
+        protection=_protection(),
+        review_signals=(
+            ReviewSignal(kind="review", author="bot", state="COMMENTED", current_head=True),
+        ),
+    )
+
+
+def test_blocked_with_merge_queue_is_ready_to_enqueue() -> None:
+    report = assess_readiness(_green_blocked_state(), merge_queue_active=True)
+
+    assert report.ready is True
+    assert any(
+        finding.severity == "info" and "Merge queue is active" in finding.message
+        for finding in report.findings
+    )
+
+
+def test_blocked_without_merge_queue_stays_a_blocker() -> None:
+    report = assess_readiness(_green_blocked_state(), merge_queue_active=False)
+
+    assert report.ready is False
+    assert any(
+        finding.severity == "blocker" and "Branch protection is blocking" in finding.message
+        for finding in report.findings
+    )


### PR DESCRIPTION
- Flip EXPECTED_STRICT to False in check_branch_protection.py: the merge
  queue (enabled 2026-07-04) validates entries against latest main via
  merge_group runs, superseding strict up-to-date.
- Teach agent-pr-ready merge-queue semantics: with a queue required,
  GitHub reports mergeStateStatus BLOCKED for direct merges even on
  ready PRs; detect the queue via GraphQL and report ready-to-enqueue
  instead of a false blocker.
- Migrate every tracked reference from Solders-Girdles/GPT-Trader to
  Solders-Girdles-Org/GPT-Trader (README badge, decision docs,
  DEFAULT_REPOSITORY constants, dedupe triage manifest).
- Update AGENTS.md merge discipline and the DEVELOPMENT_GUIDELINES CI
  contract for queue-based merges; drop the now-unused --delete-branch
  docs-currency suppression.

Closes #1127
