### PR TITLE
feat(recorder): equities snapshot source from keyless daily candles (#1229)

### DIFF
--- a/src/gpt_trader/cli/commands/ideas.py
+++ b/src/gpt_trader/cli/commands/ideas.py
@@ -55,9 +55,12 @@ from gpt_trader.features.live_trade.strategies.mean_reversion import MeanReversi
 from gpt_trader.features.live_trade.strategies.regime_switcher import RegimeSwitchingStrategy
 from gpt_trader.features.recorder import (
     DEFAULT_COINBASE_BASE_URL,
+    DEFAULT_EQUITIES_SNAPSHOT_SOURCE_LABEL,
     DEFAULT_SNAPSHOT_SOURCE_LABEL,
+    DEFAULT_STOOQ_BASE_URL,
     MarketSnapshotBuildRequest,
     build_coinbase_market_snapshot,
+    build_equities_market_snapshot,
     canonical_granularity,
 )
 from gpt_trader.features.strategy_tools import (
@@ -297,12 +300,12 @@ def register(subparsers: Any) -> None:
     snapshot_subparsers = snapshot.add_subparsers(dest="snapshot_command", required=True)
     snapshot_build = snapshot_subparsers.add_parser(
         "build",
-        help="Fetch read-only Coinbase candles and write a MarketSnapshot JSON file",
+        help="Fetch read-only market candles and write a MarketSnapshot JSON file",
         description=(
-            "Fetch public Coinbase market candles, enforce point-in-time snapshot "
+            "Fetch public market candles, enforce point-in-time snapshot "
             "bounds, and write a JSON file accepted by ideas propose-baseline. "
-            "This command requires --from-coinbase and never reads accounts or "
-            "places, modifies, or cancels orders."
+            "This command requires --from-coinbase or --from-stooq and never "
+            "reads accounts or places, modifies, or cancels orders."
         ),
     )
     snapshot_build.add_argument(
@@ -321,16 +324,24 @@ def register(subparsers: Any) -> None:
         type=Path,
         help=argparse.SUPPRESS,
     )
-    snapshot_build.add_argument(
+    snapshot_build_venue = snapshot_build.add_mutually_exclusive_group(required=True)
+    snapshot_build_venue.add_argument(
         "--from-coinbase",
         action="store_true",
-        required=True,
         help="Explicitly fetch read-only public Coinbase market candles",
+    )
+    snapshot_build_venue.add_argument(
+        "--from-stooq",
+        action="store_true",
+        help="Explicitly fetch read-only public Stooq daily equity candles (ONE_DAY only)",
     )
     snapshot_build.add_argument(
         "--symbols",
         required=True,
-        help="Comma-separated Coinbase product ids, for example BTC-USD,ETH-USD",
+        help=(
+            "Comma-separated symbols: Coinbase product ids (BTC-USD,ETH-USD) "
+            "or plain equity tickers with --from-stooq (AAPL,SPY)"
+        ),
     )
     snapshot_build.add_argument(
         "--granularity",
@@ -355,13 +366,22 @@ def register(subparsers: Any) -> None:
     )
     snapshot_build.add_argument(
         "--source-label",
-        default=DEFAULT_SNAPSHOT_SOURCE_LABEL,
-        help="Source label stamped into snapshot metadata",
+        default=None,
+        help=(
+            "Source label stamped into snapshot metadata "
+            f"(default: {DEFAULT_SNAPSHOT_SOURCE_LABEL} or "
+            f"{DEFAULT_EQUITIES_SNAPSHOT_SOURCE_LABEL} per venue)"
+        ),
     )
     snapshot_build.add_argument(
         "--coinbase-base-url",
         default=DEFAULT_COINBASE_BASE_URL,
         help="Coinbase API base URL for market-data reads",
+    )
+    snapshot_build.add_argument(
+        "--stooq-base-url",
+        default=DEFAULT_STOOQ_BASE_URL,
+        help="Stooq endpoint base URL for daily equity candle reads",
     )
     snapshot_build.set_defaults(handler=_handle_snapshot_build, subcommand="snapshot build")
 
@@ -1949,7 +1969,10 @@ def _handle_snapshot_build(args: Namespace) -> CliResponse:
             lookback=args.lookback,
             as_of=_snapshot_as_of(args.as_of),
         )
-        snapshot = asyncio.run(_build_coinbase_market_snapshot(args, request))
+        if getattr(args, "from_stooq", False):
+            snapshot = asyncio.run(_build_equities_market_snapshot(args, request))
+        else:
+            snapshot = asyncio.run(_build_coinbase_market_snapshot(args, request))
         payload = market_snapshot_to_payload(snapshot)
         args.out.parent.mkdir(parents=True, exist_ok=True)
         args.out.write_text(
@@ -1978,7 +2001,19 @@ async def _build_coinbase_market_snapshot(
     return await build_coinbase_market_snapshot(
         request,
         base_url=args.coinbase_base_url,
-        source_label=args.source_label,
+        source_label=args.source_label or DEFAULT_SNAPSHOT_SOURCE_LABEL,
+    )
+
+
+async def _build_equities_market_snapshot(
+    args: Namespace,
+    request: MarketSnapshotBuildRequest,
+) -> MarketSnapshot:
+    # Snapshot production is recorder-owned; the CLI only adapts arguments.
+    return await build_equities_market_snapshot(
+        request,
+        base_url=args.stooq_base_url,
+        source_label=args.source_label or DEFAULT_EQUITIES_SNAPSHOT_SOURCE_LABEL,
     )
 
 

--- a/src/gpt_trader/features/recorder/__init__.py
+++ b/src/gpt_trader/features/recorder/__init__.py
@@ -5,7 +5,8 @@ Extraction of the recorder role from the accepted five-role composition
 execution, so recording state is constructed by the composition root and
 injected into the trading engine rather than owned by it. This slice holds
 price-tick persistence/recovery, MarketSnapshot production over the
-read-only Coinbase candle transport, and the standalone recording loop
+read-only candle transports (Coinbase market candles and Stooq daily
+equity candles), and the standalone recording loop
 behind ``gpt-trader record`` (issue #1158). The engine's WS telemetry
 stream converges here only after strategy→proposer parity, per the
 decision record.
@@ -30,13 +31,18 @@ from gpt_trader.features.recorder.snapshot_builder import (
 )
 from gpt_trader.features.recorder.snapshot_source import (
     DEFAULT_COINBASE_BASE_URL,
+    DEFAULT_EQUITIES_SNAPSHOT_SOURCE_LABEL,
     DEFAULT_SNAPSHOT_SOURCE_LABEL,
+    DEFAULT_STOOQ_BASE_URL,
     build_coinbase_market_snapshot,
+    build_equities_market_snapshot,
 )
 
 __all__ = [
     "DEFAULT_COINBASE_BASE_URL",
+    "DEFAULT_EQUITIES_SNAPSHOT_SOURCE_LABEL",
     "DEFAULT_SNAPSHOT_SOURCE_LABEL",
+    "DEFAULT_STOOQ_BASE_URL",
     "EVENT_PRICE_TICK",
     "HistoricalCandleSource",
     "MAX_PRICE_HISTORY",
@@ -46,6 +52,7 @@ __all__ = [
     "MarketSnapshotBuilder",
     "PriceTickStore",
     "build_coinbase_market_snapshot",
+    "build_equities_market_snapshot",
     "canonical_granularity",
     "derive_recorder_bot_id",
     "granularity_duration",

--- a/src/gpt_trader/features/recorder/equities_candles.py
+++ b/src/gpt_trader/features/recorder/equities_candles.py
@@ -1,0 +1,185 @@
+"""Keyless daily equity candles from Stooq's public CSV endpoint.
+
+Recorder-owned equities market data (issue #1229): the second concrete
+``HistoricalCandleSource`` beside the Coinbase fetcher, feeding the
+venue-neutral trade-idea spine with daily stock bars for replay and paper
+evidence. Read-only public data; no credentials, no account or order paths.
+
+Granularity: ``ONE_DAY`` only. Stooq's keyless CSV endpoint serves daily
+session bars; intraday equity data requires a keyed vendor and is a recorded
+follow-up decision. Intraday requests are rejected loudly — this source never
+fabricates bars it does not have.
+
+Timestamp semantics: a daily equity bar summarizes one exchange session, not
+a UTC calendar day. Each candle is therefore timestamped at the US session
+close (16:00 America/New_York, DST-aware) converted to UTC, so a bar's
+timestamp never precedes the trading it summarizes and point-in-time
+snapshot bounds hold. The snapshot builder counts a candle as completed once
+``ts + ONE_DAY <= as_of``, so under this convention a session's bar becomes
+snapshot-eligible one calendar day after its close — deliberately
+conservative: it may lag one session but can never leak a bar from a session
+still in progress.
+
+Symbols stay venue-neutral: callers pass plain tickers (``AAPL``, ``SPY``);
+the Stooq-specific ``<ticker>.us`` form is an internal mapping here and
+never appears on the spine.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import csv
+from collections.abc import Callable
+from datetime import UTC, date, datetime, time
+from decimal import Decimal, InvalidOperation
+from io import StringIO
+from zoneinfo import ZoneInfo
+
+from gpt_trader.core import Candle
+from gpt_trader.errors import ValidationError
+
+DEFAULT_STOOQ_BASE_URL = "https://stooq.com"
+DAILY_GRANULARITY = "ONE_DAY"
+
+_US_EQUITY_SESSION_CLOSE = time(16, 0)
+_US_EQUITY_SESSION_TIMEZONE = ZoneInfo("America/New_York")
+_EXPECTED_CSV_HEADER = ("Date", "Open", "High", "Low", "Close", "Volume")
+
+
+class EquitiesCandleFeedError(ValidationError):
+    """Raised when the Stooq daily-candle feed cannot serve a request."""
+
+
+class StooqDailyCandleFetcher:
+    """Fetch completed daily equity candles from Stooq's keyless CSV endpoint.
+
+    Implements the recorder's ``HistoricalCandleSource`` protocol for plain
+    equity tickers at ``ONE_DAY`` granularity. One unauthenticated HTTP GET
+    per call; no connection state is kept between calls.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str = DEFAULT_STOOQ_BASE_URL,
+        http_get_text: Callable[[str], str] | None = None,
+        timeout_seconds: float = 10.0,
+    ) -> None:
+        """Initialize the fetcher.
+
+        Args:
+            base_url: Stooq endpoint root (overridable for tests).
+            http_get_text: Transport returning the response body for a URL;
+                defaults to a ``requests`` GET. Injected so tests never touch
+                the network.
+            timeout_seconds: Timeout for the default transport.
+        """
+        self._base_url = base_url.rstrip("/")
+        self._http_get_text = http_get_text or self._default_http_get_text
+        self._timeout_seconds = timeout_seconds
+
+    async def fetch_candles(
+        self,
+        *,
+        symbol: str,
+        granularity: str,
+        start: datetime,
+        end: datetime,
+    ) -> list[Candle]:
+        """Return daily candles for ``symbol`` with session-close timestamps in ``[start, end)``."""
+        if granularity != DAILY_GRANULARITY:
+            raise EquitiesCandleFeedError(
+                f"Stooq equities source serves {DAILY_GRANULARITY} candles only; "
+                f"got '{granularity}'. Intraday equity bars require a keyed vendor "
+                "(recorded follow-up decision) — refusing rather than fabricating bars.",
+                field="granularity",
+            )
+        stooq_symbol = _stooq_symbol(symbol)
+        url = (
+            f"{self._base_url}/q/d/l/?s={stooq_symbol}&i=d"
+            f"&d1={start.astimezone(UTC):%Y%m%d}&d2={end.astimezone(UTC):%Y%m%d}"
+        )
+        body = await asyncio.to_thread(self._http_get_text, url)
+        candles = _parse_daily_csv(body, symbol=symbol, stooq_symbol=stooq_symbol)
+        return [candle for candle in candles if start <= candle.ts < end]
+
+    def _default_http_get_text(self, url: str) -> str:
+        import requests
+
+        # Honest client identification; Stooq 404s the generic library UA.
+        response = requests.get(
+            url,
+            timeout=self._timeout_seconds,
+            headers={"User-Agent": "gpt-trader-recorder/1.0 (paper-trading research; read-only)"},
+        )
+        response.raise_for_status()
+        return response.text
+
+
+def _stooq_symbol(symbol: str) -> str:
+    """Map a venue-neutral ticker (``AAPL``) to Stooq's US form (``aapl.us``)."""
+    normalized = symbol.strip().lower()
+    if not normalized or "." in normalized:
+        raise EquitiesCandleFeedError(
+            f"Equity symbols must be plain tickers like AAPL or SPY; got '{symbol}'",
+            field="symbol",
+        )
+    return f"{normalized}.us"
+
+
+def _parse_daily_csv(body: str, *, symbol: str, stooq_symbol: str) -> list[Candle]:
+    stripped = body.strip()
+    if stripped.startswith("<") or stripped.lower() in {"access denied", "odmowa dostępu"}:
+        raise EquitiesCandleFeedError(
+            f"Stooq refused programmatic access for '{symbol}' (requested as "
+            f"'{stooq_symbol}'): the endpoint answered with a bot-detection "
+            f"challenge or an access denial instead of CSV. Retry later or "
+            f"revisit the vendor choice; this source never fabricates bars.",
+            field="candles",
+        )
+    rows = [row for row in csv.reader(StringIO(body)) if row]
+    header_ok = bool(rows) and tuple(cell.strip() for cell in rows[0]) == _EXPECTED_CSV_HEADER
+    if not header_ok or len(rows) < 2:
+        raise EquitiesCandleFeedError(
+            f"Stooq returned no daily candles for '{symbol}' (requested as "
+            f"'{stooq_symbol}'): unknown symbol, empty range, or unexpected "
+            f"response format",
+            field="candles",
+        )
+    candles = [_parse_daily_row(row, symbol=symbol) for row in rows[1:]]
+    candles.sort(key=lambda candle: candle.ts)
+    return candles
+
+
+def _parse_daily_row(row: list[str], *, symbol: str) -> Candle:
+    if len(row) != len(_EXPECTED_CSV_HEADER):
+        raise EquitiesCandleFeedError(
+            f"Malformed Stooq candle row for '{symbol}': {row!r}",
+            field="candles",
+        )
+    try:
+        session_date = date.fromisoformat(row[0].strip())
+        open_, high, low, close, volume = (Decimal(cell.strip()) for cell in row[1:6])
+    except (ValueError, InvalidOperation) as error:
+        raise EquitiesCandleFeedError(
+            f"Malformed Stooq candle row for '{symbol}': {row!r}",
+            field="candles",
+        ) from error
+    return Candle(
+        ts=_session_close_utc(session_date),
+        open=open_,
+        high=high,
+        low=low,
+        close=close,
+        volume=volume,
+    )
+
+
+def _session_close_utc(session_date: date) -> datetime:
+    """Timestamp a session's daily bar at the US market close, expressed in UTC."""
+    close_local = datetime.combine(
+        session_date,
+        _US_EQUITY_SESSION_CLOSE,
+        tzinfo=_US_EQUITY_SESSION_TIMEZONE,
+    )
+    return close_local.astimezone(UTC)

--- a/src/gpt_trader/features/recorder/snapshot_source.py
+++ b/src/gpt_trader/features/recorder/snapshot_source.py
@@ -1,14 +1,17 @@
-"""Recorder-owned Coinbase snapshot production.
+"""Recorder-owned snapshot production entry points.
 
 The recorder owns market-data acquisition: this module constructs the
-read-only Coinbase REST transport (public market candles, no auth) and
-produces ``MarketSnapshot`` artifacts through the builder. Consumers (the
-``ideas`` CLI, the Stage-1 paper cycle) receive snapshots from here instead
-of wiring clients ad hoc.
+read-only candle transports (public data, no auth) and produces
+``MarketSnapshot`` artifacts through the builder. Consumers (the ``ideas``
+CLI, the Stage-1 paper cycle) receive snapshots from here instead of wiring
+clients ad hoc. Two venues are served: Coinbase market candles and Stooq
+daily equity candles (``equities_candles.py``, which documents the
+session-close-in-UTC timestamp convention).
 """
 
 from __future__ import annotations
 
+from gpt_trader.features.recorder.equities_candles import DEFAULT_STOOQ_BASE_URL
 from gpt_trader.features.recorder.snapshot_builder import (
     MarketSnapshotBuilder,
     MarketSnapshotBuildRequest,
@@ -17,6 +20,7 @@ from gpt_trader.features.trade_ideas.snapshot import MarketSnapshot
 
 DEFAULT_COINBASE_BASE_URL = "https://api.coinbase.com"
 DEFAULT_SNAPSHOT_SOURCE_LABEL = "coinbase:market-candles"
+DEFAULT_EQUITIES_SNAPSHOT_SOURCE_LABEL = "stooq:market-candles"
 
 
 async def build_coinbase_market_snapshot(
@@ -51,3 +55,25 @@ async def build_coinbase_market_snapshot(
             client.close()
         except Exception:  # noqa: BLE001
             pass
+
+
+async def build_equities_market_snapshot(
+    request: MarketSnapshotBuildRequest,
+    *,
+    base_url: str = DEFAULT_STOOQ_BASE_URL,
+    source_label: str = DEFAULT_EQUITIES_SNAPSHOT_SOURCE_LABEL,
+) -> MarketSnapshot:
+    """Fetch keyless daily Stooq equity candles and build one snapshot.
+
+    ONE_DAY granularity only: the underlying source rejects intraday
+    requests loudly instead of fabricating bars. Symbols are plain tickers
+    (``AAPL``, ``SPY``); the Stooq symbol form stays inside the source. The
+    transport is one unauthenticated GET per symbol, nothing to close.
+    """
+    from gpt_trader.features.recorder.equities_candles import StooqDailyCandleFetcher
+
+    builder = MarketSnapshotBuilder(
+        StooqDailyCandleFetcher(base_url=base_url),
+        source_label=source_label,
+    )
+    return await builder.build(request)

--- a/tests/unit/gpt_trader/cli/commands/test_ideas_snapshot_build.py
+++ b/tests/unit/gpt_trader/cli/commands/test_ideas_snapshot_build.py
@@ -225,6 +225,38 @@ def test_snapshot_build_does_not_accept_response_output_sink(
     assert json.loads(out.read_text(encoding="utf-8")) == {"snapshot": True}
 
 
+def test_snapshot_build_from_stooq_routes_to_equities_builder(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    out = tmp_path / "snapshot.json"
+    captured: dict[str, Any] = {}
+
+    async def fake_equities_build(request: Any, **kwargs: Any) -> MarketSnapshot:
+        captured["request"] = request
+        captured["kwargs"] = kwargs
+        return _minimal_snapshot("AAPL", "ONE_DAY")
+
+    async def fail_coinbase_build(args: Any, request: Any) -> MarketSnapshot:
+        raise AssertionError("--from-stooq must not route to the Coinbase builder")
+
+    monkeypatch.setattr(ideas, "build_equities_market_snapshot", fake_equities_build)
+    monkeypatch.setattr(ideas, "_build_coinbase_market_snapshot", fail_coinbase_build)
+    argv = _snapshot_build_args(out)
+    argv[argv.index("--from-coinbase")] = "--from-stooq"
+    argv[argv.index("--symbols") + 1] = "AAPL"
+
+    exit_code, response = _run_json(capsys, argv)
+
+    assert exit_code == 0
+    assert captured["request"].symbols == ("AAPL",)
+    assert captured["kwargs"]["source_label"] == "stooq:market-candles"
+    assert captured["kwargs"]["base_url"] == "https://stooq.com"
+    assert response["data"]["snapshot"]["symbols"] == ["AAPL"]
+    assert out.exists()
+
+
 def test_snapshot_build_rejects_duplicate_symbols(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],

--- a/tests/unit/gpt_trader/features/recorder/test_equities_candles.py
+++ b/tests/unit/gpt_trader/features/recorder/test_equities_candles.py
@@ -1,0 +1,155 @@
+"""Stooq daily equity candle source: parsing, timestamps, and loud failures.
+
+All tests run against a fake HTTP transport; nothing touches the network.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+
+from gpt_trader.features.recorder.equities_candles import (
+    EquitiesCandleFeedError,
+    StooqDailyCandleFetcher,
+)
+
+START = datetime(2026, 6, 1, tzinfo=UTC)
+END = datetime(2026, 6, 12, tzinfo=UTC)
+
+NORMAL_CSV = (
+    "Date,Open,High,Low,Close,Volume\n"
+    "2026-06-08,100.0,102.5,99.5,101.25,1000000\n"
+    "2026-06-09,101.3,103.0,100.8,102.75,1200000\n"
+    "2026-06-10,102.8,104.2,102.0,103.5,900000\n"
+)
+WINTER_CSV = "Date,Open,High,Low,Close,Volume\n2026-01-05,100,101,99,100.5,500000\n"
+NO_DATA_RESPONSE = "No data"
+MALFORMED_ROW_CSV = (
+    "Date,Open,High,Low,Close,Volume\n"
+    "2026-06-08,100.0,102.5,99.5,101.25,1000000\n"
+    "2026-06-09,not-a-price,103.0,100.8,102.75,1200000\n"
+)
+
+
+class FakeHttpTransport:
+    def __init__(self, body: str) -> None:
+        self.body = body
+        self.urls: list[str] = []
+
+    def __call__(self, url: str) -> str:
+        self.urls.append(url)
+        return self.body
+
+
+def _fetcher(body: str) -> tuple[StooqDailyCandleFetcher, FakeHttpTransport]:
+    transport = FakeHttpTransport(body)
+    return StooqDailyCandleFetcher(http_get_text=transport), transport
+
+
+async def _fetch(
+    fetcher: StooqDailyCandleFetcher,
+    *,
+    symbol: str = "AAPL",
+    granularity: str = "ONE_DAY",
+    start: datetime = START,
+    end: datetime = END,
+):
+    return await fetcher.fetch_candles(symbol=symbol, granularity=granularity, start=start, end=end)
+
+
+@pytest.mark.asyncio
+async def test_fetch_parses_csv_and_timestamps_at_session_close_utc() -> None:
+    fetcher, transport = _fetcher(NORMAL_CSV)
+
+    candles = await _fetch(fetcher)
+
+    assert len(candles) == 3
+    first = candles[0]
+    # 2026-06-08 session close is 16:00 America/New_York (EDT) == 20:00 UTC.
+    assert first.ts == datetime(2026, 6, 8, 20, 0, tzinfo=UTC)
+    assert first.open == Decimal("100.0")
+    assert first.high == Decimal("102.5")
+    assert first.low == Decimal("99.5")
+    assert first.close == Decimal("101.25")
+    assert first.volume == Decimal("1000000")
+    assert [candle.ts for candle in candles] == sorted(candle.ts for candle in candles)
+    # Venue-neutral ticker maps to Stooq's <ticker>.us form inside the source.
+    assert transport.urls == ["https://stooq.com/q/d/l/?s=aapl.us&i=d&d1=20260601&d2=20260612"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_timestamps_winter_sessions_at_est_close() -> None:
+    fetcher, _ = _fetcher(WINTER_CSV)
+
+    candles = await _fetch(fetcher, start=datetime(2026, 1, 1, tzinfo=UTC), end=END)
+
+    # 2026-01-05 session close is 16:00 America/New_York (EST) == 21:00 UTC.
+    assert [candle.ts for candle in candles] == [datetime(2026, 1, 5, 21, 0, tzinfo=UTC)]
+
+
+@pytest.mark.asyncio
+async def test_fetch_filters_candles_outside_requested_window() -> None:
+    fetcher, _ = _fetcher(NORMAL_CSV)
+
+    candles = await _fetch(fetcher, end=datetime(2026, 6, 10, 0, 0, tzinfo=UTC))
+
+    # The 2026-06-10 session closes after the window end; only earlier bars remain.
+    assert [candle.ts for candle in candles] == [
+        datetime(2026, 6, 8, 20, 0, tzinfo=UTC),
+        datetime(2026, 6, 9, 20, 0, tzinfo=UTC),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_fetch_rejects_intraday_granularity_before_any_network_call() -> None:
+    fetcher, transport = _fetcher(NORMAL_CSV)
+
+    with pytest.raises(EquitiesCandleFeedError, match="ONE_DAY candles only"):
+        await _fetch(fetcher, granularity="ONE_HOUR")
+
+    assert transport.urls == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_raises_loudly_for_unknown_symbol_response() -> None:
+    fetcher, _ = _fetcher(NO_DATA_RESPONSE)
+
+    with pytest.raises(EquitiesCandleFeedError, match="no daily candles for 'NOPE'"):
+        await _fetch(fetcher, symbol="NOPE")
+
+
+@pytest.mark.asyncio
+async def test_fetch_raises_loudly_for_header_only_response() -> None:
+    fetcher, _ = _fetcher("Date,Open,High,Low,Close,Volume\n")
+
+    with pytest.raises(EquitiesCandleFeedError, match="no daily candles"):
+        await _fetch(fetcher)
+
+
+@pytest.mark.asyncio
+async def test_fetch_raises_loudly_for_bot_gate_or_access_denial() -> None:
+    for body in ("Access denied", "<!DOCTYPE html><html>challenge</html>"):
+        fetcher, _ = _fetcher(body)
+
+        with pytest.raises(EquitiesCandleFeedError, match="refused programmatic access"):
+            await _fetch(fetcher)
+
+
+@pytest.mark.asyncio
+async def test_fetch_raises_loudly_for_malformed_row() -> None:
+    fetcher, _ = _fetcher(MALFORMED_ROW_CSV)
+
+    with pytest.raises(EquitiesCandleFeedError, match="Malformed Stooq candle row"):
+        await _fetch(fetcher)
+
+
+@pytest.mark.asyncio
+async def test_fetch_rejects_non_plain_ticker_symbols() -> None:
+    fetcher, transport = _fetcher(NORMAL_CSV)
+
+    with pytest.raises(EquitiesCandleFeedError, match="plain tickers"):
+        await _fetch(fetcher, symbol="aapl.us")
+
+    assert transport.urls == []

--- a/tests/unit/gpt_trader/features/recorder/test_snapshot_source.py
+++ b/tests/unit/gpt_trader/features/recorder/test_snapshot_source.py
@@ -1,4 +1,4 @@
-"""Recorder-owned Coinbase snapshot source: transport wiring and cleanup."""
+"""Recorder-owned snapshot sources: transport wiring and cleanup."""
 
 from __future__ import annotations
 
@@ -9,7 +9,11 @@ import pytest
 
 from gpt_trader.core import Candle
 from gpt_trader.features.recorder import MarketSnapshotBuildRequest
-from gpt_trader.features.recorder.snapshot_source import build_coinbase_market_snapshot
+from gpt_trader.features.recorder.equities_candles import EquitiesCandleFeedError
+from gpt_trader.features.recorder.snapshot_source import (
+    build_coinbase_market_snapshot,
+    build_equities_market_snapshot,
+)
 
 AS_OF = datetime(2026, 6, 12, 12, 0, tzinfo=UTC)
 
@@ -123,3 +127,76 @@ async def test_build_closes_client_when_fetch_fails(
 
     assert len(clients) == 1
     assert clients[0].closed is True
+
+
+class FakeEquitiesFetcher:
+    base_urls: list[str] = []
+
+    def __init__(self, *, base_url: str) -> None:
+        FakeEquitiesFetcher.base_urls.append(base_url)
+
+    async def fetch_candles(
+        self,
+        *,
+        symbol: str,
+        granularity: str,
+        start: datetime,
+        end: datetime,
+    ) -> list[Candle]:
+        # Daily bars timestamped at US session close (20:00 UTC in June).
+        return [
+            Candle(
+                ts=datetime(2026, 6, day, 20, 0, tzinfo=UTC),
+                open=Decimal("100"),
+                high=Decimal("101"),
+                low=Decimal("99"),
+                close=Decimal("100.5"),
+                volume=Decimal("1000000"),
+            )
+            for day in (9, 10, 11)
+        ]
+
+
+@pytest.mark.asyncio
+async def test_build_equities_snapshot_labels_source_stooq(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    FakeEquitiesFetcher.base_urls = []
+    monkeypatch.setattr(
+        "gpt_trader.features.recorder.equities_candles.StooqDailyCandleFetcher",
+        FakeEquitiesFetcher,
+    )
+
+    snapshot = await build_equities_market_snapshot(
+        MarketSnapshotBuildRequest(
+            symbols=("AAPL",),
+            granularity="ONE_DAY",
+            lookback=2,
+            as_of=AS_OF,
+        )
+    )
+
+    assert FakeEquitiesFetcher.base_urls == ["https://stooq.com"]
+    assert snapshot.source.startswith("stooq:market-candles:granularity=ONE_DAY:lookback=2")
+    assert snapshot.symbols() == ("AAPL",)
+    # Only the 2026-06-10 session bar is both inside the lookback window and
+    # completed (ts + ONE_DAY <= as_of) before the 2026-06-12 12:00 as_of.
+    series = snapshot.series_for("AAPL")
+    assert series is not None
+    assert [candle.ts for candle in series.candles] == [
+        datetime(2026, 6, 10, 20, 0, tzinfo=UTC),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_build_equities_snapshot_rejects_intraday_granularity() -> None:
+    # Rejection happens before any transport call, so no network is touched.
+    with pytest.raises(EquitiesCandleFeedError, match="ONE_DAY candles only"):
+        await build_equities_market_snapshot(
+            MarketSnapshotBuildRequest(
+                symbols=("AAPL",),
+                granularity="ONE_HOUR",
+                lookback=2,
+                as_of=AS_OF,
+            )
+        )


### PR DESCRIPTION
Closes #1229

Phase-1 workstream of #1224: a second concrete `HistoricalCandleSource` beside Coinbase, serving daily equity bars to the venue-neutral spine.

## What

- `features/recorder/equities_candles.py`: `StooqDailyCandleFetcher` implementing the recorder's `HistoricalCandleSource` protocol against Stooq's keyless daily CSV endpoint (`/q/d/l/?s=<ticker>.us&i=d&d1=&d2=`). One unauthenticated GET per call, injectable transport.
- `build_equities_market_snapshot(request)` beside `build_coinbase_market_snapshot` in `snapshot_source.py`, source label `stooq:market-candles`.
- `ideas snapshot build` gains `--from-stooq` (mutually exclusive with `--from-coinbase`) and `--stooq-base-url`; `--source-label` now defaults per venue. Replay/proposers consume the resulting snapshots unchanged (venue-neutral `MarketSnapshot`).

## Contract choices (per issue spec)

- **ONE_DAY only.** Intraday granularities are rejected loudly before any network call; keyed intraday vendors stay a recorded follow-up decision. No multi-vendor abstraction.
- **Session-close timestamps in UTC.** A daily equity bar summarizes an exchange session, not a UTC day; candles are stamped at 16:00 America/New_York (DST-aware) converted to UTC. Documented in the module docstring, including the deliberately conservative interaction with the builder's `ts + ONE_DAY <= as_of` completion rule.
- **Venue-neutral symbols.** Callers pass plain tickers (`AAPL`, `SPY`); the `<ticker>.us` Stooq form never leaves the source.
- **Never fabricate bars.** Unknown symbols, empty ranges, malformed rows, and bot-gate/access-denial responses all raise `EquitiesCandleFeedError` with actionable messages.

## Tests

No network anywhere: the fetcher takes an injected `http_get_text` transport. Fixtures cover normal CSV, `No data` (unknown symbol), header-only, malformed row, bot-gate/denial bodies, DST winter/summer close times, window filtering, and intraday rejection; entry-point and CLI routing tests patch the fetcher/transport.

## Smoke test finding (important)

A live `ideas snapshot build --from-stooq --symbols AAPL` currently **fails**: stooq.com now fronts requests with a JavaScript proof-of-work bot gate, and even after that gate the `/q/d/l/` download endpoint answers `Access denied` (both stooq.com and stooq.pl; regular quote pages serve fine). The generic `python-requests` UA gets an outright 404. This matches public reports that Stooq restricted automated CSV downloads. I did not build any gate bypass into the source; it fails loudly with a clear message instead.

End-to-end behavior was verified against a local stand-in serving the documented CSV shape via `--stooq-base-url`: real transport, real CLI, real builder; the resulting snapshot feeds `ideas propose-baseline` cleanly. For comparison, Yahoo's keyless chart endpoint (`query1.finance.yahoo.com/v8/finance/chart/AAPL?interval=1d`) serves plain HTTP clients from the same machine — if Stooq's denial is not transient/IP-local, the vendor choice likely needs a follow-up decision before #1232 wires equities into any cycle.

## Verification

- `uv run local-ci` (pr profile): all PASS
- `uv run pytest tests/unit -n auto -q`: 6764 passed
- ruff / black / mypy / agent-naming: clean

Out of scope (unchanged): Stage-2 cycle/scripts wiring (#1232), tick recording, websockets, intraday vendors.