### PR TITLE
fix(live_trade): validate ticker price before recording it as a live mark

### DIFF
--- a/src/gpt_trader/features/live_trade/engines/decision_flow.py
+++ b/src/gpt_trader/features/live_trade/engines/decision_flow.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import time
 from datetime import UTC, datetime
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from typing import Any
 
 from gpt_trader.core import Position
@@ -44,8 +44,10 @@ async def process_symbol(
             engine._connection_status = "DISCONNECTED"
             return
 
-    if ticker is None or not ticker.get("price"):
-        logger.error(f"No ticker data for {symbol}")
+    price = _parse_ticker_price(ticker) if ticker is not None else None
+    if price is None:
+        raw_price = ticker.get("price") if ticker is not None else None
+        logger.error(f"No valid ticker price for {symbol}: {raw_price!r}")
         engine._connection_status = "DISCONNECTED"
         return
 
@@ -65,7 +67,6 @@ async def process_symbol(
     engine._last_latency = time.time() - start_time
     engine._connection_status = "CONNECTED"
 
-    price = Decimal(str(ticker.get("price", 0)))
     logger.info(f"{symbol} price: {price}")
 
     if engine.context.risk_manager is not None:
@@ -109,6 +110,25 @@ async def process_symbol(
         equity=equity,
         position_state=position_state,
     )
+
+
+def _parse_ticker_price(ticker: dict[str, Any]) -> Decimal | None:
+    """Validate a ticker price before it becomes a live mark (#1123).
+
+    Returns None for missing, malformed, non-finite (NaN/Infinity), or
+    non-positive prices so a bad quote is never persisted to the tick store,
+    reported, or fed into strategy/risk state.
+    """
+    raw = ticker.get("price")
+    if raw is None:
+        return None
+    try:
+        price = Decimal(str(raw))
+    except (InvalidOperation, ValueError):
+        return None
+    if not price.is_finite() or price <= 0:
+        return None
+    return price
 
 
 async def handle_decision(

--- a/tests/unit/gpt_trader/features/live_trade/engines/test_strategy_engine_marks.py
+++ b/tests/unit/gpt_trader/features/live_trade/engines/test_strategy_engine_marks.py
@@ -1,0 +1,57 @@
+"""Tests for ticker-price validation on the live-mark path (#1123).
+
+Runs against the real-flow engine (production validator/submitter/state
+stack); behavior is steered only at the broker boundary. A ticker price that
+is malformed, non-finite, or non-positive must never be recorded as a live
+mark: no tick persisted, no mark-staleness seed, no strategy decision, and
+the connection is reported DISCONNECTED.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def _recorded_marks(engine) -> list:
+    return list(engine.price_history.get("BTC-USD", []))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "raw_price",
+    [
+        "not-a-number",
+        "NaN",
+        "Infinity",
+        "-Infinity",
+        "0",
+        "-5",
+        "",
+        None,
+    ],
+)
+async def test_invalid_ticker_price_never_recorded_as_mark(real_flow_engine, raw_price) -> None:
+    engine = real_flow_engine
+    engine.context.broker.get_ticker.return_value = {"price": raw_price}
+
+    await engine._cycle()
+
+    engine.strategy.decide.assert_not_called()
+    assert engine._connection_status == "DISCONNECTED"
+    assert "BTC-USD" not in engine.context.risk_manager.last_mark_update
+    assert not _recorded_marks(engine)
+
+
+@pytest.mark.asyncio
+async def test_valid_ticker_price_recorded_as_mark(real_flow_engine) -> None:
+    engine = real_flow_engine
+    engine.context.broker.get_ticker.return_value = {"price": "50000.5"}
+
+    await engine._cycle()
+
+    engine.strategy.decide.assert_called_once()
+    assert engine._connection_status == "CONNECTED"
+    assert "BTC-USD" in engine.context.risk_manager.last_mark_update
+    marks = _recorded_marks(engine)
+    assert marks
+    assert str(marks[-1]) == "50000.5"


### PR DESCRIPTION
## Summary
- Closes #1123 (flagged on #1116, re-triaged 2026-07-04 as higher priority now that the hourly Stage-2 cycle is live).
- `process_symbol` previously did a presence-only check (`not ticker.get("price")`) then an unguarded `Decimal(str(...))`: malformed input raised uncaught, and `NaN`/`Infinity` passed through and were persisted (price-tick store), reported (status reporter), and fed into strategy/risk state.
- Now the price is parsed and validated (finite, > 0) **before** the connection is marked healthy, the mark-staleness seed is stamped, or the tick is recorded. Invalid price → `DISCONNECTED` + early return, same as a missing ticker.

## Why now
A bad quote now feeds a live loop (hourly Stage-2 cycle operational since 2026-07-04), and #1192's continuous portfolio monitors will consume these marks — mark quality was called out there as a prerequisite.

## Testing
- New `test_strategy_engine_marks.py` runs the REAL validator/submitter stack (`real_flow_engine` idiom from #1113), steering only `broker.get_ticker`: parametrized over malformed/NaN/±Infinity/zero/negative/empty/missing prices asserting no strategy decision, no mark seed, no recorded tick, and DISCONNECTED status; plus a valid-price control.
- `uv run local-ci` (pr profile) green locally; full unit suite 6671 passed.