### PR TITLE
feat(account): wire a minimal read-only snapshot provider (ADR Option A)

### DIFF
--- a/src/gpt_trader/cli/commands/account.py
+++ b/src/gpt_trader/cli/commands/account.py
@@ -49,18 +49,19 @@ def _handle_snapshot(args: Namespace) -> CliResponse | int:
         raise
 
     try:
-        # No container wiring provides account telemetry today; this command
-        # reports "not available" until a telemetry service is wired in via a
-        # fresh spec (see docs/decisions/remove-unwired-account-manager-and-strategy-lab.md).
+        # Wired by TradingBot from the container broker (account-snapshot ADR
+        # Option A, docs/decisions/account-snapshot-wire-or-remove.md); only a
+        # broker-less container leaves it unset.
         telemetry = getattr(bot, "account_telemetry", None)
         if telemetry is None or not telemetry.supports_snapshots():
+            message = "Account snapshot is unavailable: no broker is wired for this profile"
             if output_format == "json":
                 return CliResponse.error_response(
                     command=SNAPSHOT_COMMAND_NAME,
                     code=CliErrorCode.OPERATION_FAILED,
-                    message="Account snapshot telemetry is not available for this broker",
+                    message=message,
                 )
-            raise RuntimeError("Account snapshot telemetry is not available for this broker")
+            raise RuntimeError(message)
 
         snapshot = telemetry.collect_snapshot()
 

--- a/src/gpt_trader/features/live_trade/account_snapshot.py
+++ b/src/gpt_trader/features/live_trade/account_snapshot.py
@@ -1,0 +1,109 @@
+"""Read-only account snapshot provider (account-snapshot ADR Option A).
+
+Backs ``gpt-trader account snapshot`` — the runbooks' one-shot "what does the
+broker say my account holds" verification step
+(docs/decisions/account-snapshot-wire-or-remove.md). The service reads the
+same broker surface the live engine reads (``StateCollector`` over
+``list_balances`` / ``list_positions``, plus ticker marks), so the snapshot
+can never diverge from what the engine would see. Strictly read-only: no
+order authority, no state mutation.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any, cast
+
+from gpt_trader.app.config import BotConfig
+from gpt_trader.core import Balance, Position
+from gpt_trader.core.protocols import ExtendedBrokerProtocol
+from gpt_trader.features.live_trade.execution.state_collection import StateCollector
+from gpt_trader.utilities.logging_patterns import get_logger
+
+logger = get_logger(__name__, component="account_snapshot")
+
+
+def _balance_payload(balance: Balance) -> dict[str, Any]:
+    return {
+        "asset": balance.asset,
+        "total": str(balance.total),
+        "available": str(balance.available),
+        "hold": str(balance.hold),
+    }
+
+
+def _position_payload(position: Position, live_mark: str | None) -> dict[str, Any]:
+    return {
+        "symbol": position.symbol,
+        "side": position.side,
+        "quantity": str(position.quantity),
+        "entry_price": str(position.entry_price),
+        "mark_price": str(position.mark_price),
+        "live_mark": live_mark,
+        "unrealized_pnl": str(position.unrealized_pnl),
+        "realized_pnl": str(position.realized_pnl),
+        "product_type": position.product_type,
+    }
+
+
+class AccountSnapshotService:
+    """Collect a broker-truth account snapshot for operators.
+
+    ``collect_snapshot`` raises whatever the broker raises for the core reads
+    (balances/positions) — a snapshot that cannot reach the broker must fail
+    loudly, not report zeros. Per-symbol ticker marks are best-effort and
+    reported as ``null`` with the error noted, so one bad product cannot sink
+    the whole verification step.
+    """
+
+    def __init__(self, broker: Any, config: BotConfig) -> None:
+        self._broker = broker
+        self._collector = StateCollector(cast(ExtendedBrokerProtocol, broker), config)
+
+    def supports_snapshots(self) -> bool:
+        return self._broker is not None
+
+    def collect_snapshot(self) -> dict[str, Any]:
+        (
+            balances,
+            equity,
+            collateral_balances,
+            collateral_total,
+            positions,
+        ) = self._collector.collect_account_state()
+
+        marks: dict[str, str | None] = {}
+        mark_errors: dict[str, str] = {}
+        for symbol in sorted({position.symbol for position in positions}):
+            try:
+                ticker = self._broker.get_ticker(symbol) or {}
+                raw_price = ticker.get("price")
+                marks[symbol] = str(raw_price) if raw_price not in (None, "") else None
+            except Exception as exc:
+                marks[symbol] = None
+                mark_errors[symbol] = f"{type(exc).__name__}: {exc}"
+                logger.warning(f"Ticker mark unavailable for {symbol}: {exc}")
+
+        unrealized_total = sum((position.unrealized_pnl for position in positions), Decimal("0"))
+
+        payload: dict[str, Any] = {
+            "generated_at": datetime.now(UTC).isoformat(),
+            "broker": type(self._broker).__name__,
+            "balances": [_balance_payload(balance) for balance in balances],
+            "collateral_available": str(equity),
+            "collateral_total": str(collateral_total),
+            "collateral_assets": sorted(balance.asset for balance in collateral_balances),
+            "unrealized_pnl_total": str(unrealized_total),
+            "equity": str(equity + unrealized_total),
+            "positions": [
+                _position_payload(position, marks.get(position.symbol)) for position in positions
+            ],
+            "marks": marks,
+        }
+        if mark_errors:
+            payload["mark_errors"] = mark_errors
+        return payload
+
+
+__all__ = ["AccountSnapshotService"]

--- a/src/gpt_trader/features/live_trade/bot.py
+++ b/src/gpt_trader/features/live_trade/bot.py
@@ -14,6 +14,7 @@ from uuid import uuid4
 
 from gpt_trader.app.config import BotConfig
 from gpt_trader.app.runtime_ui_adapter import NullUIAdapter, RuntimeUIAdapter
+from gpt_trader.features.live_trade.account_snapshot import AccountSnapshotService
 from gpt_trader.features.live_trade.engines.base import CoordinatorContext
 from gpt_trader.features.live_trade.engines.strategy import TradingEngine
 from gpt_trader.features.live_trade.execution.status_codec import (
@@ -75,6 +76,12 @@ class TradingBot:
 
         # Get services directly from container (legacy registry removed)
         self.broker: BrokerProtocol | None = container.broker
+        # Read-only account snapshot provider (account-snapshot ADR Option A):
+        # `gpt-trader account snapshot` and the runbooks read the same broker
+        # surface the engine uses. No order authority.
+        self.account_telemetry: AccountSnapshotService | None = (
+            AccountSnapshotService(self.broker, config) if self.broker is not None else None
+        )
         self.risk_manager: RiskManagerProtocol | None = container.risk_manager
         self.runtime_state: RuntimeStateProtocol | None = getattr(container, "runtime_state", None)
 

--- a/tests/unit/gpt_trader/cli/test_commands_account.py
+++ b/tests/unit/gpt_trader/cli/test_commands_account.py
@@ -64,7 +64,7 @@ def test_account_snapshot_prints_result(monkeypatch, capsys):
 
 def test_account_snapshot_raises_when_unavailable(monkeypatch):
     class StubBot:
-        """Bot without an account_telemetry attribute (production shape)."""
+        """Bot without an account_telemetry attribute (broker-less container)."""
 
         async def shutdown(self):
             StubBot.shutdown_called = True

--- a/tests/unit/gpt_trader/features/live_trade/test_account_snapshot.py
+++ b/tests/unit/gpt_trader/features/live_trade/test_account_snapshot.py
@@ -1,0 +1,108 @@
+"""Read-only account snapshot service (account-snapshot ADR Option A, #1121).
+
+Runs the REAL service and StateCollector; behavior is steered only at the
+broker boundary (boundary-double returning real domain objects, per the
+engine-fixture idiom from #1113).
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+import pytest
+
+from gpt_trader.app.config import BotConfig
+from gpt_trader.core import Balance, Position
+from gpt_trader.features.live_trade.account_snapshot import AccountSnapshotService
+
+
+@pytest.fixture
+def config() -> BotConfig:
+    return BotConfig(symbols=["BTC-USD"], interval=1)
+
+
+@pytest.fixture
+def broker() -> MagicMock:
+    broker = MagicMock()
+    broker.list_balances.return_value = [
+        Balance(asset="USD", total=Decimal("1000"), available=Decimal("900")),
+        Balance(asset="BTC", total=Decimal("0.5"), available=Decimal("0.5")),
+    ]
+    broker.list_positions.return_value = [
+        Position(
+            symbol="BTC-USD",
+            quantity=Decimal("0.5"),
+            entry_price=Decimal("40000"),
+            mark_price=Decimal("50000"),
+            unrealized_pnl=Decimal("5000"),
+            realized_pnl=Decimal("0"),
+            side="long",
+        )
+    ]
+    broker.get_ticker.return_value = {"price": "50100"}
+    return broker
+
+
+def test_snapshot_reads_broker_truth(broker: MagicMock, config: BotConfig) -> None:
+    service = AccountSnapshotService(broker, config)
+
+    assert service.supports_snapshots() is True
+    snapshot = service.collect_snapshot()
+
+    assert snapshot["broker"] == "MagicMock"
+    assert {"asset": "USD", "total": "1000", "available": "900", "hold": "0"} in snapshot[
+        "balances"
+    ]
+    # Collateral is the USD leg; equity adds unrealized PnL on top.
+    assert snapshot["collateral_available"] == "900"
+    assert snapshot["collateral_total"] == "1000"
+    assert snapshot["collateral_assets"] == ["USD"]
+    assert snapshot["unrealized_pnl_total"] == "5000"
+    assert snapshot["equity"] == "5900"
+    (position,) = snapshot["positions"]
+    assert position["symbol"] == "BTC-USD"
+    assert position["quantity"] == "0.5"
+    assert position["mark_price"] == "50000"
+    assert position["live_mark"] == "50100"
+    assert snapshot["marks"] == {"BTC-USD": "50100"}
+    assert "mark_errors" not in snapshot
+    broker.place_order.assert_not_called()
+
+
+def test_ticker_failure_is_reported_not_fatal(broker: MagicMock, config: BotConfig) -> None:
+    broker.get_ticker.side_effect = RuntimeError("ticker feed down")
+    service = AccountSnapshotService(broker, config)
+
+    snapshot = service.collect_snapshot()
+
+    assert snapshot["marks"] == {"BTC-USD": None}
+    assert "ticker feed down" in snapshot["mark_errors"]["BTC-USD"]
+    (position,) = snapshot["positions"]
+    assert position["live_mark"] is None
+    # The balances/positions core still reports.
+    assert snapshot["equity"] == "5900"
+
+
+def test_missing_ticker_price_reads_null(broker: MagicMock, config: BotConfig) -> None:
+    broker.get_ticker.return_value = {}
+    service = AccountSnapshotService(broker, config)
+
+    snapshot = service.collect_snapshot()
+
+    assert snapshot["marks"] == {"BTC-USD": None}
+    assert "mark_errors" not in snapshot
+
+
+def test_core_broker_failure_raises(broker: MagicMock, config: BotConfig) -> None:
+    # A snapshot that cannot reach the broker must fail loudly, not report
+    # zeros a responder might mistake for account truth.
+    broker.list_balances.side_effect = RuntimeError("auth expired")
+    service = AccountSnapshotService(broker, config)
+
+    with pytest.raises(RuntimeError, match="auth expired"):
+        service.collect_snapshot()
+
+
+def test_supports_snapshots_requires_a_broker(config: BotConfig) -> None:
+    assert AccountSnapshotService(None, config).supports_snapshots() is False

--- a/tests/unit/gpt_trader/features/live_trade/test_bot_initialization.py
+++ b/tests/unit/gpt_trader/features/live_trade/test_bot_initialization.py
@@ -7,6 +7,7 @@ from unittest.mock import ANY, Mock
 import pytest
 
 import gpt_trader.features.live_trade.bot as bot_module
+from gpt_trader.features.live_trade.account_snapshot import AccountSnapshotService
 from gpt_trader.features.live_trade.bot import TradingBot
 
 
@@ -51,6 +52,8 @@ class TestTradingBotInitialization:
         assert bot.broker is mock_container.broker
         assert bot.risk_manager is mock_container.risk_manager
         assert bot.runtime_state is mock_container.runtime_state
+        # No broker means no snapshot provider (account-snapshot ADR Option A).
+        assert bot.account_telemetry is None
 
     def test_init_with_container(self, mock_config: Mock, engine_mock: Mock) -> None:
         """Test initialization with container."""
@@ -60,6 +63,10 @@ class TestTradingBotInitialization:
         bot = TradingBot(config=mock_config, container=mock_container)
 
         assert bot.container is mock_container
+        # A wired broker yields a working read-only snapshot provider
+        # (account-snapshot ADR Option A, #1121).
+        assert isinstance(bot.account_telemetry, AccountSnapshotService)
+        assert bot.account_telemetry.supports_snapshots() is True
 
     def test_init_creates_context(
         self,


### PR DESCRIPTION
## Summary
Closes #1121, implementing the accepted [account-snapshot-wire-or-remove](docs/decisions/account-snapshot-wire-or-remove.md) decision (Option A). `gpt-trader account snapshot` read `bot.account_telemetry`, which no container wiring provided — it failed unconditionally on every profile while [docs/production.md](docs/production.md) (three procedures) and [docs/RUNBOOKS.md](docs/RUNBOOKS.md) ("verify with broker") instruct operators to run it. Those runbook steps now work.

### What changed
- **Provider** (`features/live_trade/account_snapshot.py`): `AccountSnapshotService` over the exact surface the engine reads — `StateCollector.collect_account_state()` (balances, collateral equity, positions) plus per-position ticker marks — so the snapshot can never diverge from what the engine would see. Failure posture: core broker reads raise (an unreachable broker must fail loudly, never report zeros a responder could mistake for account truth); per-symbol marks are best-effort, reported `null` with the error under `mark_errors`.
- **Wiring**: `TradingBot` constructs the provider from the container broker; a broker-less container leaves it `None`.
- **CLI**: `account snapshot` keeps its shape; the unconditional "telemetry is not available" dead end is replaced by real snapshot data (or an accurate "no broker wired for this profile" error).

### Safety boundary
Read-only broker calls (balances, positions, marks) behind the existing profile/credential gates. No order authority; live-order submission remains governed by docs/DIRECTION.md.

## Testing
- New `test_account_snapshot.py`: real service + real StateCollector, boundary-double broker (#1113 idiom) — payload shape/equity math, ticker-failure isolation, missing-price null, loud core failure, no-broker unsupported.
- `test_bot_initialization.py` pins the wiring (provider present with a broker, `None` without).
- `uv run local-ci` (pr profile) fully green.