### PR TITLE
docs(status): record paper-profile drawdown-lever seed + agent ownership (#1217)

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -78,7 +78,13 @@ through one library call (`TradeIdeaService.portfolio_monitors`) by both
 `gpt-trader ideas monitors` and the console accountant page. The
 drawdown-from-peak appetite is a budget lever (`max_drawdown_from_peak_pct`,
 unset by default); a breach at any decision boundary ratchets autonomy down
-through the same audited path as the daily-loss trigger.
+through the same audited path as the daily-loss trigger. On the operational
+`paper` profile the lever is **seeded at 15%** (1.5x the 10% daily-loss cap;
+owner-approved 2026-07-07, budget version 3, #1217). The seed is a starting
+value, not an owner constant: per the [charter](DIRECTION.md), the durable
+owner of this lever is the agent, which renegotiates it through the same
+audited budget workflow as track record accumulates (the Stage 2 -> 3
+"budget renegotiation exercised" gate).
 
 **The promotion gates are now measurable in one command** (`ideas scorecard`,
 #1193): the Stage 1 -> 2 gates of the
@@ -89,9 +95,10 @@ applied, never from the batch cycle's run artifacts (test-enforced).
 Replay-derived calibration/edge over recorded snapshot windows reports
 alongside -- labeled, never blended into -- the wall-clock gates.
 Drawdown-from-peak now scores from the same equity ledger the monitors read
-(#1192); it stays not-yet-measurable until an operator sets the
-`max_drawdown_from_peak_pct` budget lever, so the scorecard cannot claim
-promotability until that appetite is configured.
+(#1192); it stays not-yet-measurable on any profile whose budget leaves the
+`max_drawdown_from_peak_pct` lever unset, so the scorecard cannot claim
+promotability until that appetite is configured. With the paper-profile seed
+in place (#1217), the gate is scoreable there.
 
 **The in-process event-driven lane exists behind a default-off gate**
 (`event_driven_paper_lane_enabled`, #1191) and is **operator-enabled on the


### PR DESCRIPTION
Part of #1212 (M4/W5, #1217).

The `max_drawdown_from_peak_pct` lever was seeded at **15%** on the operational `paper` profile today (owner-approved, budget version 3, via the audited `ideas budget set` path — operational state, not a repo change). This PR lands the documentation bullet of #1217:

- STATUS.md records the seed (value, date, budget version) and frames it as a tunable starting value, not an owner constant: the durable owner is the agent via audited budget renegotiation (the Stage 2 -> 3 "budget renegotiation exercised" gate, per DIRECTION.md).
- The scorecard paragraph now reflects that the drawdown gate is scoreable on paper (verified: `ideas scorecard` reports `max_drawdown_from_peak: pass`, 0.01% worst vs 15% limit).

Exit-criteria evidence for #1217 (all verified today):
- Lever is per-profile (ideas-root scoped), versioned, audited — `budget set` produced version 3 with all other fields carried over.
- `ideas monitors` reports `budget_version: 3`, `max_drawdown_from_peak_pct: "15"`, `drawdown_breached: false`.
- Breach-ratchet plumbing verified: 57 unit tests pass incl. `test_drawdown_breach_ratchets_bounded_autonomy_down`.

Closes #1217.