### PR TITLE
feat(core): trading-calendar service for session-aware market hours (#1228)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ dependencies = [
     "cryptography>=48.0.1,<49.0.0",
     "pyjwt>=2.9.0,<3.0.0",
     "pandas>=2.3.3,<3.0.0",
+    # Trading-session calendars (gpt_trader.core.trading_calendar, #1228)
+    "exchange-calendars>=4.10,<5.0.0",
     # Transitive security fixes (pin minimum versions for CVE patches)
     "urllib3>=2.6.0,<3.0.0",   # GHSA-gm62-xv2j-4w53, GHSA-2xpw-w6gg-jr37
 ]

--- a/src/gpt_trader/core/trading_calendar.py
+++ b/src/gpt_trader/core/trading_calendar.py
@@ -1,0 +1,176 @@
+"""Session-aware trading calendar for market-hours questions.
+
+Implements the trading-calendar service scoped in
+``docs/decisions/venue-neutrality-posture.md`` (the first leak-watch item):
+for a session identifier, answer whether the market is open at instant T,
+which session date contains T, and when the next open/close occurs.
+
+Two sessions are supported:
+
+- ``24x7`` — crypto. Always open; the session date is the UTC calendar
+  date, matching ``trading_day`` in ``risk_units.py`` (which stays as-is;
+  this module is the session-aware counterpart).
+- ``XNYS`` — US equities, regular hours only, backed by the
+  ``exchange_calendars`` package. The dependency stays behind this module;
+  callers only ever see stdlib ``datetime``/``date`` values.
+
+Timezone rule follows the repo convention (``risk_units.py``): naive
+datetimes are treated as UTC, never host-local time.
+
+Consumers (ratchet day boundary, snapshot staleness, scheduler windows) are
+NOT wired here — that migration is venue phase P1-E.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from functools import lru_cache
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    import pandas
+
+SESSION_24X7 = "24x7"
+SESSION_XNYS = "XNYS"
+
+SUPPORTED_SESSIONS = (SESSION_24X7, SESSION_XNYS)
+
+
+def _as_utc(moment: datetime) -> datetime:
+    """Normalize ``moment`` to aware UTC; naive datetimes are treated as UTC."""
+    if moment.tzinfo is None:
+        return moment.replace(tzinfo=UTC)
+    return moment.astimezone(UTC)
+
+
+class TradingCalendar(Protocol):
+    """Market-hours questions for one trading session.
+
+    ``next_open``/``next_close`` return the earliest boundary strictly after
+    ``moment`` (asking at the exact open instant yields the following
+    session's open), or ``None`` when the session has no such boundary
+    (a 24/7 market never opens or closes).
+    """
+
+    @property
+    def session_id(self) -> str:
+        """Identifier of the session this calendar answers for."""
+        ...
+
+    def is_open(self, moment: datetime) -> bool:
+        """Return True when the market is open at ``moment``.
+
+        The open instant counts as open; the close instant counts as closed.
+        """
+        ...
+
+    def session_date(self, moment: datetime) -> date:
+        """Return the date of the session containing ``moment``.
+
+        When the market is closed at ``moment``, this is the most recent
+        session at or before ``moment`` — activity between sessions belongs
+        to the session that just ended.
+        """
+        ...
+
+    def next_open(self, moment: datetime) -> datetime | None:
+        """Return the earliest open strictly after ``moment``, if any."""
+        ...
+
+    def next_close(self, moment: datetime) -> datetime | None:
+        """Return the earliest close strictly after ``moment``, if any."""
+        ...
+
+
+class AlwaysOpenCalendar:
+    """The ``24x7`` session (crypto): always open, session date = UTC date."""
+
+    @property
+    def session_id(self) -> str:
+        return SESSION_24X7
+
+    def is_open(self, moment: datetime) -> bool:
+        return True
+
+    def session_date(self, moment: datetime) -> date:
+        return _as_utc(moment).date()
+
+    def next_open(self, moment: datetime) -> datetime | None:
+        return None
+
+    def next_close(self, moment: datetime) -> datetime | None:
+        return None
+
+
+class ExchangeBackedCalendar:
+    """A regular-hours exchange session backed by ``exchange_calendars``.
+
+    Wraps the third-party calendar so the dependency does not leak: inputs
+    and outputs are stdlib ``datetime``/``date``. Queries outside the backing
+    calendar's bounds (roughly twenty years back to one year ahead) raise
+    ``ValueError`` from the underlying package.
+    """
+
+    def __init__(self, session_id: str) -> None:
+        # Deliberate lazy import: gpt_trader.core stays stdlib-only at import
+        # time, and the dependency remains an implementation detail.
+        import exchange_calendars
+
+        self._session_id = session_id
+        self._calendar = exchange_calendars.get_calendar(session_id)
+
+    @property
+    def session_id(self) -> str:
+        return self._session_id
+
+    def is_open(self, moment: datetime) -> bool:
+        return bool(self._calendar.is_open_at_time(self._as_timestamp(moment)))
+
+    def session_date(self, moment: datetime) -> date:
+        session = self._calendar.minute_to_session(
+            self._as_timestamp(moment).floor("min"), direction="previous"
+        )
+        return date(session.year, session.month, session.day)
+
+    def next_open(self, moment: datetime) -> datetime | None:
+        return self._as_datetime(self._calendar.next_open(self._as_timestamp(moment)))
+
+    def next_close(self, moment: datetime) -> datetime | None:
+        return self._as_datetime(self._calendar.next_close(self._as_timestamp(moment)))
+
+    @staticmethod
+    def _as_timestamp(moment: datetime) -> pandas.Timestamp:
+        import pandas
+
+        return pandas.Timestamp(_as_utc(moment))
+
+    @staticmethod
+    def _as_datetime(timestamp: pandas.Timestamp) -> datetime:
+        # pd.Timestamp subclasses datetime; hand callers the plain stdlib type.
+        return timestamp.to_pydatetime().astimezone(UTC)
+
+
+@lru_cache(maxsize=None)
+def get_trading_calendar(session_id: str) -> TradingCalendar:
+    """Return the calendar for ``session_id`` (one of ``SUPPORTED_SESSIONS``).
+
+    Instances are cached: building an exchange-backed calendar materializes
+    years of schedule, so repeated lookups share one instance.
+    """
+    if session_id == SESSION_24X7:
+        return AlwaysOpenCalendar()
+    if session_id == SESSION_XNYS:
+        return ExchangeBackedCalendar(SESSION_XNYS)
+    supported = ", ".join(SUPPORTED_SESSIONS)
+    raise ValueError(f"Unknown trading session {session_id!r} (supported: {supported})")
+
+
+__all__ = [
+    "SESSION_24X7",
+    "SESSION_XNYS",
+    "SUPPORTED_SESSIONS",
+    "AlwaysOpenCalendar",
+    "ExchangeBackedCalendar",
+    "TradingCalendar",
+    "get_trading_calendar",
+]

--- a/tests/unit/gpt_trader/core/test_trading_calendar.py
+++ b/tests/unit/gpt_trader/core/test_trading_calendar.py
@@ -1,0 +1,133 @@
+"""Tests for the session-aware trading calendar.
+
+These pin the service scoped by docs/decisions/venue-neutrality-posture.md
+and issue #1228: the 24x7 session must reproduce the existing UTC
+``trading_day`` semantics, and XNYS must answer regular-hours questions
+(holidays and early closes included) without leaking the backing package's
+types.
+
+XNYS fixtures use historical facts that never change: EDT regular hours are
+13:30-20:00 UTC, 2026-07-03 is the observed Independence Day holiday
+(2026-07-04 is a Saturday), and 2025-12-24 is a 13:00 ET early close.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, timedelta, timezone
+
+import pytest
+
+from gpt_trader.core.risk_units import trading_day
+from gpt_trader.core.trading_calendar import (
+    SESSION_24X7,
+    SESSION_XNYS,
+    AlwaysOpenCalendar,
+    ExchangeBackedCalendar,
+    TradingCalendar,
+    get_trading_calendar,
+)
+
+# A regular XNYS trading day: Monday 2026-07-06, 09:30-16:00 EDT.
+_MONDAY_OPEN = datetime(2026, 7, 6, 13, 30, tzinfo=UTC)
+_MONDAY_MIDDAY = datetime(2026, 7, 6, 18, 0, tzinfo=UTC)
+_MONDAY_CLOSE = datetime(2026, 7, 6, 20, 0, tzinfo=UTC)
+
+
+@pytest.fixture(scope="module")
+def xnys() -> TradingCalendar:
+    return ExchangeBackedCalendar(SESSION_XNYS)
+
+
+class TestAlwaysOpenSession:
+    def test_is_always_open(self) -> None:
+        calendar = AlwaysOpenCalendar()
+        assert calendar.session_id == SESSION_24X7
+        assert calendar.is_open(datetime(2026, 7, 4, 3, 0, tzinfo=UTC))  # weekend
+        assert calendar.is_open(datetime(2025, 12, 25, 12, 0))  # holiday, naive
+
+    def test_session_date_matches_trading_day(self) -> None:
+        calendar = AlwaysOpenCalendar()
+        moments = [
+            datetime(2026, 7, 3, 23, 59, 59, tzinfo=UTC),
+            datetime(2026, 7, 3, 23, 30),  # naive -> UTC, not host-local
+            datetime(2026, 7, 3, 20, 0, tzinfo=timezone(timedelta(hours=-5))),
+        ]
+        for moment in moments:
+            assert calendar.session_date(moment) == trading_day(moment)
+
+    def test_no_open_or_close_boundaries(self) -> None:
+        calendar = AlwaysOpenCalendar()
+        moment = datetime(2026, 7, 6, 12, 0, tzinfo=UTC)
+        assert calendar.next_open(moment) is None
+        assert calendar.next_close(moment) is None
+
+
+class TestXnysSession:
+    def test_regular_hours(self, xnys: TradingCalendar) -> None:
+        assert xnys.session_id == SESSION_XNYS
+        assert not xnys.is_open(datetime(2026, 7, 6, 13, 0, tzinfo=UTC))  # pre-open
+        assert xnys.is_open(_MONDAY_OPEN)  # open instant counts as open
+        assert xnys.is_open(_MONDAY_MIDDAY)
+        assert not xnys.is_open(_MONDAY_CLOSE)  # close instant counts as closed
+
+    def test_closed_on_weekends_and_holidays(self, xnys: TradingCalendar) -> None:
+        assert not xnys.is_open(datetime(2026, 7, 4, 15, 0, tzinfo=UTC))  # Saturday
+        # Independence Day 2026 falls on a Saturday; observed Friday 07-03.
+        assert not xnys.is_open(datetime(2026, 7, 3, 15, 0, tzinfo=UTC))
+        assert not xnys.is_open(datetime(2025, 12, 25, 15, 0, tzinfo=UTC))
+
+    def test_early_close_half_day(self, xnys: TradingCalendar) -> None:
+        # Christmas Eve 2025 closes at 13:00 EST (18:00 UTC).
+        assert xnys.is_open(datetime(2025, 12, 24, 17, 0, tzinfo=UTC))
+        assert not xnys.is_open(datetime(2025, 12, 24, 19, 0, tzinfo=UTC))
+        early_close = xnys.next_close(datetime(2025, 12, 24, 15, 0, tzinfo=UTC))
+        assert early_close == datetime(2025, 12, 24, 18, 0, tzinfo=UTC)
+
+    def test_session_date_during_session(self, xnys: TradingCalendar) -> None:
+        assert xnys.session_date(_MONDAY_MIDDAY) == date(2026, 7, 6)
+
+    def test_session_date_when_closed_is_most_recent_session(self, xnys: TradingCalendar) -> None:
+        # After Monday's close the session is still Monday's.
+        assert xnys.session_date(datetime(2026, 7, 6, 22, 0, tzinfo=UTC)) == date(2026, 7, 6)
+        # Saturday 07-04 reaches back across the observed holiday to Thursday.
+        assert xnys.session_date(datetime(2026, 7, 4, 15, 0, tzinfo=UTC)) == date(2026, 7, 2)
+
+    def test_next_open(self, xnys: TradingCalendar) -> None:
+        saturday = datetime(2026, 7, 4, 12, 0, tzinfo=UTC)
+        assert xnys.next_open(saturday) == _MONDAY_OPEN
+        # Strictly after: during Monday's session the next open is Tuesday's.
+        assert xnys.next_open(_MONDAY_MIDDAY) == datetime(2026, 7, 7, 13, 30, tzinfo=UTC)
+
+    def test_next_close(self, xnys: TradingCalendar) -> None:
+        assert xnys.next_close(_MONDAY_MIDDAY) == _MONDAY_CLOSE
+
+    def test_naive_datetimes_are_treated_as_utc(self, xnys: TradingCalendar) -> None:
+        # 18:00 naive means 18:00 UTC (14:00 EDT, mid-session) on any host.
+        naive_midday = datetime(2026, 7, 6, 18, 0)
+        assert xnys.is_open(naive_midday)
+        assert xnys.session_date(naive_midday) == date(2026, 7, 6)
+        assert xnys.next_close(naive_midday) == _MONDAY_CLOSE
+
+    def test_offset_datetimes_are_normalized(self, xnys: TradingCalendar) -> None:
+        # 09:31 US/Eastern (EDT, UTC-4) is one minute into the session.
+        eastern_open = datetime(2026, 7, 6, 9, 31, tzinfo=timezone(timedelta(hours=-4)))
+        assert xnys.is_open(eastern_open)
+
+    def test_backing_package_types_do_not_leak(self, xnys: TradingCalendar) -> None:
+        next_open = xnys.next_open(_MONDAY_MIDDAY)
+        assert type(next_open) is datetime  # not a pandas.Timestamp subclass
+        assert next_open is not None and next_open.tzinfo == UTC
+        assert type(xnys.session_date(_MONDAY_MIDDAY)) is date
+
+
+class TestGetTradingCalendar:
+    def test_returns_supported_sessions(self) -> None:
+        assert get_trading_calendar(SESSION_24X7).session_id == SESSION_24X7
+        assert get_trading_calendar(SESSION_XNYS).session_id == SESSION_XNYS
+
+    def test_instances_are_cached(self) -> None:
+        assert get_trading_calendar(SESSION_XNYS) is get_trading_calendar(SESSION_XNYS)
+
+    def test_unknown_session_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unknown trading session"):
+            get_trading_calendar("XNAS")

--- a/uv.lock
+++ b/uv.lock
@@ -375,6 +375,23 @@ wheels = [
 ]
 
 [[package]]
+name = "exchange-calendars"
+version = "4.13.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "korean-lunar-calendar" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "pyluach" },
+    { name = "toolz" },
+    { name = "tzdata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/73/460b0ece4e7444e3098b7738974c822787e134578d069d3a88b4be17d50a/exchange_calendars-4.13.2.tar.gz", hash = "sha256:a9459425dd64142cd54fbc639847403c7e0c33d60fbc326c94fc1d6bd127f002", size = 4137321, upload-time = "2026-03-10T03:24:38.536Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/4c/0469b40057bc9f8d9594dcc6024202626b981ae4b52dfcd304552e8e1c3a/exchange_calendars-4.13.2-py3-none-any.whl", hash = "sha256:fc5a2ad0d61b5c3a6539a3061cd4cbb55c59f4a903455cec7926e4b798919996", size = 213306, upload-time = "2026-03-10T03:24:37.055Z" },
+]
+
+[[package]]
 name = "execnet"
 version = "2.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -463,6 +480,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },
+    { name = "exchange-calendars" },
     { name = "pandas" },
     { name = "pydantic" },
     { name = "pyjwt" },
@@ -522,6 +540,7 @@ dev = [
 requires-dist = [
     { name = "aiohttp", marker = "extra == 'live-trade'", specifier = ">=3.12.15,<4.0.0" },
     { name = "cryptography", specifier = ">=48.0.1,<49.0.0" },
+    { name = "exchange-calendars", specifier = ">=4.10,<5.0.0" },
     { name = "fastapi", marker = "extra == 'web'", specifier = ">=0.115.0,<1.0.0" },
     { name = "jinja2", marker = "extra == 'web'", specifier = ">=3.1.4,<4.0.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.25.0,<2.0.0" },
@@ -690,6 +709,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "korean-lunar-calendar"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/9f/6160e95f3934026194dc7a0b5c78fe5c6e74761830ddea3e9cfc38e3f983/korean_lunar_calendar-0.4.0.tar.gz", hash = "sha256:be56f27bc0594fdbbdf7bbe00f504a9f929a31e311bd7d9bb93561b645afade7", size = 13425, upload-time = "2026-06-15T14:19:57.163Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/88/f56033b09fdca5c8c5e5fc2f3513950a05cd62caa9bd8e6d2750a887c86e/korean_lunar_calendar-0.4.0-py3-none-any.whl", hash = "sha256:c042e20de0bb702add6bec8d0f6da1ea8d3b170838e63846f70420cf341fe4e7", size = 11323, upload-time = "2026-06-15T14:19:56.089Z" },
 ]
 
 [[package]]
@@ -1303,6 +1331,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyluach"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/11/42568c1568a75f8803c59f26d29af01a0890352b7a8e03d41ecda8bfb5dd/pyluach-2.3.0.tar.gz", hash = "sha256:ec6e30669d1df50c9ca160486da44a8195bb4c7a5d3d533990d0c5b03accd281", size = 26910, upload-time = "2025-09-09T20:24:39.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/c8/f96208ade3ca4c23b372497d0788bcf0f2e0ff4310e5ee693366bc33fdf0/pyluach-2.3.0-py3-none-any.whl", hash = "sha256:4497b731aef59508b079dbf5f00bc5bf4329ac45090a6cd37b5a83756f0e69ab", size = 25914, upload-time = "2025-09-09T20:24:37.831Z" },
+]
+
+[[package]]
 name = "pyparsing"
 version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1590,6 +1627,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
+]
+
+[[package]]
+name = "toolz"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/d6/114b492226588d6ff54579d95847662fc69196bdeec318eb45393b24c192/toolz-1.1.0.tar.gz", hash = "sha256:27a5c770d068c110d9ed9323f24f1543e83b2f300a687b7891c1a6d56b697b5b", size = 52613, upload-time = "2025-10-17T04:03:21.661Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl", hash = "sha256:15ccc861ac51c53696de0a5d6d4607f99c210739caf987b5d2054f3efed429d8", size = 58093, upload-time = "2025-10-17T04:03:20.435Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Closes #1228 (Venues P1-A, per `docs/decisions/venue-neutrality-posture.md`).

Adds `src/gpt_trader/core/trading_calendar.py`: a core-layer trading-calendar service that answers, for a session identifier, the three market-hours questions — is the market open at instant T, which session date contains T, and when is the next open/close. Library + tests only; no consumer is migrated (that is P1-E, #1232) and nothing existing changes behavior (`trading_day` in `risk_units.py` is untouched).

Related issue / finding / routed package: #1228 (workstream of #1224)

### Design choices
- **Sessions:** `24x7` (crypto — always open, session date = UTC calendar date, matching `risk_units.trading_day`) and `XNYS` (US equities regular hours). `get_trading_calendar(session_id)` is the cached factory; unknown sessions raise `ValueError`.
- **Interface:** `TradingCalendar` Protocol with `is_open` / `session_date` / `next_open` / `next_close`. Boundary semantics: open instant counts as open, close instant as closed; `next_open`/`next_close` are strictly-after and return `None` when the session has no boundary (24/7). When the market is closed, `session_date` is the most recent session at or before T (post-close activity belongs to the session that just ended) — the natural fit for the ratchet's same-day loss window, revisitable in P1-E.
- **Dependency:** XNYS is backed by `exchange-calendars>=4.10,<5.0.0` (resolved 4.13.2) rather than hand-rolled holiday rules. The package stays behind the wrapper: imports are lazy (so `gpt_trader.core` stays stdlib-only at import time) and all inputs/outputs are stdlib `datetime`/`date` — a test pins that `pandas.Timestamp` does not leak.
- **Timezones:** naive datetimes are treated as UTC, per the `risk_units.py` convention.
- Tests use stable historical facts: 2026-07-03 observed Independence Day holiday, 2025-12-24 early close (13:00 ET), EDT/EST offsets.

## Type of change
- [x] Feature

## Scope & Impact
- Affected areas / components: `src/gpt_trader/core/trading_calendar.py` (new), tests, `pyproject.toml`/`uv.lock` (new dep)
- Any behavior changes? No — pure library addition, nothing imports it yet.

## Test Plan
- [x] Unit tests added/updated (`tests/unit/gpt_trader/core/test_trading_calendar.py`, 16 tests)
- [x] Ran locally: full unit suite green (6769 passed)

## Quality Gates
- [x] `uv run local-ci` passes locally (all blocking steps PASS)
- [x] `uv run mypy src/gpt_trader` clean
- [x] No `sys.path` hacks in tests
- [x] Import boundaries respected

## Observability & Errors
- N/A — pure functions, no I/O paths.

## Breaking Changes
- [x] None

## Safety boundary
Pure library addition; no broker calls, no behavior change to the paper loop.