### PR TITLE
feat(trade-ideas): rubric scorecard + replay-accelerated evidence from the idea-level trail

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -71,6 +71,17 @@ enabled and the autonomy log still resolves to `bounded_autonomy` at execution
 time. The execution gate reuses the daily-loss ratchet, so a breach lowers the
 mode before remaining system-approved ideas can execute.
 
+**The promotion gates are now measurable in one command** (`ideas scorecard`,
+#1193): the Stage 1 -> 2 gates of the
+[measured-outcome rubric](decisions/adopt-measured-outcome-rubric.md) score
+pass/fail from the idea-level closeout/audit trail
+(`features/trade_ideas/scorecard.py`) with the observation-window rule
+applied, never from the batch cycle's run artifacts (test-enforced).
+Replay-derived calibration/edge over recorded snapshot windows reports
+alongside -- labeled, never blended into -- the wall-clock gates.
+Drawdown-from-peak renders not-yet-measurable until the continuous portfolio
+monitors (#1192) land, so the scorecard cannot claim promotability yet.
+
 **The in-process event-driven lane exists behind a default-off gate**
 (`event_driven_paper_lane_enabled`, #1191) and is **operator-enabled on the
 `paper` profile** (recorded approval 2026-07-07; `config/profiles/paper.yaml`).

--- a/docs/specs/TRADE_IDEA_INTERFACES_DESIGN_NOTES.md
+++ b/docs/specs/TRADE_IDEA_INTERFACES_DESIGN_NOTES.md
@@ -107,6 +107,33 @@ Kernel denials are audited on the idea trail (`auto_approval_skipped` /
 `auto_execution_skipped`). Paper only: live order submission stays gated by
 [docs/DIRECTION.md](../DIRECTION.md).
 
+## Promotion scorecard and replay evidence (#1193)
+
+**`ideas scorecard`** scores the Stage 1 → 2 promotion gates of the
+[measured-outcome rubric](../decisions/adopt-measured-outcome-rubric.md) —
+track-record depth, eligibility pass rate, attribution coverage, risk
+calibration, expectancy (avg R), benchmark edge vs the deterministic baseline,
+max drawdown-from-peak — plus the loop-health reds (proposals flowing,
+attribution coverage, audit integrity), with the observation-window rule
+(rolling 60 days *and* ≥ 200 closed ideas, whichever is larger) applied.
+Every metric computes from the idea-level closeout/audit trail
+(`features/trade_ideas/scorecard.py`); the batch cycle's run artifacts are
+launchd scaffolding and are never read, test-enforced, so the evidence stays
+valid under the event-driven lane. Gates that lack inputs render
+`not_yet_measurable` rather than pass — drawdown-from-peak stays unmeasurable
+until the continuous portfolio monitors (#1192) land, so the scorecard cannot
+claim promotability before then. Thresholds are the owner-tunable values
+recorded on the rubric decision.
+
+**Replay-accelerated evidence.** The `ideas replay` commands accept a recorded
+market-snapshot payload (`ideas snapshot build` output, or a cycle run's
+persisted snapshot) as `--file` input in addition to bare candle fixtures, so
+calibration and edge compute at machine speed over recorded windows.
+`ideas scorecard --replay-report <json>` renders those figures alongside the
+wall-clock gates, always labeled `replay-derived` and never blended into a
+gate verdict; whether replay evidence counts toward promotion is a separate
+owner call recorded on the rubric decision.
+
 ## Design Principles
 
 1. **Thin adapters only.** Interfaces parse input, resolve actor identity,

--- a/src/gpt_trader/cli/commands/ideas.py
+++ b/src/gpt_trader/cli/commands/ideas.py
@@ -131,6 +131,11 @@ from gpt_trader.features.trade_ideas.report import (
     build_trade_idea_track_record_report,
     format_trade_idea_track_record_report,
 )
+from gpt_trader.features.trade_ideas.scorecard import (
+    build_replay_evidence,
+    build_stage_promotion_scorecard,
+    format_stage_promotion_scorecard,
+)
 from gpt_trader.persistence.event_store import EventStore
 
 VENUE_CHOICES = ("coinbase", "manual")
@@ -474,6 +479,37 @@ def register(subparsers: Any) -> None:
     )
     report.set_defaults(handler=_handle_report, subcommand="report")
 
+    scorecard = ideas_subparsers.add_parser(
+        "scorecard",
+        help="Score the Stage 1 -> 2 promotion gates from the idea-level trail",
+        description=(
+            "Read-only measured-outcome rubric scorecard over local trade-idea "
+            "records, audit events, and closeout attributions, with the "
+            "observation-window rule applied. Optionally reports replay-derived "
+            "evidence alongside (never blended into) the wall-clock gates. This "
+            "command never contacts a broker or account and never reads the "
+            "batch cycle manifest."
+        ),
+    )
+    _add_common_options(scorecard)
+    scorecard.add_argument(
+        "--replay-report",
+        type=Path,
+        action="append",
+        dest="replay_reports",
+        metavar="PATH",
+        help=(
+            "JSON payload from an 'ideas replay' run (single report or "
+            "tournament) to report as replay-derived evidence; repeatable"
+        ),
+    )
+    scorecard.add_argument(
+        "--output-dir",
+        type=Path,
+        help="Write a durable scorecard artifact into this directory",
+    )
+    scorecard.set_defaults(handler=_handle_scorecard, subcommand="scorecard")
+
     export_ticket = ideas_subparsers.add_parser(
         "export-ticket",
         help="Export a deterministic broker-neutral ticket artifact",
@@ -548,7 +584,10 @@ def register(subparsers: Any) -> None:
         "--file",
         type=Path,
         required=True,
-        help="JSON fixture with a top-level candles array of OHLCV bars",
+        help=(
+            "JSON fixture with a top-level candles array of OHLCV bars, or a "
+            "recorded market-snapshot payload (its series matching --symbol is used)"
+        ),
     )
     baseline.add_argument("--symbol", required=True, help="Symbol represented by the candles")
     baseline.add_argument(
@@ -623,7 +662,10 @@ def register(subparsers: Any) -> None:
         "--file",
         type=Path,
         required=True,
-        help="JSON fixture with a top-level candles array of OHLCV bars",
+        help=(
+            "JSON fixture with a top-level candles array of OHLCV bars, or a "
+            "recorded market-snapshot payload (its series matching --symbol is used)"
+        ),
     )
     regime_aware.add_argument("--symbol", required=True, help="Symbol represented by the candles")
     regime_aware.add_argument(
@@ -688,7 +730,10 @@ def register(subparsers: Any) -> None:
         "--file",
         type=Path,
         required=True,
-        help="JSON fixture with a top-level candles array of OHLCV bars",
+        help=(
+            "JSON fixture with a top-level candles array of OHLCV bars, or a "
+            "recorded market-snapshot payload (its series matching --symbol is used)"
+        ),
     )
     strategy_replay.add_argument(
         "--symbol", required=True, help="Symbol represented by the candles"
@@ -743,7 +788,10 @@ def register(subparsers: Any) -> None:
         dest="file",
         type=Path,
         required=True,
-        help="JSON fixture with a top-level candles array of OHLCV bars",
+        help=(
+            "JSON fixture with a top-level candles array of OHLCV bars, or a "
+            "recorded market-snapshot payload (its series matching --symbol is used)"
+        ),
     )
     tournament.add_argument("--symbol", required=True, help="Symbol represented by the candles")
     tournament.add_argument(
@@ -2174,6 +2222,47 @@ def _handle_report(args: Namespace) -> CliResponse:
     return _success(command, args, payload, text, was_noop=idea_count == 0)
 
 
+def _handle_scorecard(args: Namespace) -> CliResponse:
+    command = "ideas scorecard"
+    try:
+        payload = build_stage_promotion_scorecard(_service(args))
+        replay_evidence = [
+            build_replay_evidence(_load_replay_report_payload(path))
+            for path in args.replay_reports or ()
+        ]
+    except Exception as error:
+        return _mapped_error(command, args, error)
+    if replay_evidence:
+        payload = {**payload, "replay_evidence": replay_evidence}
+
+    artifact_path = _write_output_dir_artifact(
+        args,
+        stem="trade-idea-scorecard",
+        artifact_id=payload["scorecard_id"],
+        extension="json",
+        content=_json_artifact(payload),
+    )
+    if artifact_path is not None:
+        payload = {**payload, "artifact_path": artifact_path}
+
+    text = format_stage_promotion_scorecard(payload)
+    if artifact_path is not None:
+        text += f"\nartifact_path: {artifact_path}"
+    return _success(command, args, payload, text, was_noop=payload["idea_count"] == 0)
+
+
+def _load_replay_report_payload(path: Path) -> Mapping[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, Mapping):
+        raise ValueError(f"Replay report '{path}' must be a JSON object")
+    # Accept both a raw replay artifact and a CliResponse envelope from
+    # 'ideas replay ... --format json --output <path>'.
+    data = payload.get("data")
+    if isinstance(data, Mapping) and "proposer_id" not in payload and "reports" not in payload:
+        return data
+    return payload
+
+
 def _handle_export_ticket(args: Namespace) -> CliResponse | RawCliOutput:
     command = "ideas export-ticket"
     decision_id_error = _decision_id_error(command, args, args.decision_id)
@@ -2228,7 +2317,11 @@ def _handle_replay_baseline(args: Namespace) -> CliResponse:
     command = "ideas replay baseline"
     try:
         _validate_replay_granularity(args.granularity)
-        candles = _load_candle_fixture(args.file)
+        candles = _load_candle_fixture(
+            args.file,
+            symbol=args.symbol,
+            granularity=args.granularity,
+        )
         proposer_config = _replay_baseline_config_from_args(args)
         optimize_study = cast(Path | None, getattr(args, "from_optimize_study", None))
         if optimize_study is not None:
@@ -2274,7 +2367,11 @@ def _handle_replay_strategy(args: Namespace) -> CliResponse:
     command = "ideas replay strategy"
     try:
         _validate_replay_granularity(args.granularity)
-        candles = _load_candle_fixture(args.file)
+        candles = _load_candle_fixture(
+            args.file,
+            symbol=args.symbol,
+            granularity=args.granularity,
+        )
         min_history = _resolve_strategy_replay_min_history(args)
         report = TradeIdeaReplayRunner(
             _snapshot_strategy_proposer(
@@ -2297,7 +2394,11 @@ def _handle_replay_regime_aware(args: Namespace) -> CliResponse:
     command = "ideas replay regime-aware"
     try:
         _validate_replay_granularity(args.granularity)
-        candles = _load_candle_fixture(args.file)
+        candles = _load_candle_fixture(
+            args.file,
+            symbol=args.symbol,
+            granularity=args.granularity,
+        )
         proposer_config = _replay_baseline_config_from_args(args)
         regime_config = RegimeConfig()
         min_history = _resolve_replay_min_history(
@@ -2332,7 +2433,11 @@ def _handle_replay_tournament(args: Namespace) -> CliResponse:
     command = "ideas replay tournament"
     try:
         _validate_replay_granularity(args.granularity)
-        candles = _load_candle_fixture(args.file)
+        candles = _load_candle_fixture(
+            args.file,
+            symbol=args.symbol,
+            granularity=args.granularity,
+        )
         entries = _tournament_entries(args)
         min_history = _resolve_tournament_min_history(
             args, max(required for _, required in entries)

--- a/src/gpt_trader/cli/commands/ideas_input.py
+++ b/src/gpt_trader/cli/commands/ideas_input.py
@@ -205,7 +205,20 @@ def _required_payload_datetime(payload: Mapping[str, Any], key: str, field: str)
     return parsed
 
 
-def _load_candle_fixture(path: Path) -> tuple[Candle, ...]:
+def _load_candle_fixture(
+    path: Path,
+    *,
+    symbol: str | None = None,
+    granularity: str | None = None,
+) -> tuple[Candle, ...]:
+    """Load replay candles from a bare fixture or a recorded market snapshot.
+
+    Accepts either a JSON object with a top-level ``candles`` array or a
+    recorded ``MarketSnapshot`` payload (``ideas snapshot build`` output and
+    the cycle's persisted per-run snapshots), so replay can run over recorded
+    windows without hand-built fixtures. Snapshot payloads need ``symbol`` to
+    pick the series; ``granularity`` disambiguates multi-granularity series.
+    """
     try:
         raw_payload = path.read_text(encoding="utf-8")
     except OSError as error:
@@ -218,11 +231,46 @@ def _load_candle_fixture(path: Path) -> tuple[Candle, ...]:
     if not isinstance(payload, dict):
         raise CandleInputError("Candle fixture must be a JSON object", field="candles")
 
+    if "series" in payload and "candles" not in payload:
+        return _candles_from_snapshot_payload(payload, symbol=symbol, granularity=granularity)
+
     raw_candles = payload.get("candles")
     if not isinstance(raw_candles, list):
         raise CandleInputError("Candle fixture must contain a candles array", field="candles")
 
     return tuple(_parse_candle(row, index) for index, row in enumerate(raw_candles))
+
+
+def _candles_from_snapshot_payload(
+    payload: Mapping[str, Any],
+    *,
+    symbol: str | None,
+    granularity: str | None,
+) -> tuple[Candle, ...]:
+    if symbol is None:
+        raise CandleInputError(
+            "A recorded snapshot payload needs a symbol to pick its candle series",
+            field="symbol",
+        )
+    snapshot = _market_snapshot_from_payload(payload)
+    matches = [series for series in snapshot.series if series.symbol == symbol]
+    if granularity is not None and len(matches) > 1:
+        matches = [series for series in matches if series.granularity == granularity]
+    if not matches:
+        available = ", ".join(f"{series.symbol}:{series.granularity}" for series in snapshot.series)
+        raise CandleInputError(
+            f"Recorded snapshot has no candle series for '{symbol}'"
+            + (f" at granularity '{granularity}'" if granularity is not None else "")
+            + (f" (available: {available})" if available else ""),
+            field="symbol",
+        )
+    if len(matches) > 1:
+        raise CandleInputError(
+            f"Recorded snapshot has multiple candle series for '{symbol}'; "
+            "pass a granularity to disambiguate",
+            field="granularity",
+        )
+    return matches[0].candles
 
 
 def _parse_candle(row: Any, index: int) -> Candle:

--- a/src/gpt_trader/features/trade_ideas/scorecard.py
+++ b/src/gpt_trader/features/trade_ideas/scorecard.py
@@ -1,0 +1,641 @@
+"""Stage 1 → 2 promotion scorecard over the idea-level closeout/audit trail.
+
+Scores the measured-outcome rubric gates
+(docs/decisions/adopt-measured-outcome-rubric.md) from stored trade-idea
+records, audit events, and closeout attributions — never from batch-cycle
+run artifacts, which are launchd scaffolding rather than evidence
+(docs/decisions/adopt-event-driven-execution-topology.md, test-enforced in
+test_scorecard.py). Replay-derived evidence is reported alongside wall-clock
+evidence, never blended into the gate verdicts.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from enum import Enum
+from typing import Any
+
+from gpt_trader.features.trade_ideas.artifacts import stable_artifact_id
+from gpt_trader.features.trade_ideas.audit import AuditAction
+from gpt_trader.features.trade_ideas.eligibility import evaluate_eligibility
+from gpt_trader.features.trade_ideas.service import TradeIdeaService, TradeIdeaView
+from gpt_trader.features.trade_ideas.workflow import TERMINAL_STATES
+
+SCORECARD_SCHEMA_VERSION = "gpt-trader.trade_ideas.scorecard.v1"
+WALL_CLOCK_EVIDENCE_LABEL = "wall-clock"
+REPLAY_EVIDENCE_LABEL = "replay-derived"
+OBSERVATION_WINDOW_RULE = "rolling 60 days and >= 200 closed ideas, whichever is larger"
+
+_RATE_QUANT = Decimal("0.0000")
+_PERCENT_QUANT = Decimal("0.01")
+
+
+class GateStatus(str, Enum):
+    """Verdict for one promotion gate or loop-health check."""
+
+    PASS = "pass"
+    FAIL = "fail"
+    NOT_YET_MEASURABLE = "not_yet_measurable"
+
+
+@dataclass(frozen=True, slots=True)
+class ScorecardThresholds:
+    """Owner-tunable gate thresholds.
+
+    Defaults carry the starting values recorded in
+    docs/decisions/adopt-measured-outcome-rubric.md; tuning them is an owner
+    act that does not reopen the decision.
+    """
+
+    min_closed_ideas: int = 200
+    min_window_days: int = 60
+    min_eligibility_pass_rate: Decimal = Decimal("0.90")
+    min_attribution_coverage: Decimal = Decimal("1")
+    min_risk_calibration: Decimal = Decimal("0.95")
+    proposal_freshness_hours: int = 24
+    baseline_actor_prefix: str = "baseline"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "min_closed_ideas": self.min_closed_ideas,
+            "min_window_days": self.min_window_days,
+            "min_eligibility_pass_rate": str(self.min_eligibility_pass_rate),
+            "min_attribution_coverage": str(self.min_attribution_coverage),
+            "min_risk_calibration": str(self.min_risk_calibration),
+            "min_expectancy_r": "> 0",
+            "min_benchmark_edge_r": "> 0",
+            "proposal_freshness_hours": self.proposal_freshness_hours,
+            "baseline_actor_prefix": self.baseline_actor_prefix,
+        }
+
+
+def build_stage_promotion_scorecard(
+    service: TradeIdeaService,
+    *,
+    now: datetime | None = None,
+    thresholds: ScorecardThresholds | None = None,
+) -> dict[str, Any]:
+    """Score the Stage 1 → 2 gates from the idea-level trail."""
+    current_time = now or datetime.now(UTC)
+    tuned = thresholds or ScorecardThresholds()
+    views = service.list_views()
+
+    window_start = _observation_window_start(views, now=current_time, thresholds=tuned)
+    closed_views = [view for view in views if view.state in TERMINAL_STATES]
+    closed_in_window = [
+        view for view in closed_views if window_start <= _closed_at(view) <= current_time
+    ]
+    proposed_in_window = [
+        view
+        for view in views
+        if view.events and window_start <= view.events[0].timestamp <= current_time
+    ]
+
+    gates = {
+        "track_record_depth": _depth_gate(
+            views,
+            closed_in_window,
+            now=current_time,
+            thresholds=tuned,
+        ),
+        "eligibility_pass_rate": _eligibility_gate(proposed_in_window, thresholds=tuned),
+        "attribution_coverage": _attribution_gate(closed_in_window, thresholds=tuned),
+        "risk_calibration": _risk_calibration_gate(closed_in_window, thresholds=tuned),
+        "expectancy": _expectancy_gate(closed_in_window),
+        "benchmark_edge": _benchmark_edge_gate(closed_in_window, thresholds=tuned),
+        "max_drawdown_from_peak": _gate(
+            GateStatus.NOT_YET_MEASURABLE,
+            measured={},
+            detail=(
+                "drawdown-from-peak input arrives with the continuous portfolio " "monitors (#1192)"
+            ),
+        ),
+    }
+    loop_health = {
+        "proposals_flowing": _proposals_flowing_check(views, now=current_time, thresholds=tuned),
+        "attribution_coverage": _attribution_red(gates["attribution_coverage"]),
+        "audit_integrity": _audit_integrity_check(service),
+    }
+
+    status_counts = {status.value: 0 for status in GateStatus}
+    for verdict in gates.values():
+        status_counts[verdict["status"]] += 1
+    reds_failing = sorted(
+        name for name, check in loop_health.items() if check["status"] != GateStatus.PASS.value
+    )
+    promotable = status_counts[GateStatus.PASS.value] == len(gates) and not reds_failing
+
+    payload = {
+        "evidence": WALL_CLOCK_EVIDENCE_LABEL,
+        "observation_window": {
+            "rule": OBSERVATION_WINDOW_RULE,
+            "start": window_start.isoformat(),
+            "end": current_time.isoformat(),
+            "closed_idea_count": len(closed_in_window),
+        },
+        "thresholds": tuned.to_dict(),
+        "gates": gates,
+        "loop_health": loop_health,
+        "overall": {
+            "promotable": promotable,
+            "gates_passed": status_counts[GateStatus.PASS.value],
+            "gates_failed": status_counts[GateStatus.FAIL.value],
+            "gates_not_yet_measurable": status_counts[GateStatus.NOT_YET_MEASURABLE.value],
+            "loop_health_reds": reds_failing,
+        },
+    }
+    scorecard_id = stable_artifact_id(
+        "tis",
+        {"schema_version": SCORECARD_SCHEMA_VERSION, "payload": payload},
+    )
+    return {
+        "schema_version": SCORECARD_SCHEMA_VERSION,
+        "scorecard_id": scorecard_id,
+        "generated_at": current_time.isoformat(),
+        "idea_count": len(views),
+        **payload,
+    }
+
+
+def build_replay_evidence(
+    report_payload: Mapping[str, Any],
+    *,
+    baseline_proposer_prefix: str = "baseline",
+) -> dict[str, Any]:
+    """Label replay output as replay-derived calibration/edge evidence.
+
+    Accepts the JSON payload of one ``ideas replay`` run — either a single
+    ``ReplayReport`` or a ``ReplayTournamentReport`` — and reports calibration
+    per proposer plus average-R edge against the deterministic baseline when
+    both sides replayed the same window. The result is evidence *alongside*
+    the wall-clock scorecard; it never feeds a gate verdict.
+    """
+    reports = _replay_reports(report_payload)
+    calibration = [
+        {
+            "proposer_id": report["proposer_id"],
+            "ideas_proposed": report.get("ideas_proposed"),
+            "resolved_ideas": report.get("resolved_ideas"),
+            "target_hit_rate": report.get("target_hit_rate"),
+            "stop_hit_rate": report.get("stop_hit_rate"),
+            "average_return_r": report.get("average_return_r"),
+            "eligibility_pass_rate": report.get("eligibility_pass_rate"),
+        }
+        for report in reports
+    ]
+    return {
+        "evidence": REPLAY_EVIDENCE_LABEL,
+        "symbol": report_payload.get("symbol"),
+        "granularity": report_payload.get("granularity"),
+        "source": report_payload.get("source"),
+        "snapshots_evaluated": report_payload.get("snapshots_evaluated"),
+        "calibration": calibration,
+        "benchmark_edge": _replay_benchmark_edge(
+            calibration,
+            baseline_proposer_prefix=baseline_proposer_prefix,
+        ),
+    }
+
+
+def format_stage_promotion_scorecard(payload: Mapping[str, Any]) -> str:
+    """Render the scorecard for operators (CliResponse ✓/✗ convention)."""
+    overall = payload["overall"]
+    window = payload["observation_window"]
+    gates: Mapping[str, Mapping[str, Any]] = payload["gates"]
+    loop_health: Mapping[str, Mapping[str, Any]] = payload["loop_health"]
+
+    lines = [
+        "✓ ideas scorecard OK "
+        f"(gates {overall['gates_passed']}/{len(gates)} pass, "
+        f"{overall['gates_failed']} fail, "
+        f"{overall['gates_not_yet_measurable']} not-yet-measurable, "
+        f"promotable={'yes' if overall['promotable'] else 'no'})",
+        "",
+        "Observation window",
+        f"rule: {window['rule']}",
+        f"window: {window['start']} -> {window['end']}",
+        f"closed_ideas_in_window: {window['closed_idea_count']}",
+        "",
+        f"Stage 1 -> 2 gates ({payload['evidence']})",
+        *(_gate_line(name, verdict) for name, verdict in gates.items()),
+        "",
+        "Loop health",
+        *(_gate_line(name, check) for name, check in loop_health.items()),
+    ]
+    for evidence in payload.get("replay_evidence", ()):
+        lines.extend(["", *(_replay_evidence_lines(evidence))])
+    return "\n".join(lines)
+
+
+def _replay_evidence_lines(evidence: Mapping[str, Any]) -> list[str]:
+    header = (
+        f"Replay evidence ({evidence['evidence']}; reported alongside wall-clock, "
+        "not blended into gates)"
+    )
+    lines = [
+        header,
+        (
+            f"window: {evidence.get('symbol')} {evidence.get('granularity')} "
+            f"source={evidence.get('source')} "
+            f"snapshots={evidence.get('snapshots_evaluated')}"
+        ),
+    ]
+    for row in evidence["calibration"]:
+        lines.append(
+            f"{row['proposer_id']}: resolved={row['resolved_ideas']}, "
+            f"target_hit_rate={row['target_hit_rate']}, "
+            f"stop_hit_rate={row['stop_hit_rate']}, "
+            f"avg_r={row['average_return_r']}, "
+            f"eligibility_pass_rate={row['eligibility_pass_rate']}"
+        )
+    edge = evidence["benchmark_edge"]
+    if edge["comparisons"]:
+        for comparison in edge["comparisons"]:
+            lines.append(
+                f"edge vs {edge['baseline_proposer_id']}: "
+                f"{comparison['proposer_id']} avg_r {comparison['average_return_r']} "
+                f"- baseline {edge['baseline_average_return_r']} "
+                f"= {comparison['edge_r']}"
+            )
+    else:
+        lines.append(f"edge: {edge['detail']}")
+    return lines
+
+
+def _gate_line(name: str, verdict: Mapping[str, Any]) -> str:
+    marker = {
+        GateStatus.PASS.value: "✓",
+        GateStatus.FAIL.value: "✗",
+        GateStatus.NOT_YET_MEASURABLE.value: "–",
+    }[verdict["status"]]
+    detail = verdict.get("detail", "")
+    suffix = f" ({detail})" if detail else ""
+    return f"{marker} {name}: {verdict['status']}{suffix}"
+
+
+def _observation_window_start(
+    views: list[TradeIdeaView],
+    *,
+    now: datetime,
+    thresholds: ScorecardThresholds,
+) -> datetime:
+    day_start = now - timedelta(days=thresholds.min_window_days)
+    closed_at_desc = sorted(
+        (
+            _closed_at(view)
+            for view in views
+            if view.state in TERMINAL_STATES and _closed_at(view) <= now
+        ),
+        reverse=True,
+    )
+    if len(closed_at_desc) >= thresholds.min_closed_ideas:
+        count_start = closed_at_desc[thresholds.min_closed_ideas - 1]
+    elif closed_at_desc:
+        count_start = closed_at_desc[-1]
+    else:
+        count_start = day_start
+    return min(day_start, count_start)
+
+
+def _closed_at(view: TradeIdeaView) -> datetime:
+    return view.events[-1].timestamp
+
+
+def _proposing_actor(view: TradeIdeaView) -> str:
+    return view.events[0].actor_id
+
+
+def _gate(
+    status: GateStatus,
+    *,
+    measured: Mapping[str, Any],
+    detail: str = "",
+) -> dict[str, Any]:
+    return {"status": status.value, "measured": dict(measured), "detail": detail}
+
+
+def _depth_gate(
+    views: list[TradeIdeaView],
+    closed_in_window: list[TradeIdeaView],
+    *,
+    now: datetime,
+    thresholds: ScorecardThresholds,
+) -> dict[str, Any]:
+    first_events = [view.events[0].timestamp for view in views if view.events]
+    trail_age_days = (now - min(first_events)).days if first_events else 0
+    closed_count = len(closed_in_window)
+    depth_met = closed_count >= thresholds.min_closed_ideas
+    span_met = trail_age_days >= thresholds.min_window_days
+    return _gate(
+        GateStatus.PASS if depth_met and span_met else GateStatus.FAIL,
+        measured={"closed_idea_count": closed_count, "trail_age_days": trail_age_days},
+        detail=(
+            f"{closed_count}/{thresholds.min_closed_ideas} closed ideas, "
+            f"{trail_age_days}/{thresholds.min_window_days} days of trail"
+        ),
+    )
+
+
+def _eligibility_gate(
+    proposed_in_window: list[TradeIdeaView],
+    *,
+    thresholds: ScorecardThresholds,
+) -> dict[str, Any]:
+    total = len(proposed_in_window)
+    if total == 0:
+        return _gate(
+            GateStatus.NOT_YET_MEASURABLE,
+            measured={"proposed_count": 0},
+            detail="no ideas proposed in the observation window",
+        )
+    eligible = sum(1 for view in proposed_in_window if not evaluate_eligibility(view.idea))
+    rate = Decimal(eligible) / Decimal(total)
+    return _gate(
+        GateStatus.PASS if rate >= thresholds.min_eligibility_pass_rate else GateStatus.FAIL,
+        measured={
+            "eligible_count": eligible,
+            "proposed_count": total,
+            "rate": _quantized(rate),
+        },
+        detail=(
+            f"{eligible}/{total} eligible ({_as_pct(rate)}%), "
+            f"need >= {_as_pct(thresholds.min_eligibility_pass_rate)}%"
+        ),
+    )
+
+
+def _attribution_gate(
+    closed_in_window: list[TradeIdeaView],
+    *,
+    thresholds: ScorecardThresholds,
+) -> dict[str, Any]:
+    total = len(closed_in_window)
+    if total == 0:
+        return _gate(
+            GateStatus.NOT_YET_MEASURABLE,
+            measured={"closed_idea_count": 0},
+            detail="no closed ideas in the observation window",
+        )
+    attributed = sum(1 for view in closed_in_window if view.closeout_attribution is not None)
+    rate = Decimal(attributed) / Decimal(total)
+    return _gate(
+        GateStatus.PASS if rate >= thresholds.min_attribution_coverage else GateStatus.FAIL,
+        measured={
+            "attributed_count": attributed,
+            "closed_idea_count": total,
+            "rate": _quantized(rate),
+        },
+        detail=(
+            f"{attributed}/{total} closed ideas attributed ({_as_pct(rate)}%), "
+            f"need {_as_pct(thresholds.min_attribution_coverage)}%"
+        ),
+    )
+
+
+def _risk_calibration_gate(
+    closed_in_window: list[TradeIdeaView],
+    *,
+    thresholds: ScorecardThresholds,
+) -> dict[str, Any]:
+    losers = 0
+    calibrated = 0
+    losers_without_max_loss = 0
+    for view in closed_in_window:
+        closeout = view.closeout_attribution
+        if closeout is None:
+            continue
+        realized = closeout.realized_profit_loss_amount
+        if realized is None or realized >= 0:
+            continue
+        losers += 1
+        max_loss = closeout.max_loss.amount
+        if max_loss is None:
+            # A loser without a recorded max-loss estimate cannot demonstrate
+            # calibration, so it counts against the gate rather than shrinking
+            # the denominator.
+            losers_without_max_loss += 1
+            continue
+        if -realized <= max_loss:
+            calibrated += 1
+    if losers == 0:
+        return _gate(
+            GateStatus.NOT_YET_MEASURABLE,
+            measured={"loser_count": 0},
+            detail="no attributed losing closeouts in the observation window",
+        )
+    rate = Decimal(calibrated) / Decimal(losers)
+    return _gate(
+        GateStatus.PASS if rate >= thresholds.min_risk_calibration else GateStatus.FAIL,
+        measured={
+            "calibrated_count": calibrated,
+            "loser_count": losers,
+            "losers_without_max_loss": losers_without_max_loss,
+            "rate": _quantized(rate),
+        },
+        detail=(
+            f"{calibrated}/{losers} losers within recorded max loss ({_as_pct(rate)}%), "
+            f"need >= {_as_pct(thresholds.min_risk_calibration)}%"
+        ),
+    )
+
+
+def _expectancy_gate(closed_in_window: list[TradeIdeaView]) -> dict[str, Any]:
+    returns = _returns_by_actor(closed_in_window)
+    all_returns = [value for values in returns.values() for value in values]
+    if not all_returns:
+        return _gate(
+            GateStatus.NOT_YET_MEASURABLE,
+            measured={"comparable_closeout_count": 0},
+            detail="no closeouts with both realized amount and max-loss estimate",
+        )
+    average = sum(all_returns, Decimal("0")) / Decimal(len(all_returns))
+    return _gate(
+        GateStatus.PASS if average > 0 else GateStatus.FAIL,
+        measured={
+            "average_r": _quantized(average),
+            "comparable_closeout_count": len(all_returns),
+        },
+        detail=f"avg R {_quantized(average)} across {len(all_returns)} closeouts, need > 0",
+    )
+
+
+def _benchmark_edge_gate(
+    closed_in_window: list[TradeIdeaView],
+    *,
+    thresholds: ScorecardThresholds,
+) -> dict[str, Any]:
+    returns = _returns_by_actor(closed_in_window)
+    baseline_returns: list[Decimal] = []
+    candidate_returns: list[Decimal] = []
+    for actor_id, values in returns.items():
+        if actor_id.startswith(thresholds.baseline_actor_prefix):
+            baseline_returns.extend(values)
+        else:
+            candidate_returns.extend(values)
+    if not baseline_returns or not candidate_returns:
+        missing = "baseline" if not baseline_returns else "non-baseline"
+        return _gate(
+            GateStatus.NOT_YET_MEASURABLE,
+            measured={
+                "baseline_closeout_count": len(baseline_returns),
+                "candidate_closeout_count": len(candidate_returns),
+            },
+            detail=f"no comparable {missing} closeouts in the observation window",
+        )
+    baseline_avg = sum(baseline_returns, Decimal("0")) / Decimal(len(baseline_returns))
+    candidate_avg = sum(candidate_returns, Decimal("0")) / Decimal(len(candidate_returns))
+    edge = candidate_avg - baseline_avg
+    return _gate(
+        GateStatus.PASS if edge > 0 else GateStatus.FAIL,
+        measured={
+            "candidate_average_r": _quantized(candidate_avg),
+            "baseline_average_r": _quantized(baseline_avg),
+            "edge_r": _quantized(edge),
+            "baseline_closeout_count": len(baseline_returns),
+            "candidate_closeout_count": len(candidate_returns),
+        },
+        detail=(
+            f"candidate avg R {_quantized(candidate_avg)} - "
+            f"baseline avg R {_quantized(baseline_avg)} = {_quantized(edge)}, need > 0"
+        ),
+    )
+
+
+def _returns_by_actor(closed_in_window: list[TradeIdeaView]) -> dict[str, list[Decimal]]:
+    returns: dict[str, list[Decimal]] = {}
+    for view in closed_in_window:
+        closeout = view.closeout_attribution
+        if closeout is None:
+            continue
+        realized = closeout.realized_profit_loss_amount
+        max_loss = closeout.max_loss.amount
+        if realized is None or max_loss is None or max_loss <= 0:
+            continue
+        returns.setdefault(_proposing_actor(view), []).append(realized / max_loss)
+    return returns
+
+
+def _proposals_flowing_check(
+    views: list[TradeIdeaView],
+    *,
+    now: datetime,
+    thresholds: ScorecardThresholds,
+) -> dict[str, Any]:
+    proposal_times = [
+        event.timestamp
+        for view in views
+        for event in view.events
+        if event.action is AuditAction.PROPOSED
+    ]
+    if not proposal_times:
+        return _gate(
+            GateStatus.FAIL,
+            measured={"latest_proposal_at": None},
+            detail="no proposal events on the trail",
+        )
+    latest = max(proposal_times)
+    age = now - latest
+    flowing = age <= timedelta(hours=thresholds.proposal_freshness_hours)
+    return _gate(
+        GateStatus.PASS if flowing else GateStatus.FAIL,
+        measured={"latest_proposal_at": latest.isoformat()},
+        detail=(
+            f"latest proposal {latest.isoformat()}, "
+            f"freshness window {thresholds.proposal_freshness_hours}h"
+        ),
+    )
+
+
+def _attribution_red(attribution_gate: Mapping[str, Any]) -> dict[str, Any]:
+    # The loop-health red mirrors the gate: not-yet-measurable coverage is not
+    # a red (nothing has closed), but any measured gap is.
+    status = (
+        GateStatus.PASS if attribution_gate["status"] != GateStatus.FAIL.value else GateStatus.FAIL
+    )
+    return _gate(
+        status,
+        measured=attribution_gate["measured"],
+        detail=attribution_gate["detail"],
+    )
+
+
+def _audit_integrity_check(service: TradeIdeaService) -> dict[str, Any]:
+    try:
+        events = service.audit_log.verify()
+    except Exception as error:
+        return _gate(
+            GateStatus.FAIL,
+            measured={},
+            detail=f"audit verification failed: {error}",
+        )
+    return _gate(
+        GateStatus.PASS,
+        measured={"event_count": len(events)},
+        detail=f"{len(events)} events verified",
+    )
+
+
+def _replay_reports(report_payload: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    if "reports" in report_payload:
+        return [_payload_mapping(report) for report in report_payload["reports"]]
+    return [report_payload]
+
+
+def _payload_mapping(value: Any) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError("replay report entries must be JSON objects")
+    return value
+
+
+def _replay_benchmark_edge(
+    calibration: list[dict[str, Any]],
+    *,
+    baseline_proposer_prefix: str,
+) -> dict[str, Any]:
+    baseline_rows = [
+        row
+        for row in calibration
+        if str(row["proposer_id"]).startswith(baseline_proposer_prefix)
+        and row["average_return_r"] is not None
+    ]
+    candidate_rows = [
+        row
+        for row in calibration
+        if not str(row["proposer_id"]).startswith(baseline_proposer_prefix)
+        and row["average_return_r"] is not None
+    ]
+    if not baseline_rows or not candidate_rows:
+        missing = "baseline" if not baseline_rows else "non-baseline"
+        return {
+            "baseline_proposer_id": baseline_rows[0]["proposer_id"] if baseline_rows else None,
+            "baseline_average_return_r": None,
+            "comparisons": [],
+            "detail": f"no {missing} proposer with resolved replay returns in this window",
+        }
+    baseline = baseline_rows[0]
+    baseline_avg = Decimal(baseline["average_return_r"])
+    comparisons = [
+        {
+            "proposer_id": row["proposer_id"],
+            "average_return_r": row["average_return_r"],
+            "edge_r": _quantized(Decimal(row["average_return_r"]) - baseline_avg),
+        }
+        for row in candidate_rows
+    ]
+    return {
+        "baseline_proposer_id": baseline["proposer_id"],
+        "baseline_average_return_r": baseline["average_return_r"],
+        "comparisons": comparisons,
+        "detail": "",
+    }
+
+
+def _quantized(value: Decimal) -> str:
+    return str(value.quantize(_RATE_QUANT))
+
+
+def _as_pct(value: Decimal) -> str:
+    return str((value * Decimal("100")).quantize(_PERCENT_QUANT))

--- a/tests/unit/gpt_trader/cli/commands/test_ideas_replay_baseline.py
+++ b/tests/unit/gpt_trader/cli/commands/test_ideas_replay_baseline.py
@@ -336,3 +336,57 @@ def test_replay_baseline_json_output_returns_replay_report(
     assert data["target_hit_rate"] == "1"
     assert data["average_return_r"] == "2"
     assert data["ideas"][0]["outcome"] == "target_hit"
+
+
+def _snapshot_payload_fixture() -> dict[str, Any]:
+    """Recorded market-snapshot payload wrapping the baseline-hit candles."""
+    # A recorded snapshot's candles are strictly before its as_of; the last
+    # baseline-hit candle sits at AS_OF + 1h.
+    return {
+        "as_of": (AS_OF + timedelta(hours=2)).isoformat(),
+        "source": "coinbase:candles",
+        "series": [
+            {
+                "symbol": "ETH-USD",
+                "granularity": "ONE_HOUR",
+                "candles": _flat_fixture()["candles"],
+            },
+            {
+                "symbol": "BTC-USD",
+                "granularity": "ONE_HOUR",
+                "candles": _baseline_hit_fixture()["candles"],
+            },
+        ],
+    }
+
+
+def test_replay_baseline_runs_over_a_recorded_snapshot_window(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    snapshot = _write_fixture(tmp_path / "snapshot.json", _snapshot_payload_fixture())
+
+    exit_code, response = _run_json(capsys, _baseline_args(snapshot))
+
+    assert exit_code == 0
+    data = response["data"]
+    # Same window, same figures as the bare candle fixture: the recorded
+    # snapshot's BTC-USD series feeds replay directly.
+    assert data["symbol"] == "BTC-USD"
+    assert data["ideas_proposed"] == 1
+    assert data["target_hits"] == 1
+
+
+def test_replay_baseline_recorded_snapshot_without_symbol_series_is_rejected(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    payload = _snapshot_payload_fixture()
+    payload["series"] = [payload["series"][0]]  # ETH-USD only
+    snapshot = _write_fixture(tmp_path / "snapshot.json", payload)
+
+    exit_code, response = _run_json(capsys, _baseline_args(snapshot))
+
+    assert exit_code == 1
+    assert response["errors"][0]["code"] == CliErrorCode.INVALID_ARGUMENT.value
+    assert response["errors"][0]["details"]["field"] == "symbol"

--- a/tests/unit/gpt_trader/cli/commands/test_ideas_scorecard.py
+++ b/tests/unit/gpt_trader/cli/commands/test_ideas_scorecard.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from gpt_trader import cli
+
+
+def _run_json(capsys: pytest.CaptureFixture[str], argv: list[str]) -> tuple[int, dict[str, Any]]:
+    exit_code = cli.main(argv)
+    output = capsys.readouterr().out
+    assert output
+    return exit_code, json.loads(output)
+
+
+def _replay_payload() -> dict[str, Any]:
+    return {
+        "proposer_id": "baseline-ma-10-50",
+        "symbol": "BTC-USD",
+        "granularity": "ONE_HOUR",
+        "source": "fixture:candles",
+        "snapshots_evaluated": 24,
+        "ideas_proposed": 3,
+        "resolved_ideas": 2,
+        "target_hit_rate": "0.5",
+        "stop_hit_rate": "0.5",
+        "average_return_r": "0.1",
+        "eligibility_pass_rate": "1",
+    }
+
+
+def test_scorecard_empty_store_scores_all_gates(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    root = tmp_path / "ideas"
+
+    exit_code, response = _run_json(
+        capsys,
+        ["ideas", "scorecard", "--ideas-root", str(root), "--format", "json"],
+    )
+
+    assert exit_code == 0
+    assert response["success"] is True
+    assert response["metadata"]["was_noop"] is True
+    data = response["data"]
+    assert data["evidence"] == "wall-clock"
+    assert set(data["gates"]) == {
+        "track_record_depth",
+        "eligibility_pass_rate",
+        "attribution_coverage",
+        "risk_calibration",
+        "expectancy",
+        "benchmark_edge",
+        "max_drawdown_from_peak",
+    }
+    assert set(data["loop_health"]) == {
+        "proposals_flowing",
+        "attribution_coverage",
+        "audit_integrity",
+    }
+    assert data["overall"]["promotable"] is False
+    assert data["gates"]["track_record_depth"]["status"] == "fail"
+    assert data["gates"]["max_drawdown_from_peak"]["status"] == "not_yet_measurable"
+    assert "replay_evidence" not in data
+    # The command is read-only: an empty root stays empty.
+    assert not root.exists() or not any(root.rglob("*"))
+
+
+def test_scorecard_text_format_renders_gate_sections(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    root = tmp_path / "ideas"
+
+    exit_code = cli.main(["ideas", "scorecard", "--ideas-root", str(root), "--format", "text"])
+    output = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert "✓ ideas scorecard OK" in output
+    assert "Observation window" in output
+    assert "Stage 1 -> 2 gates (wall-clock)" in output
+    assert "Loop health" in output
+
+
+def test_scorecard_attaches_replay_evidence_from_raw_and_enveloped_files(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    root = tmp_path / "ideas"
+    raw_path = tmp_path / "replay-raw.json"
+    raw_path.write_text(json.dumps(_replay_payload()), encoding="utf-8")
+    enveloped_path = tmp_path / "replay-enveloped.json"
+    enveloped_path.write_text(
+        json.dumps({"success": True, "data": _replay_payload()}),
+        encoding="utf-8",
+    )
+
+    exit_code, response = _run_json(
+        capsys,
+        [
+            "ideas",
+            "scorecard",
+            "--ideas-root",
+            str(root),
+            "--replay-report",
+            str(raw_path),
+            "--replay-report",
+            str(enveloped_path),
+            "--format",
+            "json",
+        ],
+    )
+
+    assert exit_code == 0
+    data = response["data"]
+    assert len(data["replay_evidence"]) == 2
+    for evidence in data["replay_evidence"]:
+        assert evidence["evidence"] == "replay-derived"
+        assert evidence["calibration"][0]["proposer_id"] == "baseline-ma-10-50"
+    # Replay evidence rides alongside; the wall-clock gates stay untouched.
+    assert data["evidence"] == "wall-clock"
+    assert data["gates"]["benchmark_edge"]["status"] == "not_yet_measurable"
+
+
+def test_scorecard_writes_output_dir_artifact(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    root = tmp_path / "ideas"
+    artifact_dir = tmp_path / "artifacts"
+
+    exit_code, response = _run_json(
+        capsys,
+        [
+            "ideas",
+            "scorecard",
+            "--ideas-root",
+            str(root),
+            "--output-dir",
+            str(artifact_dir),
+            "--format",
+            "json",
+        ],
+    )
+
+    assert exit_code == 0
+    artifact_path = Path(response["data"]["artifact_path"])
+    assert artifact_path.exists()
+    artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
+    assert artifact["schema_version"] == "gpt-trader.trade_ideas.scorecard.v1"
+
+
+def test_scorecard_rejects_unreadable_replay_report(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    root = tmp_path / "ideas"
+    bad_path = tmp_path / "not-a-report.json"
+    bad_path.write_text(json.dumps(["not", "an", "object"]), encoding="utf-8")
+
+    exit_code = cli.main(
+        [
+            "ideas",
+            "scorecard",
+            "--ideas-root",
+            str(root),
+            "--replay-report",
+            str(bad_path),
+            "--format",
+            "json",
+        ]
+    )
+    output = capsys.readouterr().out
+
+    assert exit_code != 0
+    response = json.loads(output)
+    assert response["success"] is False

--- a/tests/unit/gpt_trader/features/trade_ideas/test_scorecard.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_scorecard.py
@@ -1,0 +1,376 @@
+"""Stage 1 -> 2 promotion scorecard over the idea-level trail.
+
+Covers the observation-window rule, per-gate verdicts against the tuned
+thresholds, loop-health reds, replay-derived evidence labeling, and the
+decision constraint that the metric path never reads the batch cycle
+manifest (docs/decisions/adopt-event-driven-execution-topology.md).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+from tests.unit.gpt_trader.features.trade_ideas.conftest import (
+    attest_account_equity,
+    build_trade_idea,
+)
+
+from gpt_trader.features.trade_ideas import (
+    CloseoutResolution,
+    TimeHorizon,
+    TradeIdeaService,
+)
+from gpt_trader.features.trade_ideas.scorecard import (
+    REPLAY_EVIDENCE_LABEL,
+    WALL_CLOCK_EVIDENCE_LABEL,
+    ScorecardThresholds,
+    build_replay_evidence,
+    build_stage_promotion_scorecard,
+    format_stage_promotion_scorecard,
+)
+
+_START = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+
+
+class _Clock:
+    """Mutable clock so one service can write events across a long window."""
+
+    def __init__(self, start: datetime) -> None:
+        self.now = start
+
+    def __call__(self) -> datetime:
+        return self.now
+
+
+def _service(root: Path, clock: _Clock) -> TradeIdeaService:
+    return TradeIdeaService(root, now_factory=clock)
+
+
+def _idea(decision_id: str, *, expires_at: datetime, **overrides: Any) -> Any:
+    return build_trade_idea(
+        decision_id=decision_id,
+        time_horizon=TimeHorizon(expected_hold="3-10 days", expires_at=expires_at),
+        **overrides,
+    )
+
+
+def _close_with_pnl(
+    service: TradeIdeaService,
+    clock: _Clock,
+    decision_id: str,
+    *,
+    proposer_actor_id: str,
+    realized_amount: Decimal,
+    closed_at: datetime,
+) -> None:
+    """Propose -> approve -> submit -> fill -> attribute one idea at ``closed_at``."""
+    clock.now = closed_at - timedelta(hours=4)
+    idea = _idea(decision_id, expires_at=closed_at + timedelta(days=30))
+    service.propose(idea, actor_id=proposer_actor_id)
+    service.approve(decision_id, actor_id="rj", reason="Risk verified")
+    service.record_submission(decision_id, actor_id="operator", venue="manual")
+    service.record_fill(decision_id, actor_id="operator", venue="manual")
+    clock.now = closed_at
+    service.record_closeout_attribution(
+        decision_id,
+        actor_id="rj",
+        resolution=(
+            CloseoutResolution.THESIS_TARGET
+            if realized_amount >= 0
+            else CloseoutResolution.INVALIDATION
+        ),
+        realized_profit_loss_amount=realized_amount,
+        evidence=("broker-statement:manual",),
+    )
+
+
+def test_default_thresholds_carry_the_rubric_starting_values() -> None:
+    thresholds = ScorecardThresholds()
+
+    assert thresholds.min_closed_ideas == 200
+    assert thresholds.min_window_days == 60
+    assert thresholds.min_eligibility_pass_rate == Decimal("0.90")
+    assert thresholds.min_attribution_coverage == Decimal("1")
+    assert thresholds.min_risk_calibration == Decimal("0.95")
+
+
+def test_scorecard_scores_gates_from_the_trail(tmp_path: Path) -> None:
+    clock = _Clock(_START)
+    service = _service(tmp_path / "ideas", clock)
+    attest_account_equity(service)
+
+    # Baseline proposer: one winner at R = 25/250 = 0.1.
+    _close_with_pnl(
+        service,
+        clock,
+        "trade-baseline-001",
+        proposer_actor_id="baseline-ma-10-50",
+        realized_amount=Decimal("25"),
+        closed_at=_START + timedelta(days=5),
+    )
+    # Candidate proposer: a winner (R 0.8) and a calibrated loser (R -0.4,
+    # |loss| 100 <= recorded max loss 250).
+    _close_with_pnl(
+        service,
+        clock,
+        "trade-candidate-001",
+        proposer_actor_id="strategy-x",
+        realized_amount=Decimal("200"),
+        closed_at=_START + timedelta(days=10),
+    )
+    _close_with_pnl(
+        service,
+        clock,
+        "trade-candidate-002",
+        proposer_actor_id="strategy-x",
+        realized_amount=Decimal("-100"),
+        closed_at=_START + timedelta(days=20),
+    )
+    # A fresh open proposal keeps the proposals-flowing red green.
+    now = _START + timedelta(days=70)
+    clock.now = now - timedelta(hours=1)
+    service.propose(
+        _idea("trade-open-001", expires_at=now + timedelta(days=30)),
+        actor_id="strategy-x",
+    )
+
+    payload = build_stage_promotion_scorecard(
+        service,
+        now=now,
+        thresholds=ScorecardThresholds(min_closed_ideas=3, min_window_days=60),
+    )
+
+    assert payload["evidence"] == WALL_CLOCK_EVIDENCE_LABEL
+    assert payload["observation_window"]["closed_idea_count"] == 3
+    gates = payload["gates"]
+    assert gates["track_record_depth"]["status"] == "pass"
+    assert gates["eligibility_pass_rate"]["status"] == "pass"
+    assert gates["attribution_coverage"]["status"] == "pass"
+    assert gates["risk_calibration"]["status"] == "pass"
+    assert gates["risk_calibration"]["measured"]["loser_count"] == 1
+    assert gates["expectancy"]["status"] == "pass"
+    assert gates["expectancy"]["measured"]["average_r"] == "0.1667"
+    assert gates["benchmark_edge"]["status"] == "pass"
+    assert gates["benchmark_edge"]["measured"]["edge_r"] == "0.1000"
+    assert gates["max_drawdown_from_peak"]["status"] == "not_yet_measurable"
+    loop_health = payload["loop_health"]
+    assert loop_health["proposals_flowing"]["status"] == "pass"
+    assert loop_health["attribution_coverage"]["status"] == "pass"
+    assert loop_health["audit_integrity"]["status"] == "pass"
+    overall = payload["overall"]
+    # Drawdown-from-peak stays unmeasurable until #1192, so the scorecard can
+    # never claim promotability from this trail yet.
+    assert overall["promotable"] is False
+    assert overall["gates_passed"] == 6
+    assert overall["gates_not_yet_measurable"] == 1
+    assert overall["loop_health_reds"] == []
+
+
+def test_observation_window_extends_past_sixty_days_to_reach_closed_depth(
+    tmp_path: Path,
+) -> None:
+    clock = _Clock(_START)
+    service = _service(tmp_path / "ideas", clock)
+    attest_account_equity(service)
+
+    for index, closed_at in enumerate((_START, _START + timedelta(days=1))):
+        _close_with_pnl(
+            service,
+            clock,
+            f"trade-old-{index:03d}",
+            proposer_actor_id="strategy-x",
+            realized_amount=Decimal("50"),
+            closed_at=closed_at,
+        )
+
+    now = _START + timedelta(days=100)
+    payload = build_stage_promotion_scorecard(
+        service,
+        now=now,
+        thresholds=ScorecardThresholds(min_closed_ideas=2, min_window_days=60),
+    )
+
+    # Both closeouts predate the rolling 60-day start, so the window must
+    # stretch back to include the most recent two closed ideas. An idea counts
+    # as closed at its terminal audit event (the fill, 4h before attribution).
+    assert payload["observation_window"]["start"] == (_START - timedelta(hours=4)).isoformat()
+    assert payload["observation_window"]["closed_idea_count"] == 2
+    assert payload["gates"]["track_record_depth"]["status"] == "pass"
+    # No proposal for 100 days: the loop-health red must fire even though the
+    # depth gate passes.
+    assert payload["loop_health"]["proposals_flowing"]["status"] == "fail"
+
+
+def test_missing_attribution_fails_the_gate_and_the_loop_health_red(
+    tmp_path: Path,
+) -> None:
+    clock = _Clock(_START)
+    service = _service(tmp_path / "ideas", clock)
+
+    idea = _idea("trade-expired-001", expires_at=_START + timedelta(days=1))
+    service.propose(idea, actor_id="strategy-x")
+    clock.now = _START + timedelta(days=2)
+    service.expire(idea.decision_id)
+
+    payload = build_stage_promotion_scorecard(
+        service,
+        now=_START + timedelta(days=3),
+        thresholds=ScorecardThresholds(min_closed_ideas=1, min_window_days=1),
+    )
+
+    assert payload["gates"]["attribution_coverage"]["status"] == "fail"
+    assert payload["loop_health"]["attribution_coverage"]["status"] == "fail"
+    assert "attribution_coverage" in payload["overall"]["loop_health_reds"]
+    assert payload["overall"]["promotable"] is False
+
+
+def test_benchmark_edge_needs_both_baseline_and_candidate_closeouts(
+    tmp_path: Path,
+) -> None:
+    clock = _Clock(_START)
+    service = _service(tmp_path / "ideas", clock)
+    attest_account_equity(service)
+
+    _close_with_pnl(
+        service,
+        clock,
+        "trade-candidate-001",
+        proposer_actor_id="strategy-x",
+        realized_amount=Decimal("50"),
+        closed_at=_START + timedelta(days=1),
+    )
+
+    payload = build_stage_promotion_scorecard(
+        service,
+        now=_START + timedelta(days=2),
+        thresholds=ScorecardThresholds(min_closed_ideas=1, min_window_days=1),
+    )
+
+    gate = payload["gates"]["benchmark_edge"]
+    assert gate["status"] == "not_yet_measurable"
+    assert gate["measured"]["baseline_closeout_count"] == 0
+
+
+def test_replay_evidence_is_labeled_and_reports_edge_vs_baseline() -> None:
+    tournament_payload = {
+        "symbol": "BTC-USD",
+        "granularity": "ONE_HOUR",
+        "source": "fixture:candles",
+        "snapshots_evaluated": 240,
+        "rankings": [],
+        "reports": [
+            {
+                "proposer_id": "baseline-ma-10-50",
+                "ideas_proposed": 12,
+                "resolved_ideas": 10,
+                "target_hit_rate": "0.4",
+                "stop_hit_rate": "0.6",
+                "average_return_r": "0.05",
+                "eligibility_pass_rate": "1",
+            },
+            {
+                "proposer_id": "regime-switcher",
+                "ideas_proposed": 9,
+                "resolved_ideas": 8,
+                "target_hit_rate": "0.5",
+                "stop_hit_rate": "0.5",
+                "average_return_r": "0.35",
+                "eligibility_pass_rate": "1",
+            },
+        ],
+    }
+
+    evidence = build_replay_evidence(tournament_payload)
+
+    assert evidence["evidence"] == REPLAY_EVIDENCE_LABEL
+    assert evidence["snapshots_evaluated"] == 240
+    assert [row["proposer_id"] for row in evidence["calibration"]] == [
+        "baseline-ma-10-50",
+        "regime-switcher",
+    ]
+    edge = evidence["benchmark_edge"]
+    assert edge["baseline_proposer_id"] == "baseline-ma-10-50"
+    assert edge["comparisons"] == [
+        {
+            "proposer_id": "regime-switcher",
+            "average_return_r": "0.35",
+            "edge_r": "0.3000",
+        }
+    ]
+
+
+def test_replay_evidence_from_single_baseline_report_has_no_edge() -> None:
+    single_payload = {
+        "proposer_id": "baseline-ma-10-50",
+        "symbol": "BTC-USD",
+        "granularity": "ONE_HOUR",
+        "source": "fixture:candles",
+        "snapshots_evaluated": 100,
+        "ideas_proposed": 5,
+        "resolved_ideas": 4,
+        "target_hit_rate": "0.5",
+        "stop_hit_rate": "0.5",
+        "average_return_r": "0.2",
+        "eligibility_pass_rate": "1",
+    }
+
+    evidence = build_replay_evidence(single_payload)
+
+    assert evidence["evidence"] == REPLAY_EVIDENCE_LABEL
+    assert evidence["benchmark_edge"]["comparisons"] == []
+    assert "non-baseline" in evidence["benchmark_edge"]["detail"]
+
+
+def test_text_rendering_separates_wall_clock_gates_from_replay_evidence(
+    tmp_path: Path,
+) -> None:
+    clock = _Clock(_START)
+    service = _service(tmp_path / "ideas", clock)
+    payload = build_stage_promotion_scorecard(service, now=_START)
+    payload["replay_evidence"] = [
+        build_replay_evidence(
+            {
+                "proposer_id": "baseline-ma-10-50",
+                "symbol": "BTC-USD",
+                "granularity": "ONE_HOUR",
+                "source": "fixture:candles",
+                "snapshots_evaluated": 10,
+                "resolved_ideas": 0,
+                "target_hit_rate": "0",
+                "stop_hit_rate": "0",
+                "average_return_r": None,
+                "eligibility_pass_rate": "0",
+            }
+        )
+    ]
+
+    text = format_stage_promotion_scorecard(payload)
+
+    assert text.startswith("✓ ideas scorecard OK")
+    assert "Stage 1 -> 2 gates (wall-clock)" in text
+    assert "Replay evidence (replay-derived" in text
+    assert "not blended into gates" in text
+
+
+def test_metric_path_never_references_the_cycle_manifest() -> None:
+    """The decision constraint: evidence comes from the idea-level trail.
+
+    ``cycle/manifest.jsonl`` is launchd scaffolding; if any metric-path module
+    starts reading (or even naming) the manifest, the scorecard would stop
+    being valid once the event-driven lane replaces the batch cycle.
+    """
+    import gpt_trader.features.trade_ideas.replay as replay
+    import gpt_trader.features.trade_ideas.report as report
+    import gpt_trader.features.trade_ideas.review_metrics as review_metrics
+    import gpt_trader.features.trade_ideas.scorecard as scorecard
+
+    for module in (scorecard, report, replay, review_metrics):
+        source = Path(module.__file__).read_text(encoding="utf-8")
+        assert "manifest" not in source.lower(), (
+            f"{module.__name__} references the cycle manifest; scorecard "
+            "metrics must compute from the idea-level closeout/audit trail"
+        )
+    assert "idea_execution" not in Path(scorecard.__file__).read_text(encoding="utf-8")


### PR DESCRIPTION
Closes #1193. Part of the accepted [adopt-event-driven-execution-topology](https://github.com/Solders-Girdles-Org/GPT-Trader/blob/main/docs/decisions/adopt-event-driven-execution-topology.md) sequence.

## What

**Rubric scorecard.** `features/trade_ideas/scorecard.py` computes the Stage 1 → 2 promotion gates of the [measured-outcome rubric](https://github.com/Solders-Girdles-Org/GPT-Trader/blob/main/docs/decisions/adopt-measured-outcome-rubric.md) — track-record depth, eligibility pass rate, attribution coverage, risk calibration, expectancy (avg R), benchmark edge vs the deterministic baseline (grouped by proposing `actor_id`), max drawdown-from-peak — plus the loop-health reds (proposals flowing, attribution coverage, audit integrity via `audit_log.verify()`), with the observation-window rule (rolling 60 days **and** ≥ 200 closed ideas, whichever is larger) applied. Thresholds default to the rubric decision's tuned starting values and stay owner-tunable via `ScorecardThresholds`.

Surfaced as `gpt-trader ideas scorecard` (CliResponse ✓/✗ convention, `--format json|text`, `--output-dir` durable artifact).

**Replay-accelerated evidence.** The `ideas replay` commands now accept a recorded market-snapshot payload (`ideas snapshot build` output / a cycle run's persisted snapshot) as `--file` input in addition to bare candle fixtures, so calibration and edge compute at machine speed over recorded windows. `ideas scorecard --replay-report <json>` reports those figures **alongside** the wall-clock gates, always labeled `replay-derived` and never blended into a gate verdict — whether replay counts toward promotion remains a separate owner call per the issue.

## The constraint

All metrics compute from the idea-level closeout/audit trail; zero reads of `cycle/manifest.jsonl` anywhere in the metric path, **test-enforced** (`test_metric_path_never_references_the_cycle_manifest` scans scorecard/report/replay/review_metrics sources and forbids `idea_execution` imports in the scorecard).

## Graceful degradation

- Drawdown-from-peak renders `not_yet_measurable` (input arrives with #1192), so `overall.promotable` can never be true yet.
- Zero-denominator gates render `not_yet_measurable`, never a vacuous pass; losers without a recorded max-loss estimate count **against** risk calibration.

## Verification

`uv run local-ci` (pr profile) passed end-to-end: 6665 unit tests (14 new scorecard + 2 recorded-snapshot replay tests), rails smoke, property/contract/integration, docs gates. STATUS.md and the trade-idea design notes updated in the same PR.