### PR TITLE
feat(cli): read-only 'orders suppressed' summary over dry-run suppression telemetry (#1109)

### DIFF
--- a/docs/production.md
+++ b/docs/production.md
@@ -114,7 +114,9 @@ Exit criteria:
 
 - Preflight report is current.
 - Runtime logs and status output are clean.
-- Risk guards produce expected decisions.
+- Risk guards produce expected decisions. Inspect the writes the dry run
+  suppressed with `uv run gpt-trader orders suppressed --profile canary`
+  (counts by action plus the most recent events).
 - Operator can stop the process and inspect state.
 
 ### Gate 3: Human-Approved Canary

--- a/src/gpt_trader/cli/commands/orders.py
+++ b/src/gpt_trader/cli/commands/orders.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import asyncio
 import json
 from argparse import Namespace
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import asdict
+from datetime import UTC, datetime
 from decimal import Decimal
 from typing import Any, Protocol, TypeVar, cast, runtime_checkable
 
@@ -14,6 +15,7 @@ from gpt_trader.app.container import create_application_container
 from gpt_trader.cli import options, services
 from gpt_trader.cli.response import CliErrorCode, CliResponse
 from gpt_trader.core import OrderSide, OrderType, TimeInForce
+from gpt_trader.persistence.event_store import EventStore
 from gpt_trader.persistence.orders_store import OrderRecord, OrdersStore, OrderStatus
 
 _CONFIG_SKIP_KEYS = {
@@ -35,6 +37,8 @@ _CONFIG_SKIP_KEYS = {
 _DEFAULT_HISTORY_LIMIT = 20
 _MAX_HISTORY_LIMIT = 200
 _HISTORY_COMMAND_NAME = "orders history list"
+_SUPPRESSED_COMMAND_NAME = "orders suppressed"
+_SUPPRESSED_EVENT_TYPE = "order_suppressed"
 T = TypeVar("T")
 
 
@@ -102,6 +106,23 @@ def register(subparsers: Any) -> None:
     )
     options.add_output_options(history_list, include_quiet=False)
     history_list.set_defaults(handler=_handle_history_list, subcommand="history list")
+
+    suppressed = orders_subparsers.add_parser(
+        "suppressed",
+        help="Summarize dry-run suppressed order writes (order_suppressed events)",
+    )
+    options.add_profile_option(suppressed, inherit_from_parent=True)
+    suppressed.add_argument(
+        "--limit",
+        type=int,
+        default=_DEFAULT_HISTORY_LIMIT,
+        help=(
+            "Maximum number of events to return (1-"
+            f"{_MAX_HISTORY_LIMIT}, default {_DEFAULT_HISTORY_LIMIT})"
+        ),
+    )
+    options.add_output_options(suppressed, include_quiet=False)
+    suppressed.set_defaults(handler=_handle_suppressed, subcommand="suppressed")
 
 
 def _handle_preview(args: Namespace) -> CliResponse | int:
@@ -322,6 +343,126 @@ def _handle_history_list(args: Namespace) -> CliResponse | int:
 
     print(_format_history_text(records, limit, symbol, status_filter))
     return 0
+
+
+def _handle_suppressed(args: Namespace) -> CliResponse | int:
+    output_format = getattr(args, "output_format", "text")
+    command_name = _SUPPRESSED_COMMAND_NAME
+
+    try:
+        limit = _validate_history_limit(args.limit)
+    except ValueError as exc:
+        message = str(exc)
+        if output_format == "json":
+            return CliResponse.error_response(
+                command=command_name,
+                code=CliErrorCode.INVALID_ARGUMENT,
+                message=message,
+                details={"limit": args.limit},
+            )
+        print(f"Error: {message}")
+        return 1
+
+    try:
+        events = _with_event_store(
+            args,
+            lambda store: store.get_recent_by_type(_SUPPRESSED_EVENT_TYPE, limit),
+        )
+    except Exception as exc:
+        if output_format == "json":
+            return CliResponse.error_response(
+                command=command_name,
+                code=CliErrorCode.OPERATION_FAILED,
+                message="Failed to read suppressed-order events",
+                details={"error": str(exc)},
+            )
+        print(f"Error: Failed to read suppressed-order events: {exc}")
+        return 1
+
+    rows = [_suppressed_row(event) for event in reversed(events)]
+    counts_by_action: dict[str, int] = {}
+    for row in rows:
+        action = cast(str, row["action"])
+        counts_by_action[action] = counts_by_action.get(action, 0) + 1
+
+    if output_format == "json":
+        return CliResponse.success_response(
+            command=command_name,
+            data={
+                "events": rows,
+                "count": len(rows),
+                "counts_by_action": counts_by_action,
+                "filters": {"limit": limit},
+            },
+        )
+
+    if not rows:
+        print("No suppressed order writes recorded.")
+        return 0
+
+    print(_format_suppressed_text(rows, counts_by_action, limit))
+    return 0
+
+
+def _suppressed_row(event: Any) -> dict[str, Any]:
+    data = event.get("data") if isinstance(event, Mapping) else None
+    if not isinstance(data, Mapping):
+        data = {}
+    timestamp = data.get("timestamp")
+    recorded_at = (
+        datetime.fromtimestamp(timestamp, tz=UTC).isoformat()
+        if isinstance(timestamp, (int, float))
+        else None
+    )
+    return {
+        "recorded_at": recorded_at,
+        "action": str(data.get("action") or "unknown"),
+        "symbol": data.get("symbol"),
+        "side": data.get("side"),
+        "quantity": data.get("quantity"),
+        "price": data.get("price"),
+        "order_id": data.get("order_id"),
+        "reason": data.get("reason"),
+        "bot_id": data.get("bot_id"),
+    }
+
+
+def _format_suppressed_text(
+    rows: list[dict[str, Any]],
+    counts_by_action: dict[str, int],
+    limit: int,
+) -> str:
+    count = len(rows)
+    counts_line = ", ".join(
+        f"{action}={counts_by_action[action]}" for action in sorted(counts_by_action)
+    )
+    lines = [
+        f"Suppressed order writes (limit={limit})",
+        f"Returned {count} event{'s' if count != 1 else ''} (newest first)",
+        f"Counts by action: {counts_line}",
+        "",
+    ]
+    for row in rows:
+        detail_parts = [
+            f"{key}={row[key]}"
+            for key in ("symbol", "side", "quantity", "price", "order_id", "bot_id")
+            if row.get(key) is not None
+        ]
+        recorded = row["recorded_at"] or "unknown-time"
+        reason = row["reason"] or "unknown"
+        detail = f" {' '.join(detail_parts)}" if detail_parts else ""
+        lines.append(f"{recorded} {row['action']} (reason={reason}){detail}")
+    return "\n".join(lines)
+
+
+def _with_event_store(args: Namespace, callback: Callable[[EventStore], T]) -> T:
+    config = services.build_config_from_args(args, skip=_CONFIG_SKIP_KEYS)
+    container = create_application_container(config)
+    store = container.event_store
+    try:
+        return callback(store)
+    finally:
+        store.close()
 
 
 def _validate_history_limit(limit: int) -> int:

--- a/tests/unit/gpt_trader/cli/orders_command_test_helpers.py
+++ b/tests/unit/gpt_trader/cli/orders_command_test_helpers.py
@@ -39,3 +39,15 @@ def make_history_args(**overrides):
     )
     defaults.update(overrides)
     return Namespace(**defaults)
+
+
+def make_suppressed_args(**overrides):
+    defaults = dict(
+        profile="dev",
+        orders_command="suppressed",
+        limit=orders_cmd._DEFAULT_HISTORY_LIMIT,
+        output_format="text",
+        subcommand="suppressed",
+    )
+    defaults.update(overrides)
+    return Namespace(**defaults)

--- a/tests/unit/gpt_trader/cli/test_commands_orders.py
+++ b/tests/unit/gpt_trader/cli/test_commands_orders.py
@@ -1,5 +1,8 @@
 """CLI `orders` command tests: payload building, previews, editing, history.
 
+The `orders suppressed` tests live in test_commands_orders_suppressed.py
+(400-line test-hygiene cap).
+
 Consolidated from test_commands_orders_editing.py and
 test_commands_orders_history.py (dedupe cluster 65a…81, #1083); all three
 shared the orders_command_test_helpers boundary doubles.

--- a/tests/unit/gpt_trader/cli/test_commands_orders_suppressed.py
+++ b/tests/unit/gpt_trader/cli/test_commands_orders_suppressed.py
@@ -1,0 +1,113 @@
+"""CLI `orders suppressed` tests: dry-run suppression telemetry consumer (#1109).
+
+Split from test_commands_orders.py to stay under the 400-line test-hygiene cap;
+shares the orders_command_test_helpers boundary doubles.
+"""
+
+from __future__ import annotations
+
+import gpt_trader.cli.commands.orders as orders_cmd
+from gpt_trader.cli.response import CliErrorCode, CliResponse
+from gpt_trader.features.brokerages.read_only import ReadOnlyBroker
+from gpt_trader.persistence.event_store import EventStore
+from tests.unit.gpt_trader.cli.orders_command_test_helpers import make_suppressed_args
+
+
+def _use_stub_event_store(monkeypatch, store: EventStore) -> None:
+    monkeypatch.setattr(
+        orders_cmd,
+        "_with_event_store",
+        lambda args, callback: callback(store),
+    )
+
+
+def test_suppressed_json_summarizes_read_only_broker_events(monkeypatch):
+    store = EventStore()
+    broker = ReadOnlyBroker(object(), store, bot_id="bot-1", reason="dry_run")
+    broker.place_order(symbol="BTC-USD", side="buy", order_type="market", quantity="0.5")
+    broker.cancel_order("order-9")
+    _use_stub_event_store(monkeypatch, store)
+
+    response = orders_cmd._handle_suppressed(make_suppressed_args(output_format="json"))
+
+    assert isinstance(response, CliResponse)
+    assert response.success
+    assert response.data["count"] == 2
+    assert response.data["counts_by_action"] == {"place_order": 1, "cancel_order": 1}
+    assert response.data["filters"]["limit"] == orders_cmd._DEFAULT_HISTORY_LIMIT
+    newest, oldest = response.data["events"]
+    assert newest["action"] == "cancel_order"
+    assert newest["order_id"] == "order-9"
+    assert oldest["action"] == "place_order"
+    assert oldest["symbol"] == "BTC-USD"
+    assert oldest["side"] == "buy"
+    assert oldest["quantity"] == "0.5"
+    assert oldest["reason"] == "dry_run"
+    assert oldest["bot_id"] == "bot-1"
+    assert oldest["recorded_at"] is not None
+
+
+def test_suppressed_text_output(monkeypatch, capsys):
+    store = EventStore()
+    store.append(
+        "order_suppressed",
+        {
+            "action": "close_position",
+            "reason": "dry_run",
+            "timestamp": 1_700_000_000.0,
+            "symbol": "ETH-USD",
+        },
+    )
+    _use_stub_event_store(monkeypatch, store)
+
+    exit_code = orders_cmd._handle_suppressed(make_suppressed_args(limit=5))
+
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    assert "Suppressed order writes (limit=5)" in output
+    assert "Counts by action: close_position=1" in output
+    assert "close_position (reason=dry_run) symbol=ETH-USD" in output
+
+
+def test_suppressed_reports_empty(monkeypatch, capsys):
+    _use_stub_event_store(monkeypatch, EventStore())
+
+    exit_code = orders_cmd._handle_suppressed(make_suppressed_args())
+
+    assert exit_code == 0
+    assert "No suppressed order writes recorded." in capsys.readouterr().out
+
+
+def test_suppressed_tolerates_malformed_event(monkeypatch):
+    store = EventStore()
+    store.append("order_suppressed", {"unexpected": True})
+    _use_stub_event_store(monkeypatch, store)
+
+    response = orders_cmd._handle_suppressed(make_suppressed_args(output_format="json"))
+
+    assert isinstance(response, CliResponse)
+    assert response.success
+    assert response.data["counts_by_action"] == {"unknown": 1}
+    assert response.data["events"][0]["recorded_at"] is None
+
+
+def test_suppressed_limit_validation():
+    response = orders_cmd._handle_suppressed(make_suppressed_args(limit=0, output_format="json"))
+
+    assert isinstance(response, CliResponse)
+    assert not response.success
+    assert response.errors[0].code == CliErrorCode.INVALID_ARGUMENT.value
+    assert response.errors[0].details == {"limit": 0}
+
+
+def test_suppressed_storage_error_returns_failure(monkeypatch):
+    def raise_error(args, callback):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(orders_cmd, "_with_event_store", raise_error)
+    response = orders_cmd._handle_suppressed(make_suppressed_args(output_format="json"))
+
+    assert isinstance(response, CliResponse)
+    assert not response.success
+    assert response.errors[0].code == CliErrorCode.OPERATION_FAILED.value
+    assert response.errors[0].details == {"error": "boom"}


### PR DESCRIPTION
Closes #1109.

**Owner decision recorded 2026-07-07:** the minimal CLI consumer (ranked option 1 on the issue) was approved; audit-log-only and console-panel options declined.

## What

`gpt-trader orders suppressed [--limit N]` — a read-only summary of the `order_suppressed` events ReadOnlyBroker records for every suppressed write in a dry run. Previously this telemetry was write-only: no surface read it, so a dry run gave no aggregate view of what the bot would have traded.

- Reads via the ready-made `EventStore.get_recent_by_type("order_suppressed", limit)` path through the same application-container persistence wiring as `orders history list` — no new state, no producer changes.
- Reports counts by action plus the most recent events (newest first): timestamp, action, symbol/side/qty/price/order_id when present, reason, bot_id. Text and JSON.
- Gate 2 (canary dry-run) exit criteria in docs/production.md now point at the command instead of grepping the event log.

## Tests

New `test_commands_orders_suppressed.py` (split module — the consolidated orders test file is at the 400-line hygiene cap), including a producer→consumer test that drives a real `ReadOnlyBroker` over an in-memory `EventStore` and asserts the CLI summarizes its events. Also covers text/empty/malformed-event/limit-validation/storage-error paths.

## Verification

- `uv run pytest tests/unit/gpt_trader/cli -q -n auto` — 429 passed
- `uv run mypy src/gpt_trader` — clean (459 files)
- Drove the real command against the dev profile: text and JSON output correct on an empty store
- `rg -n 'order_suppressed' src` now shows a consumer (acceptance criterion)