### PR TITLE
feat(trade-ideas): auto-attribute expired-unexecuted ideas in the cycle (#1214)

### DIFF
--- a/src/gpt_trader/features/idea_execution/cycle.py
+++ b/src/gpt_trader/features/idea_execution/cycle.py
@@ -136,6 +136,7 @@ class PaperCycleResult:
     finished_at: datetime
     snapshot: dict[str, Any]
     expired_decision_ids: tuple[str, ...]
+    attributed_decision_ids: tuple[str, ...]
     proposer_turns: tuple[ProposerTurn, ...]
     execution: ExecutionTurn
     queue: dict[str, Any] = field(default_factory=dict)
@@ -149,6 +150,7 @@ class PaperCycleResult:
             "outcome": "completed",
             "snapshot": self.snapshot,
             "expired_decision_ids": list(self.expired_decision_ids),
+            "attributed_decision_ids": list(self.attributed_decision_ids),
             "proposers": [turn.to_dict() for turn in self.proposer_turns],
             "execution": self.execution.to_dict(),
             "queue": self.queue,
@@ -246,6 +248,17 @@ class PaperCycleRunner:
         expired_decision_ids = tuple(view.idea.decision_id for view in expired_views)
         row["expired_decision_ids"] = list(expired_decision_ids)
 
+        # Attribute every expired-unexecuted idea so the closeout trail self-heals
+        # each turn instead of waiting for a manual `ideas closeout record`. An
+        # EXPIRED idea never opened a position (SUBMITTED cannot expire), so this
+        # records an EXPIRY closeout with realized P&L unavailable — keeping
+        # attribution coverage honest at 100% without inventing an outcome. Also
+        # backfills any pre-existing unattributed expiries (issue #1214). Filled
+        # ideas need an exit model and are left for issue #1218.
+        attributed = self._service.auto_attribute_expired_ideas()
+        attributed_decision_ids = tuple(record.decision_id for record in attributed)
+        row["attributed_decision_ids"] = list(attributed_decision_ids)
+
         # Capture the execution candidates before any slow turn work — the
         # snapshot fetch is a network call and the approval CLI does not take
         # the cycle lock, so an approval landing anywhere inside the turn must
@@ -297,6 +310,7 @@ class PaperCycleRunner:
             finished_at=self._now_factory(),
             snapshot=snapshot_info,
             expired_decision_ids=expired_decision_ids,
+            attributed_decision_ids=attributed_decision_ids,
             proposer_turns=tuple(proposer_turns),
             execution=execution,
             queue=queue_summary,

--- a/src/gpt_trader/features/trade_ideas/service.py
+++ b/src/gpt_trader/features/trade_ideas/service.py
@@ -1169,6 +1169,46 @@ class TradeIdeaService:
         )
         return self._closeouts.append(record)
 
+    def auto_attribute_expired_ideas(
+        self,
+        *,
+        actor_id: str = "closeout-auto",
+        reason: str = (
+            "Idea expired unexecuted; no position was opened, so realized "
+            "profit/loss is not applicable"
+        ),
+        evidence: tuple[str, ...] = (),
+    ) -> list[CloseoutAttribution]:
+        """Attribute every ``EXPIRED`` idea that still lacks a closeout.
+
+        An ``EXPIRED`` idea can only be reached from a pre-fill state
+        (``SUBMITTED`` cannot transition to ``EXPIRED``), so no position was ever
+        opened and realized profit/loss is genuinely unavailable. Recording an
+        ``EXPIRY`` closeout with an unavailable reason keeps ``attribution_coverage``
+        honest at 100% without inventing a market outcome, and lets unattended
+        operation self-heal every turn instead of relying on a manual
+        ``ideas closeout record`` for each expiry. Filled ideas are left alone:
+        their realized profit/loss needs an exit model (issue #1218).
+
+        Idempotent: ideas that already carry a closeout attribution (human or a
+        prior auto run) are skipped, so a human's judgment stays authoritative.
+        """
+        recorded: list[CloseoutAttribution] = []
+        for view in self.list_views(TradeIdeaState.EXPIRED):
+            if view.closeout_attribution is not None:
+                continue
+            recorded.append(
+                self.record_closeout_attribution(
+                    view.idea.decision_id,
+                    actor_id=actor_id,
+                    actor_type=ActorType.SYSTEM,
+                    resolution=CloseoutResolution.EXPIRY,
+                    realized_profit_loss_unavailable_reason=reason,
+                    evidence=evidence,
+                )
+            )
+        return recorded
+
     def get_closeout_attribution(self, decision_id: str) -> CloseoutAttribution | None:
         return self.get(decision_id).closeout_attribution
 

--- a/tests/unit/gpt_trader/features/idea_execution/test_cycle_closeout.py
+++ b/tests/unit/gpt_trader/features/idea_execution/test_cycle_closeout.py
@@ -1,0 +1,74 @@
+"""Closeout auto-attribution leg of the paper cycle (issue #1214).
+
+The turn attributes every expired-unexecuted idea so the closeout trail
+self-heals each turn. attribution_coverage is a hard Stage 1->2 promotion gate;
+an expired idea never opened a position (SUBMITTED cannot expire), so an EXPIRY
+closeout with realized P&L unavailable keeps coverage honest at 100% without a
+manual `ideas closeout record` per expiry. Shared builders live in conftest.py.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import timedelta
+from pathlib import Path
+
+from tests.unit.gpt_trader.features.idea_execution.conftest import (
+    CYCLE_NOW,
+    build_cycle_idea,
+    flat_series,
+    make_cycle_runner,
+    snapshot,
+    snapshot_provider,
+)
+
+from gpt_trader.features.trade_ideas import (
+    ActorType,
+    CloseoutResolution,
+    TimeHorizon,
+    TradeIdeaService,
+)
+
+
+def test_swept_idea_is_attributed_in_the_same_turn(
+    cycle_service: TradeIdeaService, tmp_path: Path
+) -> None:
+    decision_id = "trade-20260703-cycle-005"
+    stale = replace(
+        build_cycle_idea(decision_id),
+        time_horizon=TimeHorizon(
+            expected_hold="3-10 days",
+            expires_at=CYCLE_NOW - timedelta(hours=1),
+        ),
+    )
+    cycle_service.propose(stale, actor_id="test-proposer")
+
+    result = make_cycle_runner(cycle_service, tmp_path, proposers=[]).run(
+        snapshot_provider(snapshot(flat_series("BTC-USD")))
+    )
+
+    assert result.attributed_decision_ids == (decision_id,)
+    closeout = cycle_service.get_closeout_attribution(decision_id)
+    assert closeout is not None
+    assert closeout.resolution is CloseoutResolution.EXPIRY
+    assert closeout.actor_type == ActorType.SYSTEM.value
+    assert closeout.realized_profit_loss_amount is None
+    assert closeout.realized_profit_loss_unavailable_reason
+
+
+def test_preexisting_expired_idea_is_backfilled(
+    cycle_service: TradeIdeaService, tmp_path: Path
+) -> None:
+    decision_id = "trade-20260703-cycle-006"
+    cycle_service.propose(build_cycle_idea(decision_id), actor_id="test-proposer")
+    cycle_service.expire(decision_id)
+    assert cycle_service.get_closeout_attribution(decision_id) is None
+
+    # A later turn that expires nothing new still heals the stuck idea.
+    result = make_cycle_runner(cycle_service, tmp_path, proposers=[]).run(
+        snapshot_provider(snapshot(flat_series("BTC-USD")))
+    )
+
+    assert result.expired_decision_ids == ()
+    assert result.attributed_decision_ids == (decision_id,)
+    assert cycle_service.get_closeout_attribution(decision_id) is not None

--- a/tests/unit/gpt_trader/features/trade_ideas/test_service_closeout_auto.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_service_closeout_auto.py
@@ -1,0 +1,138 @@
+"""Auto-attribution of never-filled terminal ideas (M4/W2, issue #1214).
+
+An ``EXPIRED`` idea can only be reached from a pre-fill state (``SUBMITTED``
+cannot expire), so no position was ever opened and realized P&L is genuinely
+unavailable. Recording an ``EXPIRY`` closeout with an unavailable reason keeps
+``attribution_coverage`` honest and at 100% without inventing a market outcome.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+from tests.unit.gpt_trader.features.trade_ideas.conftest import (
+    attest_account_equity,
+    build_trade_idea,
+)
+
+from gpt_trader.features.trade_ideas import (
+    ActorType,
+    CloseoutResolution,
+    TimeHorizon,
+    TradeIdeaService,
+    TradeIdeaState,
+)
+
+_LIVE_HORIZON = TimeHorizon(
+    expected_hold="3-10 days",
+    expires_at=datetime(2026, 6, 25, 16, 0, tzinfo=UTC),
+)
+
+
+@pytest.fixture
+def service(tmp_path: Path) -> TradeIdeaService:
+    built = TradeIdeaService(
+        tmp_path / "trade_ideas",
+        now_factory=lambda: datetime(2026, 6, 20, 10, 0, tzinfo=UTC),
+    )
+    attest_account_equity(built)
+    return built
+
+
+def _propose_and_expire(service: TradeIdeaService, decision_id: str) -> None:
+    idea = build_trade_idea(decision_id=decision_id)
+    service.propose(idea, actor_id="idea-generator-v1")
+    service.expire(decision_id)
+
+
+def test_auto_attribute_records_expiry_closeout_for_expired_idea(
+    service: TradeIdeaService,
+) -> None:
+    _propose_and_expire(service, "trade-20260620-001")
+
+    recorded = service.auto_attribute_expired_ideas()
+
+    assert [record.decision_id for record in recorded] == ["trade-20260620-001"]
+    closeout = recorded[0]
+    assert closeout.resolution is CloseoutResolution.EXPIRY
+    assert closeout.actor_type == ActorType.SYSTEM.value
+    assert closeout.realized_profit_loss_amount is None
+    assert closeout.realized_profit_loss_percent is None
+    assert closeout.realized_profit_loss_unavailable_reason
+    view = service.get("trade-20260620-001")
+    assert view.state is TradeIdeaState.EXPIRED
+    assert view.closeout_attribution == closeout
+    # terminal_event_id must anchor to the idea's own terminal (expiry) event.
+    assert closeout.terminal_event_id == view.events[-1].event_id
+
+
+def test_auto_attribute_is_idempotent(service: TradeIdeaService) -> None:
+    _propose_and_expire(service, "trade-20260620-001")
+
+    first = service.auto_attribute_expired_ideas()
+    second = service.auto_attribute_expired_ideas()
+
+    assert len(first) == 1
+    assert second == []
+    assert service.get_closeout_attribution("trade-20260620-001") is not None
+
+
+def test_auto_attribute_skips_open_and_filled_ideas(service: TradeIdeaService) -> None:
+    # An open (proposed) idea has no terminal outcome yet.
+    open_idea = build_trade_idea(
+        decision_id="trade-20260620-open", instrument="ETH-USD", time_horizon=_LIVE_HORIZON
+    )
+    service.propose(open_idea, actor_id="idea-generator-v1")
+
+    # A filled idea is terminal but *did* open a position; its realized P&L needs
+    # an exit model (issue #1218), so auto-attribution must not touch it.
+    filled = build_trade_idea(
+        decision_id="trade-20260620-filled", instrument="SOL-USD", time_horizon=_LIVE_HORIZON
+    )
+    service.propose(filled, actor_id="idea-generator-v1")
+    service.approve("trade-20260620-filled", actor_id="rj", reason="verified")
+    service.record_submission("trade-20260620-filled", actor_id="executor", venue="coinbase")
+    service.record_fill("trade-20260620-filled", actor_id="coinbase", venue="coinbase")
+
+    recorded = service.auto_attribute_expired_ideas()
+
+    assert recorded == []
+    assert service.get_closeout_attribution("trade-20260620-open") is None
+    assert service.get_closeout_attribution("trade-20260620-filled") is None
+
+
+def test_auto_attribute_preserves_existing_manual_closeout(
+    service: TradeIdeaService,
+) -> None:
+    _propose_and_expire(service, "trade-20260620-001")
+    manual = service.record_closeout_attribution(
+        "trade-20260620-001",
+        actor_id="rj",
+        resolution=CloseoutResolution.INVALIDATION,
+        realized_profit_loss_amount=Decimal("-40"),
+    )
+
+    recorded = service.auto_attribute_expired_ideas()
+
+    assert recorded == []
+    # The human's attribution is authoritative and untouched.
+    assert service.get_closeout_attribution("trade-20260620-001") == manual
+
+
+def test_auto_attribute_backfills_multiple_expired_ideas(
+    service: TradeIdeaService,
+) -> None:
+    for index in range(3):
+        _propose_and_expire(service, f"trade-20260620-{index:03d}")
+
+    recorded = service.auto_attribute_expired_ideas()
+
+    assert {record.decision_id for record in recorded} == {
+        "trade-20260620-000",
+        "trade-20260620-001",
+        "trade-20260620-002",
+    }
+    assert all(record.resolution is CloseoutResolution.EXPIRY for record in recorded)


### PR DESCRIPTION
Closes #1214. Part of #1212 (M4 — Operate-to-Evidence).

## Problem

The Stage-1 paper cycle expired ideas but never attributed a closeout to them, so `attribution_coverage` — a **hard Stage 1→2 promotion gate** — sat at **0%** and `ideas scorecard` read `promotable=no` regardless of anything else. Nothing automated produced a closeout attribution: it required a manual `ideas closeout record` per idea, which never happened over 76 unattended cycles.

## Change

- **`TradeIdeaService.auto_attribute_expired_ideas()`** — every `EXPIRED` idea still lacking a closeout gets an `EXPIRY` attribution with realized P&L marked *unavailable*. An `EXPIRED` idea can only be reached from a pre-fill state (`SUBMITTED` cannot expire), so no position was ever opened and unavailable P&L is the honest record — it invents no market outcome. Idempotent (a human's attribution stays authoritative); **skips `FILLED` ideas**, whose realized P&L needs an exit model (follow-up #1218).
- **Wired into the paper cycle** right after the expiry sweep, so unattended turns self-heal and backfill pre-existing stuck expiries. Attributed ids are recorded as manifest evidence (`PaperCycleResult.attributed_decision_ids`).

## Verification

Driven against a **copy** of the real trade-idea trail (non-destructive):

| | attribution_coverage | scorecard | audit_integrity |
|---|---|---|---|
| before | 0/21 (0.00%) | 1/7 pass | 44 events ✓ |
| after | **21/21 (100.00%)** | **2/7 pass** | 44 events ✓ |

Plus unit + cycle-integration tests (`test_service_closeout_auto.py`, `test_cycle_closeout.py`). Full unit suite green (6685 passed; the 4 `web/` collection errors are a pre-existing missing-`fastapi`-extra env gap, unrelated).

## Scope

Paper-only; no live/execution behavior changes. `promotable` stays `no` — depth (200/60d), replay-measurable gates (#1216), the drawdown lever (#1217), and filled-idea outcome P&L (#1218) are the remaining M4 work.