### PR TITLE
feat(idea-execution): break proposal starvation — widen the universe, top up busy instruments (#1215)

### DIFF
--- a/docs/paper_trading.md
+++ b/docs/paper_trading.md
@@ -190,12 +190,23 @@ is required to verify max_open_notional_pct budget exposure` until a human
 attests equity.
 
 The default conservative configuration lives in
-`scripts/ops/stage1_cycle_turn.sh` (BTC-USD/ETH-USD, ONE_HOUR candles,
-lookback 200, default proposers `baseline` and `regime-aware`). Symbols,
-granularity, lookback, and the proposer set are env-overridable there
-(`CYCLE_SYMBOLS`, `CYCLE_GRANULARITY`, `CYCLE_LOOKBACK`, and space-separated
+`scripts/ops/stage1_cycle_turn.sh`: eight liquid Coinbase USD spot pairs
+(BTC, ETH, SOL, XRP, LTC, LINK, AVAX, DOT — all quoted above $1 so the default
+price precision of 0.01 stays meaningful), ONE_HOUR candles, lookback 200,
+default proposers `baseline` and `regime-aware`. A universe of just two symbols
+starves track-record depth: the busy-instrument skip admits at most one open
+idea per instrument, so per-turn proposal flow scales with the instrument set
+(issue #1215). Symbols, granularity, lookback, price precision, and the
+proposer set are env-overridable there (`CYCLE_SYMBOLS`, `CYCLE_GRANULARITY`,
+`CYCLE_LOOKBACK`, `CYCLE_PRICE_PRECISION`, and space-separated
 `CYCLE_PROPOSERS`, for example `CYCLE_PROPOSERS=baseline`); cadence belongs
 only in the scheduler entry.
+
+Shrinking `CYCLE_SYMBOLS` never strands an unresolved trade: each turn tops the
+snapshot fetch up with any instrument that still has an open idea or a filled
+idea awaiting closeout, so the exit monitor keeps receiving candles until the
+position resolves. Top-up fetches are per-symbol and non-fatal — a delisted
+instrument defers its own resolution without failing the turn.
 
 Strategy-backed proposers — the live strategy library running over the turn's
 snapshot through the `Proposer` contract — are opt-in until replay parity is

--- a/scripts/ops/stage1_cycle_turn.sh
+++ b/scripts/ops/stage1_cycle_turn.sh
@@ -15,9 +15,12 @@ cd "${REPO_ROOT}"
 # installed by the Astral installer (~/.local/bin) or Homebrew.
 export PATH="${HOME}/.local/bin:/opt/homebrew/bin:/usr/local/bin:${PATH}"
 
-: "${CYCLE_SYMBOLS:=BTC-USD,ETH-USD}"
+# Same default universe as stage2_cycle_turn.sh: liquid Coinbase USD spot
+# pairs whose quotes are all >= $1, so 0.01 price precision stays meaningful.
+: "${CYCLE_SYMBOLS:=BTC-USD,ETH-USD,SOL-USD,XRP-USD,LTC-USD,LINK-USD,AVAX-USD,DOT-USD}"
 : "${CYCLE_GRANULARITY:=ONE_HOUR}"
 : "${CYCLE_LOOKBACK:=200}"
+: "${CYCLE_PRICE_PRECISION:=0.01}"
 # Space-separated proposer names; empty means the CLI default (all proposers).
 : "${CYCLE_PROPOSERS:=}"
 
@@ -32,5 +35,6 @@ exec uv run gpt-trader ideas cycle --from-coinbase \
   --symbols "${CYCLE_SYMBOLS}" \
   --granularity "${CYCLE_GRANULARITY}" \
   --lookback "${CYCLE_LOOKBACK}" \
+  --price-precision "${CYCLE_PRICE_PRECISION}" \
   ${PROPOSER_FLAGS[@]+"${PROPOSER_FLAGS[@]}"} \
   --format json

--- a/scripts/ops/stage2_cycle_turn.sh
+++ b/scripts/ops/stage2_cycle_turn.sh
@@ -23,9 +23,15 @@ cd "${REPO_ROOT}"
 # installed by the Astral installer (~/.local/bin) or Homebrew.
 export PATH="${HOME}/.local/bin:/opt/homebrew/bin:/usr/local/bin:${PATH}"
 
-: "${CYCLE_SYMBOLS:=BTC-USD,ETH-USD}"
+# Liquid Coinbase USD spot pairs whose quotes are all >= $1, so the default
+# --price-precision of 0.01 stays meaningful. Adding a sub-cent symbol requires
+# a finer CYCLE_PRICE_PRECISION too (issue #1215: two symbols starved
+# track-record depth; the busy-instrument skip means a wider set is what keeps
+# proposals flowing every open-market turn).
+: "${CYCLE_SYMBOLS:=BTC-USD,ETH-USD,SOL-USD,XRP-USD,LTC-USD,LINK-USD,AVAX-USD,DOT-USD}"
 : "${CYCLE_GRANULARITY:=ONE_HOUR}"
 : "${CYCLE_LOOKBACK:=200}"
+: "${CYCLE_PRICE_PRECISION:=0.01}"
 # Space-separated proposer names; empty means the CLI default (all proposers).
 : "${CYCLE_PROPOSERS:=}"
 
@@ -56,5 +62,6 @@ exec uv run gpt-trader ideas cycle --from-coinbase \
   --symbols "${CYCLE_SYMBOLS}" \
   --granularity "${CYCLE_GRANULARITY}" \
   --lookback "${CYCLE_LOOKBACK}" \
+  --price-precision "${CYCLE_PRICE_PRECISION}" \
   ${PROPOSER_FLAGS[@]+"${PROPOSER_FLAGS[@]}"} \
   --format json

--- a/src/gpt_trader/cli/commands/ideas.py
+++ b/src/gpt_trader/cli/commands/ideas.py
@@ -43,6 +43,7 @@ from gpt_trader.features.idea_execution import (
     DEFAULT_PAPER_EXECUTION_ACTOR_ID,
     PaperCycleRunner,
     PaperIdeaExecutor,
+    busy_instruments,
 )
 from gpt_trader.features.intelligence.regime import RegimeConfig
 from gpt_trader.features.live_trade.strategies.baseline import (
@@ -2918,9 +2919,26 @@ def _cycle_proposer(
     )
 
 
+def _cycle_busy_symbol_extras(
+    service: TradeIdeaService, snapshot_symbols: tuple[str, ...]
+) -> tuple[str, ...]:
+    """Busy instruments the requested universe no longer covers."""
+    present = {symbol.casefold() for symbol in snapshot_symbols}
+    return tuple(
+        sorted(
+            {
+                blocker.instrument.upper()
+                for blocker in busy_instruments(service).values()
+                if blocker.instrument.casefold() not in present
+            }
+        )
+    )
+
+
 def _handle_cycle(args: Namespace) -> CliResponse:
     command = "ideas cycle"
     try:
+        service = _service(args)
         if args.snapshot is not None:
             snapshot_path = args.snapshot
 
@@ -2953,9 +2971,25 @@ def _handle_cycle(args: Namespace) -> CliResponse:
 
             def snapshot_provider() -> tuple[MarketSnapshot, str]:
                 snapshot = asyncio.run(_build_coinbase_market_snapshot(args, request))
+                # Busy instruments must keep receiving candles after the
+                # configured universe drops them: without fresh candles the
+                # exit monitor can never resolve their filled ideas, so the
+                # instrument would starve permanently (issue #1215). Top-up
+                # fetches are per-symbol and non-fatal so one delisted or
+                # renamed instrument cannot fail every future turn; its idea
+                # simply stays open until candles are available again.
+                for symbol in _cycle_busy_symbol_extras(service, snapshot.symbols()):
+                    try:
+                        extra = asyncio.run(
+                            _build_coinbase_market_snapshot(
+                                args, replace(request, symbols=(symbol,))
+                            )
+                        )
+                    except Exception:  # noqa: BLE001
+                        continue
+                    snapshot = replace(snapshot, series=(*snapshot.series, *extra.series))
                 return snapshot, snapshot.source
 
-        service = _service(args)
         selected_proposers = tuple(dict.fromkeys(args.proposers or DEFAULT_CYCLE_PROPOSERS))
         runner = PaperCycleRunner(
             service,

--- a/src/gpt_trader/features/idea_execution/__init__.py
+++ b/src/gpt_trader/features/idea_execution/__init__.py
@@ -26,12 +26,14 @@ approval; nothing in this slice weakens that boundary.
 
 from gpt_trader.features.idea_execution.cycle import (
     DEFAULT_CYCLE_ACTOR_ID,
+    BusyInstrument,
     ExecutionTurn,
     PaperCycleLockError,
     PaperCycleResult,
     PaperCycleRunner,
     ProposerTurn,
     SnapshotProvider,
+    busy_instruments,
 )
 from gpt_trader.features.idea_execution.event_lane import (
     EVENT_LANE_REASON_PREFIX,
@@ -72,6 +74,7 @@ __all__ = [
     "EventDrivenIdeaLane",
     "EventLaneOutcome",
     "EventLaneStage",
+    "BusyInstrument",
     "IdeaNotExecutableError",
     "PaperExecutionError",
     "PaperExecutionResult",
@@ -83,6 +86,7 @@ __all__ = [
     "PaperOnlyLaneError",
     "ProposerTurn",
     "SnapshotProvider",
+    "busy_instruments",
     "paper_auto_execution_gate_evidence",
     "resolve_auto_execution_enabled",
     "resolve_filled_ideas",

--- a/src/gpt_trader/features/idea_execution/cycle.py
+++ b/src/gpt_trader/features/idea_execution/cycle.py
@@ -83,6 +83,47 @@ def _instrument_key(instrument: str) -> str:
     return instrument.casefold()
 
 
+@dataclass(frozen=True, slots=True)
+class BusyInstrument:
+    """Why an instrument must not receive a new proposal this turn."""
+
+    instrument: str
+    decision_id: str
+    reason: str
+
+
+def busy_instruments(service: TradeIdeaService) -> dict[str, BusyInstrument]:
+    """Instruments blocked from new proposals, keyed by casefolded instrument.
+
+    An instrument is busy while an idea for it is open, and also while a filled
+    trade awaits closeout attribution: until the outcome is recorded, the trade
+    is unresolved and the same ongoing signal must not pyramid a second position
+    onto it. Snapshot acquisition uses the same map to keep fetching candles for
+    busy instruments even after the configured universe drops them — otherwise a
+    filled idea could never resolve and would starve its instrument permanently
+    (issue #1215).
+    """
+    busy: dict[str, BusyInstrument] = {}
+    for view in service.list_views():
+        instrument_key = _instrument_key(view.idea.instrument)
+        if view.state in _OPEN_STATES:
+            busy[instrument_key] = BusyInstrument(
+                instrument=view.idea.instrument,
+                decision_id=view.idea.decision_id,
+                reason="instrument already has an open idea",
+            )
+        elif view.state is TradeIdeaState.FILLED and view.closeout_attribution is None:
+            busy.setdefault(
+                instrument_key,
+                BusyInstrument(
+                    instrument=view.idea.instrument,
+                    decision_id=view.idea.decision_id,
+                    reason="instrument has a filled idea awaiting closeout",
+                ),
+            )
+    return busy
+
+
 def _latest_approval_event(view: TradeIdeaView) -> AuditEvent | None:
     for event in reversed(view.events):
         if event.action is AuditAction.APPROVED:
@@ -340,25 +381,8 @@ class PaperCycleRunner:
     ) -> ProposerTurn:
         candidates = proposer.propose(snapshot)
 
-        # An instrument is busy while an idea for it is open, and also while a
-        # filled trade awaits closeout attribution: until the outcome is
-        # recorded, the trade is unresolved and the same ongoing signal must
-        # not pyramid a second position onto it.
-        busy_instruments: dict[str, tuple[str, str]] = {}
-        known_decision_ids: set[str] = set()
-        for view in self._service.list_views():
-            known_decision_ids.add(view.idea.decision_id)
-            instrument_key = _instrument_key(view.idea.instrument)
-            if view.state in _OPEN_STATES:
-                busy_instruments[instrument_key] = (
-                    view.idea.decision_id,
-                    "instrument already has an open idea",
-                )
-            elif view.state is TradeIdeaState.FILLED and view.closeout_attribution is None:
-                busy_instruments.setdefault(
-                    instrument_key,
-                    (view.idea.decision_id, "instrument has a filled idea awaiting closeout"),
-                )
+        busy = busy_instruments(self._service)
+        known_decision_ids = {view.idea.decision_id for view in self._service.list_views()}
         admitted = []
         skipped: list[dict[str, str]] = []
         for idea in candidates:
@@ -375,22 +399,22 @@ class PaperCycleRunner:
                 )
                 continue
             instrument_key = _instrument_key(idea.instrument)
-            busy = busy_instruments.get(instrument_key)
-            if busy is not None:
-                existing_decision_id, reason = busy
+            blocker = busy.get(instrument_key)
+            if blocker is not None:
                 skipped.append(
                     {
                         "instrument": idea.instrument,
-                        "reason": reason,
-                        "existing_decision_id": existing_decision_id,
+                        "reason": blocker.reason,
+                        "existing_decision_id": blocker.decision_id,
                     }
                 )
                 continue
             admitted.append(idea)
             known_decision_ids.add(idea.decision_id)
-            busy_instruments[instrument_key] = (
-                idea.decision_id,
-                "instrument already has an open idea",
+            busy[instrument_key] = BusyInstrument(
+                instrument=idea.instrument,
+                decision_id=idea.decision_id,
+                reason="instrument already has an open idea",
             )
 
         proposed_decision_ids: tuple[str, ...] = ()

--- a/tests/unit/gpt_trader/cli/commands/test_ideas_cycle.py
+++ b/tests/unit/gpt_trader/cli/commands/test_ideas_cycle.py
@@ -21,9 +21,12 @@ from gpt_trader.core import Candle
 from gpt_trader.features.trade_ideas import (
     MarketSnapshot,
     SymbolSeries,
+    TimeHorizon,
+    TradeIdeaService,
     market_snapshot_to_payload,
 )
 from tests.unit.gpt_trader.cli.commands.conftest import attest_ideas_root
+from tests.unit.gpt_trader.features.trade_ideas.conftest import build_trade_idea
 
 # Relative to the wall clock: the ``ideas cycle``/``ideas approve`` CLI runs
 # on real time, and the baseline proposer derives idea expiry from the
@@ -254,6 +257,128 @@ def test_cycle_stateful_strategy_proposers_are_selectable(
         "snapshot-strategy-mean-reversion": 1,
         "snapshot-strategy-regime-switcher": 0,
     }
+
+
+def _flat_market_series(symbol: str, *, as_of: datetime) -> SymbolSeries:
+    start = as_of - timedelta(hours=60)
+    return SymbolSeries(
+        symbol=symbol,
+        granularity="ONE_HOUR",
+        candles=tuple(
+            Candle(
+                ts=start + timedelta(hours=index),
+                open=Decimal("100"),
+                high=Decimal("100"),
+                low=Decimal("100"),
+                close=Decimal("100"),
+                volume=Decimal("10"),
+            )
+            for index in range(59)
+        ),
+    )
+
+
+def _install_fake_coinbase_builder(
+    monkeypatch: pytest.MonkeyPatch, *, failing_symbols: frozenset[str] = frozenset()
+) -> list[tuple[str, ...]]:
+    """Fake the network snapshot build; returns the per-call symbol requests."""
+    requested: list[tuple[str, ...]] = []
+
+    async def fake_build(args: Any, request: Any) -> MarketSnapshot:
+        requested.append(request.symbols)
+        for symbol in request.symbols:
+            if symbol in failing_symbols:
+                raise RuntimeError(f"no candles for {symbol}")
+        return MarketSnapshot(
+            as_of=request.as_of,
+            source="test:fake-coinbase",
+            series=tuple(
+                _flat_market_series(symbol, as_of=request.as_of) for symbol in request.symbols
+            ),
+        )
+
+    monkeypatch.setattr("gpt_trader.cli.commands.ideas._build_coinbase_market_snapshot", fake_build)
+    return requested
+
+
+def _seed_busy_instrument(root: Path, instrument: str) -> str:
+    decision_id = f"trade-{datetime.now(UTC):%Y%m%d}-{instrument.replace('-', '').lower()}-busy"
+    TradeIdeaService(root).propose(
+        build_trade_idea(
+            decision_id=decision_id,
+            instrument=instrument,
+            time_horizon=TimeHorizon(
+                expected_hold="3-10 days",
+                expires_at=datetime.now(UTC) + timedelta(days=7),
+            ),
+        ),
+        actor_id="test-proposer",
+    )
+    return decision_id
+
+
+def test_cycle_snapshot_tops_up_busy_instruments_outside_the_universe(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # An open ETH idea whose symbol the configured universe no longer covers
+    # must still get candles, or its eventual fill could never resolve and the
+    # instrument would starve permanently (issue #1215).
+    root = tmp_path / "ideas"
+    attest_ideas_root(root)
+    _seed_busy_instrument(root, "ETH-USD")
+    requested = _install_fake_coinbase_builder(monkeypatch)
+
+    exit_code, response = _run_json(
+        capsys,
+        [
+            "ideas",
+            "cycle",
+            "--from-coinbase",
+            "--symbols",
+            "BTC-USD",
+            "--granularity",
+            "ONE_HOUR",
+            "--lookback",
+            "60",
+            *_root_args(root),
+        ],
+    )
+
+    assert exit_code == 0
+    assert response["success"] is True
+    assert response["data"]["snapshot"]["symbols"] == ["BTC-USD", "ETH-USD"]
+    assert requested == [("BTC-USD",), ("ETH-USD",)]
+
+
+def test_cycle_busy_instrument_top_up_failure_does_not_fail_the_turn(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "ideas"
+    attest_ideas_root(root)
+    _seed_busy_instrument(root, "ETH-USD")
+    requested = _install_fake_coinbase_builder(monkeypatch, failing_symbols=frozenset({"ETH-USD"}))
+
+    exit_code, response = _run_json(
+        capsys,
+        [
+            "ideas",
+            "cycle",
+            "--from-coinbase",
+            "--symbols",
+            "BTC-USD",
+            "--granularity",
+            "ONE_HOUR",
+            "--lookback",
+            "60",
+            *_root_args(root),
+        ],
+    )
+
+    assert exit_code == 0
+    assert response["success"] is True
+    assert response["data"]["snapshot"]["symbols"] == ["BTC-USD"]
+    # The top-up was attempted and its failure deferred, not fatal.
+    assert requested == [("BTC-USD",), ("ETH-USD",)]
 
 
 def test_cycle_from_coinbase_requires_market_parameters(

--- a/tests/unit/gpt_trader/features/idea_execution/test_cycle_busy_instruments.py
+++ b/tests/unit/gpt_trader/features/idea_execution/test_cycle_busy_instruments.py
@@ -1,0 +1,55 @@
+"""The busy-instrument map shared by re-proposal gating and snapshot top-up.
+
+``busy_instruments`` gates near-duplicate proposals inside the turn and keeps
+snapshot acquisition fetching candles for unresolved instruments after the
+configured universe drops them (issue #1215). The proposer-leg skip behavior it
+feeds is pinned in test_cycle.py; this pins the map itself across one idea's
+life. Shared builders live in conftest.py.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from pathlib import Path
+
+from tests.unit.gpt_trader.features.idea_execution.conftest import (
+    build_cycle_idea,
+    crossover_series,
+    make_cycle_runner,
+    snapshot,
+    snapshot_provider,
+)
+
+from gpt_trader.features.idea_execution import busy_instruments
+from gpt_trader.features.trade_ideas import TradeIdeaService, TradeIdeaState
+
+
+def test_busy_map_tracks_the_idea_lifecycle_and_frees_on_attribution(
+    cycle_service: TradeIdeaService, tmp_path: Path
+) -> None:
+    assert busy_instruments(cycle_service) == {}
+
+    decision_id = "trade-20260703-cycle-busy-map"
+    cycle_service.propose(build_cycle_idea(decision_id), actor_id="test-proposer")
+    blocker = busy_instruments(cycle_service)["btc-usd"]
+    assert blocker.instrument == "BTC-USD"
+    assert blocker.decision_id == decision_id
+    assert blocker.reason == "instrument already has an open idea"
+
+    cycle_service.approve(decision_id, actor_id="test-operator", reason="test approval")
+    make_cycle_runner(cycle_service, tmp_path, proposers=[]).run(
+        snapshot_provider(snapshot(crossover_series("BTC-USD")))
+    )
+    assert cycle_service.get(decision_id).state is TradeIdeaState.FILLED
+    blocker = busy_instruments(cycle_service)["btc-usd"]
+    assert blocker.reason == "instrument has a filled idea awaiting closeout"
+
+    cycle_service.record_closeout_attribution(
+        decision_id,
+        actor_id="test-operator",
+        resolution="thesis_target",
+        realized_profit_loss_amount=Decimal("10"),
+        realized_profit_loss_percent=Decimal("0.04"),
+        evidence=("test closeout",),
+    )
+    assert busy_instruments(cycle_service) == {}


### PR DESCRIPTION
Part of #1212 (M4 — Operate-to-Evidence). Closes #1215.

## Problem

Recent cycles emitted ~0 proposals: the universe was BTC/ETH only and the busy-instrument skip in `PaperCycleRunner._run_proposer` admits at most one open idea per instrument, so per-turn proposal flow scales directly with the instrument set. Track-record depth (≥ 200 closed ideas / ≥ 60 days) cannot accrue at two symbols.

## Changes

- **Widen the default universe (config-driven).** `CYCLE_SYMBOLS` in `scripts/ops/stage1_cycle_turn.sh` and `stage2_cycle_turn.sh` now defaults to eight liquid Coinbase USD spot pairs (BTC, ETH, SOL, XRP, LTC, LINK, AVAX, DOT — all quoted above \$1 so the default 0.01 price precision stays meaningful). New `CYCLE_PRICE_PRECISION` passthrough for finer-grained symbols.
- **Close the last permanent-starvation path.** With a config-driven universe, an operator can drop a symbol that still has an unresolved trade; without candles the exit monitor could never resolve it, leaving the instrument busy forever. The busy-instrument map is extracted from `_run_proposer` into `busy_instruments()`, and the `--from-coinbase` snapshot provider tops the fetch up with any busy instrument the requested universe no longer covers. Top-up fetches are per-symbol and non-fatal, so a delisted instrument defers its own resolution instead of failing every future turn.
- **Dedupe intent unchanged.** An instrument is still skipped while an idea is open or a filled trade awaits closeout; with W2 auto-attribution (#1214) and the paper-exit monitor (#1218) in the loop it now always frees once the trade resolves.

## Exit-criteria mapping (#1215)

- *proposals flow every open-market turn*: 8-symbol universe × per-series proposers; verified against the multi-symbol snapshot path in tests.
- *no permanent starvation once an idea resolves*: pinned in `test_cycle_busy_instruments.py` (busy → awaiting-closeout → free) and the CLI top-up tests (dropped symbol still fetched; top-up failure non-fatal).
- *depth accrues over a multi-day paper run*: operational follow-up — the scheduler entry must be repointed at `stage2_cycle_turn.sh` (W1 #1213's operator step) and observed over the coming days' manifest rows.

## Testing

- `uv run local-ci` (pr profile) green, including the Stage-1 rails smoke.
- New: `test_cycle_busy_instruments.py` (map across one idea's life), CLI tests for busy-instrument snapshot top-up and its non-fatal failure path.