### PR TITLE
refactor(trade-ideas): extract the runtime risk kernel from the workflow spine

### DIFF
--- a/src/gpt_trader/features/idea_execution/executor.py
+++ b/src/gpt_trader/features/idea_execution/executor.py
@@ -27,7 +27,6 @@ from gpt_trader.features.trade_ideas import (
     ActorType,
     AuditAction,
     AuditEvent,
-    AutonomyMode,
     AutonomyResolution,
     PaperFillEvent,
     PaperFillReconciler,
@@ -164,7 +163,12 @@ def paper_auto_execution_gate_evidence(
     *,
     now: datetime,
 ) -> tuple[str, ...] | None:
-    """Return submission evidence when a system approval passes the Stage 2 gate."""
+    """Return submission evidence when a system approval passes the Stage 2 gate.
+
+    The autonomy re-check is the risk kernel's execution gate; this lane adds
+    only its own admission preconditions (a sweep-issued system approval and
+    the operator-set auto-execution flag) and the env-specific evidence line.
+    """
     if approval_event is None:
         return None
     if approval_event.actor_type is not ActorType.SYSTEM:
@@ -173,10 +177,14 @@ def paper_auto_execution_gate_evidence(
         return None
     if not resolve_auto_execution_enabled():
         return None
-    resolution = service.resolve_execution_autonomy(now=now)
-    if resolution.mode is not AutonomyMode.BOUNDED_AUTONOMY:
+    check = service.kernel.check_execution(
+        approval_event.decision_id,
+        actor_type=ActorType.SYSTEM,
+        now=now,
+    )
+    if not check.admitted:
         return None
-    return _gate_evidence(approval_event, resolution)
+    return _gate_evidence(approval_event, check.autonomy)
 
 
 class PaperIdeaExecutor:

--- a/src/gpt_trader/features/trade_ideas/__init__.py
+++ b/src/gpt_trader/features/trade_ideas/__init__.py
@@ -52,6 +52,12 @@ from gpt_trader.features.trade_ideas.closeout import (
     MaxLossSnapshot,
 )
 from gpt_trader.features.trade_ideas.eligibility import evaluate_eligibility, is_eligible
+from gpt_trader.features.trade_ideas.kernel import (
+    KernelCheck,
+    KernelRuntime,
+    RiskKernel,
+    autonomy_resolution_violations,
+)
 from gpt_trader.features.trade_ideas.models import (
     AutonomyMode,
     BrokerTicket,
@@ -210,6 +216,8 @@ __all__ = [
     "ConfidenceLabel",
     "EntryZone",
     "InvalidTransitionError",
+    "KernelCheck",
+    "KernelRuntime",
     "MarketSnapshot",
     "MaxLoss",
     "MaxLossSnapshot",
@@ -241,6 +249,7 @@ __all__ = [
     "ReplayTournamentReport",
     "RiskBudget",
     "RiskBudgetLog",
+    "RiskKernel",
     "ScoringLevels",
     "SizingRecommendation",
     "SnapshotIntegrityError",
@@ -268,6 +277,7 @@ __all__ = [
     "TradeIdeaStore",
     "TradeIdeaView",
     "UnknownTradeIdeaError",
+    "autonomy_resolution_violations",
     "autonomy_transition_violations",
     "build_trade_idea_track_record_report",
     "canonical_ticket_json",

--- a/src/gpt_trader/features/trade_ideas/kernel.py
+++ b/src/gpt_trader/features/trade_ideas/kernel.py
@@ -1,0 +1,322 @@
+"""Runtime risk kernel: the one gate every execution path consults per decision.
+
+Implements the kernel extraction from
+docs/decisions/adopt-event-driven-execution-topology.md (#1189): the rails —
+budget envelope, audited autonomy state (with the automatic ratchet),
+eligibility invariants, audit append — are exposed as a single in-process,
+synchronous entry point that admits or denies an (idea, action) pair and
+records the audited event for the check. The ticket queue and approval sweep
+are one client of this kernel (the human-review client); the paper-execution
+lane is another. The kernel gates decisions, it never proposes
+(no-second-proposer-brain rule).
+
+Kernel checks are library calls with identity stamping: every check carries
+the actor type it was evaluated for, and every recorded outcome lands on the
+append-only audit log. Cross-process safety comes from the locked append
+primitives underneath (budget/autonomy logs); the kernel adds no locking of
+its own.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from typing import Protocol
+
+from gpt_trader.features.trade_ideas.audit import ActorType, AuditAction
+from gpt_trader.features.trade_ideas.autonomy import (
+    AUTONOMY_SOURCE_FAIL_CLOSED,
+    AutonomyResolution,
+)
+from gpt_trader.features.trade_ideas.budget import RiskBudget
+from gpt_trader.features.trade_ideas.models import AutonomyMode, TradeIdea
+from gpt_trader.features.trade_ideas.policy import (
+    ApprovalBudgetContext,
+    ApprovalPolicy,
+    PolicyViolationError,
+)
+from gpt_trader.features.trade_ideas.workflow import TradeIdeaState
+
+
+def autonomy_resolution_violations(resolution: AutonomyResolution) -> list[str]:
+    """Return the violation raised when autonomy resolution failed closed."""
+    if resolution.source != AUTONOMY_SOURCE_FAIL_CLOSED:
+        return []
+    return [
+        "autonomy state resolution failed closed to "
+        f"'{resolution.mode.value}': {resolution.error}"
+    ]
+
+
+class KernelRuntime(Protocol):
+    """Audited state a kernel check consults, implemented by ``TradeIdeaService``.
+
+    The kernel owns no storage: budget, autonomy, exposure, and audit append
+    all resolve through the same logs the workflow clients already share, so
+    a kernel admit/deny is always evaluated against — and recorded on — the
+    single source of truth.
+    """
+
+    def current_budget(self) -> RiskBudget: ...
+
+    def approval_budget_context(
+        self,
+        *,
+        exclude_decision_id: str | None = None,
+        now: datetime | None = None,
+    ) -> ApprovalBudgetContext: ...
+
+    def open_approved_count(self) -> int: ...
+
+    def decision_autonomy(
+        self,
+        *,
+        now: datetime,
+        budget: RiskBudget | None = None,
+        budget_context: ApprovalBudgetContext | None = None,
+    ) -> AutonomyResolution: ...
+
+    def review_started_at(self, decision_id: str) -> datetime | None: ...
+
+    def append_audit(
+        self,
+        idea: TradeIdea,
+        *,
+        action: AuditAction,
+        after_state: TradeIdeaState,
+        actor_type: ActorType,
+        actor_id: str,
+        reason: str,
+        evidence: tuple[str, ...] = (),
+    ) -> None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class KernelCheck:
+    """Admit/deny outcome of one kernel check, with the inputs it was judged on.
+
+    ``budget`` and ``budget_context`` are populated for approval checks;
+    execution checks resolve autonomy only and leave them ``None`` so a
+    render- or execution-path check never seeds the budget log as a side
+    effect.
+    """
+
+    action: AuditAction
+    decision_id: str
+    actor_type: ActorType
+    evaluated_at: datetime
+    autonomy: AutonomyResolution
+    violations: tuple[str, ...]
+    budget: RiskBudget | None = None
+    budget_context: ApprovalBudgetContext | None = None
+    candidate_max_loss_pct: Decimal | None = None
+
+    @property
+    def admitted(self) -> bool:
+        return not self.violations
+
+    def _autonomy_evidence(self) -> str:
+        return (
+            f"autonomy_state version {self.autonomy.version} "
+            f"mode={self.autonomy.mode.value} "
+            f"(source={self.autonomy.source})"
+        )
+
+    def _require_approval_inputs(self) -> tuple[RiskBudget, ApprovalBudgetContext]:
+        if self.budget is None or self.budget_context is None:
+            raise ValueError(
+                "Evidence for an approval outcome requires an approval check; "
+                f"this check gated action '{self.action.value}' without budget inputs"
+            )
+        return self.budget, self.budget_context
+
+    @property
+    def budget_version(self) -> int:
+        """Version of the budget this approval check was judged against."""
+        budget, _ = self._require_approval_inputs()
+        return budget.version
+
+    def admission_evidence(self) -> tuple[str, ...]:
+        """Evidence recorded with a system approval admitted by this check."""
+        budget, budget_context = self._require_approval_inputs()
+        return (
+            self._autonomy_evidence(),
+            f"risk budget version {budget.version}: approval_violations=0",
+            "budget envelope: "
+            f"same_day_realized_loss_pct={budget_context.same_day_realized_loss_pct} "
+            f"open_approved_at_risk_pct={budget_context.open_approved_at_risk_pct} "
+            f"candidate_max_loss_pct={self.candidate_max_loss_pct} "
+            f"max_daily_loss_pct={budget.max_daily_loss_pct}",
+        )
+
+    def denial_evidence(self) -> tuple[str, ...]:
+        """Evidence recorded when a denied check is audited rather than raised."""
+        budget, _ = self._require_approval_inputs()
+        return (
+            self._autonomy_evidence(),
+            f"risk budget version {budget.version}: " f"approval_violations={len(self.violations)}",
+            *(f"violation: {violation}" for violation in self.violations),
+        )
+
+
+class RiskKernel:
+    """In-process gate that admits or denies an (idea, action) pair per decision.
+
+    Checks are synchronous library calls: resolve the envelope and the
+    decision-time autonomy mode (applying the automatic ratchet), evaluate the
+    approval policy, and return every violation. Recording an outcome appends
+    the audited event through the same append the workflow clients use.
+    """
+
+    def __init__(
+        self,
+        runtime: KernelRuntime,
+        *,
+        now_factory: Callable[[], datetime],
+    ) -> None:
+        self._runtime = runtime
+        self._now = now_factory
+
+    def check_approval(
+        self,
+        idea: TradeIdea,
+        *,
+        actor_type: ActorType,
+        now: datetime | None = None,
+    ) -> KernelCheck:
+        """Gate one approval decision against budget + autonomy + eligibility."""
+        evaluated_at = now or self._now()
+        budget = self._runtime.current_budget()
+        budget_context = self._runtime.approval_budget_context(
+            exclude_decision_id=idea.decision_id,
+            now=evaluated_at,
+        )
+        resolution = self._runtime.decision_autonomy(
+            now=evaluated_at,
+            budget=budget,
+            budget_context=budget_context,
+        )
+        policy = ApprovalPolicy(resolution.mode)
+        violations = (
+            *autonomy_resolution_violations(resolution),
+            *policy.approval_violations(
+                idea,
+                actor_type=actor_type,
+                budget=budget,
+                open_approved_count=self._runtime.open_approved_count(),
+                now=evaluated_at,
+                review_started_at=self._runtime.review_started_at(idea.decision_id),
+                budget_context=budget_context,
+            ),
+        )
+        return KernelCheck(
+            action=AuditAction.APPROVED,
+            decision_id=idea.decision_id,
+            actor_type=actor_type,
+            evaluated_at=evaluated_at,
+            autonomy=resolution,
+            violations=violations,
+            budget=budget,
+            budget_context=budget_context,
+            candidate_max_loss_pct=idea.max_loss.percent_of_account,
+        )
+
+    def check_execution(
+        self,
+        decision_id: str,
+        *,
+        actor_type: ActorType,
+        now: datetime | None = None,
+    ) -> KernelCheck:
+        """Gate one system execution decision by re-resolving autonomy at execution time.
+
+        Generalizes the Stage 2 execution gate (#1177): the audited autonomy
+        mode is re-resolved — ratchet applied — at the moment of execution, so
+        an approval granted under ``bounded_autonomy`` cannot be executed
+        after the level ratcheted down. The check itself carries no budget
+        envelope inputs (budget exposure was gated at approval); the ratchet
+        may still consult the active budget, exactly as at any decision
+        boundary.
+        """
+        evaluated_at = now or self._now()
+        resolution = self._runtime.decision_autonomy(now=evaluated_at)
+        violations = list(autonomy_resolution_violations(resolution))
+        if resolution.mode is not AutonomyMode.BOUNDED_AUTONOMY:
+            violations.append(
+                "system-approved execution requires audited autonomy mode "
+                f"'{AutonomyMode.BOUNDED_AUTONOMY.value}'; resolved "
+                f"'{resolution.mode.value}' (source={resolution.source})"
+            )
+        return KernelCheck(
+            action=AuditAction.SUBMITTED,
+            decision_id=decision_id,
+            actor_type=actor_type,
+            evaluated_at=evaluated_at,
+            autonomy=resolution,
+            violations=tuple(violations),
+        )
+
+    def record_approval(
+        self,
+        idea: TradeIdea,
+        check: KernelCheck,
+        *,
+        actor_id: str,
+        reason: str,
+        evidence: tuple[str, ...] = (),
+    ) -> None:
+        """Append the audited APPROVED event for an admitted approval check."""
+        if not check.admitted:
+            raise PolicyViolationError(
+                f"Cannot record approval of '{check.decision_id}': the kernel "
+                "denied it: " + "; ".join(check.violations),
+                list(check.violations),
+            )
+        self._runtime.append_audit(
+            idea,
+            action=AuditAction.APPROVED,
+            after_state=TradeIdeaState.APPROVED,
+            actor_type=check.actor_type,
+            actor_id=actor_id,
+            reason=reason,
+            evidence=evidence,
+        )
+
+    def record_denied_approval(
+        self,
+        idea: TradeIdea,
+        check: KernelCheck,
+        *,
+        actor_id: str,
+        reason: str,
+    ) -> None:
+        """Append the audited AUTO_APPROVAL_SKIPPED event for a denied check.
+
+        Used by clients that record denials instead of raising (the Stage 2
+        sweep); the idea stays ``proposed`` for human review with every
+        violation on the audit trail — never silently dropped.
+        """
+        if check.admitted:
+            raise PolicyViolationError(
+                f"Cannot record a denial for '{check.decision_id}': the kernel " "admitted it",
+                [],
+            )
+        self._runtime.append_audit(
+            idea,
+            action=AuditAction.AUTO_APPROVAL_SKIPPED,
+            after_state=TradeIdeaState.PROPOSED,
+            actor_type=check.actor_type,
+            actor_id=actor_id,
+            reason=reason,
+            evidence=check.denial_evidence(),
+        )
+
+
+__all__ = [
+    "KernelCheck",
+    "KernelRuntime",
+    "RiskKernel",
+    "autonomy_resolution_violations",
+]

--- a/src/gpt_trader/features/trade_ideas/service.py
+++ b/src/gpt_trader/features/trade_ideas/service.py
@@ -64,6 +64,10 @@ from gpt_trader.features.trade_ideas.closeout import (
     CloseoutResolution,
     MaxLossSnapshot,
 )
+from gpt_trader.features.trade_ideas.kernel import (
+    RiskKernel,
+    autonomy_resolution_violations,
+)
 from gpt_trader.features.trade_ideas.models import (
     AutonomyMode,
     ConfidenceLabel,
@@ -284,6 +288,12 @@ class TradeIdeaService:
         self._budget_log = RiskBudgetLog(root / "risk_budget.jsonl")
         self._autonomy_log = AutonomyStateLog(root / "autonomy_state.jsonl")
         self._now = now_factory
+        self._kernel = RiskKernel(self, now_factory=self._now)
+
+    @property
+    def kernel(self) -> RiskKernel:
+        """Runtime risk kernel gating every (idea, action) decision on this store."""
+        return self._kernel
 
     @property
     def root(self) -> Path:
@@ -416,7 +426,7 @@ class TradeIdeaService:
         self._autonomy_log.append(entry)
         return entry
 
-    def _decision_autonomy(
+    def decision_autonomy(
         self,
         *,
         now: datetime,
@@ -467,16 +477,7 @@ class TradeIdeaService:
 
     def resolve_execution_autonomy(self, *, now: datetime | None = None) -> AutonomyResolution:
         """Resolve autonomy at an execution decision boundary, applying the ratchet."""
-        return self._decision_autonomy(now=now or self._now())
-
-    @staticmethod
-    def _autonomy_resolution_violations(resolution: AutonomyResolution) -> list[str]:
-        if resolution.source != AUTONOMY_SOURCE_FAIL_CLOSED:
-            return []
-        return [
-            "autonomy state resolution failed closed to "
-            f"'{resolution.mode.value}': {resolution.error}"
-        ]
+        return self.decision_autonomy(now=now or self._now())
 
     def approval_violations(
         self,
@@ -520,14 +521,14 @@ class TradeIdeaService:
     ) -> list[str]:
         policy = ApprovalPolicy(resolution.mode)
         return [
-            *self._autonomy_resolution_violations(resolution),
+            *autonomy_resolution_violations(resolution),
             *policy.approval_violations(
                 idea,
                 actor_type=actor_type,
                 budget=budget,
                 open_approved_count=self.open_approved_count(),
                 now=self._now(),
-                review_started_at=self._review_started_at(idea.decision_id),
+                review_started_at=self.review_started_at(idea.decision_id),
                 budget_context=self.approval_budget_context(
                     exclude_decision_id=idea.decision_id,
                 ),
@@ -691,10 +692,10 @@ class TradeIdeaService:
     def update_budget(self, budget: RiskBudget, actor_type: ActorType, actor_id: str) -> None:
         """Enact a new budget version, subject to the autonomy-mode policy."""
         now = self._now()
-        resolution = self._decision_autonomy(now=now)
+        resolution = self.decision_autonomy(now=now)
         policy = ApprovalPolicy(resolution.mode)
         violations = [
-            *self._autonomy_resolution_violations(resolution),
+            *autonomy_resolution_violations(resolution),
             *policy.budget_change_violations(actor_type),
         ]
         if violations:
@@ -713,7 +714,7 @@ class TradeIdeaService:
         # The enacted budget is part of this decision: re-check the ratchet
         # against it so tightening max_daily_loss_pct below already-realized
         # same-day losses lowers the level now, not at some later decision.
-        self._decision_autonomy(now=now)
+        self.decision_autonomy(now=now)
 
     # -- lifecycle actions -------------------------------------------------
 
@@ -727,7 +728,7 @@ class TradeIdeaService:
     ) -> TradeIdeaView:
         self.validate_new_proposal(idea)
         self._store.save(idea)
-        self._append(
+        self.append_audit(
             idea,
             action=AuditAction.PROPOSED,
             after_state=TradeIdeaState.PROPOSED,
@@ -760,7 +761,7 @@ class TradeIdeaService:
             for idea in ideas:
                 created_decision_ids.append(idea.decision_id)
                 self._store.save(idea)
-                self._append(
+                self.append_audit(
                     idea,
                     action=AuditAction.PROPOSED,
                     after_state=TradeIdeaState.PROPOSED,
@@ -780,7 +781,7 @@ class TradeIdeaService:
 
     def request_changes(self, decision_id: str, actor_id: str, reason: str) -> TradeIdeaView:
         idea = self._require_idea(decision_id)
-        self._append(
+        self.append_audit(
             idea,
             action=AuditAction.CHANGED,
             after_state=TradeIdeaState.NEEDS_CHANGES,
@@ -799,7 +800,7 @@ class TradeIdeaService:
     ) -> TradeIdeaView:
         self.validate_resubmission(idea)
         self._store.save(idea)
-        self._append(
+        self.append_audit(
             idea,
             action=AuditAction.PROPOSED,
             after_state=TradeIdeaState.PROPOSED,
@@ -810,43 +811,15 @@ class TradeIdeaService:
         return self.get(idea.decision_id)
 
     def approve(self, decision_id: str, actor_id: str, reason: str) -> TradeIdeaView:
+        """Human-review client of the risk kernel: deny raises, admit is recorded."""
         idea = self._require_idea(decision_id)
-        now = self._now()
-        budget = self.current_budget()
-        budget_context = self.approval_budget_context(
-            exclude_decision_id=decision_id,
-            now=now,
-        )
-        resolution = self._decision_autonomy(
-            now=now,
-            budget=budget,
-            budget_context=budget_context,
-        )
-        policy = ApprovalPolicy(resolution.mode)
-        violations = [
-            *self._autonomy_resolution_violations(resolution),
-            *policy.approval_violations(
-                idea,
-                actor_type=ActorType.HUMAN,
-                budget=budget,
-                open_approved_count=self.open_approved_count(),
-                now=now,
-                review_started_at=self._review_started_at(decision_id),
-                budget_context=budget_context,
-            ),
-        ]
-        if violations:
+        check = self._kernel.check_approval(idea, actor_type=ActorType.HUMAN)
+        if not check.admitted:
             raise PolicyViolationError(
-                f"Approval of '{decision_id}' refused: " + "; ".join(violations), violations
+                f"Approval of '{decision_id}' refused: " + "; ".join(check.violations),
+                list(check.violations),
             )
-        self._append(
-            idea,
-            action=AuditAction.APPROVED,
-            after_state=TradeIdeaState.APPROVED,
-            actor_type=ActorType.HUMAN,
-            actor_id=actor_id,
-            reason=reason,
-        )
+        self._kernel.record_approval(idea, check, actor_id=actor_id, reason=reason)
         return self.get(decision_id)
 
     def auto_approve_sweep(
@@ -875,8 +848,8 @@ class TradeIdeaService:
                 gate_violations,
             )
         now = self._now()
-        resolution = self._decision_autonomy(now=now)
-        gate_violations.extend(self._autonomy_resolution_violations(resolution))
+        resolution = self.decision_autonomy(now=now)
+        gate_violations.extend(autonomy_resolution_violations(resolution))
         if resolution.mode is not AutonomyMode.BOUNDED_AUTONOMY:
             gate_violations.append(
                 "auto-approval requires audited autonomy mode "
@@ -897,78 +870,33 @@ class TradeIdeaService:
         skipped: list[AutoApprovalSkip] = []
         for candidate in candidates:
             idea = candidate.idea
-            decision_time = self._now()
-            budget = self.current_budget()
-            budget_context = self.approval_budget_context(
-                exclude_decision_id=idea.decision_id,
-                now=decision_time,
-            )
-            decision_resolution = self._decision_autonomy(
-                now=decision_time,
-                budget=budget,
-                budget_context=budget_context,
-            )
-            policy = ApprovalPolicy(decision_resolution.mode)
-            violations = [
-                *self._autonomy_resolution_violations(decision_resolution),
-                *policy.approval_violations(
+            check = self._kernel.check_approval(idea, actor_type=ActorType.SYSTEM)
+            if not check.admitted:
+                self._kernel.record_denied_approval(
                     idea,
-                    actor_type=ActorType.SYSTEM,
-                    budget=budget,
-                    open_approved_count=self.open_approved_count(),
-                    now=decision_time,
-                    review_started_at=self._review_started_at(idea.decision_id),
-                    budget_context=budget_context,
-                ),
-            ]
-            if violations:
-                self._append(
-                    idea,
-                    action=AuditAction.AUTO_APPROVAL_SKIPPED,
-                    after_state=TradeIdeaState.PROPOSED,
-                    actor_type=ActorType.SYSTEM,
+                    check,
                     actor_id=actor_id,
                     reason=(
                         f"{AUTO_APPROVAL_REASON_PREFIX}skipped because "
                         "approval-policy violations remain"
                     ),
-                    evidence=(
-                        f"autonomy_state version {decision_resolution.version} "
-                        f"mode={decision_resolution.mode.value} "
-                        f"(source={decision_resolution.source})",
-                        f"risk budget version {budget.version}: "
-                        f"approval_violations={len(violations)}",
-                        *(f"violation: {violation}" for violation in violations),
-                    ),
                 )
                 skipped.append(
                     AutoApprovalSkip(
                         decision_id=idea.decision_id,
-                        violations=tuple(violations),
+                        violations=check.violations,
                     )
                 )
                 continue
-            self._append(
+            self._kernel.record_approval(
                 idea,
-                action=AuditAction.APPROVED,
-                after_state=TradeIdeaState.APPROVED,
-                actor_type=ActorType.SYSTEM,
+                check,
                 actor_id=actor_id,
                 reason=(
                     f"{AUTO_APPROVAL_REASON_PREFIX}zero approval-policy violations "
-                    f"inside the budget envelope of risk budget version {budget.version}"
+                    f"inside the budget envelope of risk budget version {check.budget_version}"
                 ),
-                evidence=(
-                    f"autonomy_state version {decision_resolution.version} "
-                    f"mode={decision_resolution.mode.value} "
-                    f"(source={decision_resolution.source})",
-                    f"risk budget version {budget.version}: approval_violations=0",
-                    "budget envelope: "
-                    f"same_day_realized_loss_pct={budget_context.same_day_realized_loss_pct} "
-                    f"open_approved_at_risk_pct={budget_context.open_approved_at_risk_pct} "
-                    f"candidate_max_loss_pct={idea.max_loss.percent_of_account} "
-                    f"max_daily_loss_pct={budget.max_daily_loss_pct}",
-                ),
+                evidence=check.admission_evidence(),
             )
             approved.append(self.get(idea.decision_id))
         return AutoApprovalSweepResult(
@@ -987,7 +915,7 @@ class TradeIdeaService:
         actor_type: ActorType = ActorType.HUMAN,
     ) -> TradeIdeaView:
         idea = self._require_idea(decision_id)
-        self._append(
+        self.append_audit(
             idea,
             action=AuditAction.REJECTED,
             after_state=TradeIdeaState.REJECTED,
@@ -1005,7 +933,7 @@ class TradeIdeaService:
         actor_type: ActorType = ActorType.HUMAN,
     ) -> TradeIdeaView:
         idea = self._require_idea(decision_id)
-        self._append(
+        self.append_audit(
             idea,
             action=AuditAction.CANCELLED,
             after_state=TradeIdeaState.CANCELLED,
@@ -1023,7 +951,7 @@ class TradeIdeaService:
         actor_type: ActorType = ActorType.SYSTEM,
     ) -> TradeIdeaView:
         idea = self._require_idea(decision_id)
-        self._append(
+        self.append_audit(
             idea,
             action=AuditAction.EXPIRED,
             after_state=TradeIdeaState.EXPIRED,
@@ -1080,7 +1008,7 @@ class TradeIdeaService:
     ) -> TradeIdeaView:
         venue = _validate_audit_venue(venue)
         idea = self._require_idea(decision_id)
-        self._append(
+        self.append_audit(
             idea,
             action=AuditAction.SUBMITTED,
             after_state=TradeIdeaState.SUBMITTED,
@@ -1104,7 +1032,7 @@ class TradeIdeaService:
     ) -> TradeIdeaView:
         venue = _validate_audit_venue(venue)
         idea = self._require_idea(decision_id)
-        self._append(
+        self.append_audit(
             idea,
             action=AuditAction.FILLED,
             after_state=TradeIdeaState.FILLED,
@@ -1189,7 +1117,7 @@ class TradeIdeaService:
         autonomy_resolution = self.peek_autonomy()
         policy = ApprovalPolicy(autonomy_resolution.mode)
         policy_violations = [
-            *self._autonomy_resolution_violations(autonomy_resolution),
+            *autonomy_resolution_violations(autonomy_resolution),
             *policy.approval_violations(
                 view.idea,
                 actor_type=ActorType.HUMAN,
@@ -1666,7 +1594,7 @@ class TradeIdeaService:
             value=broker_ticket.to_dict(),
         )
 
-    def _review_started_at(self, decision_id: str) -> datetime | None:
+    def review_started_at(self, decision_id: str) -> datetime | None:
         return self._review_started_at_from_events(tuple(self._audit.read_events(decision_id)))
 
     def _review_started_at_from_events(self, events: tuple[AuditEvent, ...]) -> datetime | None:
@@ -1680,7 +1608,7 @@ class TradeIdeaService:
                 return event.timestamp
         return None
 
-    def _append(
+    def append_audit(
         self,
         idea: TradeIdea,
         *,

--- a/tests/unit/gpt_trader/features/trade_ideas/test_kernel.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_kernel.py
@@ -1,0 +1,195 @@
+"""Kernel-level tests: the one gate every execution path consults (#1189).
+
+The batch approve/sweep and paper-execution behavior the kernel now backs is
+pinned by the existing service and executor suites; these tests pin the
+kernel API itself — admit/deny outcomes, evidence, and the audited record of
+the check.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from tests.unit.gpt_trader.features.trade_ideas.conftest import (
+    attest_account_equity,
+    build_trade_idea,
+)
+
+from gpt_trader.features.trade_ideas import (
+    ActorType,
+    AuditAction,
+    AutonomyMode,
+    KernelCheck,
+    PolicyViolationError,
+    TradeIdeaService,
+    TradeIdeaState,
+)
+
+FROZEN_NOW = datetime(2026, 6, 12, 10, 0, tzinfo=UTC)
+
+
+@pytest.fixture
+def service(tmp_path: Path) -> TradeIdeaService:
+    return TradeIdeaService(tmp_path / "ideas", now_factory=lambda: FROZEN_NOW)
+
+
+def proposed_idea(service: TradeIdeaService, decision_id: str = "trade-20260612-001"):
+    attest_account_equity(service)
+    idea = build_trade_idea(decision_id=decision_id)
+    service.propose(idea, actor_id="idea-generator-v1")
+    return idea
+
+
+class TestCheckApproval:
+    def test_admits_eligible_idea_for_human_actor(self, service: TradeIdeaService) -> None:
+        idea = proposed_idea(service)
+
+        check = service.kernel.check_approval(idea, actor_type=ActorType.HUMAN)
+
+        assert check.admitted
+        assert check.violations == ()
+        assert check.decision_id == idea.decision_id
+        assert check.actor_type is ActorType.HUMAN
+        assert check.action is AuditAction.APPROVED
+        assert check.budget is not None
+        assert check.budget_context is not None
+        assert check.candidate_max_loss_pct == idea.max_loss.percent_of_account
+
+    def test_denies_system_actor_in_human_approved_mode(self, service: TradeIdeaService) -> None:
+        idea = proposed_idea(service)
+
+        check = service.kernel.check_approval(idea, actor_type=ActorType.SYSTEM)
+
+        assert not check.admitted
+        assert any("human_approved_execution" in violation for violation in check.violations)
+
+    def test_matches_service_approval_violations(self, service: TradeIdeaService) -> None:
+        """The kernel and the pre-existing violations surface judge identically."""
+        attest_account_equity(service)
+        ineligible = build_trade_idea(
+            decision_id="trade-20260612-002",
+            thesis=" ",
+        )
+        service.propose(ineligible, actor_id="idea-generator-v1")
+
+        check = service.kernel.check_approval(ineligible, actor_type=ActorType.HUMAN)
+
+        assert list(check.violations) == service.approval_violations(
+            ineligible, actor_type=ActorType.HUMAN
+        )
+        assert not check.admitted
+
+    def test_denial_evidence_lists_every_violation(self, service: TradeIdeaService) -> None:
+        idea = proposed_idea(service)
+
+        check = service.kernel.check_approval(idea, actor_type=ActorType.AI)
+
+        evidence = check.denial_evidence()
+        assert evidence[0].startswith("autonomy_state version ")
+        assert f"approval_violations={len(check.violations)}" in evidence[1]
+        assert all(f"violation: {violation}" in evidence for violation in check.violations)
+
+    def test_admission_evidence_carries_budget_envelope(self, service: TradeIdeaService) -> None:
+        idea = proposed_idea(service)
+
+        check = service.kernel.check_approval(idea, actor_type=ActorType.HUMAN)
+
+        evidence = check.admission_evidence()
+        assert f"risk budget version {check.budget_version}: approval_violations=0" in evidence
+        assert any(entry.startswith("budget envelope: ") for entry in evidence)
+        assert any(
+            f"candidate_max_loss_pct={idea.max_loss.percent_of_account}" in entry
+            for entry in evidence
+        )
+
+
+class TestRecordOutcomes:
+    def test_record_approval_appends_audited_event(self, service: TradeIdeaService) -> None:
+        idea = proposed_idea(service)
+        check = service.kernel.check_approval(idea, actor_type=ActorType.HUMAN)
+
+        service.kernel.record_approval(idea, check, actor_id="rj", reason="Risk verified")
+
+        view = service.get(idea.decision_id)
+        assert view.state is TradeIdeaState.APPROVED
+        approval = view.events[-1]
+        assert approval.action is AuditAction.APPROVED
+        assert approval.actor_type is ActorType.HUMAN
+        assert approval.actor_id == "rj"
+
+    def test_record_approval_refuses_denied_check(self, service: TradeIdeaService) -> None:
+        idea = proposed_idea(service)
+        check = service.kernel.check_approval(idea, actor_type=ActorType.AI)
+
+        with pytest.raises(PolicyViolationError, match="the kernel denied it"):
+            service.kernel.record_approval(idea, check, actor_id="bot", reason="nope")
+        assert service.get(idea.decision_id).state is TradeIdeaState.PROPOSED
+
+    def test_record_denied_approval_appends_skip_with_evidence(
+        self, service: TradeIdeaService
+    ) -> None:
+        idea = proposed_idea(service)
+        check = service.kernel.check_approval(idea, actor_type=ActorType.SYSTEM)
+
+        service.kernel.record_denied_approval(
+            idea, check, actor_id="auto-approval-sweep", reason="skipped"
+        )
+
+        view = service.get(idea.decision_id)
+        assert view.state is TradeIdeaState.PROPOSED
+        skip = view.events[-1]
+        assert skip.action is AuditAction.AUTO_APPROVAL_SKIPPED
+        assert skip.evidence == check.denial_evidence()
+
+    def test_record_denied_approval_refuses_admitted_check(self, service: TradeIdeaService) -> None:
+        idea = proposed_idea(service)
+        check = service.kernel.check_approval(idea, actor_type=ActorType.HUMAN)
+
+        with pytest.raises(PolicyViolationError, match="the kernel admitted it"):
+            service.kernel.record_denied_approval(
+                idea, check, actor_id="auto-approval-sweep", reason="skipped"
+            )
+
+
+class TestCheckExecution:
+    def test_denies_outside_bounded_autonomy(self, service: TradeIdeaService) -> None:
+        check = service.kernel.check_execution("trade-20260612-001", actor_type=ActorType.SYSTEM)
+
+        assert not check.admitted
+        assert any("bounded_autonomy" in violation for violation in check.violations)
+        assert check.action is AuditAction.SUBMITTED
+        assert check.budget is None
+        assert check.budget_context is None
+
+    def test_admits_under_bounded_autonomy(self, service: TradeIdeaService) -> None:
+        attest_account_equity(service)
+        service.set_autonomy_mode(
+            AutonomyMode.BOUNDED_AUTONOMY,
+            actor_type=ActorType.HUMAN,
+            actor_id="rj",
+            reason="Stage 2 exercised in tests",
+        )
+
+        check = service.kernel.check_execution("trade-20260612-001", actor_type=ActorType.SYSTEM)
+
+        assert check.admitted
+        assert check.autonomy.mode is AutonomyMode.BOUNDED_AUTONOMY
+
+    def test_execution_check_has_no_approval_evidence(self, service: TradeIdeaService) -> None:
+        check = service.kernel.check_execution("trade-20260612-001", actor_type=ActorType.SYSTEM)
+
+        with pytest.raises(ValueError, match="requires an approval check"):
+            check.admission_evidence()
+        with pytest.raises(ValueError, match="requires an approval check"):
+            check.denial_evidence()
+
+
+def test_kernel_check_is_immutable(service: TradeIdeaService) -> None:
+    idea = proposed_idea(service)
+    check = service.kernel.check_approval(idea, actor_type=ActorType.HUMAN)
+
+    assert isinstance(check, KernelCheck)
+    with pytest.raises(AttributeError):
+        check.violations = ()  # type: ignore[misc]

--- a/var/agents/configuration/environment_variables.json
+++ b/var/agents/configuration/environment_variables.json
@@ -777,7 +777,7 @@
       ],
       "code_references": [
         {
-          "line": 256,
+          "line": 260,
           "path": "src/gpt_trader/features/trade_ideas/service.py",
           "reader": "os.environ.get"
         }
@@ -1189,7 +1189,7 @@
       ],
       "code_references": [
         {
-          "line": 269,
+          "line": 273,
           "path": "src/gpt_trader/features/trade_ideas/service.py",
           "reader": "os.environ.get"
         }
@@ -1205,7 +1205,7 @@
       ],
       "code_references": [
         {
-          "line": 127,
+          "line": 126,
           "path": "src/gpt_trader/features/idea_execution/executor.py",
           "reader": "os.environ.get"
         }
@@ -1221,7 +1221,7 @@
       ],
       "code_references": [
         {
-          "line": 246,
+          "line": 250,
           "path": "src/gpt_trader/features/trade_ideas/service.py",
           "reader": "os.environ.get"
         }


### PR DESCRIPTION
## What

First step of the accepted [adopt-event-driven-execution-topology](docs/decisions/adopt-event-driven-execution-topology.md) decision (#1189): the rails are now exposed as an in-process **runtime risk kernel** — a single gate any execution path consults per decision, returning admit/deny plus the audited record of the check.

- **New `trade_ideas/kernel.py`** — `RiskKernel` with one approval entry point (`check_approval`: budget envelope + decision-time autonomy with the ratchet + eligibility via `ApprovalPolicy`) and one execution entry point (`check_execution`: the generalized Stage 2 execution-time autonomy re-check from #1177). `KernelCheck` carries the admit/deny outcome, the inputs it was judged on, and the evidence builders; `record_approval` / `record_denied_approval` append the audited event.
- **The queue/sweep workflow is now a kernel client, not the spine.** `TradeIdeaService.approve` (human-review client, raises on deny) and `auto_approve_sweep` (Stage 2 client, records `AUTO_APPROVAL_SKIPPED` on deny) both consult the kernel; the service satisfies the narrow `KernelRuntime` protocol (`decision_autonomy`, `review_started_at`, `append_audit` made public for the kernel seam).
- **Paper-execution lane** consumes `kernel.check_execution` for the system-approval gate; lane-specific preconditions (sweep-issued approval, operator env flag) stay in the lane.
- Carries forward the no-second-proposer-brain rule: the kernel gates decisions, it does not propose.

## Behavior

No behavior change. Violation strings, audit evidence, deny semantics, and log-seeding side effects are identical; the pre-existing 475 trade_ideas + idea_execution unit tests pass unchanged as characterization tests, plus 13 new kernel-level tests.

## Safety

Paper-only mechanisms, same gates. No broker call, no live execution, no autonomy change.

Closes #1189