### PR TITLE
feat(core): structured Instrument taxonomy behind the opaque instrument string (#1230)

### DIFF
--- a/src/gpt_trader/core/__init__.py
+++ b/src/gpt_trader/core/__init__.py
@@ -24,6 +24,14 @@ from gpt_trader.core.errors import (
     RateLimitError,
 )
 
+# Instrument taxonomy
+from gpt_trader.core.instruments import (
+    AssetClass,
+    Instrument,
+    InstrumentParseError,
+    ProductType,
+)
+
 # Market data types
 from gpt_trader.core.market import (
     Candle,
@@ -60,6 +68,11 @@ __all__ = [
     "TimeInForce",
     "MarketType",
     "OrderStatus",
+    # Instrument taxonomy
+    "AssetClass",
+    "Instrument",
+    "InstrumentParseError",
+    "ProductType",
     # Market data
     "Candle",
     "Quote",

--- a/src/gpt_trader/core/instruments.py
+++ b/src/gpt_trader/core/instruments.py
@@ -1,0 +1,89 @@
+"""Structured instrument taxonomy behind the opaque instrument string.
+
+Persisted records (trade ideas, audit events, exports) keep the plain string
+form — those records are content-hashed, so their serialization must never
+change. This module supplies the structured view derived from that string:
+an :class:`Instrument` value type plus a total, loud-on-ambiguity classifier
+for the two legacy shapes (crypto spot pairs like ``BTC-USD`` and bare equity
+tickers like ``AAPL``). See docs/decisions/venue-neutrality-posture.md.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+
+
+class AssetClass(str, Enum):
+    """Top-level asset-class vocabulary for instruments."""
+
+    CRYPTO = "crypto"
+    EQUITY = "equity"
+
+
+class ProductType(str, Enum):
+    """Product-structure vocabulary shared by trade ideas and budget layers."""
+
+    SPOT = "spot"
+    FUTURES = "futures"
+    OPTIONS = "options"
+    EVENT_CONTRACT = "event_contract"
+    OTHER = "other"
+
+
+class InstrumentParseError(ValueError):
+    """Raised when an instrument string does not match a known shape.
+
+    The classifier refuses to guess: anything that is not unambiguously a
+    crypto ``BASE-QUOTE`` pair or a bare uppercase equity ticker is an error.
+    """
+
+
+# BASE-QUOTE pair, e.g. BTC-USD: uppercase alphanumeric segments, one dash.
+_CRYPTO_PAIR = re.compile(r"^[A-Z0-9]+-[A-Z0-9]+$")
+# Bare uppercase ticker, e.g. AAPL: letters only.
+_EQUITY_TICKER = re.compile(r"^[A-Z]+$")
+
+
+@dataclass(frozen=True, slots=True)
+class Instrument:
+    """Structured identity of a tradeable instrument.
+
+    ``symbol`` preserves the exact string used by persisted records, snapshot
+    contracts, broker payloads, and busy-instrument tracking — those continue
+    to key on the string; this type only adds structure on top of it.
+    """
+
+    symbol: str
+    asset_class: AssetClass
+    product_type: ProductType
+
+    @classmethod
+    def parse(cls, raw: str) -> Instrument:
+        """Classify a legacy instrument string into a structured instrument.
+
+        Rules (total, no guessing):
+
+        - ``BASE-QUOTE`` pairs of uppercase alphanumeric segments
+          (``BTC-USD``) -> crypto spot.
+        - Bare uppercase tickers (``AAPL``) -> equity spot.
+        - Anything else raises :class:`InstrumentParseError`.
+        """
+        if _CRYPTO_PAIR.fullmatch(raw):
+            return cls(
+                symbol=raw,
+                asset_class=AssetClass.CRYPTO,
+                product_type=ProductType.SPOT,
+            )
+        if _EQUITY_TICKER.fullmatch(raw):
+            return cls(
+                symbol=raw,
+                asset_class=AssetClass.EQUITY,
+                product_type=ProductType.SPOT,
+            )
+        raise InstrumentParseError(
+            f"ambiguous instrument string {raw!r}: expected an uppercase "
+            "BASE-QUOTE crypto pair (e.g. 'BTC-USD') or a bare uppercase "
+            "equity ticker (e.g. 'AAPL')"
+        )

--- a/src/gpt_trader/features/trade_ideas/models.py
+++ b/src/gpt_trader/features/trade_ideas/models.py
@@ -20,6 +20,8 @@ from decimal import Decimal
 from enum import Enum
 from typing import Any
 
+from gpt_trader.core.instruments import Instrument, ProductType
+
 _SAFE_DECISION_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 
 
@@ -32,14 +34,6 @@ class AutonomyMode(str, Enum):
     RESEARCH_ONLY = "research_only"
     HUMAN_APPROVED_EXECUTION = "human_approved_execution"
     BOUNDED_AUTONOMY = "bounded_autonomy"
-
-
-class ProductType(str, Enum):
-    SPOT = "spot"
-    FUTURES = "futures"
-    OPTIONS = "options"
-    EVENT_CONTRACT = "event_contract"
-    OTHER = "other"
 
 
 class TradeDirection(str, Enum):
@@ -359,6 +353,18 @@ class TradeIdea:
     def __post_init__(self) -> None:
         if not is_safe_decision_id(self.decision_id):
             raise ValueError("decision_id must be a safe path segment")
+
+    @property
+    def instrument_info(self) -> Instrument:
+        """Structured view of the instrument string (derived, never persisted).
+
+        The persisted schema keeps ``instrument`` as a plain string: idea
+        records are content-hashed and audit events chain on those hashes, so
+        the serialized form must not change. Raises
+        :class:`gpt_trader.core.instruments.InstrumentParseError` when the
+        string does not match a known shape.
+        """
+        return Instrument.parse(self.instrument)
 
     def to_dict(self) -> dict[str, Any]:
         payload: dict[str, Any] = {

--- a/tests/unit/gpt_trader/core/test_instruments.py
+++ b/tests/unit/gpt_trader/core/test_instruments.py
@@ -1,0 +1,83 @@
+"""Tests for the structured instrument taxonomy (core/instruments.py)."""
+
+from __future__ import annotations
+
+import pytest
+
+from gpt_trader.core.instruments import (
+    AssetClass,
+    Instrument,
+    InstrumentParseError,
+    ProductType,
+)
+
+
+@pytest.mark.parametrize("raw", ["BTC-USD", "ETH-USD", "SOL-USDC", "1INCH-USD"])
+def test_parse_classifies_base_quote_pairs_as_crypto_spot(raw: str) -> None:
+    instrument = Instrument.parse(raw)
+
+    assert instrument == Instrument(
+        symbol=raw,
+        asset_class=AssetClass.CRYPTO,
+        product_type=ProductType.SPOT,
+    )
+
+
+@pytest.mark.parametrize("raw", ["AAPL", "F", "GOOGL", "TSLA"])
+def test_parse_classifies_bare_uppercase_tickers_as_equity(raw: str) -> None:
+    instrument = Instrument.parse(raw)
+
+    assert instrument == Instrument(
+        symbol=raw,
+        asset_class=AssetClass.EQUITY,
+        product_type=ProductType.SPOT,
+    )
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "",
+        " ",
+        "btc-usd",  # lowercase pair
+        "aapl",  # lowercase ticker
+        "BTC-USD-PERP",  # more than one dash: contract structure is out of scope
+        "BTC-",  # missing quote segment
+        "-USD",  # missing base segment
+        "BRK.B",  # share-class dot: ambiguous, refuse to guess
+        "BTC/USD",  # wrong separator
+        "AAPL ",  # stray whitespace
+        "ES2026",  # digits in a bare token: not a bare equity ticker
+    ],
+)
+def test_parse_is_loud_on_ambiguous_strings(raw: str) -> None:
+    with pytest.raises(InstrumentParseError, match="ambiguous instrument string"):
+        Instrument.parse(raw)
+
+
+def test_parse_error_is_a_value_error() -> None:
+    with pytest.raises(ValueError):
+        Instrument.parse("???")
+
+
+def test_instrument_preserves_the_exact_symbol_string() -> None:
+    assert Instrument.parse("BTC-USD").symbol == "BTC-USD"
+    assert Instrument.parse("AAPL").symbol == "AAPL"
+
+
+def test_product_type_vocabulary_is_unchanged() -> None:
+    # Persisted trade-idea records serialize these exact values; the enum
+    # moved to core but its vocabulary must not drift.
+    assert [member.value for member in ProductType] == [
+        "spot",
+        "futures",
+        "options",
+        "event_contract",
+        "other",
+    ]
+
+
+def test_feature_layer_reexports_the_same_product_type() -> None:
+    from gpt_trader.features.trade_ideas import ProductType as FeatureProductType
+
+    assert FeatureProductType is ProductType

--- a/tests/unit/gpt_trader/features/trade_ideas/test_models_instrument.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_models_instrument.py
@@ -1,0 +1,104 @@
+"""Golden-record and instrument-accessor tests for TradeIdea.
+
+The golden payload and its record hash were captured from a TradeIdea
+serialized BEFORE the structured Instrument taxonomy existed (#1230). Idea
+records are content-hashed and audit events chain on those hashes, so this
+test failing means the persisted schema changed and the audit trail would be
+corrupted. Do not update the pinned hash to make it pass — fix the
+serialization instead.
+"""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+from tests.unit.gpt_trader.features.trade_ideas.conftest import build_trade_idea
+
+from gpt_trader.core.instruments import (
+    AssetClass,
+    Instrument,
+    InstrumentParseError,
+    ProductType,
+)
+from gpt_trader.features.trade_ideas import TradeIdea
+
+# Captured on main at c681c6ec, before core/instruments.py existed.
+GOLDEN_RECORD_HASH = "350ec4901f3f6c8ccc409628c656384882c307af0d19d95159215076b841d58d"
+
+GOLDEN_PAYLOAD: dict[str, object] = {
+    "decision_id": "trade-20260612-001",
+    "autonomy_mode": "human_approved_execution",
+    "thesis": "BTC reclaiming the 50-day average with rising spot volume",
+    "instrument": "BTC-USD",
+    "product_type": "spot",
+    "direction": "long",
+    "entry_zone": {"lower": "60000", "upper": "61500", "trigger": ""},
+    "invalidation": "Daily close below 58000",
+    "target_exit": "Take profit at 67000 or exit after 10 trading days",
+    "max_loss": {
+        "amount": "250",
+        "percent_of_account": "1.5",
+        "assumptions": ["Fill at zone midpoint", "No slippage beyond 10 bps"],
+    },
+    "sizing_recommendation": {
+        "quantity": "0.1",
+        "notional": "6075",
+        "rationale": "Half-Kelly on backtested edge",
+    },
+    "time_horizon": {
+        "expected_hold": "3-10 days",
+        "expires_at": "2026-06-19T16:00:00+00:00",
+    },
+    "data_used": ["coinbase:candles:BTC-USD:1d:2026-06-11"],
+    "confidence": {
+        "label": "medium",
+        "rationale": "Volume confirmation present, macro calendar risk this week",
+    },
+    "failure_mode": "False breakout into a macro-driven selloff",
+    "do_not_trade_if": ["FOMC announcement within 24 hours"],
+    "broker_ticket": {"venue": "none", "status": "not_created"},
+}
+
+
+def test_golden_record_round_trips_unchanged() -> None:
+    idea = TradeIdea.from_dict(copy.deepcopy(GOLDEN_PAYLOAD))
+
+    assert idea.to_dict() == GOLDEN_PAYLOAD
+    assert isinstance(idea.to_dict()["instrument"], str)
+
+
+def test_golden_record_hash_is_pinned() -> None:
+    idea = TradeIdea.from_dict(copy.deepcopy(GOLDEN_PAYLOAD))
+
+    assert idea.record_hash() == GOLDEN_RECORD_HASH
+
+
+def test_instrument_info_derives_structure_from_the_string() -> None:
+    idea = build_trade_idea()
+
+    assert idea.instrument_info == Instrument(
+        symbol="BTC-USD",
+        asset_class=AssetClass.CRYPTO,
+        product_type=ProductType.SPOT,
+    )
+
+
+def test_instrument_info_classifies_equity_tickers() -> None:
+    idea = build_trade_idea(instrument="AAPL")
+
+    assert idea.instrument_info.asset_class is AssetClass.EQUITY
+
+
+def test_instrument_info_is_loud_on_ambiguous_strings() -> None:
+    idea = build_trade_idea(instrument="btc/usd")
+
+    with pytest.raises(InstrumentParseError, match="ambiguous instrument string"):
+        _ = idea.instrument_info
+
+
+def test_instrument_info_is_derived_and_never_persisted() -> None:
+    payload = build_trade_idea().to_dict()
+
+    assert "instrument_info" not in payload
+    assert "asset_class" not in payload


### PR DESCRIPTION
## Summary
Closes #1230 (Venues P1-C, Phase-1 workstream of #1224).

Introduces the structured instrument taxonomy the venue-neutrality record flags as the "instrument-as-string is thin" leak-watch item, while leaving every persisted byte untouched:

- **`gpt_trader/core/instruments.py`** — new `Instrument` frozen value type (`symbol`, `asset_class`, `product_type`), `AssetClass` vocabulary (`crypto` | `equity`), and `InstrumentParseError`.
- **Total, loud-on-ambiguity classifier** `Instrument.parse`: uppercase `X-Y` pairs (`BTC-USD`) → crypto spot; bare uppercase tickers (`AAPL`) → equity spot; everything else (lowercase, extra dashes, dots, digits-in-bare-token, whitespace) raises `InstrumentParseError` rather than guessing.
- **`TradeIdea.instrument_info`** — derived property returning the structured form; lazy, never persisted.

### Import-boundary design rationale
The issue offered two options: define a parallel core-level product vocabulary and map from the feature layer, or relocate `ProductType`. I **relocated `ProductType` from `features/trade_ideas/models.py` to `core/instruments.py` and re-export it from the feature module**, because:

- `core` must not import feature slices, but the `trade_ideas` dependency freeze in `scripts/ci/check_import_boundaries.py` explicitly allows `features.trade_ideas` → `gpt_trader.core`, so the relocated import is a legal edge (guard passes).
- A parallel core enum + mapping layer would create two vocabularies for one concept — exactly the "two risk vocabularies" smell this repo already paid to remove (#1120).
- It is a `str` Enum with identical values (`spot`/`futures`/`options`/`event_contract`/`other`), and the re-export means `from gpt_trader.features.trade_ideas import ProductType` still yields the *same class object* — zero serialization or identity change. A test pins both facts (`test_product_type_vocabulary_is_unchanged`, `test_feature_layer_reexports_the_same_product_type`).

Pre-existing note (untouched): `core/account.py` has its own `ProductType = Literal["SPOT", "FUTURE"]` alias, module-local and never exported from `gpt_trader.core`; unifying it is out of scope here.

### The critical invariant: persisted schema unchanged
`TradeIdea.instrument` stays a plain string in `to_dict`/`from_dict`; idea records are content-hashed (`record_hash`) and audit events chain on those hashes. New golden-record tests (`tests/unit/gpt_trader/features/trade_ideas/test_models_instrument.py`) pin a payload serialized on main @ `c681c6ec` **before this change** and assert it round-trips byte-identically and hashes to the pinned literal `350ec4901f3f6c8ccc409628c656384882c307af0d19d95159215076b841d58d` after it.

### Explicitly not touched (per issue)
Snapshot contracts, broker payloads, and busy-instrument tracking continue to key on the string — consumer adoption comes with #1231/#1232. Options/futures contract structure and venue routing are out of scope.

## Type of change
- [x] Feature

## Scope & Impact
- Affected areas / components: `gpt_trader/core` (new module + exports), `features/trade_ideas/models.py` (enum relocation re-export + derived accessor).
- Any behavior changes? None on any execution/persistence path; `instrument_info` is a new derived accessor that raises `InstrumentParseError` on ambiguous strings (tested).

## Test Plan
- [x] Unit tests added/updated (`tests/unit/gpt_trader/core/test_instruments.py`, `tests/unit/gpt_trader/features/trade_ideas/test_models_instrument.py`)
- [ ] Integration tests added/updated (n/a — type + parser + accessor only)
- [ ] Contract tests (if applicable) (n/a)
- [x] Ran locally: full unit suite `uv run pytest tests/unit -n auto -q` — 6782 passed
- [x] Markers used appropriately

## Quality Gates
- [x] `uv run local-ci` passes locally (all blocking steps PASS)
- [x] `uv run mypy src/gpt_trader` clean
- [x] No `sys.path` hacks in tests; `AsyncMock` (not `MagicMock`) on `async def`
- [x] Import boundaries respected (`scripts/ci/check_import_boundaries.py` passes)

## Observability & Errors
- [x] Errors include diagnostic context (`InstrumentParseError` message carries the raw string and the accepted forms)

## Agent Artifacts & Config (if touched)
- n/a (no `var/agents/**`-relevant inputs changed; docs untouched)

## Breaking Changes
- [x] None