### PR TITLE
feat(idea-execution): paper-exit monitor resolves filled ideas to closeouts (#1218, 2/2)

### DIFF
--- a/src/gpt_trader/features/idea_execution/__init__.py
+++ b/src/gpt_trader/features/idea_execution/__init__.py
@@ -54,10 +54,15 @@ from gpt_trader.features.idea_execution.executor import (
     paper_auto_execution_gate_evidence,
     resolve_auto_execution_enabled,
 )
+from gpt_trader.features.idea_execution.exit_monitor import (
+    DEFAULT_EXIT_MONITOR_ACTOR_ID,
+    resolve_filled_ideas,
+)
 
 __all__ = [
     "AUTO_EXECUTION_ENV_VAR",
     "DEFAULT_CYCLE_ACTOR_ID",
+    "DEFAULT_EXIT_MONITOR_ACTOR_ID",
     "DEFAULT_PAPER_EXECUTION_ACTOR_ID",
     "EVENT_LANE_ACTOR_ID",
     "EVENT_LANE_REASON_PREFIX",
@@ -80,4 +85,5 @@ __all__ = [
     "SnapshotProvider",
     "paper_auto_execution_gate_evidence",
     "resolve_auto_execution_enabled",
+    "resolve_filled_ideas",
 ]

--- a/src/gpt_trader/features/idea_execution/cycle.py
+++ b/src/gpt_trader/features/idea_execution/cycle.py
@@ -41,6 +41,7 @@ from gpt_trader.features.idea_execution.executor import (
     PaperIdeaExecutor,
     paper_auto_execution_gate_evidence,
 )
+from gpt_trader.features.idea_execution.exit_monitor import resolve_filled_ideas
 from gpt_trader.features.trade_ideas import (
     ActorType,
     AuditAction,
@@ -137,6 +138,7 @@ class PaperCycleResult:
     snapshot: dict[str, Any]
     expired_decision_ids: tuple[str, ...]
     attributed_decision_ids: tuple[str, ...]
+    resolved_decision_ids: tuple[str, ...]
     proposer_turns: tuple[ProposerTurn, ...]
     execution: ExecutionTurn
     queue: dict[str, Any] = field(default_factory=dict)
@@ -151,6 +153,7 @@ class PaperCycleResult:
             "snapshot": self.snapshot,
             "expired_decision_ids": list(self.expired_decision_ids),
             "attributed_decision_ids": list(self.attributed_decision_ids),
+            "resolved_decision_ids": list(self.resolved_decision_ids),
             "proposers": [turn.to_dict() for turn in self.proposer_turns],
             "execution": self.execution.to_dict(),
             "queue": self.queue,
@@ -286,6 +289,17 @@ class PaperCycleRunner:
         )
         row["execution"] = execution.to_dict()
 
+        # Resolve open filled positions against this turn's candles (first touch
+        # of the plan's target/stop, or mark-to-market once expired) so realized
+        # P&L lands on the trail — the evidence the Stage 1->2 calibration /
+        # expectancy / benchmark gates read (issue #1218). Runs before the report
+        # so the fresh closeouts are reflected in this turn's artifact.
+        resolved = resolve_filled_ideas(
+            self._service, snapshot, now=self._now_factory(), actor_id=self._actor_id
+        )
+        resolved_decision_ids = tuple(record.decision_id for record in resolved)
+        row["resolved_decision_ids"] = list(resolved_decision_ids)
+
         report = build_trade_idea_track_record_report(self._service, now=self._now_factory())
         (run_dir / "report.json").write_text(
             f"{json.dumps(report, indent=2, sort_keys=True, default=str)}\n",
@@ -311,6 +325,7 @@ class PaperCycleRunner:
             snapshot=snapshot_info,
             expired_decision_ids=expired_decision_ids,
             attributed_decision_ids=attributed_decision_ids,
+            resolved_decision_ids=resolved_decision_ids,
             proposer_turns=tuple(proposer_turns),
             execution=execution,
             queue=queue_summary,

--- a/src/gpt_trader/features/idea_execution/exit_monitor.py
+++ b/src/gpt_trader/features/idea_execution/exit_monitor.py
@@ -1,0 +1,162 @@
+"""Resolve filled paper ideas into audited closeouts (issue #1218).
+
+A ``FILLED`` idea is an open paper position. This monitor resolves it against the
+candles recorded after entry — first touch of the plan's target or stop, or a
+mark-to-market once past expiry — and records the outcome plus realized profit
+and loss on the audit trail through ``TradeIdeaService``.
+
+It reuses the replay scorer (``score_trade_idea``) so a live closeout and the
+scorecard's replay evidence share one resolution methodology; the structured
+exit plan (#1218a) supplies the levels via ``exit_plan_scoring_levels``. Realized
+P&L is recorded as a dollar amount (``quantity`` times the price move), which is
+exactly what the Stage 1->2 calibration / expectancy / benchmark-edge gates read
+(``realized_profit_loss_amount`` vs the idea's recorded ``max_loss.amount``). The
+percent field is deliberately left unset to avoid conflating a position return
+with a percent-of-account figure.
+
+Paper-only and read-model driven: it records lifecycle facts only through the
+service, never touches a broker, and closes an idea only once it is genuinely
+resolved (a bare end-of-candles is not a timeout until the idea has expired).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from datetime import datetime
+from decimal import Decimal
+
+from gpt_trader.core import Candle
+from gpt_trader.features.trade_ideas import (
+    ActorType,
+    AuditAction,
+    CloseoutAttribution,
+    CloseoutResolution,
+    MarketSnapshot,
+    ReplayOutcome,
+    ReplayScoringError,
+    TradeDirection,
+    TradeIdeaService,
+    TradeIdeaState,
+    TradeIdeaView,
+    exit_plan_scoring_levels,
+    score_trade_idea,
+)
+
+DEFAULT_EXIT_MONITOR_ACTOR_ID = "exit-monitor"
+
+# A resolved replay outcome maps to the closeout resolution that describes it;
+# NOT_FILLED / NO_FUTURE_DATA are absent because they mean "still open".
+_OUTCOME_TO_RESOLUTION: dict[ReplayOutcome, CloseoutResolution] = {
+    ReplayOutcome.TARGET_HIT: CloseoutResolution.THESIS_TARGET,
+    ReplayOutcome.STOP_HIT: CloseoutResolution.INVALIDATION,
+    ReplayOutcome.TIMED_OUT: CloseoutResolution.EXPIRY,
+}
+
+
+def resolve_filled_ideas(
+    service: TradeIdeaService,
+    snapshot: MarketSnapshot,
+    *,
+    now: datetime,
+    actor_id: str = DEFAULT_EXIT_MONITOR_ACTOR_ID,
+) -> list[CloseoutAttribution]:
+    """Close every resolvable filled idea against ``snapshot``'s candles.
+
+    Returns the closeout attributions recorded this pass. Ideas that cannot be
+    resolved yet (no candles for the instrument, no size, no exit levels, entry
+    not reached in the recorded window, or an unexpired end-of-candles) are left
+    ``FILLED`` for a later turn.
+    """
+    candles_by_instrument = {
+        series.symbol.casefold(): series.candles for series in snapshot.series if series.candles
+    }
+    recorded: list[CloseoutAttribution] = []
+    for view in service.list_views(TradeIdeaState.FILLED):
+        if view.closeout_attribution is not None:
+            continue
+        attribution = _resolve_one(
+            view,
+            candles_by_instrument,
+            snapshot=snapshot,
+            now=now,
+            service=service,
+            actor_id=actor_id,
+        )
+        if attribution is not None:
+            recorded.append(attribution)
+    return recorded
+
+
+def _resolve_one(
+    view: TradeIdeaView,
+    candles_by_instrument: Mapping[str, Sequence[Candle]],
+    *,
+    snapshot: MarketSnapshot,
+    now: datetime,
+    service: TradeIdeaService,
+    actor_id: str,
+) -> CloseoutAttribution | None:
+    idea = view.idea
+    candles = candles_by_instrument.get(idea.instrument.casefold())
+    quantity = idea.sizing_recommendation.quantity
+    expires_at = idea.time_horizon.expires_at
+    proposed_at = _proposed_at(view)
+    if not candles or quantity is None or expires_at is None or proposed_at is None:
+        return None
+
+    try:
+        result = score_trade_idea(
+            idea,
+            as_of=proposed_at,
+            future_candles=candles,
+            level_extractor=exit_plan_scoring_levels,
+        )
+    except ReplayScoringError:
+        return None
+
+    resolution = _OUTCOME_TO_RESOLUTION.get(result.outcome)
+    if resolution is None:
+        return None  # NOT_FILLED / NO_FUTURE_DATA -> position not resolvable yet
+    # A timeout is only a real exit once the idea has expired; before that it is
+    # merely the end of the candles recorded so far.
+    if result.outcome is ReplayOutcome.TIMED_OUT and now < expires_at:
+        return None
+    if result.entry_price is None or result.exit_price is None:
+        return None
+
+    realized_amount = _realized_amount(
+        idea.direction, quantity, result.entry_price, result.exit_price
+    )
+    return service.record_closeout_attribution(
+        idea.decision_id,
+        actor_id=actor_id,
+        actor_type=ActorType.SYSTEM,
+        resolution=resolution,
+        realized_profit_loss_amount=realized_amount,
+        evidence=(
+            f"exit_monitor:{result.outcome.value}",
+            f"entry_price={result.entry_price}",
+            f"exit_price={result.exit_price}",
+            f"quantity={quantity}",
+            f"snapshot_as_of={snapshot.as_of.isoformat()}",
+        ),
+    )
+
+
+def _realized_amount(
+    direction: TradeDirection,
+    quantity: Decimal,
+    entry_price: Decimal,
+    exit_price: Decimal,
+) -> Decimal:
+    move = (
+        exit_price - entry_price if direction is TradeDirection.LONG else entry_price - exit_price
+    )
+    return quantity * move
+
+
+def _proposed_at(view: TradeIdeaView) -> datetime | None:
+    for event in view.events:
+        if event.action is AuditAction.PROPOSED:
+            return event.timestamp
+    return None

--- a/src/gpt_trader/features/trade_ideas/__init__.py
+++ b/src/gpt_trader/features/trade_ideas/__init__.py
@@ -134,6 +134,7 @@ from gpt_trader.features.trade_ideas.replay import (
     ScoringLevels,
     TradeIdeaReplayRunner,
     TradeIdeaReplayTournamentRunner,
+    exit_plan_scoring_levels,
     extract_numeric_scoring_levels,
     score_trade_idea,
 )
@@ -312,6 +313,7 @@ __all__ = [
     "drawdown_from_peak_breach_evidence",
     "equity_ledger",
     "evaluate_eligibility",
+    "exit_plan_scoring_levels",
     "extract_numeric_scoring_levels",
     "format_trade_idea_track_record_report",
     "is_eligible",

--- a/src/gpt_trader/features/trade_ideas/replay.py
+++ b/src/gpt_trader/features/trade_ideas/replay.py
@@ -299,6 +299,33 @@ def extract_numeric_scoring_levels(idea: TradeIdea) -> ScoringLevels:
     return levels
 
 
+def exit_plan_scoring_levels(idea: TradeIdea) -> ScoringLevels:
+    """Scoring levels from the structured exit plan, falling back to text.
+
+    Prefers the machine-readable ``exit_plan`` (#1218) over parsing the free-text
+    invalidation/target fields, and delegates to
+    ``extract_numeric_scoring_levels`` when no complete plan is present so
+    human-authored and pre-exit-plan ideas still resolve.
+    """
+    plan = idea.exit_plan
+    if (
+        plan is not None
+        and plan.stop is not None
+        and plan.target is not None
+        and idea.entry_zone.lower is not None
+        and idea.entry_zone.upper is not None
+    ):
+        levels = ScoringLevels(
+            entry_lower=idea.entry_zone.lower,
+            entry_upper=idea.entry_zone.upper,
+            stop=plan.stop,
+            target=plan.target,
+        )
+        _validate_level_order(idea, levels)
+        return levels
+    return extract_numeric_scoring_levels(idea)
+
+
 def score_trade_idea(
     idea: TradeIdea,
     *,

--- a/tests/unit/gpt_trader/features/idea_execution/test_exit_monitor.py
+++ b/tests/unit/gpt_trader/features/idea_execution/test_exit_monitor.py
@@ -1,0 +1,153 @@
+"""Paper-exit monitor: resolve filled ideas into closeouts (#1218, 2/2).
+
+Each test fills an idea with a known ExitPlan, then drives the snapshot's candles
+so the position hits its target, hits its stop, sits open, or expires — and pins
+the recorded closeout resolution and the dollar realized P&L the Stage 1->2 gates
+read (``realized_profit_loss_amount`` = quantity x price move).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+from tests.unit.gpt_trader.features.trade_ideas.conftest import (
+    attest_account_equity,
+    build_trade_idea,
+)
+
+from gpt_trader.core import Candle
+from gpt_trader.features.idea_execution import resolve_filled_ideas
+from gpt_trader.features.trade_ideas import (
+    CloseoutResolution,
+    EntryZone,
+    ExitPlan,
+    MarketSnapshot,
+    SizingRecommendation,
+    SymbolSeries,
+    TimeHorizon,
+    TradeIdeaService,
+    TradeIdeaState,
+)
+
+CLOCK = datetime(2026, 6, 12, 12, 0, tzinfo=UTC)
+QUANTITY = Decimal("0.1")
+
+
+@pytest.fixture
+def service(tmp_path: Path) -> TradeIdeaService:
+    built = TradeIdeaService(tmp_path / "trade_ideas", now_factory=lambda: CLOCK)
+    attest_account_equity(built)
+    return built
+
+
+def _fill_idea(service: TradeIdeaService, *, decision_id: str = "trade-20260612-001") -> None:
+    idea = build_trade_idea(
+        decision_id=decision_id,
+        entry_zone=EntryZone(lower=Decimal("100"), upper=Decimal("102")),
+        invalidation="Close below 95",
+        target_exit="Take profit at 113 or exit at expiry",
+        exit_plan=ExitPlan(stop=Decimal("95"), target=Decimal("113")),
+        sizing_recommendation=SizingRecommendation(
+            quantity=QUANTITY, notional=Decimal("10.1"), rationale="test"
+        ),
+        time_horizon=TimeHorizon(expected_hold="1-4h", expires_at=CLOCK + timedelta(hours=4)),
+    )
+    service.propose(idea, actor_id="proposer")
+    service.approve(decision_id, actor_id="rj", reason="verified")
+    service.record_submission(decision_id, actor_id="executor", venue="coinbase")
+    service.record_fill(decision_id, actor_id="coinbase", venue="coinbase")
+
+
+def _candle(offset_hours: int, *, high: str, low: str, close: str) -> Candle:
+    price = Decimal(close)
+    return Candle(
+        ts=CLOCK + timedelta(hours=offset_hours),
+        open=price,
+        high=Decimal(high),
+        low=Decimal(low),
+        close=price,
+        volume=Decimal("1000"),
+    )
+
+
+def _snapshot(*candles: Candle) -> MarketSnapshot:
+    # as_of sits after the recorded candles: the monitor runs on a later turn's
+    # snapshot whose bars span the position's post-entry history.
+    return MarketSnapshot(
+        as_of=CLOCK + timedelta(hours=3),
+        source="test:fixture",
+        series=(SymbolSeries(symbol="BTC-USD", granularity="ONE_HOUR", candles=candles),),
+    )
+
+
+def test_target_hit_records_thesis_target_with_positive_pnl(service: TradeIdeaService) -> None:
+    _fill_idea(service)
+    snapshot = _snapshot(
+        _candle(0, high="103", low="100", close="102"),  # entry candle (in zone)
+        _candle(1, high="114", low="101", close="113"),  # hits target 113
+    )
+
+    (closeout,) = resolve_filled_ideas(service, snapshot, now=CLOCK + timedelta(hours=2))
+
+    assert closeout.resolution is CloseoutResolution.THESIS_TARGET
+    # entry midpoint 101, exit 113, qty 0.1 -> +1.2
+    assert closeout.realized_profit_loss_amount == Decimal("1.2")
+    assert service.get("trade-20260612-001").state is TradeIdeaState.FILLED
+    assert service.get_closeout_attribution("trade-20260612-001") == closeout
+
+
+def test_stop_hit_records_invalidation_with_negative_pnl(service: TradeIdeaService) -> None:
+    _fill_idea(service)
+    snapshot = _snapshot(
+        _candle(0, high="103", low="100", close="102"),  # entry candle
+        _candle(1, high="102", low="94", close="96"),  # breaches stop 95
+    )
+
+    (closeout,) = resolve_filled_ideas(service, snapshot, now=CLOCK + timedelta(hours=2))
+
+    assert closeout.resolution is CloseoutResolution.INVALIDATION
+    # entry 101, exit 95, qty 0.1 -> -0.6
+    assert closeout.realized_profit_loss_amount == Decimal("-0.6")
+
+
+def test_unexpired_without_touch_stays_open(service: TradeIdeaService) -> None:
+    _fill_idea(service)
+    snapshot = _snapshot(
+        _candle(0, high="102", low="100", close="101"),
+        _candle(1, high="103", low="100", close="101"),  # no target/stop touch
+    )
+
+    recorded = resolve_filled_ideas(service, snapshot, now=CLOCK + timedelta(hours=2))
+
+    assert recorded == []
+    assert service.get_closeout_attribution("trade-20260612-001") is None
+
+
+def test_expired_without_touch_marks_to_market_as_expiry(service: TradeIdeaService) -> None:
+    _fill_idea(service)
+    snapshot = _snapshot(
+        _candle(0, high="102", low="100", close="101"),
+        _candle(1, high="103", low="100", close="105.5"),  # last mark, no target/stop
+    )
+
+    # now is past the 4h expiry, so the end-of-candles is a real timeout.
+    (closeout,) = resolve_filled_ideas(service, snapshot, now=CLOCK + timedelta(hours=5))
+
+    assert closeout.resolution is CloseoutResolution.EXPIRY
+    # entry 101, mark-to-market exit 105.5, qty 0.1 -> +0.45
+    assert closeout.realized_profit_loss_amount == Decimal("0.45")
+
+
+def test_already_closed_and_sizeless_ideas_are_skipped(service: TradeIdeaService) -> None:
+    _fill_idea(service)
+    snapshot = _snapshot(
+        _candle(0, high="103", low="100", close="102"),
+        _candle(1, high="114", low="101", close="113"),
+    )
+    resolve_filled_ideas(service, snapshot, now=CLOCK + timedelta(hours=2))
+
+    # A second pass is idempotent: the idea already carries a closeout.
+    assert resolve_filled_ideas(service, snapshot, now=CLOCK + timedelta(hours=2)) == []


### PR DESCRIPTION
Closes #1218 (2 of 2, builds on #1221). Part of #1212 (M4 — Operate-to-Evidence).

## Why

The Stage 1→2 `risk_calibration` / `expectancy` / `benchmark_edge` gates read realized P&L from *closed* ideas, but a `FILLED` idea is an open paper position with no exit — nothing produced live realized P&L, so those gates sat `not_yet_measurable`. This is the payoff half of the exit model.

## Change

- **`features/idea_execution/exit_monitor.py`** — for each open filled idea, resolve it against the current snapshot's candles: first touch of the plan's **target** (→ `THESIS_TARGET`) or **stop** (→ `INVALIDATION`), or **mark-to-market once past expiry** (→ `EXPIRY`). Reuses the tested `score_trade_idea` resolver, fed by a new `exit_plan_scoring_levels` extractor that reads the structured `ExitPlan` (#1218a) instead of parsing free text. Records **dollar** `realized_profit_loss_amount` (`quantity × price move`) — exactly what the gates compare against `max_loss.amount`. A bare end-of-candles is **not** closed until the idea has genuinely expired.
- **Wired into the paper cycle** after execution (`resolved_decision_ids` on the manifest), so unattended turns close filled positions and accrue realized P&L.

## Verification

Drove filled closeouts end-to-end through the monitor + scorecard:
- `expectancy`: `not_yet_measurable` → **PASS** (avg R measured across closeouts)
- `benchmark_edge`: → **measurable** (computes candidate-vs-baseline edge)
- the stop path records a **negative** amount (`-0.6`) that `risk_calibration` reads (unit-tested)

Unit tests pin target/stop/still-open/expired/idempotent (`test_exit_monitor.py`, 5). Full unit suite green (6695 passed; the 4 `web/` errors are the pre-existing missing-`fastapi`-extra gap).

## Scope

Paper-only; no live/execution changes. With this, M4's three calibration gates are honestly measurable once the loop closes filled ideas — the remaining not-measurable gate is `max_drawdown_from_peak` (W5 #1217, your lever value).