### PR TITLE
feat(idea-execution): session-gate the paper cycle's proposer leg with manifest evidence

### DIFF
--- a/src/gpt_trader/core/trading_calendar.py
+++ b/src/gpt_trader/core/trading_calendar.py
@@ -27,6 +27,8 @@ from datetime import UTC, date, datetime
 from functools import lru_cache
 from typing import TYPE_CHECKING, Protocol
 
+from gpt_trader.core.instruments import AssetClass, Instrument
+
 if TYPE_CHECKING:
     import pandas
 
@@ -34,6 +36,14 @@ SESSION_24X7 = "24x7"
 SESSION_XNYS = "XNYS"
 
 SUPPORTED_SESSIONS = (SESSION_24X7, SESSION_XNYS)
+
+# Phase-1 venue assumption (issue #1224): every equity instrument trades US
+# regular hours, every crypto instrument trades around the clock. When a
+# second equity venue arrives this becomes instrument metadata, not a map.
+SESSION_ID_BY_ASSET_CLASS: dict[AssetClass, str] = {
+    AssetClass.CRYPTO: SESSION_24X7,
+    AssetClass.EQUITY: SESSION_XNYS,
+}
 
 
 def _as_utc(moment: datetime) -> datetime:
@@ -165,12 +175,30 @@ def get_trading_calendar(session_id: str) -> TradingCalendar:
     raise ValueError(f"Unknown trading session {session_id!r} (supported: {supported})")
 
 
+def get_calendar_for_instrument(instrument: str) -> TradingCalendar:
+    """Return the session calendar an instrument string trades on.
+
+    Classification comes from the structured taxonomy
+    (:meth:`~gpt_trader.core.instruments.Instrument.parse`), never ad-hoc
+    string sniffing. The lookup is case-insensitive to match the repo's
+    casefolded instrument keying (busy tracking, snapshot marks); the
+    instrument string itself is never rewritten. Raises
+    :class:`~gpt_trader.core.instruments.InstrumentParseError` when the
+    string does not classify — callers decide whether that is a loud skip
+    or a hard failure.
+    """
+    asset_class = Instrument.parse(instrument.upper()).asset_class
+    return get_trading_calendar(SESSION_ID_BY_ASSET_CLASS[asset_class])
+
+
 __all__ = [
     "SESSION_24X7",
+    "SESSION_ID_BY_ASSET_CLASS",
     "SESSION_XNYS",
     "SUPPORTED_SESSIONS",
     "AlwaysOpenCalendar",
     "ExchangeBackedCalendar",
     "TradingCalendar",
+    "get_calendar_for_instrument",
     "get_trading_calendar",
 ]

--- a/src/gpt_trader/features/idea_execution/__init__.py
+++ b/src/gpt_trader/features/idea_execution/__init__.py
@@ -32,6 +32,7 @@ from gpt_trader.features.idea_execution.cycle import (
     PaperCycleResult,
     PaperCycleRunner,
     ProposerTurn,
+    SessionCalendarResolver,
     SnapshotProvider,
     busy_instruments,
 )
@@ -85,6 +86,7 @@ __all__ = [
     "PaperIdeaExecutor",
     "PaperOnlyLaneError",
     "ProposerTurn",
+    "SessionCalendarResolver",
     "SnapshotProvider",
     "busy_instruments",
     "paper_auto_execution_gate_evidence",

--- a/src/gpt_trader/features/idea_execution/cycle.py
+++ b/src/gpt_trader/features/idea_execution/cycle.py
@@ -33,6 +33,8 @@ from typing import Any
 
 from filelock import FileLock, Timeout
 
+from gpt_trader.core.instruments import InstrumentParseError
+from gpt_trader.core.trading_calendar import TradingCalendar, get_calendar_for_instrument
 from gpt_trader.errors import ValidationError
 from gpt_trader.features.brokerages.mock import DeterministicBroker
 from gpt_trader.features.idea_execution.executor import (
@@ -76,6 +78,16 @@ SnapshotProvider = Callable[[], tuple[MarketSnapshot, str]]
 The provider owns acquisition (network fetch or file load); the runner never
 imports a market-data client, so the paper lane's import topology stays
 paper-only.
+"""
+
+SessionCalendarResolver = Callable[[str], TradingCalendar]
+"""Maps an instrument string to the session calendar it trades on.
+
+Injected like ``SnapshotProvider`` so deterministic tests can pin session
+state; the default resolves through the instrument taxonomy
+(``get_calendar_for_instrument``). May raise ``InstrumentParseError`` for
+unclassifiable instruments — the runner turns that into a loud per-candidate
+skip, never a silent pass.
 """
 
 
@@ -143,6 +155,7 @@ class ProposerTurn:
     proposal_count: int
     proposed_decision_ids: tuple[str, ...]
     skipped_open_instruments: tuple[dict[str, str], ...]
+    skipped_closed_sessions: tuple[dict[str, str], ...] = ()
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -150,6 +163,7 @@ class ProposerTurn:
             "proposal_count": self.proposal_count,
             "proposed_decision_ids": list(self.proposed_decision_ids),
             "skipped_open_instruments": list(self.skipped_open_instruments),
+            "skipped_closed_sessions": list(self.skipped_closed_sessions),
         }
 
 
@@ -184,6 +198,7 @@ class PaperCycleResult:
     execution: ExecutionTurn
     queue: dict[str, Any] = field(default_factory=dict)
     report_summary: dict[str, Any] = field(default_factory=dict)
+    session_gate: tuple[dict[str, Any], ...] = ()
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -192,6 +207,7 @@ class PaperCycleResult:
             "finished_at": self.finished_at.isoformat(),
             "outcome": "completed",
             "snapshot": self.snapshot,
+            "session_gate": [dict(decision) for decision in self.session_gate],
             "expired_decision_ids": list(self.expired_decision_ids),
             "attributed_decision_ids": list(self.attributed_decision_ids),
             "resolved_decision_ids": list(self.resolved_decision_ids),
@@ -226,6 +242,7 @@ class PaperCycleRunner:
         execute_approved: bool = True,
         actor_id: str = DEFAULT_CYCLE_ACTOR_ID,
         now_factory: Callable[[], datetime] | None = None,
+        session_calendar_resolver: SessionCalendarResolver | None = None,
     ) -> None:
         self._service = service
         self._cycle_root = cycle_root
@@ -234,6 +251,7 @@ class PaperCycleRunner:
         self._execute_approved = execute_approved
         self._actor_id = actor_id
         self._now_factory = now_factory or (lambda: datetime.now(UTC))
+        self._session_calendar_resolver = session_calendar_resolver or get_calendar_for_instrument
         # The executor must share the turn's clock: with an injected clock
         # (deterministic or historical turns) a wall-clock expiry check would
         # refuse ideas the rest of the turn still considers live.
@@ -317,9 +335,17 @@ class PaperCycleRunner:
         snapshot_info = self._persist_snapshot(snapshot, snapshot_reference, run_dir)
         row["snapshot"] = snapshot_info
 
+        # One session decision per snapshot instrument per turn, evaluated at
+        # the turn's own clock and recorded on the manifest row so a quiet
+        # turn (equity market closed) explains itself in the evidence trail.
+        session_gate = tuple(
+            self._session_decision(series.symbol, started_at) for series in snapshot.series
+        )
+        row["session_gate"] = [dict(decision) for decision in session_gate]
+
         proposer_turns: list[ProposerTurn] = []
         for proposer in self._proposers:
-            turn = self._run_proposer(proposer, snapshot, snapshot_reference)
+            turn = self._run_proposer(proposer, snapshot, snapshot_reference, started_at)
             proposer_turns.append(turn)
             row["proposers"] = [item.to_dict() for item in proposer_turns]
 
@@ -371,13 +397,47 @@ class PaperCycleRunner:
             execution=execution,
             queue=queue_summary,
             report_summary=report_summary,
+            session_gate=session_gate,
         )
+
+    def _session_decision(self, instrument: str, moment: datetime) -> dict[str, Any]:
+        """Answer "may this instrument trade at ``moment``?" as manifest evidence."""
+        try:
+            calendar = self._session_calendar_resolver(instrument)
+        except InstrumentParseError as error:
+            return {
+                "instrument": instrument,
+                "session": None,
+                "open": False,
+                "reason": f"instrument is not classifiable: {error}",
+            }
+        decision: dict[str, Any] = {
+            "instrument": instrument,
+            "session": calendar.session_id,
+            "open": calendar.is_open(moment),
+        }
+        if not decision["open"]:
+            next_open = calendar.next_open(moment)
+            decision["reason"] = (
+                f"market closed for session {calendar.session_id} "
+                f"at {moment.isoformat()}"
+                + (f"; next open {next_open.isoformat()}" if next_open is not None else "")
+            )
+        return decision
+
+    def _closed_session_skip(self, instrument: str, moment: datetime) -> dict[str, str] | None:
+        """Return a skip entry when ``instrument`` must not trade at ``moment``."""
+        decision = self._session_decision(instrument, moment)
+        if decision["open"]:
+            return None
+        return {"instrument": instrument, "reason": str(decision["reason"])}
 
     def _run_proposer(
         self,
         proposer: Proposer,
         snapshot: MarketSnapshot,
         snapshot_reference: str,
+        moment: datetime,
     ) -> ProposerTurn:
         candidates = proposer.propose(snapshot)
 
@@ -385,6 +445,7 @@ class PaperCycleRunner:
         known_decision_ids = {view.idea.decision_id for view in self._service.list_views()}
         admitted = []
         skipped: list[dict[str, str]] = []
+        skipped_closed: list[dict[str, str]] = []
         for idea in candidates:
             # Deterministic proposers emit the same decision_id for the same
             # snapshot, so a rerun over a saved snapshot must skip
@@ -397,6 +458,14 @@ class PaperCycleRunner:
                         "existing_decision_id": idea.decision_id,
                     }
                 )
+                continue
+            # Session gate (issue #1232): a sessioned instrument outside its
+            # market hours is skipped loudly and — deliberately — without
+            # touching the busy map, so the skip cannot block a later
+            # proposer or a later turn.
+            closed_skip = self._closed_session_skip(idea.instrument, moment)
+            if closed_skip is not None:
+                skipped_closed.append(closed_skip)
                 continue
             instrument_key = _instrument_key(idea.instrument)
             blocker = busy.get(instrument_key)
@@ -440,6 +509,7 @@ class PaperCycleRunner:
             proposal_count=len(proposed_decision_ids),
             proposed_decision_ids=proposed_decision_ids,
             skipped_open_instruments=tuple(skipped),
+            skipped_closed_sessions=tuple(skipped_closed),
         )
 
     def _execute_approved_ideas(

--- a/tests/unit/gpt_trader/core/test_trading_calendar.py
+++ b/tests/unit/gpt_trader/core/test_trading_calendar.py
@@ -17,6 +17,7 @@ from datetime import UTC, date, datetime, timedelta, timezone
 
 import pytest
 
+from gpt_trader.core.instruments import InstrumentParseError
 from gpt_trader.core.risk_units import trading_day
 from gpt_trader.core.trading_calendar import (
     SESSION_24X7,
@@ -24,6 +25,7 @@ from gpt_trader.core.trading_calendar import (
     AlwaysOpenCalendar,
     ExchangeBackedCalendar,
     TradingCalendar,
+    get_calendar_for_instrument,
     get_trading_calendar,
 )
 
@@ -131,3 +133,21 @@ class TestGetTradingCalendar:
     def test_unknown_session_raises(self) -> None:
         with pytest.raises(ValueError, match="Unknown trading session"):
             get_trading_calendar("XNAS")
+
+
+class TestGetCalendarForInstrument:
+    def test_crypto_pair_maps_to_24x7(self) -> None:
+        assert get_calendar_for_instrument("BTC-USD").session_id == SESSION_24X7
+
+    def test_equity_ticker_maps_to_xnys(self) -> None:
+        assert get_calendar_for_instrument("AAPL").session_id == SESSION_XNYS
+
+    def test_lookup_is_case_insensitive_like_instrument_keying(self) -> None:
+        # Busy tracking and snapshot marks key on casefolded instrument
+        # strings, so session resolution must accept the same spellings.
+        assert get_calendar_for_instrument("btc-usd").session_id == SESSION_24X7
+        assert get_calendar_for_instrument("aapl").session_id == SESSION_XNYS
+
+    def test_unclassifiable_instrument_raises(self) -> None:
+        with pytest.raises(InstrumentParseError):
+            get_calendar_for_instrument("BTC-USD-PERP")

--- a/tests/unit/gpt_trader/features/idea_execution/conftest.py
+++ b/tests/unit/gpt_trader/features/idea_execution/conftest.py
@@ -139,6 +139,7 @@ def make_cycle_runner(
     *,
     proposers: list | None = None,
     execute_approved: bool = True,
+    now: datetime = CYCLE_NOW,
 ) -> PaperCycleRunner:
     return PaperCycleRunner(
         service,
@@ -146,7 +147,7 @@ def make_cycle_runner(
         proposers=proposers if proposers is not None else [BaselineProposer()],
         broker=DeterministicBroker(),
         execute_approved=execute_approved,
-        now_factory=lambda: CYCLE_NOW,
+        now_factory=lambda: now,
     )
 
 

--- a/tests/unit/gpt_trader/features/idea_execution/test_cycle_session_gate.py
+++ b/tests/unit/gpt_trader/features/idea_execution/test_cycle_session_gate.py
@@ -1,0 +1,155 @@
+"""Session gating of the paper-cycle proposer leg (issue #1232).
+
+The Stage-2 turn runs on a fixed schedule regardless of market sessions, so
+equity instruments must be skipped loudly — with the decision on the manifest
+row — whenever XNYS is closed, while crypto instruments proceed every turn.
+A market-closed skip must never mark an instrument busy: the gate blocks this
+turn only, not later proposers or later turns.
+
+Session fixtures reuse the historical facts pinned in
+tests/unit/gpt_trader/core/test_trading_calendar.py: 2026-07-03 (the module's
+``CYCLE_NOW`` date) is the observed Independence Day holiday, and Monday
+2026-07-06 13:30-20:00 UTC is a regular XNYS session.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from tests.unit.gpt_trader.features.idea_execution.conftest import (
+    CYCLE_NOW,
+    build_cycle_idea,
+    flat_series,
+    make_cycle_runner,
+    manifest_rows,
+    snapshot,
+    snapshot_provider,
+)
+
+from gpt_trader.features.idea_execution import busy_instruments
+from gpt_trader.features.trade_ideas import MarketSnapshot, TradeIdea, TradeIdeaService
+
+# CYCLE_NOW (2026-07-03 12:00 UTC) is already a closed XNYS instant: the
+# observed Independence Day holiday. A regular open instant for contrast:
+XNYS_OPEN_NOW = datetime(2026, 7, 6, 18, 0, tzinfo=UTC)
+
+
+class FixedProposer:
+    """Emits a fixed candidate list regardless of the snapshot."""
+
+    def __init__(self, proposer_id: str, ideas: list[TradeIdea]) -> None:
+        self.proposer_id = proposer_id
+        self._ideas = ideas
+
+    def propose(self, market_snapshot: MarketSnapshot) -> list[TradeIdea]:
+        return list(self._ideas)
+
+
+class TestProposerSessionGate:
+    def test_equity_candidate_is_skipped_when_xnys_is_closed(
+        self, cycle_service: TradeIdeaService, tmp_path: Path
+    ) -> None:
+        proposer = FixedProposer(
+            "test-mixed-proposer",
+            [
+                build_cycle_idea("trade-20260703-gate-aapl", instrument="AAPL"),
+                build_cycle_idea("trade-20260703-gate-btc", instrument="BTC-USD"),
+            ],
+        )
+        result = make_cycle_runner(cycle_service, tmp_path, proposers=[proposer]).run(
+            snapshot_provider(snapshot(flat_series("BTC-USD")))
+        )
+
+        (proposer_turn,) = result.proposer_turns
+        # Crypto proceeds every turn; the equity candidate waits for the open.
+        assert proposer_turn.proposal_count == 1
+        assert proposer_turn.proposed_decision_ids == ("trade-20260703-gate-btc",)
+        (skip,) = proposer_turn.skipped_closed_sessions
+        assert skip["instrument"] == "AAPL"
+        assert "market closed for session XNYS" in skip["reason"]
+        assert "next open 2026-07-06T13:30:00+00:00" in skip["reason"]
+        # The skip left no record behind: nothing to expire, nothing busy.
+        assert [view.idea.instrument for view in cycle_service.list_views()] == ["BTC-USD"]
+
+    def test_equity_candidate_is_proposed_during_xnys_session(
+        self, cycle_service: TradeIdeaService, tmp_path: Path
+    ) -> None:
+        proposer = FixedProposer(
+            "test-equity-proposer",
+            [build_cycle_idea("trade-20260706-gate-open", instrument="AAPL")],
+        )
+        result = make_cycle_runner(
+            cycle_service, tmp_path, proposers=[proposer], now=XNYS_OPEN_NOW
+        ).run(snapshot_provider(snapshot(flat_series("AAPL"))))
+
+        (proposer_turn,) = result.proposer_turns
+        assert proposer_turn.proposal_count == 1
+        assert proposer_turn.skipped_closed_sessions == ()
+
+    def test_closed_session_skip_does_not_mark_the_instrument_busy(
+        self, cycle_service: TradeIdeaService, tmp_path: Path
+    ) -> None:
+        # Two proposers emit the same equity instrument in one closed-market
+        # turn: the second must see another closed-session skip, not an
+        # "instrument already has an open idea" block from the first.
+        first = FixedProposer(
+            "test-first-proposer",
+            [build_cycle_idea("trade-20260703-gate-first", instrument="AAPL")],
+        )
+        second = FixedProposer(
+            "test-second-proposer",
+            [build_cycle_idea("trade-20260703-gate-second", instrument="AAPL")],
+        )
+        result = make_cycle_runner(cycle_service, tmp_path, proposers=[first, second]).run(
+            snapshot_provider(snapshot(flat_series("BTC-USD")))
+        )
+
+        for proposer_turn in result.proposer_turns:
+            assert proposer_turn.skipped_open_instruments == ()
+            (skip,) = proposer_turn.skipped_closed_sessions
+            assert skip["instrument"] == "AAPL"
+        assert busy_instruments(cycle_service) == {}
+
+        # The next turn, at the open, proposes the instrument normally.
+        reopened = make_cycle_runner(
+            cycle_service, tmp_path, proposers=[second], now=XNYS_OPEN_NOW
+        ).run(snapshot_provider(snapshot(flat_series("AAPL"))))
+        assert reopened.proposer_turns[0].proposed_decision_ids == ("trade-20260703-gate-second",)
+
+    def test_unclassifiable_instrument_is_skipped_loudly(
+        self, cycle_service: TradeIdeaService, tmp_path: Path
+    ) -> None:
+        proposer = FixedProposer(
+            "test-odd-proposer",
+            [build_cycle_idea("trade-20260703-gate-odd", instrument="BTC-USD-PERP")],
+        )
+        result = make_cycle_runner(cycle_service, tmp_path, proposers=[proposer]).run(
+            snapshot_provider(snapshot(flat_series("BTC-USD")))
+        )
+
+        (proposer_turn,) = result.proposer_turns
+        assert proposer_turn.proposal_count == 0
+        (skip,) = proposer_turn.skipped_closed_sessions
+        assert skip["instrument"] == "BTC-USD-PERP"
+        assert "not classifiable" in skip["reason"]
+
+
+class TestManifestSessionEvidence:
+    def test_manifest_row_records_the_session_decision_per_instrument(
+        self, cycle_service: TradeIdeaService, tmp_path: Path
+    ) -> None:
+        result = make_cycle_runner(cycle_service, tmp_path, proposers=[]).run(
+            snapshot_provider(snapshot(flat_series("AAPL"), flat_series("BTC-USD")))
+        )
+
+        decisions = {decision["instrument"]: decision for decision in result.session_gate}
+        assert decisions["BTC-USD"]["session"] == "24x7"
+        assert decisions["BTC-USD"]["open"] is True
+        assert decisions["AAPL"]["session"] == "XNYS"
+        assert decisions["AAPL"]["open"] is False
+        assert "next open 2026-07-06T13:30:00+00:00" in decisions["AAPL"]["reason"]
+
+        (row,) = manifest_rows(tmp_path)
+        assert row["session_gate"] == [dict(decision) for decision in result.session_gate]
+        assert row["started_at"] == CYCLE_NOW.isoformat()


### PR DESCRIPTION
## Summary

Step 1 of the prescribed #1232 split (Part of #1232 — the issue stays open; the universe flip is blocked on #1238).

- **Proposer-leg session gate**: equity candidates — classified via the `Instrument` taxonomy (#1234), never ad-hoc string sniffing — are skipped loudly when XNYS is closed at the turn's clock; crypto candidates proceed every turn. Unclassifiable instrument strings are also a loud per-candidate skip, never a silent pass or a whole-turn failure.
- **Manifest evidence**: every turn's manifest row now carries a `session_gate` array (one decision per snapshot instrument: session id, open/closed, and — when closed — a reason including the next open), and each proposer turn records `skipped_closed_sessions`, so quiet turns explain themselves in `cycle/manifest.jsonl`.
- **Busy map untouched by the gate**: a market-closed skip never marks an instrument busy — it blocks this turn only, pinned by a two-proposer test plus a reopen-next-turn test.
- **Injection seam, no globals**: `PaperCycleRunner` takes a `SessionCalendarResolver` (like the existing `SnapshotProvider`); the default is the new `core.trading_calendar.get_calendar_for_instrument`, a taxonomy-backed instrument→session mapping (Phase-1 assumption documented in code: equities = XNYS regular hours, crypto = 24x7). The lookup is case-insensitive to match the repo's casefolded instrument keying; the instrument string itself is never rewritten.

## Safety

Paper lane only; adds skip behavior and evidence, no new execution authority, no live/broker calls. Executor/exit-monitor guards and session-date accounting follow in the next two PRs; the universe flip (the only operational change) stays blocked on the #1238 vendor decision.

## Testing

- `uv run pytest tests/unit -n auto -q` — 6819 passed
- `uv run local-ci` (pr profile) — passed