### PR TITLE
feat(risk): continuous portfolio monitors — HWM, drawdown-from-peak, exposure

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -71,6 +71,15 @@ enabled and the autonomy log still resolves to `bounded_autonomy` at execution
 time. The execution gate reuses the daily-loss ratchet, so a breach lowers the
 mode before remaining system-approved ideas can execute.
 
+**Portfolio-level risk is a continuous monitor** (#1192): HWM,
+drawdown-from-peak, and open exposure are derived from the attested-equity
+ledger and the open-idea trail (`features/trade_ideas/monitors.py`) and read
+through one library call (`TradeIdeaService.portfolio_monitors`) by both
+`gpt-trader ideas monitors` and the console accountant page. The
+drawdown-from-peak appetite is a budget lever (`max_drawdown_from_peak_pct`,
+unset by default); a breach at any decision boundary ratchets autonomy down
+through the same audited path as the daily-loss trigger.
+
 **The promotion gates are now measurable in one command** (`ideas scorecard`,
 #1193): the Stage 1 -> 2 gates of the
 [measured-outcome rubric](decisions/adopt-measured-outcome-rubric.md) score
@@ -79,8 +88,10 @@ pass/fail from the idea-level closeout/audit trail
 applied, never from the batch cycle's run artifacts (test-enforced).
 Replay-derived calibration/edge over recorded snapshot windows reports
 alongside -- labeled, never blended into -- the wall-clock gates.
-Drawdown-from-peak renders not-yet-measurable until the continuous portfolio
-monitors (#1192) land, so the scorecard cannot claim promotability yet.
+Drawdown-from-peak now scores from the same equity ledger the monitors read
+(#1192); it stays not-yet-measurable until an operator sets the
+`max_drawdown_from_peak_pct` budget lever, so the scorecard cannot claim
+promotability until that appetite is configured.
 
 **The in-process event-driven lane exists behind a default-off gate**
 (`event_driven_paper_lane_enabled`, #1191) and is **operator-enabled on the

--- a/src/gpt_trader/cli/commands/ideas.py
+++ b/src/gpt_trader/cli/commands/ideas.py
@@ -166,6 +166,7 @@ BUDGET_FIELDS = (
     "allow_futures_leverage",
     "allow_naked_shorts",
     "account_equity",
+    "max_drawdown_from_peak_pct",
 )
 
 
@@ -1222,7 +1223,22 @@ def register(subparsers: Any) -> None:
             "max_open_notional_pct approval gate"
         ),
     )
+    budget_set.add_argument(
+        "--max-drawdown-from-peak-pct",
+        type=_non_negative_decimal_value,
+        help=(
+            "Drawdown-from-peak appetite for the continuous portfolio "
+            "monitors; breach ratchets autonomy down through the audited path"
+        ),
+    )
     budget_set.set_defaults(handler=_handle_budget_set, subcommand="budget set")
+
+    monitors = ideas_subparsers.add_parser(
+        "monitors",
+        help="Show continuous portfolio monitors (HWM, drawdown-from-peak, exposure)",
+    )
+    _add_common_options(monitors)
+    monitors.set_defaults(handler=_handle_monitors, subcommand="monitors")
 
     autonomy = ideas_subparsers.add_parser(
         "autonomy", help="Inspect or change the audited autonomy level"
@@ -2980,6 +2996,29 @@ def _handle_budget_show(args: Namespace) -> CliResponse:
     payload["headroom"] = budget_headroom
     text = _budget_text(payload)
     return _success(command, args, payload, text)
+
+
+def _handle_monitors(args: Namespace) -> CliResponse:
+    command = "ideas monitors"
+    try:
+        service = _service(args)
+        snapshot = service.portfolio_monitors()
+    except Exception as error:
+        return _mapped_error(command, args, error)
+    payload = snapshot.to_dict()
+    breaches = [
+        name
+        for name, breached in (
+            ("drawdown_from_peak", snapshot.drawdown_breached),
+            ("open_notional", snapshot.open_notional_breached),
+            ("daily_loss", snapshot.daily_loss_breached),
+        )
+        if breached
+    ]
+    detail = "breaches=" + (",".join(breaches) if breaches else "none")
+    lines = [_status_line(command, "OK", detail)]
+    lines.extend(f"{key}: {value}" for key, value in payload.items())
+    return _success(command, args, payload, "\n".join(lines))
 
 
 def _handle_budget_set(args: Namespace) -> CliResponse:

--- a/src/gpt_trader/features/trade_ideas/__init__.py
+++ b/src/gpt_trader/features/trade_ideas/__init__.py
@@ -6,6 +6,13 @@ records, humans approve them, and every state change lands in an append-only
 audit log. No module in this slice may submit orders.
 """
 
+from gpt_trader.features.trade_ideas.accounting import (
+    EquityLedgerPoint,
+    PaperAccountingSummary,
+    compute_paper_accounting,
+    equity_ledger,
+    max_drawdown_from_peak_percent,
+)
 from gpt_trader.features.trade_ideas.audit import (
     ActorType,
     AuditAction,
@@ -23,6 +30,7 @@ from gpt_trader.features.trade_ideas.autonomy import (
     AutonomyStateLog,
     autonomy_transition_violations,
     daily_loss_breach_evidence,
+    drawdown_from_peak_breach_evidence,
     resolve_autonomy,
 )
 from gpt_trader.features.trade_ideas.baseline import (
@@ -78,6 +86,10 @@ from gpt_trader.features.trade_ideas.models import (
     TradeDirection,
     TradeIdea,
     is_safe_decision_id,
+)
+from gpt_trader.features.trade_ideas.monitors import (
+    PortfolioMonitorSnapshot,
+    compute_portfolio_monitors,
 )
 from gpt_trader.features.trade_ideas.optimize_bridge import (
     REPLAY_OPTIMIZE_OBJECTIVES,
@@ -222,6 +234,7 @@ __all__ = [
     "Confidence",
     "ConfidenceLabel",
     "EntryZone",
+    "EquityLedgerPoint",
     "InvalidTransitionError",
     "KernelCheck",
     "KernelRuntime",
@@ -237,7 +250,9 @@ __all__ = [
     "PaperFillProfileError",
     "PaperFillReconciliationEntry",
     "PaperFillReconciliationReport",
+    "PaperAccountingSummary",
     "PaperFillReconciler",
+    "PortfolioMonitorSnapshot",
     "PreApprovalBrokerTicketError",
     "PolicyViolationError",
     "PositionSizerLike",
@@ -289,7 +304,11 @@ __all__ = [
     "build_trade_idea_track_record_report",
     "canonical_ticket_json",
     "create_trade_idea_service",
+    "compute_paper_accounting",
+    "compute_portfolio_monitors",
     "daily_loss_breach_evidence",
+    "drawdown_from_peak_breach_evidence",
+    "equity_ledger",
     "evaluate_eligibility",
     "extract_numeric_scoring_levels",
     "format_trade_idea_track_record_report",
@@ -297,6 +316,7 @@ __all__ = [
     "is_safe_decision_id",
     "load_optimize_baseline_candidates",
     "market_snapshot_to_payload",
+    "max_drawdown_from_peak_percent",
     "new_event_id",
     "optimize_replay_min_history",
     "paper_fill_events_from_store_events",

--- a/src/gpt_trader/features/trade_ideas/accounting.py
+++ b/src/gpt_trader/features/trade_ideas/accounting.py
@@ -53,6 +53,24 @@ class EquityAttestation:
 
 
 @dataclass(frozen=True, slots=True)
+class EquityLedgerPoint:
+    """One resolved equity level in the paper ledger, with its running peak.
+
+    Points exist only once an attested basis exists: attestations and the
+    closeouts that adjust an attested level each produce a point. Drawdown is
+    measured from the historical peak of the whole ledger (never reset by a
+    re-attestation). ``drawdown_percent`` is ``None`` only when the peak is
+    non-positive (percent-of-peak is undefined).
+    """
+
+    timestamp: datetime
+    equity: Decimal
+    high_water_mark: Decimal
+    drawdown_amount: Decimal
+    drawdown_percent: Decimal | None
+
+
+@dataclass(frozen=True, slots=True)
 class PaperAccountingSummary:
     """Paper equity ledger totals; ``None`` means no attested basis exists."""
 
@@ -85,18 +103,13 @@ def _attestations(entries: Iterable[BudgetLogEntry]) -> list[EquityAttestation]:
     return attestations
 
 
-def compute_paper_accounting(
+def _merged_ledger_events(
     budget_entries: Iterable[BudgetLogEntry],
     closeouts: Iterable[CloseoutAttribution],
-    *,
-    terminal_times: Mapping[str, datetime] | None = None,
-) -> PaperAccountingSummary:
-    """Fold attestations and closeout amounts into the paper equity ledger.
-
-    ``terminal_times`` maps a closeout's ``terminal_event_id`` to the audit
-    timestamp of that terminal event; a closeout without a mapping falls back
-    to its attribution timestamp.
-    """
+    terminal_times: Mapping[str, datetime] | None,
+) -> tuple[
+    list[EquityAttestation], list[tuple[datetime, int, EquityAttestation | CloseoutAttribution]]
+]:
     attestations = _attestations(budget_entries)
     resolved_terminal_times = terminal_times or {}
 
@@ -109,6 +122,95 @@ def compute_paper_accounting(
         (attestation.timestamp, 0, attestation) for attestation in attestations
     ] + [(_closeout_time(record), 1, record) for record in closeouts]
     events.sort(key=lambda event: (event[0], event[1]))
+    return attestations, events
+
+
+def equity_ledger(
+    budget_entries: Iterable[BudgetLogEntry],
+    closeouts: Iterable[CloseoutAttribution],
+    *,
+    terminal_times: Mapping[str, datetime] | None = None,
+) -> list[EquityLedgerPoint]:
+    """Fold the trail into the resolved equity/peak series, one point per move.
+
+    Same fold as ``compute_paper_accounting`` (same merge order, same
+    pre-attestation and amount-unavailable rules) but keeps every intermediate
+    level so windowed questions — e.g. max drawdown-from-peak over the
+    scorecard's observation window — read from the trail, not from any stored
+    monitor state.
+    """
+    _attestation_list, events = _merged_ledger_events(budget_entries, closeouts, terminal_times)
+    points: list[EquityLedgerPoint] = []
+    equity: Decimal | None = None
+    high_water_mark: Decimal | None = None
+
+    def _point(timestamp: datetime) -> EquityLedgerPoint:
+        assert equity is not None and high_water_mark is not None
+        drawdown_amount = max(high_water_mark - equity, Decimal("0"))
+        drawdown_percent = (
+            drawdown_amount / high_water_mark * Decimal("100") if high_water_mark > 0 else None
+        )
+        return EquityLedgerPoint(
+            timestamp=timestamp,
+            equity=equity,
+            high_water_mark=high_water_mark,
+            drawdown_amount=drawdown_amount,
+            drawdown_percent=drawdown_percent,
+        )
+
+    for timestamp, _order, event in events:
+        if isinstance(event, EquityAttestation):
+            equity = event.equity
+            high_water_mark = equity if high_water_mark is None else max(high_water_mark, equity)
+            points.append(_point(timestamp))
+            continue
+        amount = event.realized_profit_loss_amount
+        if amount is None or equity is None:
+            continue
+        equity += amount
+        if high_water_mark is not None:
+            high_water_mark = max(high_water_mark, equity)
+        points.append(_point(timestamp))
+    return points
+
+
+def max_drawdown_from_peak_percent(
+    points: Iterable[EquityLedgerPoint],
+    *,
+    window_start: datetime | None = None,
+    window_end: datetime | None = None,
+) -> Decimal | None:
+    """Worst drawdown-from-peak percent among ledger points inside the window.
+
+    ``None`` bounds are open. Returns ``None`` when no point in the window has
+    a measurable percent — no attested basis, or a non-positive peak.
+    """
+    worst: Decimal | None = None
+    for point in points:
+        if window_start is not None and point.timestamp < window_start:
+            continue
+        if window_end is not None and point.timestamp > window_end:
+            continue
+        if point.drawdown_percent is None:
+            continue
+        if worst is None or point.drawdown_percent > worst:
+            worst = point.drawdown_percent
+    return worst
+
+
+def compute_paper_accounting(
+    budget_entries: Iterable[BudgetLogEntry],
+    closeouts: Iterable[CloseoutAttribution],
+    *,
+    terminal_times: Mapping[str, datetime] | None = None,
+) -> PaperAccountingSummary:
+    """Fold attestations and closeout amounts into the paper equity ledger.
+
+    ``terminal_times`` maps a closeout's ``terminal_event_id`` to the audit
+    timestamp of that terminal event; a closeout without a mapping falls back
+    to its attribution timestamp.
+    """
+    attestations, events = _merged_ledger_events(budget_entries, closeouts, terminal_times)
 
     equity: Decimal | None = None
     high_water_mark: Decimal | None = None

--- a/src/gpt_trader/features/trade_ideas/autonomy.py
+++ b/src/gpt_trader/features/trade_ideas/autonomy.py
@@ -270,6 +270,37 @@ def daily_loss_breach_evidence(
     )
 
 
+def drawdown_from_peak_breach_evidence(
+    *,
+    drawdown_from_peak_pct: Decimal | None,
+    max_drawdown_from_peak_pct: Decimal | None,
+    budget_version: int,
+    high_water_mark: Decimal | None,
+    current_equity: Decimal | None,
+    moment: datetime,
+) -> tuple[str, ...] | None:
+    """Return ratchet evidence when drawdown-from-peak breaches the budget cap.
+
+    Continuous-portfolio-monitor trigger (#1192), defined against the same
+    unified vocabulary as ``daily_loss_breach_evidence``: one appetite source
+    (``max_drawdown_from_peak_pct`` on the active ``RiskBudget``) and one
+    measurement (drawdown-from-peak derived from the attested-equity ledger,
+    the charter's "realized gains are not principal"). Returns ``None`` when
+    no limit is configured, the drawdown is not yet measurable, or there is
+    no breach.
+    """
+    if max_drawdown_from_peak_pct is None or drawdown_from_peak_pct is None:
+        return None
+    if drawdown_from_peak_pct <= max_drawdown_from_peak_pct:
+        return None
+    return (
+        f"drawdown_from_peak_pct={drawdown_from_peak_pct} exceeds "
+        f"max_drawdown_from_peak_pct={max_drawdown_from_peak_pct} from risk budget "
+        f"version {budget_version} at {moment.isoformat()} "
+        f"(high_water_mark={high_water_mark}, current_equity={current_equity})",
+    )
+
+
 __all__ = [
     "AUTONOMY_RANK",
     "AUTONOMY_SOURCE_FAIL_CLOSED",
@@ -284,5 +315,6 @@ __all__ = [
     "RATCHET_ACTOR_ID",
     "autonomy_transition_violations",
     "daily_loss_breach_evidence",
+    "drawdown_from_peak_breach_evidence",
     "resolve_autonomy",
 ]

--- a/src/gpt_trader/features/trade_ideas/budget.py
+++ b/src/gpt_trader/features/trade_ideas/budget.py
@@ -77,12 +77,21 @@ class RiskBudget:
     # supply its own denominator. None means notional exposure cannot be
     # verified from the budget alone.
     account_equity: Decimal | None = None
+    # Drawdown-from-peak appetite for the continuous portfolio monitors
+    # (#1192): breach ratchets autonomy down through the audited path.
+    # None means no drawdown limit is configured — nothing to breach.
+    max_drawdown_from_peak_pct: Decimal | None = None
 
     def __post_init__(self) -> None:
         if self.account_equity is not None:
             _require_finite_decimal(self.account_equity, "account_equity")
             if self.account_equity <= 0:
                 raise ValueError("account_equity must be positive")
+        if self.max_drawdown_from_peak_pct is not None:
+            _require_finite_decimal(self.max_drawdown_from_peak_pct, "max_drawdown_from_peak_pct")
+            _require_non_negative_decimal(
+                self.max_drawdown_from_peak_pct, "max_drawdown_from_peak_pct"
+            )
         _require_finite_decimal(self.max_loss_per_idea_pct, "max_loss_per_idea_pct")
         _require_finite_decimal(self.max_daily_loss_pct, "max_daily_loss_pct")
         _require_finite_decimal(self.max_open_notional_pct, "max_open_notional_pct")
@@ -110,6 +119,11 @@ class RiskBudget:
             "allow_naked_shorts": self.allow_naked_shorts,
             "reason": self.reason,
             "account_equity": str(self.account_equity) if self.account_equity is not None else None,
+            "max_drawdown_from_peak_pct": (
+                str(self.max_drawdown_from_peak_pct)
+                if self.max_drawdown_from_peak_pct is not None
+                else None
+            ),
         }
 
     @classmethod
@@ -135,6 +149,13 @@ class RiskBudget:
             account_equity=(
                 Decimal(str(payload["account_equity"]))
                 if payload.get("account_equity") is not None
+                else None
+            ),
+            # Optional lever added after logs already existed (#1192); absent
+            # in older entries means no drawdown limit was configured.
+            max_drawdown_from_peak_pct=(
+                Decimal(str(payload["max_drawdown_from_peak_pct"]))
+                if payload.get("max_drawdown_from_peak_pct") is not None
                 else None
             ),
         )

--- a/src/gpt_trader/features/trade_ideas/monitors.py
+++ b/src/gpt_trader/features/trade_ideas/monitors.py
@@ -1,0 +1,141 @@
+"""Continuous portfolio monitors: HWM, drawdown-from-peak, open exposure.
+
+Implements #1192 from the accepted adopt-event-driven-execution-topology
+decision: portfolio-level risk is a running monitor evaluated against the
+budget envelope, not a per-cycle check. Everything here is a pure computation
+over the same durable evidence the accountant and approval paths already read
+— the attested-equity ledger (``accounting.compute_paper_accounting``) and the
+aggregate exposure context (``ApprovalBudgetContext``) — so monitor state is
+always derivable from the trail and there is no new state store to audit.
+
+One snapshot type serves every consumer: the CLI (``gpt-trader ideas
+monitors``), the operator console, and the ratchet trigger all read the same
+``TradeIdeaService.portfolio_monitors()`` call.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+
+from gpt_trader.features.trade_ideas.accounting import PaperAccountingSummary
+from gpt_trader.features.trade_ideas.budget import RiskBudget
+from gpt_trader.features.trade_ideas.policy import ApprovalBudgetContext
+
+
+def _decimal_to_str(value: Decimal | None) -> str | None:
+    return None if value is None else str(value)
+
+
+@dataclass(frozen=True, slots=True)
+class PortfolioMonitorSnapshot:
+    """Point-in-time monitor readings against the active budget envelope.
+
+    Breach verdicts are tri-state: ``True``/``False`` when the measurement and
+    limit are both available, ``None`` when the question cannot be answered
+    yet (no configured limit, no attested basis, or no equity denominator) —
+    an unanswerable monitor must read as "unknown", never as "healthy".
+    """
+
+    evaluated_at: datetime
+    budget_version: int
+
+    # Equity monitors (attested-equity ledger).
+    current_equity: Decimal | None
+    high_water_mark: Decimal | None
+    drawdown_amount: Decimal | None
+    drawdown_from_peak_pct: Decimal | None
+
+    # Exposure monitors (aggregate open ideas).
+    account_equity_snapshot: Decimal | None
+    open_notional: Decimal
+    open_notional_pct: Decimal | None
+    open_notional_unavailable_count: int
+    open_approved_at_risk_pct: Decimal
+    open_at_risk_unavailable_count: int
+    same_day_realized_loss_pct: Decimal
+
+    # Envelope limits in force when the snapshot was taken.
+    max_drawdown_from_peak_pct: Decimal | None
+    max_open_notional_pct: Decimal
+    max_daily_loss_pct: Decimal
+
+    # Breach verdicts.
+    drawdown_breached: bool | None
+    open_notional_breached: bool | None
+    daily_loss_breached: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "evaluated_at": self.evaluated_at.isoformat(),
+            "budget_version": self.budget_version,
+            "current_equity": _decimal_to_str(self.current_equity),
+            "high_water_mark": _decimal_to_str(self.high_water_mark),
+            "drawdown_amount": _decimal_to_str(self.drawdown_amount),
+            "drawdown_from_peak_pct": _decimal_to_str(self.drawdown_from_peak_pct),
+            "account_equity_snapshot": _decimal_to_str(self.account_equity_snapshot),
+            "open_notional": str(self.open_notional),
+            "open_notional_pct": _decimal_to_str(self.open_notional_pct),
+            "open_notional_unavailable_count": self.open_notional_unavailable_count,
+            "open_approved_at_risk_pct": str(self.open_approved_at_risk_pct),
+            "open_at_risk_unavailable_count": self.open_at_risk_unavailable_count,
+            "same_day_realized_loss_pct": str(self.same_day_realized_loss_pct),
+            "max_drawdown_from_peak_pct": _decimal_to_str(self.max_drawdown_from_peak_pct),
+            "max_open_notional_pct": str(self.max_open_notional_pct),
+            "max_daily_loss_pct": str(self.max_daily_loss_pct),
+            "drawdown_breached": self.drawdown_breached,
+            "open_notional_breached": self.open_notional_breached,
+            "daily_loss_breached": self.daily_loss_breached,
+        }
+
+
+def compute_portfolio_monitors(
+    *,
+    now: datetime,
+    budget: RiskBudget,
+    accounting: PaperAccountingSummary,
+    exposure: ApprovalBudgetContext,
+) -> PortfolioMonitorSnapshot:
+    """Combine the equity ledger and exposure context into one monitor snapshot."""
+    drawdown_breached: bool | None = None
+    if budget.max_drawdown_from_peak_pct is not None and accounting.drawdown_percent is not None:
+        drawdown_breached = accounting.drawdown_percent > budget.max_drawdown_from_peak_pct
+
+    account_equity = exposure.account_equity_snapshot
+    open_notional_pct: Decimal | None = None
+    open_notional_breached: bool | None = None
+    if account_equity is not None and account_equity > 0:
+        open_notional_pct = abs(exposure.open_notional) / account_equity * Decimal("100")
+        open_notional_breached = open_notional_pct > budget.max_open_notional_pct
+
+    daily_loss_breached = exposure.same_day_realized_loss_pct > budget.max_daily_loss_pct
+
+    return PortfolioMonitorSnapshot(
+        evaluated_at=now,
+        budget_version=budget.version,
+        current_equity=accounting.current_equity,
+        high_water_mark=accounting.high_water_mark,
+        drawdown_amount=accounting.drawdown_amount,
+        drawdown_from_peak_pct=accounting.drawdown_percent,
+        account_equity_snapshot=account_equity,
+        open_notional=exposure.open_notional,
+        open_notional_pct=open_notional_pct,
+        open_notional_unavailable_count=exposure.open_notional_unavailable_count,
+        open_approved_at_risk_pct=exposure.open_approved_at_risk_pct,
+        open_at_risk_unavailable_count=exposure.open_at_risk_unavailable_count,
+        same_day_realized_loss_pct=exposure.same_day_realized_loss_pct,
+        max_drawdown_from_peak_pct=budget.max_drawdown_from_peak_pct,
+        max_open_notional_pct=budget.max_open_notional_pct,
+        max_daily_loss_pct=budget.max_daily_loss_pct,
+        drawdown_breached=drawdown_breached,
+        open_notional_breached=open_notional_breached,
+        daily_loss_breached=daily_loss_breached,
+    )
+
+
+__all__ = [
+    "PortfolioMonitorSnapshot",
+    "compute_portfolio_monitors",
+]

--- a/src/gpt_trader/features/trade_ideas/scorecard.py
+++ b/src/gpt_trader/features/trade_ideas/scorecard.py
@@ -18,6 +18,7 @@ from decimal import Decimal
 from enum import Enum
 from typing import Any
 
+from gpt_trader.features.trade_ideas.accounting import max_drawdown_from_peak_percent
 from gpt_trader.features.trade_ideas.artifacts import stable_artifact_id
 from gpt_trader.features.trade_ideas.audit import AuditAction
 from gpt_trader.features.trade_ideas.eligibility import evaluate_eligibility
@@ -106,12 +107,10 @@ def build_stage_promotion_scorecard(
         "risk_calibration": _risk_calibration_gate(closed_in_window, thresholds=tuned),
         "expectancy": _expectancy_gate(closed_in_window),
         "benchmark_edge": _benchmark_edge_gate(closed_in_window, thresholds=tuned),
-        "max_drawdown_from_peak": _gate(
-            GateStatus.NOT_YET_MEASURABLE,
-            measured={},
-            detail=(
-                "drawdown-from-peak input arrives with the continuous portfolio " "monitors (#1192)"
-            ),
+        "max_drawdown_from_peak": _drawdown_gate(
+            service,
+            window_start=window_start,
+            now=current_time,
         ),
     }
     loop_health = {
@@ -500,6 +499,52 @@ def _benchmark_edge_gate(
         detail=(
             f"candidate avg R {_quantized(candidate_avg)} - "
             f"baseline avg R {_quantized(baseline_avg)} = {_quantized(edge)}, need > 0"
+        ),
+    )
+
+
+def _drawdown_gate(
+    service: TradeIdeaService,
+    *,
+    window_start: datetime,
+    now: datetime,
+) -> dict[str, Any]:
+    """Score max drawdown-from-peak over the window from the equity ledger.
+
+    Reads the same trail-derived ledger as the continuous portfolio monitors
+    (#1192): the appetite is ``max_drawdown_from_peak_pct`` on the active risk
+    budget (one measurement, two consumers — this promotion gate and the
+    ratchet's down-ladder).
+    """
+    limit = service.peek_budget().max_drawdown_from_peak_pct
+    points = service.equity_ledger_points()
+    worst = max_drawdown_from_peak_percent(points, window_start=window_start, window_end=now)
+    if worst is None:
+        return _gate(
+            GateStatus.NOT_YET_MEASURABLE,
+            measured={"ledger_point_count": len(points)},
+            detail="no attested-equity ledger points in the observation window",
+        )
+    measured: dict[str, Any] = {
+        "max_drawdown_from_peak_pct": str(worst.quantize(_PERCENT_QUANT)),
+        "ledger_point_count": len(points),
+    }
+    if limit is None:
+        return _gate(
+            GateStatus.NOT_YET_MEASURABLE,
+            measured=measured,
+            detail=(
+                "no max_drawdown_from_peak_pct configured on the risk budget; "
+                "set the lever to make this gate scoreable"
+            ),
+        )
+    measured["max_drawdown_from_peak_limit_pct"] = str(limit)
+    return _gate(
+        GateStatus.PASS if worst <= limit else GateStatus.FAIL,
+        measured=measured,
+        detail=(
+            f"max drawdown-from-peak {worst.quantize(_PERCENT_QUANT)}% over the window, "
+            f"budget limit {limit}%"
         ),
     )
 

--- a/src/gpt_trader/features/trade_ideas/service.py
+++ b/src/gpt_trader/features/trade_ideas/service.py
@@ -23,6 +23,12 @@ from gpt_trader.core.risk_units import (
     same_trading_day,
 )
 from gpt_trader.errors import ValidationError
+from gpt_trader.features.trade_ideas.accounting import (
+    EquityLedgerPoint,
+    PaperAccountingSummary,
+    compute_paper_accounting,
+    equity_ledger,
+)
 from gpt_trader.features.trade_ideas.audit import (
     ActorType,
     AuditAction,
@@ -44,6 +50,7 @@ from gpt_trader.features.trade_ideas.autonomy import (
     AutonomyStateLog,
     autonomy_transition_violations,
     daily_loss_breach_evidence,
+    drawdown_from_peak_breach_evidence,
     resolve_autonomy,
 )
 from gpt_trader.features.trade_ideas.broker_payloads import (
@@ -74,6 +81,10 @@ from gpt_trader.features.trade_ideas.models import (
     TicketStatus,
     TicketVenue,
     TradeIdea,
+)
+from gpt_trader.features.trade_ideas.monitors import (
+    PortfolioMonitorSnapshot,
+    compute_portfolio_monitors,
 )
 from gpt_trader.features.trade_ideas.policy import (
     ApprovalBudgetContext,
@@ -455,6 +466,26 @@ class TradeIdeaService:
             budget_version=active_budget.version,
             moment=now,
         )
+        reason = (
+            "Automatic ratchet-down: same-trading-day realized loss breached max_daily_loss_pct"
+        )
+        if evidence is None and active_budget.max_drawdown_from_peak_pct is not None:
+            # Continuous portfolio monitor (#1192): drawdown-from-peak is
+            # derived from the attested-equity ledger at every decision
+            # boundary, so a breach halts autonomy through the same audited
+            # ratchet as the daily-loss trigger — never a silent stop.
+            accounting = self.paper_accounting()
+            evidence = drawdown_from_peak_breach_evidence(
+                drawdown_from_peak_pct=accounting.drawdown_percent,
+                max_drawdown_from_peak_pct=active_budget.max_drawdown_from_peak_pct,
+                budget_version=active_budget.version,
+                high_water_mark=accounting.high_water_mark,
+                current_equity=accounting.current_equity,
+                moment=now,
+            )
+            reason = (
+                "Automatic ratchet-down: drawdown-from-peak breached max_drawdown_from_peak_pct"
+            )
         if evidence is None:
             return resolution
         entry = AutonomyStateEntry(
@@ -463,9 +494,7 @@ class TradeIdeaService:
             mode=AutonomyMode.HUMAN_APPROVED_EXECUTION,
             actor_type=ActorType.SYSTEM,
             actor_id=RATCHET_ACTOR_ID,
-            reason=(
-                "Automatic ratchet-down: same-trading-day realized loss breached max_daily_loss_pct"
-            ),
+            reason=reason,
             evidence=evidence,
         )
         self._autonomy_log.append(entry)
@@ -654,6 +683,51 @@ class TradeIdeaService:
                 state.value for state in OPEN_BUDGET_EXPOSURE_STATES
             ),
         }
+
+    def closeout_terminal_times(self) -> dict[str, datetime]:
+        """Map audit event ids to timestamps for folding closeouts at resolution time.
+
+        Only non-FILLED events are mapped: a FILLED audit event is the entry
+        fill, not the later market close, so filled trades keep their
+        attribution timestamp (the closest available evidence). A delayed
+        attribution therefore cannot re-apply P&L an intervening attestation
+        already includes.
+        """
+        return {
+            event.event_id: event.timestamp
+            for event in self.list_audit_events().items
+            if event.action is not AuditAction.FILLED
+        }
+
+    def paper_accounting(self) -> PaperAccountingSummary:
+        """Read-only paper equity / HWM / drawdown-from-peak from the trail."""
+        return compute_paper_accounting(
+            self.budget_log.history(),
+            self.query_closeout_records().items,
+            terminal_times=self.closeout_terminal_times(),
+        )
+
+    def equity_ledger_points(self) -> list[EquityLedgerPoint]:
+        """Read-only resolved equity/peak series for windowed monitor reads."""
+        return equity_ledger(
+            self.budget_log.history(),
+            self.query_closeout_records().items,
+            terminal_times=self.closeout_terminal_times(),
+        )
+
+    def portfolio_monitors(self, *, now: datetime | None = None) -> PortfolioMonitorSnapshot:
+        """One snapshot of the continuous portfolio monitors (#1192).
+
+        Non-mutating read shared by the CLI and the console; the ratchet acts
+        on the same measurements at decision boundaries (``decision_autonomy``).
+        """
+        evaluation_time = now or self._now()
+        return compute_portfolio_monitors(
+            now=evaluation_time,
+            budget=self.peek_budget(),
+            accounting=self.paper_accounting(),
+            exposure=self.approval_budget_context(now=evaluation_time),
+        )
 
     def validate_new_proposal(self, idea: TradeIdea) -> None:
         """Validate proposal lifecycle preconditions without writing state."""

--- a/src/gpt_trader/web/app.py
+++ b/src/gpt_trader/web/app.py
@@ -20,8 +20,7 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 
 from gpt_trader.errors import ValidationError
-from gpt_trader.features.trade_ideas.accounting import compute_paper_accounting
-from gpt_trader.features.trade_ideas.audit import ActorType, AuditAction
+from gpt_trader.features.trade_ideas.audit import ActorType
 from gpt_trader.features.trade_ideas.autonomy import (
     AUTONOMY_SOURCE_FAIL_CLOSED,
     RATCHET_ACTOR_ID,
@@ -159,6 +158,7 @@ _BUDGET_LEVER_FIELDS = (
     "allow_futures_leverage",
     "allow_naked_shorts",
     "account_equity",
+    "max_drawdown_from_peak_pct",
 )
 
 
@@ -221,6 +221,16 @@ def _budget_from_form(
             raise ValueError(
                 f"account_equity must be a decimal number or blank, got {equity_raw!r}"
             ) from error
+    drawdown_raw = str(values["max_drawdown_from_peak_pct"]).strip()
+    max_drawdown_from_peak_pct: Decimal | None = None
+    if drawdown_raw:
+        try:
+            max_drawdown_from_peak_pct = Decimal(drawdown_raw)
+        except ArithmeticError as error:
+            raise ValueError(
+                "max_drawdown_from_peak_pct must be a decimal number or blank, "
+                f"got {drawdown_raw!r}"
+            ) from error
     return RiskBudget(
         version=base_version + 1,
         max_loss_per_idea_pct=_decimal("max_loss_per_idea_pct"),
@@ -234,6 +244,7 @@ def _budget_from_form(
         allow_naked_shorts=bool(values["allow_naked_shorts"]),
         reason=reason,
         account_equity=account_equity,
+        max_drawdown_from_peak_pct=max_drawdown_from_peak_pct,
     )
 
 
@@ -408,6 +419,7 @@ def create_app(
         allow_futures_leverage: bool = Form(False),
         allow_naked_shorts: bool = Form(False),
         account_equity: str = Form(""),
+        max_drawdown_from_peak_pct: str = Form(""),
     ) -> HTMLResponse | RedirectResponse:
         form_values: dict[str, str | bool] = {
             "max_loss_per_idea_pct": max_loss_per_idea_pct,
@@ -420,6 +432,7 @@ def create_app(
             "allow_futures_leverage": allow_futures_leverage,
             "allow_naked_shorts": allow_naked_shorts,
             "account_equity": account_equity,
+            "max_drawdown_from_peak_pct": max_drawdown_from_peak_pct,
         }
 
         def _form_error(message: str) -> HTMLResponse:
@@ -475,27 +488,16 @@ def create_app(
 
     @app.get("/accountant", response_class=HTMLResponse)
     def accountant(request: Request) -> HTMLResponse:
-        # Closeouts fold at their resolution time so a delayed attribution
-        # cannot re-apply P&L an intervening attestation already includes.
-        # Only non-FILLED terminal events are mapped: a FILLED audit event is
-        # the entry fill, not the later market close, so filled trades keep
-        # their attribution timestamp (the closest available evidence).
-        terminal_times = {
-            event.event_id: event.timestamp
-            for event in resolved_service.list_audit_events().items
-            if event.action is not AuditAction.FILLED
-        }
-        summary = compute_paper_accounting(
-            resolved_service.budget_log.history(),
-            resolved_service.query_closeout_records().items,
-            terminal_times=terminal_times,
-        )
+        # Both the summary and the monitor snapshot are the same service
+        # library calls the CLI reads (`ideas monitors`), so console and CLI
+        # can never disagree about HWM, drawdown-from-peak, or exposure.
         return templates.TemplateResponse(
             request=request,
             name="accountant.html",
             context={
                 "actor_id": resolved_actor,
-                "summary": summary,
+                "summary": resolved_service.paper_accounting(),
+                "monitors": resolved_service.portfolio_monitors(),
                 "budget": resolved_service.peek_budget(),
                 "headroom": resolved_service.budget_headroom(),
                 "open_approved_count": resolved_service.open_approved_count(),

--- a/src/gpt_trader/web/templates/accountant.html
+++ b/src/gpt_trader/web/templates/accountant.html
@@ -65,6 +65,24 @@
     <td>{{ headroom.open_notional_headroom_pct | percent }} <span class="muted">({{ headroom.open_notional_headroom | money }})</span></td>
   </tr>
   <tr>
+    <td>Drawdown from peak</td>
+    <td>
+      {% if monitors.max_drawdown_from_peak_pct is not none %}{{ monitors.max_drawdown_from_peak_pct | percent }}
+      {% else %}<span class="muted">no limit set</span>{% endif %}
+    </td>
+    <td>
+      {% if monitors.drawdown_from_peak_pct is not none %}
+      <span class="{{ 'bad' if monitors.drawdown_breached }}">{{ monitors.drawdown_from_peak_pct | percent }}</span>
+      {% else %}<span class="muted">not yet measurable</span>{% endif %}
+    </td>
+    <td>
+      {% if monitors.drawdown_breached %}<span class="bad">breached — ratchets autonomy down</span>
+      {% elif monitors.max_drawdown_from_peak_pct is not none and monitors.drawdown_from_peak_pct is not none %}
+      {{ (monitors.max_drawdown_from_peak_pct - monitors.drawdown_from_peak_pct) | percent }}
+      {% else %}—{% endif %}
+    </td>
+  </tr>
+  <tr>
     <td>Concurrent approved tickets</td>
     <td>{{ budget.max_concurrent_approved_tickets }}</td>
     <td>{{ open_approved_count }}</td>

--- a/src/gpt_trader/web/templates/envelope.html
+++ b/src/gpt_trader/web/templates/envelope.html
@@ -92,6 +92,9 @@
     <label>Attested account equity ($, blank = unverified)
       <input type="text" name="account_equity" value="{{ form.account_equity }}">
     </label>
+    <label>Max drawdown from peak (%, blank = no limit)
+      <input type="text" name="max_drawdown_from_peak_pct" value="{{ form.max_drawdown_from_peak_pct }}">
+    </label>
     <label class="check"><input type="checkbox" name="sizing_capped_by_budget" {{ "checked" if form.sizing_capped_by_budget }}> Sizing capped by budget</label>
     <label class="check"><input type="checkbox" name="allow_futures_leverage" {{ "checked" if form.allow_futures_leverage }}> Allow futures leverage</label>
     <label class="check"><input type="checkbox" name="allow_naked_shorts" {{ "checked" if form.allow_naked_shorts }}> Allow naked shorts</label>

--- a/tests/unit/gpt_trader/cli/commands/test_ideas_monitors.py
+++ b/tests/unit/gpt_trader/cli/commands/test_ideas_monitors.py
@@ -1,0 +1,116 @@
+"""CLI surface for the continuous portfolio monitors (#1192).
+
+`ideas monitors` must read the same service library call as the console, so
+these tests drive the real CLI entry point over a trail built through the
+service and assert the snapshot payload and breach summary line.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from gpt_trader import cli
+from gpt_trader.features.trade_ideas import CloseoutResolution, TradeIdeaService
+from tests.unit.gpt_trader.features.trade_ideas.conftest import (
+    attest_account_equity,
+    build_trade_idea,
+)
+
+
+def _run_json(capsys: pytest.CaptureFixture[str], argv: list[str]) -> tuple[int, dict[str, Any]]:
+    exit_code = cli.main(argv)
+    output = capsys.readouterr().out
+    assert output
+    return exit_code, json.loads(output)
+
+
+def _root_args(root: Path) -> list[str]:
+    return ["--ideas-root", str(root), "--format", "json"]
+
+
+def _service(root: Path) -> TradeIdeaService:
+    return TradeIdeaService(
+        root,
+        now_factory=lambda: datetime(2026, 6, 12, 10, 0, tzinfo=UTC),
+    )
+
+
+def _close_with_loss(service: TradeIdeaService, decision_id: str, amount: str) -> None:
+    idea = build_trade_idea(decision_id=decision_id)
+    service.propose(idea, actor_id="idea-generator-v1")
+    service.approve(decision_id, actor_id="rj", reason="Risk verified")
+    service.record_submission(decision_id, actor_id="operator", venue="manual")
+    service.record_fill(decision_id, actor_id="operator", venue="manual")
+    service.record_closeout_attribution(
+        decision_id,
+        actor_id="rj",
+        resolution=CloseoutResolution.INVALIDATION,
+        realized_profit_loss_amount=Decimal(amount),
+    )
+
+
+def test_monitors_on_fresh_root_reads_unknown_without_seeding(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = tmp_path / "ideas"
+
+    exit_code, response = _run_json(capsys, ["ideas", "monitors", *_root_args(root)])
+
+    assert exit_code == 0
+    data = response["data"]
+    assert data["current_equity"] is None
+    assert data["high_water_mark"] is None
+    assert data["drawdown_breached"] is None
+    assert data["daily_loss_breached"] is False
+    # Render-only read: the budget and autonomy logs must not be seeded.
+    assert not (root / "risk_budget.jsonl").exists()
+    assert not (root / "autonomy_state.jsonl").exists()
+
+
+def test_monitors_reports_drawdown_breach_from_the_trail(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = tmp_path / "ideas"
+    service = _service(root)
+    attest_account_equity(service)  # 20000
+
+    exit_code, response = _run_json(
+        capsys,
+        [
+            "ideas",
+            "budget",
+            "set",
+            *_root_args(root),
+            "--actor",
+            "rj",
+            "--max-drawdown-from-peak-pct",
+            "2",
+            "--reason",
+            "Configure the drawdown-from-peak appetite",
+        ],
+    )
+    assert exit_code == 0
+    assert response["data"]["max_drawdown_from_peak_pct"] == "2"
+
+    _close_with_loss(service, "trade-20260612-dd", "-600")
+
+    exit_code, response = _run_json(capsys, ["ideas", "monitors", *_root_args(root)])
+
+    assert exit_code == 0
+    data = response["data"]
+    assert data["high_water_mark"] == "20000"
+    assert data["current_equity"] == "19400"
+    assert data["drawdown_from_peak_pct"] == "3.00"
+    assert data["max_drawdown_from_peak_pct"] == "2"
+    assert data["drawdown_breached"] is True
+
+    exit_code = cli.main(["ideas", "monitors", "--ideas-root", str(root), "--format", "text"])
+    text = capsys.readouterr().out
+    assert exit_code == 0
+    assert "breaches=drawdown_from_peak" in text

--- a/tests/unit/gpt_trader/features/trade_ideas/test_accounting.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_accounting.py
@@ -6,7 +6,11 @@ from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 
-from gpt_trader.features.trade_ideas.accounting import compute_paper_accounting
+from gpt_trader.features.trade_ideas.accounting import (
+    compute_paper_accounting,
+    equity_ledger,
+    max_drawdown_from_peak_percent,
+)
 from gpt_trader.features.trade_ideas.audit import ActorType
 from gpt_trader.features.trade_ideas.budget import DEFAULT_RISK_BUDGET, BudgetLogEntry
 from gpt_trader.features.trade_ideas.closeout import (
@@ -181,3 +185,71 @@ def test_closeout_before_first_attestation_counts_toward_total_only() -> None:
     assert summary.current_equity == Decimal("1000")
     assert summary.realized_profit_loss_total == Decimal("75")
     assert summary.realized_profit_loss_since_attestation == Decimal("0")
+
+
+def test_equity_ledger_tracks_every_move_with_running_peak() -> None:
+    entries = [_budget_entry(1, at=_START, equity=Decimal("1000"))]
+    closeouts = [
+        _closeout("trade-1", at=_START + timedelta(hours=1), amount=Decimal("200")),
+        _closeout("trade-2", at=_START + timedelta(hours=2), amount=Decimal("-300")),
+        _closeout("trade-3", at=_START + timedelta(hours=3), amount=None),
+    ]
+
+    points = equity_ledger(entries, closeouts)
+
+    # The attestation, then the two closeouts with amounts; the amount-less
+    # closeout cannot move the ledger and produces no point.
+    assert [(p.equity, p.high_water_mark) for p in points] == [
+        (Decimal("1000"), Decimal("1000")),
+        (Decimal("1200"), Decimal("1200")),
+        (Decimal("900"), Decimal("1200")),
+    ]
+    assert points[-1].drawdown_amount == Decimal("300")
+    assert points[-1].drawdown_percent == Decimal("300") / Decimal("1200") * Decimal("100")
+
+
+def test_equity_ledger_matches_summary_fold_semantics() -> None:
+    # Re-attestation moves the level but never erases the historical peak,
+    # and closeouts before the first attestation produce no ledger point.
+    entries = [
+        _budget_entry(1, at=_START + timedelta(hours=1), equity=Decimal("1000")),
+        _budget_entry(2, at=_START + timedelta(hours=3), equity=Decimal("700")),
+    ]
+    closeouts = [
+        _closeout("trade-0", at=_START, amount=Decimal("50")),
+        _closeout("trade-1", at=_START + timedelta(hours=2), amount=Decimal("100")),
+    ]
+
+    points = equity_ledger(entries, closeouts)
+    summary = compute_paper_accounting(entries, closeouts)
+
+    assert [(p.equity, p.high_water_mark) for p in points] == [
+        (Decimal("1000"), Decimal("1000")),
+        (Decimal("1100"), Decimal("1100")),
+        (Decimal("700"), Decimal("1100")),
+    ]
+    assert points[-1].equity == summary.current_equity
+    assert points[-1].high_water_mark == summary.high_water_mark
+    assert points[-1].drawdown_amount == summary.drawdown_amount
+    assert points[-1].drawdown_percent == summary.drawdown_percent
+
+
+def test_max_drawdown_over_window_reads_worst_point_inside_bounds() -> None:
+    entries = [_budget_entry(1, at=_START, equity=Decimal("1000"))]
+    closeouts = [
+        _closeout("trade-1", at=_START + timedelta(hours=1), amount=Decimal("-400")),
+        _closeout("trade-2", at=_START + timedelta(hours=2), amount=Decimal("300")),
+        _closeout("trade-3", at=_START + timedelta(hours=3), amount=Decimal("-100")),
+    ]
+
+    points = equity_ledger(entries, closeouts)
+
+    # Whole trail: the worst point is the hour-1 trough (400/1000 = 40%).
+    assert max_drawdown_from_peak_percent(points) == Decimal("40")
+    # A window that starts after the trough only sees the later, shallower
+    # drawdowns (hour-3: 200/1000 = 20%).
+    windowed = max_drawdown_from_peak_percent(points, window_start=_START + timedelta(hours=2))
+    assert windowed == Decimal("20")
+    # No points in the window: not measurable.
+    assert max_drawdown_from_peak_percent(points, window_start=_START + timedelta(days=2)) is None
+    assert max_drawdown_from_peak_percent([]) is None

--- a/tests/unit/gpt_trader/features/trade_ideas/test_autonomy.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_autonomy.py
@@ -17,6 +17,7 @@ from gpt_trader.features.trade_ideas import (
     AutonomyStateLog,
     autonomy_transition_violations,
     daily_loss_breach_evidence,
+    drawdown_from_peak_breach_evidence,
     resolve_autonomy,
 )
 from gpt_trader.features.trade_ideas.autonomy import (
@@ -315,3 +316,61 @@ def test_breach_evidence_pins_appetite_source_and_trading_day() -> None:
     assert "max_daily_loss_pct=10" in evidence[0]
     assert "risk budget version 3" in evidence[0]
     assert "trading_day=2026-07-03" in evidence[0]
+
+
+def test_drawdown_breach_evidence_requires_limit_and_measurement() -> None:
+    moment = datetime(2026, 7, 7, 12, 0, tzinfo=UTC)
+    # No limit configured: nothing to breach.
+    assert (
+        drawdown_from_peak_breach_evidence(
+            drawdown_from_peak_pct=Decimal("50"),
+            max_drawdown_from_peak_pct=None,
+            budget_version=1,
+            high_water_mark=Decimal("1000"),
+            current_equity=Decimal("500"),
+            moment=moment,
+        )
+        is None
+    )
+    # No measurable drawdown (no attested basis yet): nothing to breach.
+    assert (
+        drawdown_from_peak_breach_evidence(
+            drawdown_from_peak_pct=None,
+            max_drawdown_from_peak_pct=Decimal("10"),
+            budget_version=1,
+            high_water_mark=None,
+            current_equity=None,
+            moment=moment,
+        )
+        is None
+    )
+    # Within appetite: no breach.
+    assert (
+        drawdown_from_peak_breach_evidence(
+            drawdown_from_peak_pct=Decimal("10"),
+            max_drawdown_from_peak_pct=Decimal("10"),
+            budget_version=1,
+            high_water_mark=Decimal("1000"),
+            current_equity=Decimal("900"),
+            moment=moment,
+        )
+        is None
+    )
+
+
+def test_drawdown_breach_evidence_pins_appetite_source_and_ledger_levels() -> None:
+    evidence = drawdown_from_peak_breach_evidence(
+        drawdown_from_peak_pct=Decimal("15"),
+        max_drawdown_from_peak_pct=Decimal("10"),
+        budget_version=4,
+        high_water_mark=Decimal("2000"),
+        current_equity=Decimal("1700"),
+        moment=datetime(2026, 7, 7, 12, 0, tzinfo=UTC),
+    )
+
+    assert evidence is not None
+    assert "drawdown_from_peak_pct=15" in evidence[0]
+    assert "max_drawdown_from_peak_pct=10" in evidence[0]
+    assert "version 4" in evidence[0]
+    assert "high_water_mark=2000" in evidence[0]
+    assert "current_equity=1700" in evidence[0]

--- a/tests/unit/gpt_trader/features/trade_ideas/test_budget.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_budget.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from dataclasses import replace
 from datetime import UTC, datetime
 from decimal import Decimal
 from pathlib import Path
@@ -201,3 +202,33 @@ def test_renegotiated_budget_becomes_current(budget_log: RiskBudgetLog) -> None:
 
     assert budget_log.current() == widened
     assert [entry.budget.version for entry in budget_log.history()] == [1, 2]
+
+
+def test_max_drawdown_from_peak_lever_round_trips_and_validates() -> None:
+    budget = replace(
+        DEFAULT_RISK_BUDGET,
+        max_drawdown_from_peak_pct=Decimal("20"),
+        reason="Configure the drawdown-from-peak appetite",
+    )
+
+    restored = RiskBudget.from_dict(budget.to_dict())
+    assert restored.max_drawdown_from_peak_pct == Decimal("20")
+
+    with pytest.raises(ValueError, match="max_drawdown_from_peak_pct"):
+        replace(DEFAULT_RISK_BUDGET, max_drawdown_from_peak_pct=Decimal("-1"))
+    with pytest.raises(ValueError, match="max_drawdown_from_peak_pct"):
+        replace(DEFAULT_RISK_BUDGET, max_drawdown_from_peak_pct=Decimal("NaN"))
+
+
+def test_budget_payload_without_drawdown_lever_still_loads() -> None:
+    # Budget logs written before the lever existed (#1192) must keep loading;
+    # an absent key means no drawdown limit is configured.
+    payload = {
+        key: value
+        for key, value in DEFAULT_RISK_BUDGET.to_dict().items()
+        if key != "max_drawdown_from_peak_pct"
+    }
+
+    restored = RiskBudget.from_dict(payload)
+
+    assert restored.max_drawdown_from_peak_pct is None

--- a/tests/unit/gpt_trader/features/trade_ideas/test_monitors.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_monitors.py
@@ -1,0 +1,138 @@
+"""Continuous portfolio monitors: snapshot verdicts against the envelope (#1192)."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, datetime
+from decimal import Decimal
+
+from gpt_trader.features.trade_ideas.accounting import compute_paper_accounting
+from gpt_trader.features.trade_ideas.audit import ActorType
+from gpt_trader.features.trade_ideas.budget import DEFAULT_RISK_BUDGET, BudgetLogEntry
+from gpt_trader.features.trade_ideas.closeout import (
+    CloseoutAttribution,
+    CloseoutResolution,
+    MaxLossSnapshot,
+)
+from gpt_trader.features.trade_ideas.monitors import compute_portfolio_monitors
+from gpt_trader.features.trade_ideas.policy import ApprovalBudgetContext
+
+_NOW = datetime(2026, 7, 7, 12, 0, tzinfo=UTC)
+
+
+def _budget(**overrides):
+    return replace(DEFAULT_RISK_BUDGET, **overrides)
+
+
+def _accounting(entries=(), closeouts=()):
+    return compute_paper_accounting(entries, closeouts)
+
+
+def _budget_entry(version: int, *, at: datetime, equity: Decimal) -> BudgetLogEntry:
+    return BudgetLogEntry(
+        timestamp=at,
+        actor_type=ActorType.HUMAN,
+        actor_id="rj",
+        budget=replace(
+            DEFAULT_RISK_BUDGET,
+            version=version,
+            account_equity=equity,
+            reason="test budget version",
+        ),
+    )
+
+
+def _closeout(decision_id: str, *, at: datetime, amount: Decimal) -> CloseoutAttribution:
+    return CloseoutAttribution(
+        decision_id=decision_id,
+        timestamp=at,
+        actor_type="human",
+        actor_id="rj",
+        terminal_event_id="event-1",
+        record_hash="hash-1",
+        resolution=CloseoutResolution.INVALIDATION,
+        max_loss=MaxLossSnapshot(amount=Decimal("100")),
+        realized_profit_loss_amount=amount,
+    )
+
+
+def test_unconfigured_and_unmeasurable_monitors_read_unknown() -> None:
+    snapshot = compute_portfolio_monitors(
+        now=_NOW,
+        budget=_budget(),
+        accounting=_accounting(),
+        exposure=ApprovalBudgetContext(),
+    )
+
+    assert snapshot.evaluated_at == _NOW
+    assert snapshot.current_equity is None
+    assert snapshot.high_water_mark is None
+    assert snapshot.drawdown_from_peak_pct is None
+    # No limit configured and no attested basis: unknown, never "healthy".
+    assert snapshot.drawdown_breached is None
+    # No attested equity denominator: open-notional verdict is unknown too.
+    assert snapshot.open_notional_pct is None
+    assert snapshot.open_notional_breached is None
+    assert snapshot.daily_loss_breached is False
+
+
+def test_drawdown_breach_verdict_reads_limit_and_ledger() -> None:
+    entries = [_budget_entry(1, at=_NOW, equity=Decimal("1000"))]
+    closeouts = [_closeout("trade-1", at=_NOW, amount=Decimal("-80"))]
+    accounting = _accounting(entries, closeouts)
+    assert accounting.drawdown_percent == Decimal("8")
+
+    within = compute_portfolio_monitors(
+        now=_NOW,
+        budget=_budget(max_drawdown_from_peak_pct=Decimal("10")),
+        accounting=accounting,
+        exposure=ApprovalBudgetContext(),
+    )
+    breached = compute_portfolio_monitors(
+        now=_NOW,
+        budget=_budget(max_drawdown_from_peak_pct=Decimal("5")),
+        accounting=accounting,
+        exposure=ApprovalBudgetContext(),
+    )
+
+    assert within.drawdown_breached is False
+    assert breached.drawdown_breached is True
+    assert breached.drawdown_from_peak_pct == Decimal("8")
+    assert breached.max_drawdown_from_peak_pct == Decimal("5")
+
+
+def test_exposure_verdicts_use_attested_denominator() -> None:
+    exposure = ApprovalBudgetContext(
+        open_notional=Decimal("600"),
+        account_equity_snapshot=Decimal("1000"),
+        same_day_realized_loss_pct=Decimal("12"),
+    )
+    snapshot = compute_portfolio_monitors(
+        now=_NOW,
+        budget=_budget(
+            max_open_notional_pct=Decimal("50"),
+            max_daily_loss_pct=Decimal("10"),
+        ),
+        accounting=_accounting(),
+        exposure=exposure,
+    )
+
+    assert snapshot.open_notional_pct == Decimal("60")
+    assert snapshot.open_notional_breached is True
+    assert snapshot.daily_loss_breached is True
+
+
+def test_to_dict_is_json_ready() -> None:
+    snapshot = compute_portfolio_monitors(
+        now=_NOW,
+        budget=_budget(max_drawdown_from_peak_pct=Decimal("20")),
+        accounting=_accounting(),
+        exposure=ApprovalBudgetContext(open_notional=Decimal("100")),
+    )
+    payload = snapshot.to_dict()
+
+    assert payload["evaluated_at"] == _NOW.isoformat()
+    assert payload["max_drawdown_from_peak_pct"] == "20"
+    assert payload["open_notional"] == "100"
+    assert payload["drawdown_breached"] is None
+    assert payload["current_equity"] is None

--- a/tests/unit/gpt_trader/features/trade_ideas/test_scorecard.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_scorecard.py
@@ -161,8 +161,9 @@ def test_scorecard_scores_gates_from_the_trail(tmp_path: Path) -> None:
     assert loop_health["attribution_coverage"]["status"] == "pass"
     assert loop_health["audit_integrity"]["status"] == "pass"
     overall = payload["overall"]
-    # Drawdown-from-peak stays unmeasurable until #1192, so the scorecard can
-    # never claim promotability from this trail yet.
+    # The drawdown gate measures from this trail but no
+    # max_drawdown_from_peak_pct is configured on the budget, so it stays
+    # not-yet-measurable and the scorecard cannot claim promotability.
     assert overall["promotable"] is False
     assert overall["gates_passed"] == 6
     assert overall["gates_not_yet_measurable"] == 1

--- a/tests/unit/gpt_trader/features/trade_ideas/test_scorecard_drawdown_gate.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_scorecard_drawdown_gate.py
@@ -1,0 +1,115 @@
+"""Scorecard max-drawdown-from-peak gate: windowed read from the equity ledger (#1192).
+
+Split from test_scorecard.py to respect the test-hygiene module-size cap; the
+shared trail-building helpers are imported from that module.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from decimal import Decimal
+from pathlib import Path
+
+from tests.unit.gpt_trader.features.trade_ideas.conftest import attest_account_equity
+from tests.unit.gpt_trader.features.trade_ideas.test_scorecard import (
+    _START,
+    _Clock,
+    _close_with_pnl,
+    _service,
+)
+
+from gpt_trader.features.trade_ideas import TradeIdeaService
+from gpt_trader.features.trade_ideas.scorecard import build_stage_promotion_scorecard
+
+
+def _configure_drawdown_appetite(service: TradeIdeaService, limit: str) -> None:
+    from dataclasses import replace
+
+    from gpt_trader.features.trade_ideas import ActorType
+
+    current = service.current_budget()
+    service.update_budget(
+        replace(
+            current,
+            version=current.version + 1,
+            max_drawdown_from_peak_pct=Decimal(limit),
+            reason="Configure the drawdown-from-peak appetite",
+        ),
+        ActorType.HUMAN,
+        "rj",
+    )
+
+
+def test_drawdown_gate_not_measurable_without_attested_ledger(tmp_path: Path) -> None:
+    clock = _Clock(_START)
+    service = _service(tmp_path / "ideas", clock)
+
+    payload = build_stage_promotion_scorecard(service, now=_START + timedelta(days=70))
+
+    gate = payload["gates"]["max_drawdown_from_peak"]
+    assert gate["status"] == "not_yet_measurable"
+    assert "no attested-equity ledger points" in gate["detail"]
+
+
+def test_drawdown_gate_reports_measurement_even_without_a_limit(tmp_path: Path) -> None:
+    clock = _Clock(_START)
+    service = _service(tmp_path / "ideas", clock)
+    attest_account_equity(service)  # 20000
+    _close_with_pnl(
+        service,
+        clock,
+        "trade-loss-001",
+        proposer_actor_id="strategy-x",
+        realized_amount=Decimal("-200"),
+        closed_at=_START + timedelta(days=5),
+    )
+
+    payload = build_stage_promotion_scorecard(service, now=_START + timedelta(days=30))
+
+    gate = payload["gates"]["max_drawdown_from_peak"]
+    assert gate["status"] == "not_yet_measurable"
+    assert gate["measured"]["max_drawdown_from_peak_pct"] == "1.00"  # 200/20000
+    assert "no max_drawdown_from_peak_pct configured" in gate["detail"]
+
+
+def test_drawdown_gate_scores_windowed_max_against_the_budget_limit(tmp_path: Path) -> None:
+    clock = _Clock(_START)
+    service = _service(tmp_path / "ideas", clock)
+    attest_account_equity(service)  # 20000
+    _configure_drawdown_appetite(service, "2")
+    # Trough of 600 below the 20200 peak: max drawdown-from-peak ~2.97%.
+    _close_with_pnl(
+        service,
+        clock,
+        "trade-win-001",
+        proposer_actor_id="strategy-x",
+        realized_amount=Decimal("200"),
+        closed_at=_START + timedelta(days=2),
+    )
+    _close_with_pnl(
+        service,
+        clock,
+        "trade-loss-001",
+        proposer_actor_id="strategy-x",
+        realized_amount=Decimal("-600"),
+        closed_at=_START + timedelta(days=5),
+    )
+    _close_with_pnl(
+        service,
+        clock,
+        "trade-win-002",
+        proposer_actor_id="strategy-x",
+        realized_amount=Decimal("500"),
+        closed_at=_START + timedelta(days=10),
+    )
+
+    payload = build_stage_promotion_scorecard(service, now=_START + timedelta(days=30))
+
+    gate = payload["gates"]["max_drawdown_from_peak"]
+    assert gate["status"] == "fail"
+    assert gate["measured"]["max_drawdown_from_peak_pct"] == "2.97"
+    assert gate["measured"]["max_drawdown_from_peak_limit_pct"] == "2"
+
+    _configure_drawdown_appetite(service, "10")
+    relaxed = build_stage_promotion_scorecard(service, now=_START + timedelta(days=30))
+    assert relaxed["gates"]["max_drawdown_from_peak"]["status"] == "pass"

--- a/tests/unit/gpt_trader/features/trade_ideas/test_service_monitors.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_service_monitors.py
@@ -1,0 +1,163 @@
+"""Service-level portfolio monitors: one trail-derived read for every consumer (#1192)."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, datetime
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+from tests.unit.gpt_trader.features.trade_ideas.conftest import (
+    attest_account_equity,
+    build_trade_idea,
+)
+
+from gpt_trader.features.trade_ideas import (
+    ActorType,
+    AutonomyMode,
+    CloseoutResolution,
+)
+from gpt_trader.features.trade_ideas.autonomy import RATCHET_ACTOR_ID
+from gpt_trader.features.trade_ideas.service import TradeIdeaService
+
+
+@pytest.fixture
+def service(tmp_path: Path) -> TradeIdeaService:
+    return TradeIdeaService(
+        tmp_path / "trade_ideas",
+        now_factory=lambda: datetime(2026, 6, 12, 10, 0, tzinfo=UTC),
+    )
+
+
+def _close_with_loss(service: TradeIdeaService, decision_id: str, amount: str) -> None:
+    idea = build_trade_idea(decision_id=decision_id)
+    service.propose(idea, actor_id="idea-generator-v1")
+    service.approve(decision_id, actor_id="rj", reason="Risk verified")
+    service.record_submission(decision_id, actor_id="operator", venue="manual")
+    service.record_fill(decision_id, actor_id="operator", venue="manual")
+    service.record_closeout_attribution(
+        decision_id,
+        actor_id="rj",
+        resolution=CloseoutResolution.INVALIDATION,
+        realized_profit_loss_amount=Decimal(amount),
+    )
+
+
+def test_portfolio_monitors_snapshot_reads_the_trail(service: TradeIdeaService) -> None:
+    attest_account_equity(service)  # 20000
+    current = service.current_budget()
+    service.update_budget(
+        replace(
+            current,
+            version=current.version + 1,
+            max_drawdown_from_peak_pct=Decimal("2"),
+            reason="Configure the drawdown-from-peak appetite",
+        ),
+        ActorType.HUMAN,
+        "rj",
+    )
+    _close_with_loss(service, "trade-20260612-dd", "-600")
+
+    snapshot = service.portfolio_monitors()
+
+    assert snapshot.high_water_mark == Decimal("20000")
+    assert snapshot.current_equity == Decimal("19400")
+    assert snapshot.drawdown_amount == Decimal("600")
+    assert snapshot.drawdown_from_peak_pct == Decimal("3")
+    assert snapshot.max_drawdown_from_peak_pct == Decimal("2")
+    assert snapshot.drawdown_breached is True
+    assert snapshot.account_equity_snapshot == Decimal("20000")
+    assert snapshot.budget_version == service.peek_budget().version
+
+
+def test_portfolio_monitors_is_a_non_seeding_read(
+    service: TradeIdeaService, tmp_path: Path
+) -> None:
+    snapshot = service.portfolio_monitors()
+
+    assert snapshot.current_equity is None
+    assert snapshot.drawdown_breached is None
+    root = tmp_path / "trade_ideas"
+    assert not (root / "risk_budget.jsonl").exists()
+    assert not (root / "autonomy_state.jsonl").exists()
+
+
+def test_equity_ledger_points_match_the_accounting_summary(service: TradeIdeaService) -> None:
+    attest_account_equity(service)
+    _close_with_loss(service, "trade-20260612-dd", "-600")
+
+    points = service.equity_ledger_points()
+    summary = service.paper_accounting()
+
+    assert points
+    assert points[-1].equity == summary.current_equity
+    assert points[-1].high_water_mark == summary.high_water_mark
+    assert points[-1].drawdown_percent == summary.drawdown_percent
+
+
+def _configure_drawdown_appetite(service: TradeIdeaService, limit: str) -> None:
+    current = service.current_budget()
+    service.update_budget(
+        replace(
+            current,
+            version=current.version + 1,
+            max_drawdown_from_peak_pct=Decimal(limit),
+            reason="Configure the drawdown-from-peak appetite",
+        ),
+        ActorType.HUMAN,
+        "rj",
+    )
+
+
+def _enter_bounded_autonomy(service: TradeIdeaService) -> None:
+    service.set_autonomy_mode(
+        AutonomyMode.BOUNDED_AUTONOMY,
+        actor_type=ActorType.HUMAN,
+        actor_id="rj",
+        reason="Test: enter bounded autonomy through the audited path",
+    )
+
+
+def test_drawdown_breach_ratchets_bounded_autonomy_down(service: TradeIdeaService) -> None:
+    attest_account_equity(service)  # 20000 attested basis
+    _configure_drawdown_appetite(service, "2")
+    _enter_bounded_autonomy(service)
+    # -600 on a 20000 peak: drawdown-from-peak 3% (> 2% appetite) while the
+    # same-day realized loss (3%) stays inside max_daily_loss_pct (10%), so
+    # only the drawdown monitor can be the trigger.
+    _close_with_loss(service, "trade-20260612-dd", "-600")
+
+    resolution = service.resolve_execution_autonomy()
+
+    assert resolution.mode is AutonomyMode.HUMAN_APPROVED_EXECUTION
+    latest = service.autonomy_history()[-1]
+    assert latest.actor_type is ActorType.SYSTEM
+    assert latest.actor_id == RATCHET_ACTOR_ID
+    assert "drawdown-from-peak" in latest.reason
+    assert latest.evidence
+    assert "drawdown_from_peak_pct=3" in latest.evidence[0]
+    assert "max_drawdown_from_peak_pct=2" in latest.evidence[0]
+    assert "high_water_mark=20000" in latest.evidence[0]
+
+
+def test_no_drawdown_ratchet_within_appetite(service: TradeIdeaService) -> None:
+    attest_account_equity(service)
+    _configure_drawdown_appetite(service, "5")
+    _enter_bounded_autonomy(service)
+    _close_with_loss(service, "trade-20260612-dd", "-600")
+
+    resolution = service.resolve_execution_autonomy()
+
+    assert resolution.mode is AutonomyMode.BOUNDED_AUTONOMY
+    assert service.autonomy_history()[-1].actor_id != RATCHET_ACTOR_ID
+
+
+def test_no_drawdown_ratchet_without_configured_limit(service: TradeIdeaService) -> None:
+    attest_account_equity(service)
+    _enter_bounded_autonomy(service)
+    _close_with_loss(service, "trade-20260612-dd", "-600")
+
+    resolution = service.resolve_execution_autonomy()
+
+    assert resolution.mode is AutonomyMode.BOUNDED_AUTONOMY

--- a/tests/unit/gpt_trader/web/test_console_accountant.py
+++ b/tests/unit/gpt_trader/web/test_console_accountant.py
@@ -161,3 +161,56 @@ def test_accountant_marks_daily_loss_usage_incomplete_when_evidence_is_missing(
 
     assert response.status_code == 200
     assert "incomplete: 1 record without loss evidence" in response.text
+
+
+def _configure_drawdown_appetite(service: TradeIdeaService, limit: Decimal) -> None:
+    current = service.current_budget()
+    service.update_budget(
+        replace(
+            current,
+            version=current.version + 1,
+            max_drawdown_from_peak_pct=limit,
+            reason="Configure the drawdown-from-peak appetite",
+        ),
+        ActorType.HUMAN,
+        "rj",
+    )
+
+
+def test_accountant_monitor_row_shows_no_limit_until_configured(
+    service: TradeIdeaService, client: TestClient
+) -> None:
+    _record_closed_trade(service, Decimal("-400"))
+
+    response = client.get("/accountant")
+
+    assert response.status_code == 200
+    assert "Drawdown from peak" in response.text
+    assert "no limit set" in response.text
+    assert "breached" not in response.text
+
+
+def test_accountant_monitor_row_flags_drawdown_breach(
+    service: TradeIdeaService, client: TestClient
+) -> None:
+    _record_closed_trade(service, Decimal("-600"))  # 3% of the 20000 peak
+    _configure_drawdown_appetite(service, Decimal("2"))
+
+    response = client.get("/accountant")
+
+    assert response.status_code == 200
+    assert "3.00%" in response.text
+    assert "breached — ratchets autonomy down" in response.text
+
+
+def test_accountant_monitor_row_shows_headroom_within_appetite(
+    service: TradeIdeaService, client: TestClient
+) -> None:
+    _record_closed_trade(service, Decimal("-600"))  # 3% of the 20000 peak
+    _configure_drawdown_appetite(service, Decimal("10"))
+
+    response = client.get("/accountant")
+
+    assert response.status_code == 200
+    assert "breached" not in response.text
+    assert "7.00%" in response.text  # 10% appetite - 3% in use

--- a/tests/unit/gpt_trader/web/test_console_envelope.py
+++ b/tests/unit/gpt_trader/web/test_console_envelope.py
@@ -46,6 +46,11 @@ def _lever_form(service: TradeIdeaService, **overrides: str) -> dict[str, str]:
         "max_review_latency_hours": str(budget.max_review_latency_hours),
         "gain_retention_floor_pct": str(budget.gain_retention_floor_pct),
         "account_equity": "" if budget.account_equity is None else str(budget.account_equity),
+        "max_drawdown_from_peak_pct": (
+            ""
+            if budget.max_drawdown_from_peak_pct is None
+            else str(budget.max_drawdown_from_peak_pct)
+        ),
     }
     if budget.sizing_capped_by_budget:
         payload["sizing_capped_by_budget"] = "on"
@@ -261,3 +266,56 @@ def test_exception_framing_separates_violations_from_inside_envelope(
     assert "max_loss_per_idea_pct" in response.text  # violation text on the exception
     assert "Inside the envelope:" in response.text
     assert "trade-20260612-001" in response.text
+
+
+def test_drawdown_lever_can_be_set_and_cleared_through_the_form(
+    service: TradeIdeaService, client: TestClient
+) -> None:
+    response = client.post(
+        "/envelope/budget",
+        data=_lever_form(
+            service,
+            max_drawdown_from_peak_pct="15",
+            reason="Configure the drawdown-from-peak appetite",
+        ),
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    enacted = service.budget_log.history()[-1].budget
+    assert enacted.max_drawdown_from_peak_pct == Decimal("15")
+
+    # Blank clears the limit (no drawdown appetite configured).
+    response = client.post(
+        "/envelope/budget",
+        data=_lever_form(
+            service,
+            max_drawdown_from_peak_pct="",
+            reason="Remove the drawdown limit",
+        ),
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert service.budget_log.history()[-1].budget.max_drawdown_from_peak_pct is None
+    rendered = client.get("/envelope")
+    assert "max_drawdown_from_peak_pct: 15 → None" in rendered.text
+
+
+def test_non_numeric_drawdown_lever_re_renders_with_field_named_error(
+    service: TradeIdeaService, client: TestClient
+) -> None:
+    response = client.post(
+        "/envelope/budget",
+        data=_lever_form(
+            service,
+            max_drawdown_from_peak_pct="not-a-number",
+            reason="Bad drawdown input",
+        ),
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 400
+    assert "max_drawdown_from_peak_pct must be a decimal number or blank" in response.text
+    # The rejected submission must not have enacted anything.
+    assert service.budget_log.history() == []

--- a/var/agents/configuration/environment_variables.json
+++ b/var/agents/configuration/environment_variables.json
@@ -777,7 +777,7 @@
       ],
       "code_references": [
         {
-          "line": 260,
+          "line": 271,
           "path": "src/gpt_trader/features/trade_ideas/service.py",
           "reader": "os.environ.get"
         }
@@ -1189,7 +1189,7 @@
       ],
       "code_references": [
         {
-          "line": 273,
+          "line": 284,
           "path": "src/gpt_trader/features/trade_ideas/service.py",
           "reader": "os.environ.get"
         }
@@ -1221,7 +1221,7 @@
       ],
       "code_references": [
         {
-          "line": 250,
+          "line": 261,
           "path": "src/gpt_trader/features/trade_ideas/service.py",
           "reader": "os.environ.get"
         }


### PR DESCRIPTION
## Summary
Closes #1192 (accepted [adopt-event-driven-execution-topology](docs/decisions/adopt-event-driven-execution-topology.md) decision; the last open item besides monitors' consumers). Mark-quality prerequisite #1123 is in flight as #1207.

Portfolio-level risk becomes a **running monitor** evaluated against the budget envelope, with every reading derivable from the trail (budget log attestations + closeout attributions + audit terminal times) — no new unauditable state store.

### What changed
- **Equity ledger** (`accounting.py`): the existing paper-accounting fold now also exposes the resolved equity/peak series (`equity_ledger`, `EquityLedgerPoint`) and `max_drawdown_from_peak_percent` over a window. Same merge order and pre-attestation rules as `compute_paper_accounting` (shared fold helper), so summary and ledger can never disagree.
- **New budget lever** `max_drawdown_from_peak_pct` (optional; absent in pre-existing log entries ⇒ no limit configured). Settable via `ideas budget set --max-drawdown-from-peak-pct` and the console envelope form (blank clears it).
- **One snapshot, every consumer** (`monitors.py` + `TradeIdeaService.portfolio_monitors()`): HWM / drawdown-from-peak / open notional / open at-risk / same-day loss vs the envelope, with tri-state breach verdicts (`None` = not answerable yet — an unmeasurable monitor must read unknown, never healthy). `gpt-trader ideas monitors` and the console `/accountant` page read this same call; `/accountant`'s inline terminal-times fold moved into the service (`paper_accounting()`).
- **Audited ratchet, not a silent halt**: `decision_autonomy` now checks `drawdown_from_peak_breach_evidence` beside the #1170 daily-loss trigger; a breach at any decision boundary (approval, execution, budget enactment, event lane) ratchets `bounded_autonomy` → `human_approved_execution` with the ledger levels pinned in the evidence.
- **Scorecard gate is now real** (#1193 placeholder replaced): `max_drawdown_from_peak` scores the windowed max from the same ledger against the budget lever — one measurement, two consumers (promotion gate + down-ladder). Not-yet-measurable until an operator sets the lever, so promotability still requires an explicit appetite.
- docs/STATUS.md updated; `var/agents` regenerated.

### Done-when from the issue
- [x] HWM / drawdown-from-peak / exposure continuously maintained and queryable — CLI + console read the same library call
- [x] Configured drawdown-from-peak limit breach triggers the audited ratchet in paper, demonstrated in tests (`test_service_monitors.py::test_drawdown_breach_ratchets_bounded_autonomy_down`)
- [x] Rubric scorecard reads max drawdown-from-peak over the observation window from the trail

## Testing
- 18 new unit tests across accounting ledger/window math, breach-evidence triggers, snapshot verdicts, the service ratchet demonstration (drawdown fires while daily-loss stays inside appetite), CLI (`ideas monitors` JSON/text incl. non-seeding fresh-root read), console accountant/envelope rendering, and the scorecard gate (fail at 2% limit vs 2.97% measured, pass at 10%).
- `uv run local-ci` (pr profile) fully green: 6690+ unit tests, smoke/property/contract/integration lanes, docs gates, artifacts freshness, hygiene (two grown test modules split).