### PR TITLE
fix(trade-ideas): skip proposals whose rounded levels have no defined risk (#1226)

### DIFF
--- a/docs/paper_trading.md
+++ b/docs/paper_trading.md
@@ -354,7 +354,10 @@ directory under `var/data/trade_ideas/replay_evidence/<UTC timestamp>/`:
 the snapshot, per-symbol tournament reports, and the durable scorecard
 artifact. Override `REPLAY_SYMBOLS`, `REPLAY_GRANULARITY`, `REPLAY_LOOKBACK`,
 `REPLAY_PROPOSERS`, or `REPLAY_EVIDENCE_DIR` per invocation; everything is
-broker-free and never reads accounts or places orders.
+broker-free and never reads accounts or places orders. A symbol whose
+tournament fails keeps its error envelope in the run directory as evidence
+but is excluded from the scorecard render; the turn only fails when every
+tournament fails.
 
 To attach replay evidence to any scorecard render by hand:
 

--- a/scripts/ops/replay_evidence.sh
+++ b/scripts/ops/replay_evidence.sh
@@ -47,14 +47,25 @@ REPORT_FLAGS=()
 IFS=',' read -r -a SYMBOLS <<<"${REPLAY_SYMBOLS}"
 for symbol in "${SYMBOLS[@]}"; do
   report="${RUN_DIR}/tournament_${symbol}.json"
-  uv run gpt-trader ideas replay tournament \
+  # A failed tournament writes its error envelope to the report path — kept
+  # as run evidence, excluded from the scorecard render. One symbol must not
+  # abort the turn: the other symbols' evidence still renders.
+  if ! uv run gpt-trader ideas replay tournament \
     --file "${RUN_DIR}/snapshot.json" \
     --symbol "${symbol}" \
     --granularity "${REPLAY_GRANULARITY}" \
     --proposers "${REPLAY_PROPOSERS}" \
     --format json \
-    --output "${report}"
+    --output "${report}"; then
+    echo "replay_evidence: tournament failed for ${symbol}; error envelope kept at ${report}" >&2
+    continue
+  fi
   REPORT_FLAGS+=(--replay-report "${report}")
 done
+
+if [ ${#REPORT_FLAGS[@]} -eq 0 ]; then
+  echo "replay_evidence: every tournament failed; no scorecard rendered (see ${RUN_DIR})" >&2
+  exit 1
+fi
 
 exec uv run gpt-trader ideas scorecard "${REPORT_FLAGS[@]}" --output-dir "${RUN_DIR}"

--- a/src/gpt_trader/cli/commands/ideas.py
+++ b/src/gpt_trader/cli/commands/ideas.py
@@ -2293,7 +2293,13 @@ def _load_replay_report_payload(path: Path) -> Mapping[str, Any]:
     # 'ideas replay ... --format json --output <path>'.
     data = payload.get("data")
     if isinstance(data, Mapping) and "proposer_id" not in payload and "reports" not in payload:
-        return data
+        payload = data
+    if "proposer_id" not in payload and "reports" not in payload:
+        raise ValueError(
+            f"Replay report '{path}' is not a replay artifact (no proposer_id or "
+            "reports field); a failed 'ideas replay' run writes its error "
+            "envelope to --output, so check the run succeeded"
+        )
     return payload
 
 

--- a/src/gpt_trader/features/trade_ideas/baseline.py
+++ b/src/gpt_trader/features/trade_ideas/baseline.py
@@ -134,6 +134,14 @@ class BaselineProposer:
         target = (close + config.reward_multiple * (close - stop_level)).quantize(
             config.price_precision
         )
+        # On low-priced symbols the price precision can round the stop, entry
+        # midpoint, and target into a set with no defined risk per unit (e.g.
+        # a $0.82 close within half a cent of the long average at 0.01
+        # precision). A trade whose stop is not strictly below the entry
+        # midpoint and target is not proposable.
+        entry_midpoint = (entry_lower + entry_upper) / 2
+        if not stop_level < entry_midpoint < target:
+            return None
         # Size against the worst permitted long entry (the top of the entry
         # zone): a fill at entry_upper is explicitly allowed, so the persisted
         # risk snapshot must not assume a cheaper fill at the last close.

--- a/tests/unit/gpt_trader/cli/commands/test_ideas_scorecard.py
+++ b/tests/unit/gpt_trader/cli/commands/test_ideas_scorecard.py
@@ -154,6 +154,48 @@ def test_scorecard_writes_output_dir_artifact(
     assert artifact["schema_version"] == "gpt-trader.trade_ideas.scorecard.v1"
 
 
+def test_scorecard_rejects_failure_envelope_replay_report(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # A failed 'ideas replay' run writes its error envelope to --output
+    # (data null, no reports); the scorecard must name the file instead of
+    # leaking a KeyError (#1226).
+    root = tmp_path / "ideas"
+    failed_path = tmp_path / "failed-tournament.json"
+    failed_path.write_text(
+        json.dumps(
+            {
+                "success": False,
+                "exit_code": 1,
+                "data": None,
+                "errors": [{"code": "VALIDATION_ERROR", "message": "boom"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    exit_code = cli.main(
+        [
+            "ideas",
+            "scorecard",
+            "--ideas-root",
+            str(root),
+            "--replay-report",
+            str(failed_path),
+            "--format",
+            "json",
+        ]
+    )
+    output = capsys.readouterr().out
+
+    assert exit_code != 0
+    response = json.loads(output)
+    assert response["success"] is False
+    assert "not a replay artifact" in response["errors"][0]["message"]
+    assert "failed-tournament.json" in response["errors"][0]["message"]
+
+
 def test_scorecard_rejects_unreadable_replay_report(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],

--- a/tests/unit/gpt_trader/features/trade_ideas/test_baseline_proposer.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_baseline_proposer.py
@@ -180,6 +180,24 @@ def test_stale_crossover_outside_lookback_produces_nothing() -> None:
     assert BaselineProposer(CONFIG).propose(snapshot_of(make_series(stale))) == []
 
 
+def test_degenerate_rounded_levels_produce_nothing() -> None:
+    # A sub-dollar close within half a cent of the long average rounds the
+    # stop and the entry midpoint to the same 0.01-precision level, leaving
+    # no defined risk per unit (#1226): stop 0.82, entry zone 0.81-0.83.
+    degenerate = ["0.82"] * 29 + ["0.821"]
+
+    assert BaselineProposer(CONFIG).propose(snapshot_of(make_series(degenerate))) == []
+
+
+def test_sub_dollar_crossover_with_clear_ma_gap_still_proposes() -> None:
+    clear_gap = ["0.80"] * 28 + ["0.81", "0.83"]
+
+    ideas = BaselineProposer(CONFIG).propose(snapshot_of(make_series(clear_gap)))
+
+    assert len(ideas) == 1
+    assert ideas[0].direction is TradeDirection.LONG
+
+
 def test_insufficient_history_produces_nothing() -> None:
     short_history = ["100"] * 10 + ["102", "104"]
 


### PR DESCRIPTION
Closes #1226. Fallout from the first full W4 replay-evidence turn (#1216 / PR #1225).

## What

- **`BaselineProposer`**: skip a crossover proposal when the quantized levels do not strictly order (`stop < entry midpoint < target`). At DOT-USD ≈ \$0.82 with the default 0.01 precision, a close within half a cent of the 50-bar average produced stop 0.82 / entry zone 0.81–0.83 (midpoint 0.82) / target 0.83 — zero risk per unit at the midpoint. The regime-aware proposer is covered by delegation. **This also protects the live Stage-2 cycle**, which runs the same deterministic proposer on the same universe and would have admitted the same degenerate idea into the paper loop on the next tight DOT crossover.
- **`ideas scorecard --replay-report`**: a payload that is not a replay artifact (e.g. the error envelope a failed `ideas replay … --output` run writes) now fails with a clear message naming the file, instead of `✗ ideas scorecard FAILED: 'proposer_id'`.
- **`scripts/ops/replay_evidence.sh`**: one symbol's tournament failure no longer aborts the turn — the error envelope stays in the run directory as evidence, the symbol is excluded from the scorecard render, and the turn only fails when every tournament fails. Documented in the paper-trading replay-evidence section.

## Verification

- Reproduced the DOT failure against the saved 2026-07-07 snapshot, then confirmed with the fix: `ideas replay tournament` on DOT-USD completes (244 snapshots, 4 ideas proposed, degenerate one skipped, 3 resolved).
- New tests: degenerate sub-dollar rounding proposes nothing; a clear-gap sub-dollar crossover still proposes; scorecard rejects a failure envelope naming the file.
- `uv run local-ci` (pr profile) passes.