### PR TITLE
feat(trade-ideas): replay-accelerated Stage 1→2 scorecard evidence (#1216)

### DIFF
--- a/docs/paper_trading.md
+++ b/docs/paper_trading.md
@@ -326,6 +326,50 @@ print(f"consecutive clean days: {streak} (through {max(days, default='n/a')})")
 EOF
 ```
 
+## Replay Evidence for the Stage 1 → 2 Scorecard
+
+Three scorecard gates (`risk_calibration`, `expectancy`, `benchmark_edge`)
+need closed-idea outcomes, and the wall-clock observation window is 60 days.
+Replay evidence makes those quantities readable now, without waiting:
+`ideas replay tournament` replays proposers point-in-time over a recorded
+snapshot window, and `ideas scorecard --replay-report <path>` reports the
+result as replay-labeled evidence **alongside** the wall-clock gates — it is
+never blended into a gate verdict, so the two evidence classes stay
+distinguishable in every output.
+
+One replay-evidence turn is scripted:
+
+```bash
+scripts/ops/replay_evidence.sh
+```
+
+The script mirrors the Stage-2 cycle turn's universe and granularity so the
+replay measures the proposer set that is actually running: it snapshot-builds
+the paper universe from read-only public Coinbase candles
+(`ideas snapshot build --from-coinbase`), runs one tournament per symbol with
+the active pair (`baseline-ma-10-50,regime-aware-ma-10-50` — the deterministic
+baseline is the benchmark side of the edge comparison), then renders the
+scorecard with all reports attached. Each run writes a self-contained
+directory under `var/data/trade_ideas/replay_evidence/<UTC timestamp>/`:
+the snapshot, per-symbol tournament reports, and the durable scorecard
+artifact. Override `REPLAY_SYMBOLS`, `REPLAY_GRANULARITY`, `REPLAY_LOOKBACK`,
+`REPLAY_PROPOSERS`, or `REPLAY_EVIDENCE_DIR` per invocation; everything is
+broker-free and never reads accounts or places orders.
+
+To attach replay evidence to any scorecard render by hand:
+
+```bash
+uv run gpt-trader ideas scorecard \
+  --replay-report var/data/trade_ideas/replay_evidence/<run>/tournament_BTC-USD.json \
+  --replay-report var/data/trade_ideas/replay_evidence/<run>/tournament_ETH-USD.json
+```
+
+Both raw replay artifacts and the CliResponse envelope written by
+`--format json --output <path>` are accepted. Interpretation: per-proposer
+`target_hit_rate` / `stop_hit_rate` are the replay read on risk calibration,
+`average_return_r` is the replay read on expectancy, and the `edge vs
+baseline-ma-…` lines are the replay read on benchmark edge.
+
 ## Readiness Evidence Inputs
 
 Paper trading produces evidence that feeds the readiness checklist; it does not

--- a/scripts/ops/replay_evidence.sh
+++ b/scripts/ops/replay_evidence.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# One replay-evidence turn for the Stage 1 -> 2 scorecard (issue #1216).
+#
+# Builds a point-in-time snapshot of the paper universe from read-only public
+# Coinbase candles, replays the active proposer set head-to-head against the
+# deterministic baseline over that window (one tournament per symbol), and
+# renders the scorecard with every tournament report attached. Replay results
+# are reported as replay-labeled evidence alongside the wall-clock gates —
+# never blended into them — so calibration, expectancy, and benchmark edge
+# read now while wall-clock track-record depth accrues in parallel.
+#
+# Everything here is broker-free: no accounts are read and no orders are
+# placed, modified, or canceled. Each run writes a self-contained evidence
+# directory (snapshot, per-symbol tournament reports, scorecard artifact)
+# under REPLAY_EVIDENCE_DIR so runs are comparable over time.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+# Schedulers start jobs with a minimal PATH; make uv reachable whether it was
+# installed by the Astral installer (~/.local/bin) or Homebrew.
+export PATH="${HOME}/.local/bin:/opt/homebrew/bin:/usr/local/bin:${PATH}"
+
+# Defaults mirror the Stage-2 cycle turn (scripts/ops/stage2_cycle_turn.sh):
+# same universe and granularity, so replay evidence measures the proposer set
+# that is actually running. The proposer ids are the cycle's active pair —
+# the deterministic baseline plus the regime-aware overlay — at the cycle's
+# default MA windows (10/50).
+: "${REPLAY_SYMBOLS:=BTC-USD,ETH-USD,SOL-USD,XRP-USD,LTC-USD,LINK-USD,AVAX-USD,DOT-USD}"
+: "${REPLAY_GRANULARITY:=ONE_HOUR}"
+: "${REPLAY_LOOKBACK:=300}"
+: "${REPLAY_PROPOSERS:=baseline-ma-10-50,regime-aware-ma-10-50}"
+: "${REPLAY_EVIDENCE_DIR:=var/data/trade_ideas/replay_evidence}"
+
+RUN_DIR="${REPLAY_EVIDENCE_DIR}/$(date -u +%Y%m%dT%H%M%SZ)"
+mkdir -p "${RUN_DIR}"
+
+uv run gpt-trader ideas snapshot build --from-coinbase \
+  --symbols "${REPLAY_SYMBOLS}" \
+  --granularity "${REPLAY_GRANULARITY}" \
+  --lookback "${REPLAY_LOOKBACK}" \
+  --out "${RUN_DIR}/snapshot.json" \
+  --format json >"${RUN_DIR}/snapshot_build.json"
+
+REPORT_FLAGS=()
+IFS=',' read -r -a SYMBOLS <<<"${REPLAY_SYMBOLS}"
+for symbol in "${SYMBOLS[@]}"; do
+  report="${RUN_DIR}/tournament_${symbol}.json"
+  uv run gpt-trader ideas replay tournament \
+    --file "${RUN_DIR}/snapshot.json" \
+    --symbol "${symbol}" \
+    --granularity "${REPLAY_GRANULARITY}" \
+    --proposers "${REPLAY_PROPOSERS}" \
+    --format json \
+    --output "${report}"
+  REPORT_FLAGS+=(--replay-report "${report}")
+done
+
+exec uv run gpt-trader ideas scorecard "${REPORT_FLAGS[@]}" --output-dir "${RUN_DIR}"

--- a/src/gpt_trader/cli/commands/ideas.py
+++ b/src/gpt_trader/cli/commands/ideas.py
@@ -810,9 +810,10 @@ def register(subparsers: Any) -> None:
         "--proposers",
         required=True,
         help=(
-            "Comma-separated proposer ids: baseline-ma-<short>-<long> or "
+            "Comma-separated proposer ids: baseline-ma-<short>-<long>, "
+            "regime-aware-ma-<short>-<long>, or "
             f"strategy-backed ids ({', '.join(STRATEGY_BACKED_PROPOSER_IDS)}), "
-            "for example baseline-ma-2-4,strategy-baseline-spot"
+            "for example baseline-ma-10-50,regime-aware-ma-10-50"
         ),
     )
     tournament.add_argument(
@@ -1689,29 +1690,45 @@ def _tournament_entries(args: Namespace) -> list[tuple[Proposer, int]]:
                     _strategy_replay_floor(strategy_name)[0],
                 )
             )
+        elif proposer_id.startswith("regime-aware-ma-"):
+            config = _ma_config_from_proposer_id(args, proposer_id, prefix="regime-aware-ma")
+            regime_config = RegimeConfig()
+            entries.append(
+                (
+                    RegimeAwareProposer(
+                        RegimeAwareProposerConfig(
+                            baseline_config=config,
+                            regime_config=regime_config,
+                        ),
+                    ),
+                    _default_regime_replay_min_history(config, regime_config),
+                )
+            )
         else:
-            config = _baseline_config_from_proposer_id(args, proposer_id)
+            config = _ma_config_from_proposer_id(args, proposer_id, prefix="baseline-ma")
             entries.append((BaselineProposer(config), _default_replay_min_history(config)))
     return entries
 
 
-def _baseline_config_from_proposer_id(
+def _ma_config_from_proposer_id(
     args: Namespace,
     proposer_id: str,
+    *,
+    prefix: str,
 ) -> BaselineProposerConfig:
-    parts = proposer_id.split("-")
-    if len(parts) != 4 or parts[0] != "baseline" or parts[1] != "ma":
+    parts = proposer_id.removeprefix(f"{prefix}-").split("-")
+    if not proposer_id.startswith(f"{prefix}-") or len(parts) != 2:
         raise CandleInputError(
             (
                 f"Unsupported proposer id '{proposer_id}'; expected "
-                "baseline-ma-<short>-<long> or one of "
+                "baseline-ma-<short>-<long>, regime-aware-ma-<short>-<long>, or one of "
                 f"{', '.join(STRATEGY_BACKED_PROPOSER_IDS)}"
             ),
             field="proposers",
         )
     try:
-        short_window = int(parts[2])
-        long_window = int(parts[3])
+        short_window = int(parts[0])
+        long_window = int(parts[1])
     except ValueError as error:
         raise CandleInputError(
             (f"Unsupported proposer id '{proposer_id}'; expected numeric MA windows"),

--- a/tests/unit/gpt_trader/cli/commands/test_ideas_replay_tournament.py
+++ b/tests/unit/gpt_trader/cli/commands/test_ideas_replay_tournament.py
@@ -244,3 +244,68 @@ def test_replay_tournament_rejects_unknown_proposer_id(
     assert exit_code == 1
     assert response["errors"][0]["code"] == CliErrorCode.INVALID_ARGUMENT.value
     assert response["errors"][0]["details"]["field"] == "proposers"
+
+
+def _regime_history_fixture() -> dict[str, list[dict[str, str]]]:
+    """55 flat closes (the regime-aware floor for ma-2-4) then a crossover tail."""
+    closes = ["100"] * 55 + ["110", "90", "112", "112", "132"]
+    return {
+        "candles": [
+            _candle(index - len(closes), open_=close, high=close, low=close, close=close)
+            for index, close in enumerate(closes)
+        ]
+    }
+
+
+def test_replay_tournament_ranks_regime_aware_beside_baseline(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    fixture = _write_fixture(tmp_path / "regime-candles.json", _regime_history_fixture())
+    argv = _tournament_args(fixture)
+    argv[argv.index("--proposers") + 1] = "baseline-ma-2-4,regime-aware-ma-2-4"
+
+    exit_code, response = _run_json(capsys, argv)
+
+    assert exit_code == 0
+    data = response["data"]
+    assert data["proposer_count"] == 2
+    proposer_ids = {report["proposer_id"] for report in data["reports"]}
+    assert proposer_ids == {"baseline-ma-2-4", "regime-aware-ma-2-4"}
+    # The shared window starts at the regime-confirmation floor and both
+    # proposers trade: the regime-aware proposer only relabels confidence.
+    assert all(report["ideas_proposed"] >= 1 for report in data["reports"])
+
+
+def test_replay_tournament_regime_aware_floor_dominates_min_history(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    fixture = _write_fixture(tmp_path / "regime-candles.json", _regime_history_fixture())
+    argv = _tournament_args(fixture)
+    argv[argv.index("--proposers") + 1] = "baseline-ma-2-4,regime-aware-ma-2-4"
+    argv.extend(["--min-history", "10"])
+
+    exit_code, response = _run_json(capsys, argv)
+
+    assert exit_code == 1
+    assert response["errors"][0]["code"] == CliErrorCode.INVALID_ARGUMENT.value
+    # The shared window floor is the regime-aware proposer's confirmation
+    # floor (long-EMA 50 + min-regime-ticks 5 = 55), not the baseline's.
+    assert "--min-history must be at least 55" in response["errors"][0]["message"]
+
+
+def test_replay_tournament_rejects_malformed_regime_aware_windows(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    fixture = _write_fixture(tmp_path / "candles.json", _tournament_fixture())
+    argv = _tournament_args(fixture)
+    argv[argv.index("--proposers") + 1] = "regime-aware-ma-2"
+
+    exit_code, response = _run_json(capsys, argv)
+
+    assert exit_code == 1
+    assert response["errors"][0]["code"] == CliErrorCode.INVALID_ARGUMENT.value
+    assert response["errors"][0]["details"]["field"] == "proposers"
+    assert "regime-aware-ma-<short>-<long>" in response["errors"][0]["message"]


### PR DESCRIPTION
Closes #1216 (M4/W4, part of #1212).

## What

Three scorecard gates (`risk_calibration`, `expectancy`, `benchmark_edge`) need closed-idea outcomes and a 60-day wall-clock window. The replay plumbing to read them now already existed (`ideas replay`, `build_replay_evidence`, `ideas scorecard --replay-report`) — but the tournament runner couldn't replay the **active** proposer set: `regime-aware` had no tournament proposer id, so the cycle's actual pair could never produce a head-to-head benchmark edge.

- `ideas replay tournament` now accepts `regime-aware-ma-<short>-<long>` (baseline MA config + default `RegimeConfig`, min-history floor = long-EMA 50 + min-regime-ticks 5). `--proposers` help and the unsupported-id error enumerate all three id forms.
- New `scripts/ops/replay_evidence.sh`: one repeatable replay-evidence turn mirroring the Stage-2 cycle's universe/granularity — snapshot-build the 8-symbol paper universe from read-only public Coinbase candles, run one tournament per symbol with `baseline-ma-10-50,regime-aware-ma-10-50`, render the scorecard with all reports attached, and write a self-contained run directory (snapshot + reports + durable scorecard artifact) under `var/data/trade_ideas/replay_evidence/<UTC ts>/`. Env-overridable (`REPLAY_SYMBOLS`, `REPLAY_GRANULARITY`, `REPLAY_LOOKBACK`, `REPLAY_PROPOSERS`, `REPLAY_EVIDENCE_DIR`). Broker-free.
- `docs/paper_trading.md`: "Replay Evidence for the Stage 1 → 2 Scorecard" section documenting the workflow and how to interpret the replay-labeled rows.

## Exit criteria mapping

- *Calibration / expectancy / benchmark edge measurable (replay-labeled)*: verified live — a 2-symbol run of the script rendered per-proposer `target_hit_rate`/`stop_hit_rate` (calibration), `average_return_r` (expectancy), and `edge vs baseline-ma-10-50` lines (benchmark edge) for both active proposers over 244 evaluated snapshots per symbol.
- *Replay and wall-clock evidence stay distinguished*: replay sections are labeled `replay-derived; reported alongside wall-clock, not blended into gates`; gate verdicts are untouched (existing `build_replay_evidence` contract, unchanged).

Honest finding from the verification run: the regime-aware overlay only relabels confidence, so its replay entries/exits are identical to baseline — edge reads exactly 0.0000. That's the alpha story (parked as M5), now measurable.

## Verification

- `uv run local-ci` (pr profile): all checks pass.
- New tests: regime-aware ranks beside baseline in a tournament, regime floor (55) dominates `--min-history`, malformed regime-aware id rejected with the updated message.
- End-to-end script run against live public candles produced the full evidence directory and scorecard render.