### PR TITLE
feat(trade-ideas): split eligibility into invariant vs mode-dependent constraints

### DIFF
--- a/docs/DIRECTION.md
+++ b/docs/DIRECTION.md
@@ -92,11 +92,17 @@ trade-idea record, append-only audit log, approval workflow, eligibility gate,
 and versioned risk budget exist in code — that *is* their specification. What
 remains gated before any non-manual execution lane opens:
 
-- **Strategy eligibility.** An idea is eligible only if it survives human review
-  latency: multi-hour/day horizon, explicit entry/invalidation/exit/max-loss,
+- **Strategy eligibility.** Eligibility splits into two constraint classes
+  ([adopt-event-driven-execution-topology](decisions/adopt-event-driven-execution-topology.md)).
+  *Invariant, at every autonomy level:* explicit entry/invalidation/exit/max-loss,
   explainable from recorded data, sizeable before entry, with an expiry. Missing
   invalidation, missing max-loss, no reproducible data source, or a need for
-  continuous babysitting are automatic rejections.
+  continuous babysitting are automatic rejections. *Mode-dependent:* surviving
+  human review latency (multi-hour/day horizon) applies only under
+  `human_approved_execution`; under `bounded_autonomy` the horizon floor comes
+  from measured capability, not human latency. Rejection reasons record which
+  class failed so track-record evidence can distinguish an unsound idea from
+  one that is merely too fast for a human review loop.
 - **Numeric risk budget.** Max loss per idea, max daily loss, max open notional
   by product type, max concurrent approved-but-unexecuted tickets, max review
   latency, and whether sizing is advisory or hard-capped must be chosen values.

--- a/src/gpt_trader/features/trade_ideas/__init__.py
+++ b/src/gpt_trader/features/trade_ideas/__init__.py
@@ -51,7 +51,12 @@ from gpt_trader.features.trade_ideas.closeout import (
     DuplicateCloseoutAttributionError,
     MaxLossSnapshot,
 )
-from gpt_trader.features.trade_ideas.eligibility import evaluate_eligibility, is_eligible
+from gpt_trader.features.trade_ideas.eligibility import (
+    INVARIANT_ELIGIBILITY_PREFIX,
+    MODE_DEPENDENT_ELIGIBILITY_PREFIX,
+    evaluate_eligibility,
+    is_eligible,
+)
 from gpt_trader.features.trade_ideas.kernel import (
     KernelCheck,
     KernelRuntime,
@@ -187,6 +192,8 @@ __all__ = [
     "DuplicateCloseoutAttributionError",
     "DuplicateTradeIdeaError",
     "IDEAS_ROOT_ENV_VAR",
+    "INVARIANT_ELIGIBILITY_PREFIX",
+    "MODE_DEPENDENT_ELIGIBILITY_PREFIX",
     "TICKET_PAYLOAD_SCHEMA_VERSION",
     "TERMINAL_STATES",
     "ActorType",

--- a/src/gpt_trader/features/trade_ideas/eligibility.py
+++ b/src/gpt_trader/features/trade_ideas/eligibility.py
@@ -1,18 +1,40 @@
-"""Strategy-eligibility gate for trade ideas.
+"""Strategy-eligibility gate for trade ideas, split into two constraint classes.
 
-Encodes the automatic rejection conditions from the accepted framework
-(docs/DIRECTION.md, Decision 2): ideas without an
-invalidation level, max-loss estimate, reproducible data source, defined
-entry, exit rule, or expiry must never reach a reviewer as actionable.
+Implements the eligibility split from
+docs/decisions/adopt-event-driven-execution-topology.md (#1190):
+
+- **Invariant constraints** (this module's checks) apply identically at every
+  autonomy level. They are blast-radius controls from the accepted framework
+  (docs/DIRECTION.md, Decision 2): ideas without an invalidation level,
+  max-loss estimate, reproducible data source, defined entry, exit rule, or
+  expiry are never actionable, no matter who or what is approving.
+- **Mode-dependent constraints** (review-latency survivability, enforced by
+  ``ApprovalPolicy.review_latency_violation``) exist only because a human
+  review loop is in the decision path. They apply under
+  ``human_approved_execution`` (and the fail-closed ``research_only``); under
+  ``bounded_autonomy`` the horizon floor comes from measured capability, not
+  human latency.
+
+Rejection reasons carry their class prefix so the audit trail can distinguish
+"unsound idea" from "too fast for a human" when building track-record
+evidence.
 """
 
 from __future__ import annotations
 
 from gpt_trader.features.trade_ideas.models import TradeIdea
 
+INVARIANT_ELIGIBILITY_PREFIX = "invariant eligibility: "
+MODE_DEPENDENT_ELIGIBILITY_PREFIX = "mode-dependent eligibility (human_approved_execution): "
+
 
 def evaluate_eligibility(idea: TradeIdea) -> list[str]:
-    """Return human-readable rejection reasons; an empty list means eligible."""
+    """Return invariant rejection reasons; an empty list means eligible.
+
+    Every check here is autonomy-level invariant. Mode-dependent constraints
+    never belong in this function — they live on ``ApprovalPolicy``, which
+    knows the resolved autonomy mode.
+    """
     reasons: list[str] = []
 
     if not idea.thesis.strip():
@@ -39,5 +61,5 @@ def evaluate_eligibility(idea: TradeIdea) -> list[str]:
 
 
 def is_eligible(idea: TradeIdea) -> bool:
-    """True when the idea survives every automatic rejection condition."""
+    """True when the idea survives every invariant rejection condition."""
     return not evaluate_eligibility(idea)

--- a/src/gpt_trader/features/trade_ideas/policy.py
+++ b/src/gpt_trader/features/trade_ideas/policy.py
@@ -20,7 +20,11 @@ from decimal import Decimal
 from gpt_trader.errors import ValidationError
 from gpt_trader.features.trade_ideas.audit import ActorType
 from gpt_trader.features.trade_ideas.budget import RiskBudget
-from gpt_trader.features.trade_ideas.eligibility import evaluate_eligibility
+from gpt_trader.features.trade_ideas.eligibility import (
+    INVARIANT_ELIGIBILITY_PREFIX,
+    MODE_DEPENDENT_ELIGIBILITY_PREFIX,
+    evaluate_eligibility,
+)
 from gpt_trader.features.trade_ideas.models import (
     AutonomyMode,
     ProductType,
@@ -112,7 +116,9 @@ class ApprovalPolicy:
                 BOUNDED_AUTONOMY_ACTOR_APPROVAL_VIOLATION + f"; got actor_type '{actor_type.value}'"
             )
 
-        violations.extend(evaluate_eligibility(idea))
+        violations.extend(
+            INVARIANT_ELIGIBILITY_PREFIX + reason for reason in evaluate_eligibility(idea)
+        )
 
         if has_budget_context and budget_context.same_day_realized_loss_unavailable_count:
             violations.append(
@@ -227,6 +233,18 @@ class ApprovalPolicy:
 
         return violations
 
+    @property
+    def review_latency_applies(self) -> bool:
+        """True when human-review-latency survivability constrains this mode.
+
+        Mode-dependent eligibility (#1190): review latency exists only because
+        a human review loop is in the decision path. Under ``bounded_autonomy``
+        the horizon floor comes from measured capability, not human latency,
+        so the constraint does not apply. Every other mode — including the
+        fail-closed ``research_only`` — keeps it, conservatively.
+        """
+        return self._autonomy_mode is not AutonomyMode.BOUNDED_AUTONOMY
+
     def review_latency_violation(
         self,
         *,
@@ -234,14 +252,21 @@ class ApprovalPolicy:
         budget: RiskBudget,
         now: datetime,
     ) -> str | None:
-        """Return a violation when the active review window has elapsed."""
+        """Return a violation when the active review window has elapsed.
+
+        Mode-dependent: returns ``None`` unconditionally when
+        ``review_latency_applies`` is false for the policy's autonomy mode.
+        """
+        if not self.review_latency_applies:
+            return None
         if review_started_at is None:
             return None
         review_deadline = review_started_at + timedelta(hours=budget.max_review_latency_hours)
         if review_deadline > now:
             return None
         return (
-            f"Idea review deadline expired at {review_deadline.isoformat()} "
+            MODE_DEPENDENT_ELIGIBILITY_PREFIX
+            + f"Idea review deadline expired at {review_deadline.isoformat()} "
             f"after max_review_latency_hours={budget.max_review_latency_hours}"
         )
 

--- a/src/gpt_trader/features/trade_ideas/service.py
+++ b/src/gpt_trader/features/trade_ideas/service.py
@@ -971,9 +971,11 @@ class TradeIdeaService:
         """Expire all stale ideas that can legally transition to expired."""
         now = self._now()
         budget = self._budget_log.current() or DEFAULT_RISK_BUDGET
-        # Review-latency checks are autonomy-mode independent; a static policy
-        # is safe here and keeps the expiry sweep read-only on the autonomy log.
-        policy = ApprovalPolicy()
+        # Review-latency expiry is mode-dependent eligibility (#1190): it keys
+        # off the audited autonomy log via a read-only peek, so the sweep still
+        # never seeds or ratchets state. A fail-closed resolution yields
+        # research_only, which conservatively keeps latency expiry active.
+        policy = ApprovalPolicy(self.peek_autonomy().mode)
         expired: list[TradeIdeaView] = []
         for view in self.list_views():
             if view.state not in EXPIRABLE_STATES:
@@ -1275,6 +1277,10 @@ class TradeIdeaService:
                 sort_by=TradeIdeaListSortKey.EXPIRES_AT,
             )
         ).views
+        # Review-latency deadlines are mode-dependent eligibility (#1190):
+        # warn about them only when the resolved mode still enforces them, so
+        # the queue never predicts an expiration the sweep would not perform.
+        review_latency_applies = ApprovalPolicy(self.peek_autonomy().mode).review_latency_applies
         upcoming_expirations: list[TradeIdeaQueueExpiration] = []
         for view in (*proposed, *needs_changes):
             expiration = _queue_expiration(
@@ -1283,6 +1289,7 @@ class TradeIdeaService:
                 window_end,
                 budget,
                 review_started_at=self._review_started_at_from_events(view.events),
+                review_latency_applies=review_latency_applies,
             )
             if expiration is not None:
                 upcoming_expirations.append(expiration)
@@ -1778,12 +1785,13 @@ def _queue_expiration(
     budget: RiskBudget,
     *,
     review_started_at: datetime | None,
+    review_latency_applies: bool = True,
 ) -> TradeIdeaQueueExpiration | None:
     deadlines: list[tuple[str, datetime]] = []
     horizon_expires_at = view.idea.time_horizon.expires_at
     if horizon_expires_at is not None:
         deadlines.append(("time_horizon", horizon_expires_at))
-    if review_started_at is not None:
+    if review_latency_applies and review_started_at is not None:
         review_deadline = review_started_at + timedelta(hours=budget.max_review_latency_hours)
         deadlines.append(("review_latency", review_deadline))
 

--- a/tests/unit/gpt_trader/features/trade_ideas/test_eligibility_split.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_eligibility_split.py
@@ -1,0 +1,245 @@
+"""Eligibility split: invariant vs mode-dependent constraints (#1190).
+
+Invariant checks apply identically at every autonomy level; review-latency
+survivability applies only when a human review loop is in the decision path
+(every mode except ``bounded_autonomy``). Rejection reasons carry their
+constraint-class prefix so the audit trail distinguishes "unsound idea" from
+"too fast for a human".
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from tests.unit.gpt_trader.features.trade_ideas.conftest import (
+    attest_account_equity,
+    build_trade_idea,
+)
+
+from gpt_trader.features.trade_ideas import (
+    DEFAULT_RISK_BUDGET,
+    INVARIANT_ELIGIBILITY_PREFIX,
+    MODE_DEPENDENT_ELIGIBILITY_PREFIX,
+    ActorType,
+    ApprovalPolicy,
+    AutonomyMode,
+    TradeIdeaService,
+    TradeIdeaState,
+)
+
+START = datetime(2026, 6, 12, 10, 0, tzinfo=UTC)
+FAR_EXPIRY = datetime(2026, 6, 19, 16, 0, tzinfo=UTC)
+
+
+class MutableClock:
+    def __init__(self, start: datetime) -> None:
+        self.now = start
+
+    def __call__(self) -> datetime:
+        return self.now
+
+    def advance(self, **kwargs: float) -> None:
+        self.now = self.now + timedelta(**kwargs)
+
+
+@pytest.fixture
+def clock() -> MutableClock:
+    return MutableClock(START)
+
+
+@pytest.fixture
+def service(tmp_path: Path, clock: MutableClock) -> TradeIdeaService:
+    return TradeIdeaService(tmp_path / "ideas", now_factory=clock)
+
+
+def enable_bounded_autonomy(service: TradeIdeaService) -> None:
+    service.set_autonomy_mode(
+        AutonomyMode.BOUNDED_AUTONOMY,
+        actor_type=ActorType.HUMAN,
+        actor_id="rj",
+        reason="Stage 2 exercised in tests",
+    )
+
+
+def tighten_review_latency(service: TradeIdeaService, hours: int = 1) -> None:
+    current = service.current_budget()
+    service.update_budget(
+        replace(
+            current,
+            version=current.version + 1,
+            max_review_latency_hours=hours,
+            reason="Short review window for latency tests",
+        ),
+        ActorType.HUMAN,
+        "rj",
+    )
+
+
+class TestInvariantClass:
+    def test_invariant_checks_apply_in_every_mode(self) -> None:
+        """The same invariant rejections surface no matter the autonomy mode."""
+        ineligible = build_trade_idea(thesis=" ", invalidation=" ")
+        expected = {
+            f"{INVARIANT_ELIGIBILITY_PREFIX}Missing thesis: "
+            "no plain-language reason the trade exists",
+            f"{INVARIANT_ELIGIBILITY_PREFIX}Missing invalidation: "
+            "no level or condition that makes the thesis false",
+        }
+        for mode, actor_type in (
+            (AutonomyMode.HUMAN_APPROVED_EXECUTION, ActorType.HUMAN),
+            (AutonomyMode.BOUNDED_AUTONOMY, ActorType.SYSTEM),
+            (AutonomyMode.RESEARCH_ONLY, ActorType.HUMAN),
+        ):
+            violations = ApprovalPolicy(mode).approval_violations(
+                ineligible,
+                actor_type=actor_type,
+                budget=DEFAULT_RISK_BUDGET,
+                open_approved_count=0,
+                now=START,
+            )
+            assert expected <= set(violations), f"mode={mode.value}"
+
+    def test_invariant_reasons_carry_class_prefix(self, service: TradeIdeaService) -> None:
+        attest_account_equity(service)
+        ineligible = build_trade_idea(failure_mode=" ")
+        service.propose(ineligible, actor_id="idea-generator-v1")
+
+        check = service.kernel.check_approval(ineligible, actor_type=ActorType.HUMAN)
+
+        assert any(
+            violation.startswith(INVARIANT_ELIGIBILITY_PREFIX) for violation in check.violations
+        )
+
+
+class TestModeDependentClass:
+    def test_latency_violation_in_human_mode_carries_class_prefix(self) -> None:
+        policy = ApprovalPolicy(AutonomyMode.HUMAN_APPROVED_EXECUTION)
+        assert policy.review_latency_applies
+        violation = policy.review_latency_violation(
+            review_started_at=START - timedelta(hours=2),
+            budget=replace(DEFAULT_RISK_BUDGET, max_review_latency_hours=1),
+            now=START,
+        )
+        assert violation is not None
+        assert violation.startswith(MODE_DEPENDENT_ELIGIBILITY_PREFIX)
+        assert "review deadline expired" in violation
+
+    def test_latency_never_violates_under_bounded_autonomy(self) -> None:
+        policy = ApprovalPolicy(AutonomyMode.BOUNDED_AUTONOMY)
+        assert not policy.review_latency_applies
+        violation = policy.review_latency_violation(
+            review_started_at=START - timedelta(hours=200),
+            budget=replace(DEFAULT_RISK_BUDGET, max_review_latency_hours=1),
+            now=START,
+        )
+        assert violation is None
+
+    def test_latency_applies_in_fail_closed_research_only(self) -> None:
+        """The conservative direction: an integrity-broken log keeps the constraint."""
+        assert ApprovalPolicy(AutonomyMode.RESEARCH_ONLY).review_latency_applies
+
+
+class TestExpirySweepAcrossModes:
+    def prepare_stale_review(self, service: TradeIdeaService, clock: MutableClock) -> str:
+        """Propose an idea, tighten the review window, and let it elapse."""
+        attest_account_equity(service)
+        tighten_review_latency(service, hours=1)
+        idea = build_trade_idea()
+        service.propose(idea, actor_id="idea-generator-v1")
+        clock.advance(hours=2)
+        return idea.decision_id
+
+    def test_sweep_expires_stale_review_in_human_mode(
+        self, service: TradeIdeaService, clock: MutableClock
+    ) -> None:
+        decision_id = self.prepare_stale_review(service, clock)
+
+        expired = service.expire_due_ideas()
+
+        assert [view.idea.decision_id for view in expired] == [decision_id]
+
+    def test_sweep_keeps_stale_review_under_bounded_autonomy(
+        self, service: TradeIdeaService, clock: MutableClock
+    ) -> None:
+        enable_bounded_autonomy(service)
+        decision_id = self.prepare_stale_review(service, clock)
+
+        assert service.expire_due_ideas() == []
+        assert service.get(decision_id).state is TradeIdeaState.PROPOSED
+        # The idea's own expiry stays invariant: once it passes, the sweep acts.
+        clock.now = FAR_EXPIRY + timedelta(minutes=1)
+        assert [view.idea.decision_id for view in service.expire_due_ideas()] == [decision_id]
+
+    def test_mode_drop_reinstates_latency_expiry(
+        self, service: TradeIdeaService, clock: MutableClock
+    ) -> None:
+        """Ratchet-down mid-lifecycle: proposed under bounded, mode drops later."""
+        enable_bounded_autonomy(service)
+        decision_id = self.prepare_stale_review(service, clock)
+        assert service.expire_due_ideas() == []
+
+        # Lowering is open to any actor — this is the ratchet's path.
+        service.set_autonomy_mode(
+            AutonomyMode.HUMAN_APPROVED_EXECUTION,
+            actor_type=ActorType.SYSTEM,
+            actor_id="autonomy-ratchet",
+            reason="Simulated ratchet-down",
+        )
+
+        expired = service.expire_due_ideas()
+        assert [view.idea.decision_id for view in expired] == [decision_id]
+
+
+class TestApprovalAcrossModeTransitions:
+    def test_ratchet_down_before_execution_reinstates_latency_check(
+        self, service: TradeIdeaService, clock: MutableClock
+    ) -> None:
+        """An idea admitted under bounded autonomy is re-judged after the drop."""
+        enable_bounded_autonomy(service)
+        attest_account_equity(service)
+        tighten_review_latency(service, hours=1)
+        idea = build_trade_idea()
+        service.propose(idea, actor_id="idea-generator-v1")
+        clock.advance(hours=2)
+
+        under_bounded = service.kernel.check_approval(idea, actor_type=ActorType.SYSTEM)
+        assert under_bounded.admitted
+
+        service.set_autonomy_mode(
+            AutonomyMode.HUMAN_APPROVED_EXECUTION,
+            actor_type=ActorType.SYSTEM,
+            actor_id="autonomy-ratchet",
+            reason="Simulated ratchet-down",
+        )
+
+        after_drop = service.kernel.check_approval(idea, actor_type=ActorType.HUMAN)
+        assert not after_drop.admitted
+        assert any(
+            violation.startswith(MODE_DEPENDENT_ELIGIBILITY_PREFIX)
+            for violation in after_drop.violations
+        )
+
+
+class TestQueueStatusAcrossModes:
+    def test_review_latency_warning_only_when_mode_enforces_it(
+        self, service: TradeIdeaService, clock: MutableClock
+    ) -> None:
+        attest_account_equity(service)
+        tighten_review_latency(service, hours=1)
+        idea = build_trade_idea()
+        service.propose(idea, actor_id="idea-generator-v1")
+
+        in_human_mode = service.queue_status(warning_window_hours=24)
+        assert [expiration.deadline_type for expiration in in_human_mode.upcoming_expirations] == [
+            "review_latency"
+        ]
+
+        enable_bounded_autonomy(service)
+        under_bounded = service.queue_status(warning_window_hours=24)
+        assert all(
+            expiration.deadline_type != "review_latency"
+            for expiration in under_bounded.upcoming_expirations
+        )


### PR DESCRIPTION
## What

Second step of the accepted [adopt-event-driven-execution-topology](docs/decisions/adopt-event-driven-execution-topology.md) decision (#1190). Eligibility now has two explicit constraint classes:

- **Invariant (every autonomy level)** — everything in `evaluate_eligibility` (explicit entry/invalidation/exit/max-loss, reproducible data, expiry, thesis, failure mode). Unchanged semantics; these are blast-radius controls and never relax. Approval violations now carry the `invariant eligibility:` prefix.
- **Mode-dependent (`human_approved_execution` only)** — review-latency survivability. `ApprovalPolicy` gains `review_latency_applies` (false only under `bounded_autonomy`); `review_latency_violation` gates itself on it and prefixes its reason with `mode-dependent eligibility (human_approved_execution):`, so track-record evidence can distinguish "unsound idea" from "too fast for a human".

## Shape

- Mode-dependence keys off the **audited autonomy log resolution**, not config flags: the kernel/approval path already carries the decision-time resolution; `expire_due_ideas` and `queue_status` use a read-only `peek_autonomy()` so sweeps and render paths still never seed or ratchet state. Fail-closed resolution yields `research_only`, which conservatively keeps the latency constraint.
- The idea's own `expires_at` stays invariant — under `bounded_autonomy` an idea still expires on its own horizon, just not on the human review window.
- `queue_status` no longer warns about `review_latency` deadlines the sweep would not enforce.
- DIRECTION.md's strategy-eligibility gate paragraph is updated in this PR (docs_link_audit couples code and docs).

## Behavior

No change to what today's `human_approved_execution` mode admits: all 6607 pre-existing unit tests pass unchanged (violation assertions are substring-based and absorb the class prefixes). 10 new tests cover both classes across mode transitions, including ratchet-down mid-lifecycle (proposed under `bounded_autonomy`, mode drops before execution → latency checks reinstate).

## Safety

Paper-only policy mechanics; no broker call, no live execution, no autonomy change. Under the live `bounded_autonomy` cycle this removes only the human-latency constraint, exactly as the accepted decision scopes.

Closes #1190

Unblocks #1191 (in-process event-driven idea lane) — both prerequisites (#1189, #1190) are then merged.