### PR TITLE
feat(profiles): operator-enable the event-driven paper lane on the paper profile

### DIFF
--- a/config/profiles/paper.yaml
+++ b/config/profiles/paper.yaml
@@ -31,6 +31,10 @@ execution:
   dry_run: true
   mock_broker: true
   mock_fills: true
+  # Operator-enabled 2026-07-07 (RJ): event-driven paper lane (#1191).
+  # Paper-only; still requires GPT_TRADER_IDEAS_AUTO_APPROVAL /
+  # GPT_TRADER_IDEAS_AUTO_EXECUTION and an audited bounded_autonomy mode.
+  event_driven_paper_lane: true
 
 monitoring:
   log_level: "INFO"

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -71,9 +71,11 @@ enabled and the autonomy log still resolves to `bounded_autonomy` at execution
 time. The execution gate reuses the daily-loss ratchet, so a breach lowers the
 mode before remaining system-approved ideas can execute.
 
-**The in-process event-driven lane now exists behind a default-off gate**
-(`event_driven_paper_lane_enabled`, #1191). When the operator enables it, the
-live engine carries each proposed idea through the risk kernel — system
+**The in-process event-driven lane exists behind a default-off gate**
+(`event_driven_paper_lane_enabled`, #1191) and is **operator-enabled on the
+`paper` profile** (recorded approval 2026-07-07; `config/profiles/paper.yaml`).
+With the gate on, the live engine carries each proposed idea through the risk
+kernel — system
 approval, then an execution-time autonomy re-check — into paper execution in
 the same engine cycle (`features/idea_execution/event_lane.py`), honoring the
 same two env gates and the audited autonomy mode per decision. Kernel denials
@@ -83,9 +85,9 @@ the next event, not the next hourly turn. The hourly batch cycle continues
 unchanged as the evidence harness
 ([adopt-event-driven-execution-topology](decisions/adopt-event-driven-execution-topology.md)).
 
-This is mechanism state, not a promotion claim. Live order submission remains
-out of scope, and operationally flipping either flag remains an operator act
-gated by the measured-outcome rubric.
+This is not a promotion claim. Live order submission remains out of scope; the
+lane is paper-only and still bounded by the two env gates, the audited
+autonomy mode, and the budget envelope at event time.
 
 ## The structural fact
 


### PR DESCRIPTION
## What

Sets `execution.event_driven_paper_lane: true` on `config/profiles/paper.yaml`, operationally enabling the in-process event-driven idea lane (#1191, merged in #1204) on the paper profile. Updates `docs/STATUS.md` in the same PR (its honesty rule: state changes land with the change).

## Authority

STATUS.md marks flipping this flag as an operator act. Recorded operator approval: RJ, 2026-07-07 — "Enabling the lane operationally is your call — it's just `execution.event_driven_paper_lane: true` on a profile, since the launchd setup already has both env gates on and bounded_autonomy attested."

This crosses no new authority boundary: the Stage-2 envelope is already operationally entered (both env gates on, $1K attested, audited `bounded_autonomy`), and the lane runs the same risk kernel with the same gates — it only removes the hourly denial latency. Paper-only; live order submission remains gated by `docs/DIRECTION.md`.

## Verification

- `uv run local-ci` (pr profile): **passed** end-to-end (6646 unit tests, rails smoke, property/contract/integration, docs gates).
- No test pins the paper profile's lane flag off; profile-loader mapping (`execution.event_driven_paper_lane` → `BotConfig.event_driven_paper_lane_enabled`) is covered by existing tests.

Part of the [adopt-event-driven-execution-topology](https://github.com/Solders-Girdles-Org/GPT-Trader/blob/main/docs/decisions/adopt-event-driven-execution-topology.md) sequence; remaining: #1192 (blocked on #1123), #1193 (in progress).