### PR TITLE
feat(ops): bounded-autonomy Stage-2 paper cycle turn (#1213)

### DIFF
--- a/docs/paper_trading.md
+++ b/docs/paper_trading.md
@@ -210,6 +210,32 @@ above that (the default 200 is). For sub-cent symbols the proposal price
 levels quantize to zero at the default precision and fail closed; pass a
 finer `--price-precision` for the turn.
 
+### Bounded-autonomy turns (Stage 2)
+
+`scripts/ops/stage2_cycle_turn.sh` runs the same turn under bounded autonomy. It
+sets the two audited Stage-2 gates (`GPT_TRADER_IDEAS_AUTO_APPROVAL=1`,
+`GPT_TRADER_IDEAS_AUTO_EXECUTION=1`), system-approves every violation-free
+proposal inside the budget envelope (`ideas approve --auto-sweep`), then runs one
+cycle turn so those approvals paper-execute against the turn's snapshot. It is
+paper-only and never contacts a live broker. To run unattended Stage-2 turns,
+point the launchd/cron entry below at `stage2_cycle_turn.sh` instead of
+`stage1_cycle_turn.sh`; the same env overrides (`CYCLE_SYMBOLS`, etc.), overlap
+lock, and manifest-row evidence contract apply.
+
+Enabling Stage 2 is an operator act with two audited preconditions:
+
+- The autonomy log resolves to `bounded_autonomy` (`ideas autonomy show`). Set it
+  with `ideas autonomy set bounded_autonomy --actor <you> --reason "..."`. Both
+  gates silently no-op under any other mode, so a breach that ratchets autonomy
+  down (daily-loss or drawdown-from-peak) halts auto-approval and auto-execution
+  until the mode is re-earned — the down-ratchet is audited, never silent.
+- Account equity is attested (the same Stage-1 prerequisite above).
+
+Reverting is immediate and reversible: point the scheduler back at
+`stage1_cycle_turn.sh`, or run
+`ideas autonomy set human_approved_execution --actor <you> --reason "..."` to drop
+the audited mode so both gates no-op regardless of the env vars.
+
 ### launchd (macOS)
 
 Save as `~/Library/LaunchAgents/com.gpt-trader.stage1-cycle.plist`, replacing

--- a/scripts/ops/stage2_cycle_turn.sh
+++ b/scripts/ops/stage2_cycle_turn.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# One bounded-autonomy (Stage 2) paper cycle turn, for launchd/cron entries.
+#
+# Unlike stage1_cycle_turn.sh (which only proposes and executes ideas a human
+# already approved), this enables the audited Stage-2 gates and runs the full
+# unattended loop: system-approve every violation-free proposal inside the
+# budget envelope, then run one cycle turn so those approvals paper-execute
+# against the turn's own snapshot (and expire + closeout-attribute the rest).
+#
+# It is paper-only and never contacts a live broker or account. Every approval
+# and fill is still bounded by the audited bounded_autonomy mode and the
+# versioned budget; each gate silently no-ops under any other mode, so a breach
+# that ratchets autonomy down (daily-loss or drawdown-from-peak) halts
+# auto-approval and auto-execution until the mode is re-earned. Enabling Stage 2
+# is an operator act — see docs/paper_trading.md, "Bounded-autonomy turns
+# (Stage 2)". One invocation is one turn; cadence lives only in the scheduler.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+# Schedulers start jobs with a minimal PATH; make uv reachable whether it was
+# installed by the Astral installer (~/.local/bin) or Homebrew.
+export PATH="${HOME}/.local/bin:/opt/homebrew/bin:/usr/local/bin:${PATH}"
+
+: "${CYCLE_SYMBOLS:=BTC-USD,ETH-USD}"
+: "${CYCLE_GRANULARITY:=ONE_HOUR}"
+: "${CYCLE_LOOKBACK:=200}"
+# Space-separated proposer names; empty means the CLI default (all proposers).
+: "${CYCLE_PROPOSERS:=}"
+
+# The two Stage-2 gates. Both must be enabled for the loop to auto-approve and
+# auto-execute, and each still no-ops unless the audited autonomy mode resolves
+# to bounded_autonomy at decision time
+# (docs/decisions/stage2-auto-approval-workflow.md, stage2-execution-gate.md).
+export GPT_TRADER_IDEAS_AUTO_APPROVAL=1
+export GPT_TRADER_IDEAS_AUTO_EXECUTION=1
+
+PROPOSER_FLAGS=()
+for proposer in ${CYCLE_PROPOSERS}; do
+  PROPOSER_FLAGS+=(--proposer "${proposer}")
+done
+
+# Approve eligible proposals from prior turns inside the budget envelope, then
+# run the turn so those approvals execute against this turn's snapshot. The
+# sweep is a no-op when nothing is eligible or the audited mode is not
+# bounded_autonomy. Keep it non-fatal: the cycle turn is the streak evidence and
+# must still append its manifest row even if the sweep step fails.
+if ! uv run gpt-trader ideas approve --auto-sweep --format json; then
+  echo "stage2: auto-approve sweep step failed (non-fatal); running the cycle turn" >&2
+fi
+
+# ${arr[@]+...} guards the empty-array expansion under set -u on bash 3.2
+# (the macOS system bash that the launchd example invokes).
+exec uv run gpt-trader ideas cycle --from-coinbase \
+  --symbols "${CYCLE_SYMBOLS}" \
+  --granularity "${CYCLE_GRANULARITY}" \
+  --lookback "${CYCLE_LOOKBACK}" \
+  ${PROPOSER_FLAGS[@]+"${PROPOSER_FLAGS[@]}"} \
+  --format json


### PR DESCRIPTION
Closes #1213. Part of #1212 (M4 — Operate-to-Evidence).

## Problem

The scheduled paper loop proposed ideas but never completed a turn. The launchd/cron wrapper `scripts/ops/stage1_cycle_turn.sh` runs only `ideas cycle`, which by design **never approves** — so over 76 unattended turns nothing was ever approved, every proposal expired, and `execution.executed` was empty every time. RJ recorded the intent to run bounded-autonomy paper turns on 2026-07-04 (autonomy log → `bounded_autonomy`), but the orchestration was never wired to fulfill it.

The auto-approval + auto-execution path and the breach down-ratchet are **already implemented and test-enforced** (`test_cycle_auto_approval.py`: `test_system_auto_approval_executes_when_execution_gate_passes`, `test_execution_leg_ratchets_down_system_approvals_but_not_human_approvals`). The only gap was orchestration.

## Change

- **`scripts/ops/stage2_cycle_turn.sh`** — sets the two audited Stage-2 gates (`GPT_TRADER_IDEAS_AUTO_APPROVAL` / `GPT_TRADER_IDEAS_AUTO_EXECUTION`), system-approves violation-free proposals inside the budget envelope (`ideas approve --auto-sweep`), then runs one cycle turn so those approvals paper-execute against the turn's snapshot. Paper-only; each gate no-ops unless the audited mode resolves to `bounded_autonomy`, so a down-ratchet halts it. The sweep step is non-fatal so the cycle still appends its evidence manifest row.
- **`docs/paper_trading.md`** — a "Bounded-autonomy turns (Stage 2)" section: the two audited preconditions (bounded_autonomy mode, attested equity) and the immediate revert path.

## Verification

Driven end-to-end against a **copy** of the real trade-idea trail:

`ideas approve --auto-sweep` → **2 real proposed ideas → SYSTEM-approved** → `execute-paper` (auto-execution gate on) → **FILLED** (order `MOCK_000001` @ 62000). The loop + breach ratchet are covered by the existing `test_cycle_auto_approval.py` (3 pass); docs link audit passes.

## Exit criteria

- [x] Recorded operator enablement on `paper` (autonomy log `bounded_autonomy`, set 2026-07-04; RJ re-confirmed 2026-07-07; documented).
- [x] Cycle completes propose→approve→execute→fill on paper (verified end-to-end).
- [x] A breach ratchets autonomy down mid-run (test-enforced, pre-existing).

## Operator follow-up (not in this PR)

To make the **live** scheduled job turn the loop, repoint the launchd/cron entry from `stage1_cycle_turn.sh` to `stage2_cycle_turn.sh` (a `launchctl` change on the operator's machine). Paper-only throughout; no live/real-capital authorization.