### PR TITLE
feat(trade-ideas): cash-account buying-power dimension in the risk budget (#1231)

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -80,6 +80,20 @@ drawdown-from-peak appetite is a budget lever (`max_drawdown_from_peak_pct`,
 unset by default); a breach at any decision boundary ratchets autonomy down
 through the same audited path as the daily-loss trigger.
 
+**The budget vocabulary carries a cash-account buying-power dimension**
+(#1231): the `max_equity_buying_power_pct` lever (unset by default; 100 =
+cash-account fidelity) caps projected equity buying-power usage — open equity
+notional, the candidate idea, and equity sale proceeds still inside their
+settlement window — as a percent of the attested `account_equity`, enforced at
+approval time beside the notional check (`features/trade_ideas/policy.py`).
+Settlement lag is data derived from `Instrument.asset_class`
+(`core/instruments.py`: crypto spot settles immediately, equities T+1), so
+crypto-spot approval outcomes are unchanged (test-pinned) and no product
+boolean was added. With the lever configured, anything the check cannot verify
+— an unclassifiable instrument, missing notional, unattested equity — refuses
+the approval loudly. Margin, pattern-day-trading, and the options defined-risk
+half stay deferred; equity executor/cycle wiring is #1232.
+
 **The promotion gates are now measurable in one command** (`ideas scorecard`,
 #1193): the Stage 1 -> 2 gates of the
 [measured-outcome rubric](decisions/adopt-measured-outcome-rubric.md) score

--- a/docs/specs/TRADE_IDEA_CLI_SPEC.md
+++ b/docs/specs/TRADE_IDEA_CLI_SPEC.md
@@ -626,7 +626,9 @@ Thin wrappers over `service.reject` / `service.request_changes` /
   `--max-open-notional-pct`, `--max-concurrent-approved-tickets`,
   `--max-review-latency-hours`, `--sizing-capped-by-budget {true,false}`,
   `--gain-retention-floor-pct`, `--allow-futures-leverage {true,false}`,
-  `--allow-naked-shorts {true,false}`), plus required `--reason`. Build the
+  `--allow-naked-shorts {true,false}`, `--account-equity`,
+  `--max-drawdown-from-peak-pct`, `--max-equity-buying-power-pct`),
+  plus required `--reason`. Build the
   new `RiskBudget` by copying the current one with overrides and
   `version = current.version + 1`; call
   `service.update_budget(budget, ActorType.HUMAN, actor_id)`.

--- a/src/gpt_trader/cli/commands/ideas.py
+++ b/src/gpt_trader/cli/commands/ideas.py
@@ -168,6 +168,7 @@ BUDGET_FIELDS = (
     "allow_naked_shorts",
     "account_equity",
     "max_drawdown_from_peak_pct",
+    "max_equity_buying_power_pct",
 )
 
 
@@ -1231,6 +1232,15 @@ def register(subparsers: Any) -> None:
         help=(
             "Drawdown-from-peak appetite for the continuous portfolio "
             "monitors; breach ratchets autonomy down through the audited path"
+        ),
+    )
+    budget_set.add_argument(
+        "--max-equity-buying-power-pct",
+        type=_non_negative_decimal_value,
+        help=(
+            "Cash-account buying-power cap for equity instruments, in percent "
+            "of attested account equity; 100 = cash-account fidelity. Crypto "
+            "spot is never checked against it"
         ),
     )
     budget_set.set_defaults(handler=_handle_budget_set, subcommand="budget set")

--- a/src/gpt_trader/core/instruments.py
+++ b/src/gpt_trader/core/instruments.py
@@ -45,6 +45,16 @@ _CRYPTO_PAIR = re.compile(r"^[A-Z0-9]+-[A-Z0-9]+$")
 # Bare uppercase ticker, e.g. AAPL: letters only.
 _EQUITY_TICKER = re.compile(r"^[A-Z]+$")
 
+# Cash-account settlement lag, in trading days, keyed by asset class (data,
+# not venue branching — docs/decisions/venue-neutrality-posture.md leak-watch
+# item 3): crypto spot settles immediately; US equities settle T+1 under the
+# post-May-2024 regime. Sale proceeds are not spendable buying power until
+# this many trading days after the closing trade.
+_SETTLEMENT_DAYS: dict[AssetClass, int] = {
+    AssetClass.CRYPTO: 0,
+    AssetClass.EQUITY: 1,
+}
+
 
 @dataclass(frozen=True, slots=True)
 class Instrument:
@@ -58,6 +68,11 @@ class Instrument:
     symbol: str
     asset_class: AssetClass
     product_type: ProductType
+
+    @property
+    def settlement_days(self) -> int:
+        """Trading days until sale proceeds settle into spendable cash."""
+        return _SETTLEMENT_DAYS[self.asset_class]
 
     @classmethod
     def parse(cls, raw: str) -> Instrument:

--- a/src/gpt_trader/features/trade_ideas/budget.py
+++ b/src/gpt_trader/features/trade_ideas/budget.py
@@ -81,6 +81,15 @@ class RiskBudget:
     # (#1192): breach ratchets autonomy down through the audited path.
     # None means no drawdown limit is configured — nothing to breach.
     max_drawdown_from_peak_pct: Decimal | None = None
+    # Cash-account buying-power cap for equity-asset-class instruments
+    # (#1231), in percent points of the attested account_equity: projected
+    # open equity notional plus the candidate plus same-settlement-window
+    # (T+1) unsettled equity sale proceeds may not exceed this share of the
+    # attested equity. Crypto spot settles immediately and is never checked
+    # against it — max_open_notional_pct remains its complete story. None
+    # means the buying-power dimension is not configured; the existing
+    # notional check still applies unchanged.
+    max_equity_buying_power_pct: Decimal | None = None
 
     def __post_init__(self) -> None:
         if self.account_equity is not None:
@@ -91,6 +100,11 @@ class RiskBudget:
             _require_finite_decimal(self.max_drawdown_from_peak_pct, "max_drawdown_from_peak_pct")
             _require_non_negative_decimal(
                 self.max_drawdown_from_peak_pct, "max_drawdown_from_peak_pct"
+            )
+        if self.max_equity_buying_power_pct is not None:
+            _require_finite_decimal(self.max_equity_buying_power_pct, "max_equity_buying_power_pct")
+            _require_non_negative_decimal(
+                self.max_equity_buying_power_pct, "max_equity_buying_power_pct"
             )
         _require_finite_decimal(self.max_loss_per_idea_pct, "max_loss_per_idea_pct")
         _require_finite_decimal(self.max_daily_loss_pct, "max_daily_loss_pct")
@@ -122,6 +136,11 @@ class RiskBudget:
             "max_drawdown_from_peak_pct": (
                 str(self.max_drawdown_from_peak_pct)
                 if self.max_drawdown_from_peak_pct is not None
+                else None
+            ),
+            "max_equity_buying_power_pct": (
+                str(self.max_equity_buying_power_pct)
+                if self.max_equity_buying_power_pct is not None
                 else None
             ),
         }
@@ -158,6 +177,13 @@ class RiskBudget:
                 if payload.get("max_drawdown_from_peak_pct") is not None
                 else None
             ),
+            # Optional lever added after logs already existed (#1231); absent
+            # in older entries means no buying-power cap was configured.
+            max_equity_buying_power_pct=(
+                Decimal(str(payload["max_equity_buying_power_pct"]))
+                if payload.get("max_equity_buying_power_pct") is not None
+                else None
+            ),
         )
 
 
@@ -176,6 +202,10 @@ DEFAULT_RISK_BUDGET = RiskBudget(
         "Seeded aggressive defaults accepted 2026-06-11: principal fully at risk, "
         "gain-retention floor defends 50% of peak gains above the high-water mark"
     ),
+    # max_equity_buying_power_pct stays unconfigured in the seeded default:
+    # configuring it here would newly refuse ideas whose instrument cannot be
+    # classified (test-pinned: crypto approval outcomes are unchanged until
+    # an operator versions the lever in — 100 = cash-account fidelity).
 )
 
 

--- a/src/gpt_trader/features/trade_ideas/policy.py
+++ b/src/gpt_trader/features/trade_ideas/policy.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from decimal import Decimal
 
+from gpt_trader.core.instruments import AssetClass, InstrumentParseError
 from gpt_trader.errors import ValidationError
 from gpt_trader.features.trade_ideas.audit import ActorType
 from gpt_trader.features.trade_ideas.budget import RiskBudget
@@ -65,6 +66,16 @@ class ApprovalBudgetContext:
     open_notional: Decimal = Decimal("0")
     open_notional_unavailable_count: int = 0
     account_equity_snapshot: Decimal | None = None
+    # Cash-account buying-power inputs (#1231), aggregated over equity-asset-
+    # class instruments only: open exposure that consumed settled cash, plus
+    # sale proceeds still inside their settlement window (T+1) and therefore
+    # not yet spendable. Unavailable counts cover open ideas and closeouts
+    # whose equity exposure or proceeds cannot be verified — including
+    # instruments that fail classification.
+    open_equity_notional: Decimal = Decimal("0")
+    open_equity_notional_unavailable_count: int = 0
+    unsettled_equity_proceeds: Decimal = Decimal("0")
+    unsettled_equity_proceeds_unavailable_count: int = 0
 
 
 def _decimal(value: Decimal | int | str) -> Decimal:
@@ -73,6 +84,91 @@ def _decimal(value: Decimal | int | str) -> Decimal:
 
 def _format_decimal(value: Decimal) -> str:
     return format(value.normalize(), "f")
+
+
+def _equity_buying_power_violations(
+    idea: TradeIdea,
+    budget: RiskBudget,
+    context: ApprovalBudgetContext,
+) -> list[str]:
+    """Cash-account buying-power check for equity candidates (#1231).
+
+    Runs only when ``max_equity_buying_power_pct`` is configured on the
+    budget. Crypto-spot candidates settle immediately and are never checked
+    here — ``max_open_notional_pct`` remains their complete story — so
+    configuring the lever provably cannot change a crypto approval outcome.
+    Every input that cannot be verified (unclassifiable instrument, missing
+    candidate notional, unverifiable open equity exposure or unsettled
+    proceeds, missing or non-positive attested equity) refuses the approval
+    loudly rather than passing silently.
+    """
+    if budget.max_equity_buying_power_pct is None:
+        return []
+    try:
+        instrument = idea.instrument_info
+    except InstrumentParseError as error:
+        return [
+            "instrument cannot be classified to verify max_equity_buying_power_pct "
+            f"budget exposure: {error}"
+        ]
+    if instrument.asset_class is not AssetClass.EQUITY:
+        return []
+    violations: list[str] = []
+    if context.open_equity_notional_unavailable_count:
+        violations.append(
+            "open budget exposure includes "
+            f"{context.open_equity_notional_unavailable_count} idea(s) whose equity "
+            "notional cannot be verified; max_equity_buying_power_pct budget "
+            "exposure cannot be verified"
+        )
+    if context.unsettled_equity_proceeds_unavailable_count:
+        violations.append(
+            "unsettled equity closeouts include "
+            f"{context.unsettled_equity_proceeds_unavailable_count} closeout(s) whose "
+            "sale proceeds cannot be verified; max_equity_buying_power_pct budget "
+            "exposure cannot be verified"
+        )
+    candidate_notional = idea.sizing_recommendation.notional
+    if candidate_notional is None:
+        violations.append(
+            "sizing_recommendation.notional is required to verify "
+            "max_equity_buying_power_pct budget exposure"
+        )
+        return violations
+    projected_usage = (
+        abs(context.open_equity_notional)
+        + abs(candidate_notional)
+        + abs(context.unsettled_equity_proceeds)
+    )
+    if projected_usage <= 0:
+        return violations
+    account_equity = context.account_equity_snapshot
+    if account_equity is None:
+        violations.append(
+            "account_equity_snapshot is required to verify "
+            "max_equity_buying_power_pct budget exposure"
+        )
+        return violations
+    if account_equity <= 0:
+        violations.append(
+            "account_equity_snapshot must be positive to verify "
+            "max_equity_buying_power_pct budget exposure; "
+            f"got {_format_decimal(account_equity)}"
+        )
+        return violations
+    projected_usage_pct = projected_usage / account_equity * _decimal(100)
+    if projected_usage_pct > budget.max_equity_buying_power_pct:
+        violations.append(
+            "max_equity_buying_power_pct budget breached: projected equity "
+            f"buying-power usage {_format_decimal(projected_usage_pct)}% exceeds "
+            f"limit {_format_decimal(budget.max_equity_buying_power_pct)}% "
+            f"(open_equity_notional={_format_decimal(abs(context.open_equity_notional))}, "
+            f"candidate_notional={_format_decimal(abs(candidate_notional))}, "
+            "unsettled_equity_proceeds="
+            f"{_format_decimal(abs(context.unsettled_equity_proceeds))}, "
+            f"account_equity_snapshot={_format_decimal(account_equity)})"
+        )
+    return violations
 
 
 class ApprovalPolicy:
@@ -204,6 +300,7 @@ class ApprovalPolicy:
                                 f"(projected_open_notional={_format_decimal(projected_notional)}, "
                                 f"account_equity_snapshot={_format_decimal(account_equity)})"
                             )
+            violations.extend(_equity_buying_power_violations(idea, budget, budget_context))
 
         if idea.product_type is ProductType.FUTURES and not budget.allow_futures_leverage:
             violations.append(

--- a/src/gpt_trader/features/trade_ideas/service.py
+++ b/src/gpt_trader/features/trade_ideas/service.py
@@ -17,6 +17,7 @@ from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Any, cast
 
+from gpt_trader.core.instruments import AssetClass, InstrumentParseError
 from gpt_trader.core.risk_units import (
     fraction_to_pct_points,
     pct_points_to_fraction,
@@ -233,6 +234,51 @@ def _absolute_notional(idea: TradeIdea) -> Decimal | None:
     if notional is None:
         return None
     return abs(notional)
+
+
+def _open_equity_notional(idea: TradeIdea) -> tuple[Decimal, int]:
+    """(equity notional, unavailable count) one open idea adds to buying power.
+
+    Crypto-spot exposure contributes nothing — it settles immediately and
+    stays governed solely by the notional check. An instrument that cannot be
+    classified, or an equity idea without a notional, counts as unavailable
+    so the buying-power check refuses loudly instead of skipping it (#1231).
+    """
+    try:
+        instrument = idea.instrument_info
+    except InstrumentParseError:
+        return Decimal("0"), 1
+    if instrument.asset_class is not AssetClass.EQUITY:
+        return Decimal("0"), 0
+    notional = _absolute_notional(idea)
+    if notional is None:
+        return Decimal("0"), 1
+    return notional, 0
+
+
+def _unsettled_equity_proceeds(
+    idea: TradeIdea,
+    closeout: CloseoutAttribution,
+) -> tuple[Decimal, int]:
+    """(unsettled proceeds, unavailable count) one same-day closeout holds back.
+
+    Callers pass only same-trading-day closeouts, which is exactly the T+1
+    settlement window (`Instrument.settlement_days` is 0 or 1 today; a class
+    settling later than T+1 would need a wider window than the caller's
+    same-day filter). Proceeds are entry notional plus realized profit/loss;
+    when either is unrecorded the proceeds count as unavailable rather than
+    zero (#1231).
+    """
+    try:
+        instrument = idea.instrument_info
+    except InstrumentParseError:
+        return Decimal("0"), 1
+    if instrument.settlement_days <= 0:
+        return Decimal("0"), 0
+    notional = _absolute_notional(idea)
+    if notional is None or closeout.realized_profit_loss_amount is None:
+        return Decimal("0"), 1
+    return max(notional + closeout.realized_profit_loss_amount, Decimal("0")), 0
 
 
 def _page_items(
@@ -574,7 +620,7 @@ class TradeIdeaService:
         evaluation_time = now or self._now()
         latest_events = self._latest_audit_events_by_decision_id()
         open_ideas: list[TradeIdea] = []
-        closeouts: list[CloseoutAttribution] = []
+        same_day_closeouts: list[tuple[TradeIdea, CloseoutAttribution]] = []
         for decision_id, event in latest_events.items():
             if event.after_state in OPEN_BUDGET_EXPOSURE_STATES:
                 if decision_id == exclude_decision_id:
@@ -598,7 +644,8 @@ class TradeIdeaService:
                     event.after_state is TradeIdeaState.FILLED
                     or _closeout_has_realized_profit_loss(closeout)
                 ):
-                    closeouts.append(closeout)
+                    same_day_closeouts.append((idea, closeout))
+        closeouts = [closeout for _, closeout in same_day_closeouts]
         account_equity_snapshot = self._account_equity_snapshot(
             # Non-mutating read: building a budget context (e.g. during a
             # render-only ticket export) must not seed risk_budget.jsonl.
@@ -627,6 +674,10 @@ class TradeIdeaService:
             (notional for notional in open_notionals if notional is not None), Decimal("0")
         )
         open_notional_unavailable_count = sum(1 for notional in open_notionals if notional is None)
+        equity_notionals = tuple(_open_equity_notional(idea) for idea in open_ideas)
+        unsettled_proceeds = tuple(
+            _unsettled_equity_proceeds(idea, closeout) for idea, closeout in same_day_closeouts
+        )
         return ApprovalBudgetContext(
             same_day_realized_loss_pct=same_day_realized_loss_pct,
             same_day_realized_loss_unavailable_count=(same_day_realized_loss_unavailable_count),
@@ -635,6 +686,14 @@ class TradeIdeaService:
             open_notional=open_notional,
             open_notional_unavailable_count=open_notional_unavailable_count,
             account_equity_snapshot=account_equity_snapshot,
+            open_equity_notional=sum((amount for amount, _ in equity_notionals), Decimal("0")),
+            open_equity_notional_unavailable_count=sum(count for _, count in equity_notionals),
+            unsettled_equity_proceeds=sum(
+                (amount for amount, _ in unsettled_proceeds), Decimal("0")
+            ),
+            unsettled_equity_proceeds_unavailable_count=sum(
+                count for _, count in unsettled_proceeds
+            ),
         )
 
     def budget_headroom(self, *, now: datetime | None = None) -> dict[str, object]:

--- a/src/gpt_trader/web/app.py
+++ b/src/gpt_trader/web/app.py
@@ -159,6 +159,7 @@ _BUDGET_LEVER_FIELDS = (
     "allow_naked_shorts",
     "account_equity",
     "max_drawdown_from_peak_pct",
+    "max_equity_buying_power_pct",
 )
 
 
@@ -231,6 +232,16 @@ def _budget_from_form(
                 "max_drawdown_from_peak_pct must be a decimal number or blank, "
                 f"got {drawdown_raw!r}"
             ) from error
+    buying_power_raw = str(values["max_equity_buying_power_pct"]).strip()
+    max_equity_buying_power_pct: Decimal | None = None
+    if buying_power_raw:
+        try:
+            max_equity_buying_power_pct = Decimal(buying_power_raw)
+        except ArithmeticError as error:
+            raise ValueError(
+                "max_equity_buying_power_pct must be a decimal number or blank, "
+                f"got {buying_power_raw!r}"
+            ) from error
     return RiskBudget(
         version=base_version + 1,
         max_loss_per_idea_pct=_decimal("max_loss_per_idea_pct"),
@@ -245,6 +256,7 @@ def _budget_from_form(
         reason=reason,
         account_equity=account_equity,
         max_drawdown_from_peak_pct=max_drawdown_from_peak_pct,
+        max_equity_buying_power_pct=max_equity_buying_power_pct,
     )
 
 
@@ -420,6 +432,7 @@ def create_app(
         allow_naked_shorts: bool = Form(False),
         account_equity: str = Form(""),
         max_drawdown_from_peak_pct: str = Form(""),
+        max_equity_buying_power_pct: str = Form(""),
     ) -> HTMLResponse | RedirectResponse:
         form_values: dict[str, str | bool] = {
             "max_loss_per_idea_pct": max_loss_per_idea_pct,
@@ -433,6 +446,7 @@ def create_app(
             "allow_naked_shorts": allow_naked_shorts,
             "account_equity": account_equity,
             "max_drawdown_from_peak_pct": max_drawdown_from_peak_pct,
+            "max_equity_buying_power_pct": max_equity_buying_power_pct,
         }
 
         def _form_error(message: str) -> HTMLResponse:

--- a/src/gpt_trader/web/templates/envelope.html
+++ b/src/gpt_trader/web/templates/envelope.html
@@ -95,6 +95,9 @@
     <label>Max drawdown from peak (%, blank = no limit)
       <input type="text" name="max_drawdown_from_peak_pct" value="{{ form.max_drawdown_from_peak_pct }}">
     </label>
+    <label>Max equity buying power (% of attested equity, blank = not configured)
+      <input type="text" name="max_equity_buying_power_pct" value="{{ form.max_equity_buying_power_pct }}">
+    </label>
     <label class="check"><input type="checkbox" name="sizing_capped_by_budget" {{ "checked" if form.sizing_capped_by_budget }}> Sizing capped by budget</label>
     <label class="check"><input type="checkbox" name="allow_futures_leverage" {{ "checked" if form.allow_futures_leverage }}> Allow futures leverage</label>
     <label class="check"><input type="checkbox" name="allow_naked_shorts" {{ "checked" if form.allow_naked_shorts }}> Allow naked shorts</label>

--- a/tests/unit/gpt_trader/core/test_instruments.py
+++ b/tests/unit/gpt_trader/core/test_instruments.py
@@ -65,6 +65,26 @@ def test_instrument_preserves_the_exact_symbol_string() -> None:
     assert Instrument.parse("AAPL").symbol == "AAPL"
 
 
+def test_settlement_days_derive_from_asset_class() -> None:
+    # Cash-account settlement is data keyed off the asset class (#1231):
+    # crypto spot settles immediately, US equities settle T+1.
+    assert Instrument.parse("BTC-USD").settlement_days == 0
+    assert Instrument.parse("AAPL").settlement_days == 1
+
+
+def test_settlement_days_are_total_over_the_asset_class_vocabulary() -> None:
+    # Every classifiable instrument must have a settlement answer; a new
+    # asset class without one would KeyError here before it could reach the
+    # buying-power check.
+    for asset_class in AssetClass:
+        instrument = Instrument(
+            symbol="X",
+            asset_class=asset_class,
+            product_type=ProductType.SPOT,
+        )
+        assert instrument.settlement_days >= 0
+
+
 def test_product_type_vocabulary_is_unchanged() -> None:
     # Persisted trade-idea records serialize these exact values; the enum
     # moved to core but its vocabulary must not drift.

--- a/tests/unit/gpt_trader/features/trade_ideas/test_budget.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_budget.py
@@ -232,3 +232,41 @@ def test_budget_payload_without_drawdown_lever_still_loads() -> None:
     restored = RiskBudget.from_dict(payload)
 
     assert restored.max_drawdown_from_peak_pct is None
+
+
+def test_equity_buying_power_lever_round_trips_and_validates() -> None:
+    budget = replace(
+        DEFAULT_RISK_BUDGET,
+        max_equity_buying_power_pct=Decimal("100"),
+        reason="Configure cash-account buying power for equities",
+    )
+
+    restored = RiskBudget.from_dict(budget.to_dict())
+    assert restored.max_equity_buying_power_pct == Decimal("100")
+
+    with pytest.raises(ValueError, match="max_equity_buying_power_pct"):
+        replace(DEFAULT_RISK_BUDGET, max_equity_buying_power_pct=Decimal("-1"))
+    with pytest.raises(ValueError, match="max_equity_buying_power_pct"):
+        replace(DEFAULT_RISK_BUDGET, max_equity_buying_power_pct=Decimal("NaN"))
+
+
+def test_equity_buying_power_lever_is_unconfigured_by_default() -> None:
+    # The seeded default keeps the lever off (#1231): configuring it changes
+    # what an unclassifiable instrument does at approval time, and crypto
+    # approval outcomes are pinned unchanged until an operator versions the
+    # lever in (100 = cash-account fidelity).
+    assert DEFAULT_RISK_BUDGET.max_equity_buying_power_pct is None
+
+
+def test_budget_payload_without_buying_power_lever_still_loads() -> None:
+    # Budget logs written before the lever existed (#1231) must keep loading;
+    # an absent key means the buying-power dimension is not configured.
+    payload = {
+        key: value
+        for key, value in DEFAULT_RISK_BUDGET.to_dict().items()
+        if key != "max_equity_buying_power_pct"
+    }
+
+    restored = RiskBudget.from_dict(payload)
+
+    assert restored.max_equity_buying_power_pct is None

--- a/tests/unit/gpt_trader/features/trade_ideas/test_policy_buying_power.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_policy_buying_power.py
@@ -1,0 +1,225 @@
+"""Cash-account buying-power dimension of the risk budget (#1231).
+
+Equity ideas must not be approvable beyond what a cash account could fund
+given settlement; crypto-spot approval outcomes are pinned unchanged.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+
+from tests.unit.gpt_trader.features.trade_ideas.conftest import build_trade_idea
+
+from gpt_trader.features.trade_ideas import (
+    DEFAULT_RISK_BUDGET,
+    ActorType,
+    ApprovalBudgetContext,
+    ApprovalPolicy,
+    RiskBudget,
+    SizingRecommendation,
+    TradeIdea,
+)
+
+NOW = datetime(2026, 6, 12, 10, 0, tzinfo=UTC)
+
+# The lever is unconfigured in the seeded default; CONFIGURED versions in
+# cash-account fidelity (100% of attested equity is spendable buying power).
+CONFIGURED = replace(
+    DEFAULT_RISK_BUDGET,
+    max_equity_buying_power_pct=Decimal("100"),
+    reason="Configure cash-account buying power for equities",
+)
+UNCONFIGURED = DEFAULT_RISK_BUDGET
+
+
+def equity_idea(**overrides: Any) -> TradeIdea:
+    fields: dict[str, Any] = {
+        "instrument": "AAPL",
+        "thesis": "Earnings momentum with sector breadth confirmation",
+        "data_used": ("provider:candles:AAPL:1d:2026-06-11",),
+    }
+    fields.update(overrides)
+    return build_trade_idea(**fields)
+
+
+def violations(
+    idea: TradeIdea,
+    budget: RiskBudget = CONFIGURED,
+    **context_overrides: Any,
+) -> list[str]:
+    context_fields: dict[str, Any] = {"account_equity_snapshot": Decimal("10000")}
+    context_fields.update(context_overrides)
+    return ApprovalPolicy().approval_violations(
+        idea,
+        actor_type=ActorType.HUMAN,
+        budget=budget,
+        open_approved_count=0,
+        now=NOW,
+        budget_context=ApprovalBudgetContext(**context_fields),
+    )
+
+
+def test_open_equity_exposure_plus_candidate_breaches_buying_power() -> None:
+    found = violations(equity_idea(), open_equity_notional=Decimal("4000"))
+
+    assert any(
+        "max_equity_buying_power_pct budget breached: projected equity "
+        "buying-power usage 100.75% exceeds limit 100%" in violation
+        for violation in found
+    )
+
+
+def test_unsettled_equity_proceeds_consume_buying_power() -> None:
+    # 6075 candidate fits attested equity alone, but 4000 of same-day sale
+    # proceeds are still unsettled: a cash account cannot fund the buy.
+    found = violations(equity_idea(), unsettled_equity_proceeds=Decimal("4000"))
+
+    assert any(
+        "unsettled_equity_proceeds=4000" in violation and "max_equity_buying_power_pct" in violation
+        for violation in found
+    )
+
+
+def test_equity_candidate_within_settled_cash_is_not_flagged() -> None:
+    found = violations(equity_idea())
+
+    assert not any("max_equity_buying_power_pct" in violation for violation in found)
+
+
+def test_unconfigured_lever_adds_no_buying_power_violations() -> None:
+    # None = not configured: the pre-existing checks are the entire story.
+    found = violations(
+        equity_idea(),
+        budget=UNCONFIGURED,
+        open_equity_notional=Decimal("9000"),
+        unsettled_equity_proceeds=Decimal("9000"),
+    )
+
+    assert not any("max_equity_buying_power_pct" in violation for violation in found)
+
+
+def test_missing_equity_snapshot_reports_cannot_verify_not_silence() -> None:
+    found = ApprovalPolicy().approval_violations(
+        equity_idea(),
+        actor_type=ActorType.HUMAN,
+        budget=CONFIGURED,
+        open_approved_count=0,
+        now=NOW,
+        budget_context=ApprovalBudgetContext(account_equity_snapshot=None),
+    )
+
+    assert any(
+        "account_equity_snapshot is required to verify "
+        "max_equity_buying_power_pct budget exposure" in violation
+        for violation in found
+    )
+
+
+def test_non_positive_equity_snapshot_reports_cannot_verify() -> None:
+    found = violations(equity_idea(), account_equity_snapshot=Decimal("0"))
+
+    assert any(
+        "account_equity_snapshot must be positive to verify "
+        "max_equity_buying_power_pct budget exposure" in violation
+        for violation in found
+    )
+
+
+def test_unverifiable_open_equity_exposure_is_refused_loudly() -> None:
+    found = violations(equity_idea(), open_equity_notional_unavailable_count=2)
+
+    assert any(
+        "2 idea(s) whose equity notional cannot be verified" in violation for violation in found
+    )
+
+
+def test_unverifiable_unsettled_proceeds_are_refused_loudly() -> None:
+    found = violations(equity_idea(), unsettled_equity_proceeds_unavailable_count=1)
+
+    assert any(
+        "1 closeout(s) whose sale proceeds cannot be verified" in violation for violation in found
+    )
+
+
+def test_equity_candidate_without_notional_cannot_verify_buying_power() -> None:
+    idea = equity_idea(
+        sizing_recommendation=SizingRecommendation(
+            quantity=Decimal("10"),
+            notional=None,
+            rationale="Missing notional cannot prove buying-power compliance",
+        )
+    )
+
+    found = violations(idea)
+
+    assert any(
+        "sizing_recommendation.notional is required to verify "
+        "max_equity_buying_power_pct budget exposure" in violation
+        for violation in found
+    )
+
+
+def test_unclassifiable_instrument_is_refused_loudly_when_lever_is_set() -> None:
+    found = violations(build_trade_idea(instrument="BRK.B"))
+
+    assert any(
+        "instrument cannot be classified to verify max_equity_buying_power_pct" in violation
+        for violation in found
+    )
+
+
+def test_crypto_spot_approval_outcomes_are_pinned_unchanged() -> None:
+    # Representative crypto-spot candidates must evaluate identically whether
+    # the buying-power lever is configured or absent — even against hostile
+    # equity aggregates, which crypto never consumes.
+    candidates = (
+        build_trade_idea(),
+        build_trade_idea(
+            instrument="ETH-USD",
+            sizing_recommendation=SizingRecommendation(
+                quantity=Decimal("2"),
+                notional=Decimal("9500"),
+                rationale="Near the notional cap but inside it",
+            ),
+        ),
+        build_trade_idea(
+            instrument="SOL-USDC",
+            sizing_recommendation=SizingRecommendation(
+                quantity=Decimal("100"),
+                notional=Decimal("20000"),
+                rationale="Breaches max_open_notional_pct either way",
+            ),
+        ),
+        build_trade_idea(
+            instrument="BTC-USD",
+            sizing_recommendation=SizingRecommendation(
+                quantity=Decimal("0.1"),
+                notional=None,
+                rationale="Missing notional fails the notional check either way",
+            ),
+        ),
+    )
+
+    for candidate in candidates:
+        with_lever = violations(
+            candidate,
+            budget=CONFIGURED,
+            open_equity_notional=Decimal("9999"),
+            unsettled_equity_proceeds=Decimal("9999"),
+            open_equity_notional_unavailable_count=3,
+            unsettled_equity_proceeds_unavailable_count=3,
+        )
+        without_lever = violations(
+            candidate,
+            budget=UNCONFIGURED,
+            open_equity_notional=Decimal("9999"),
+            unsettled_equity_proceeds=Decimal("9999"),
+            open_equity_notional_unavailable_count=3,
+            unsettled_equity_proceeds_unavailable_count=3,
+        )
+
+        assert with_lever == without_lever
+        assert not any("max_equity_buying_power_pct" in violation for violation in with_lever)

--- a/tests/unit/gpt_trader/features/trade_ideas/test_service_buying_power.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_service_buying_power.py
@@ -1,0 +1,229 @@
+"""Service-level cash-account buying-power aggregation and enforcement (#1231)."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, datetime
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import pytest
+from tests.unit.gpt_trader.features.trade_ideas.conftest import (
+    attest_account_equity,
+    build_trade_idea,
+)
+
+from gpt_trader.features.trade_ideas import (
+    ActorType,
+    CloseoutResolution,
+    PolicyViolationError,
+    SizingRecommendation,
+    TradeIdea,
+    TradeIdeaState,
+)
+from gpt_trader.features.trade_ideas.service import TradeIdeaService
+
+
+def configure_buying_power(
+    service: TradeIdeaService,
+    pct: Decimal | None = Decimal("100"),
+) -> None:
+    """Version the cash-account buying-power lever onto the current budget."""
+    current = service.current_budget()
+    service.update_budget(
+        replace(
+            current,
+            version=current.version + 1,
+            max_equity_buying_power_pct=pct,
+            reason="Configure cash-account buying power for equities",
+        ),
+        ActorType.HUMAN,
+        "rj",
+    )
+
+
+@pytest.fixture
+def service(tmp_path: Path) -> TradeIdeaService:
+    built = TradeIdeaService(
+        tmp_path / "trade_ideas",
+        now_factory=lambda: datetime(2026, 6, 12, 10, 0, tzinfo=UTC),
+    )
+    attest_account_equity(built, equity=Decimal("10000"))
+    configure_buying_power(built)
+    return built
+
+
+def equity_idea(decision_id: str, instrument: str, **overrides: Any) -> TradeIdea:
+    fields: dict[str, Any] = {
+        "decision_id": decision_id,
+        "instrument": instrument,
+        "thesis": "Earnings momentum with sector breadth confirmation",
+        "data_used": (f"provider:candles:{instrument}:1d:2026-06-11",),
+    }
+    fields.update(overrides)
+    return build_trade_idea(**fields)
+
+
+def test_open_equity_exposure_blocks_a_second_equity_idea(
+    service: TradeIdeaService,
+) -> None:
+    first = equity_idea("trade-20260612-open-aapl", "AAPL")
+    service.propose(first, actor_id="idea-generator-v1")
+    service.approve(first.decision_id, actor_id="rj", reason="Risk verified")
+    candidate = equity_idea("trade-20260612-candidate-msft", "MSFT")
+    service.propose(candidate, actor_id="idea-generator-v1")
+
+    # 6075 open + 6075 candidate = 121.5% of the attested 10000 equity: the
+    # configured 100% cash-account lever refuses it beside the notional check.
+    with pytest.raises(PolicyViolationError) as exc_info:
+        service.approve(candidate.decision_id, actor_id="rj", reason="Risk verified")
+
+    assert any(
+        "max_equity_buying_power_pct budget breached" in violation
+        and "open_equity_notional=6075" in violation
+        for violation in exc_info.value.violations
+    )
+    assert service.get(candidate.decision_id).state is TradeIdeaState.PROPOSED
+
+
+def test_same_day_equity_sale_proceeds_are_unsettled_buying_power(
+    service: TradeIdeaService,
+) -> None:
+    closed = equity_idea("trade-20260612-closed-aapl", "AAPL")
+    service.propose(closed, actor_id="idea-generator-v1")
+    service.approve(closed.decision_id, actor_id="rj", reason="Risk verified")
+    service.record_submission(closed.decision_id, actor_id="executor", venue="manual")
+    service.record_fill(
+        closed.decision_id,
+        actor_id="executor",
+        venue="manual",
+        external_order_id="paper-1",
+    )
+    service.record_closeout_attribution(
+        closed.decision_id,
+        actor_id="rj",
+        resolution=CloseoutResolution.THESIS_TARGET,
+        realized_profit_loss_amount=Decimal("100"),
+        evidence=("paper-statement:paper-1",),
+    )
+    candidate = equity_idea("trade-20260612-candidate-msft", "MSFT")
+    service.propose(candidate, actor_id="idea-generator-v1")
+
+    context = service.approval_budget_context(exclude_decision_id=candidate.decision_id)
+    # T+1: today's sale proceeds (6075 entry + 100 realized) are not settled
+    # cash yet, so the 6075 candidate cannot be funded from 10000 equity.
+    assert context.unsettled_equity_proceeds == Decimal("6175")
+    assert context.open_equity_notional == Decimal("0")
+
+    with pytest.raises(PolicyViolationError) as exc_info:
+        service.approve(candidate.decision_id, actor_id="rj", reason="Risk verified")
+
+    assert any(
+        "max_equity_buying_power_pct budget breached" in violation
+        and "unsettled_equity_proceeds=6175" in violation
+        for violation in exc_info.value.violations
+    )
+
+
+def test_crypto_exposure_never_counts_toward_equity_buying_power(
+    service: TradeIdeaService,
+) -> None:
+    crypto = build_trade_idea(decision_id="trade-20260612-open-btc")
+    service.propose(crypto, actor_id="idea-generator-v1")
+    service.approve(crypto.decision_id, actor_id="rj", reason="Risk verified")
+
+    context = service.approval_budget_context()
+
+    assert context.open_notional == Decimal("6075")
+    assert context.open_equity_notional == Decimal("0")
+    assert context.open_equity_notional_unavailable_count == 0
+    assert context.unsettled_equity_proceeds == Decimal("0")
+
+
+def test_crypto_approval_is_unchanged_with_the_lever_configured(
+    service: TradeIdeaService,
+) -> None:
+    # The fixture configures max_equity_buying_power_pct=100; a crypto-spot
+    # idea inside the notional cap must approve exactly as before #1231.
+    crypto = build_trade_idea(decision_id="trade-20260612-btc-approves")
+    service.propose(crypto, actor_id="idea-generator-v1")
+
+    approved = service.approve(crypto.decision_id, actor_id="rj", reason="Risk verified")
+
+    assert approved.state is TradeIdeaState.APPROVED
+
+
+def test_equity_idea_without_notional_fails_closed_on_buying_power(
+    service: TradeIdeaService,
+) -> None:
+    candidate = equity_idea(
+        "trade-20260612-no-notional",
+        "AAPL",
+        sizing_recommendation=SizingRecommendation(
+            quantity=Decimal("10"),
+            notional=None,
+            rationale="Missing notional cannot prove buying-power compliance",
+        ),
+    )
+    service.propose(candidate, actor_id="idea-generator-v1")
+
+    with pytest.raises(PolicyViolationError) as exc_info:
+        service.approve(candidate.decision_id, actor_id="rj", reason="Risk verified")
+
+    assert any(
+        "sizing_recommendation.notional is required to verify "
+        "max_equity_buying_power_pct budget exposure" in violation
+        for violation in exc_info.value.violations
+    )
+
+
+def test_open_idea_with_unclassifiable_instrument_counts_unavailable(
+    service: TradeIdeaService,
+) -> None:
+    # An unclassifiable instrument approved before the lever was configured
+    # (lever set to None, the pre-#1231 posture) must poison later equity
+    # buying-power verification instead of being skipped silently.
+    lever_off = service.current_budget()
+    service.update_budget(
+        replace(
+            lever_off,
+            version=lever_off.version + 1,
+            max_equity_buying_power_pct=None,
+            reason="Model a budget log from before the buying-power lever",
+        ),
+        ActorType.HUMAN,
+        "rj",
+    )
+    odd = build_trade_idea(
+        decision_id="trade-20260612-odd-instrument",
+        instrument="BRK.B",
+        data_used=("provider:candles:BRK.B:1d:2026-06-11",),
+    )
+    service.propose(odd, actor_id="idea-generator-v1")
+    service.approve(odd.decision_id, actor_id="rj", reason="Risk verified")
+    lever_on = service.current_budget()
+    service.update_budget(
+        replace(
+            lever_on,
+            version=lever_on.version + 1,
+            max_equity_buying_power_pct=Decimal("100"),
+            reason="Configure cash-account buying power for equities",
+        ),
+        ActorType.HUMAN,
+        "rj",
+    )
+
+    context = service.approval_budget_context()
+
+    assert context.open_equity_notional_unavailable_count == 1
+
+    candidate = equity_idea("trade-20260612-candidate-msft", "MSFT")
+    service.propose(candidate, actor_id="idea-generator-v1")
+
+    with pytest.raises(PolicyViolationError) as exc_info:
+        service.approve(candidate.decision_id, actor_id="rj", reason="Risk verified")
+
+    assert any(
+        "equity notional cannot be verified" in violation for violation in exc_info.value.violations
+    )

--- a/var/agents/configuration/environment_variables.json
+++ b/var/agents/configuration/environment_variables.json
@@ -777,7 +777,7 @@
       ],
       "code_references": [
         {
-          "line": 271,
+          "line": 317,
           "path": "src/gpt_trader/features/trade_ideas/service.py",
           "reader": "os.environ.get"
         }
@@ -1189,7 +1189,7 @@
       ],
       "code_references": [
         {
-          "line": 284,
+          "line": 330,
           "path": "src/gpt_trader/features/trade_ideas/service.py",
           "reader": "os.environ.get"
         }
@@ -1221,7 +1221,7 @@
       ],
       "code_references": [
         {
-          "line": 261,
+          "line": 307,
           "path": "src/gpt_trader/features/trade_ideas/service.py",
           "reader": "os.environ.get"
         }


### PR DESCRIPTION
## Summary
Venues P1-D (#1224 workstream): the budget vocabulary can now express, and the accountant/approval path enforce, a cash-account buying-power constraint for equity instruments — closing the "the budget thinks in notional" leak-watch item at cash-account fidelity.

Closes #1231

- **New budget lever** `max_equity_buying_power_pct` (`RiskBudget`): optional, `None` = not configured, validated in `__post_init__` (finite, non-negative), versioned through the append-only `RiskBudgetLog`, serialized in `to_dict`/`from_dict` (older log entries load as `None`). Renegotiable via `ideas budget set --max-equity-buying-power-pct` and the console envelope form.
- **Check** (`policy._equity_buying_power_violations`, beside the `max_open_notional_pct` enforcement): when configured and the candidate classifies as equity, projected usage — open equity notional + candidate notional + unsettled equity sale proceeds — may not exceed the configured percent of the attested `account_equity`. 100 = "cannot exceed attested equity" (cash-account fidelity per the issue DoD).
- **Settlement as data, not venue branching**: `Instrument.settlement_days` derives from `AssetClass` (crypto spot 0, US equities T+1). Same-trading-day equity closeout proceeds (entry notional + realized P&L) are held back as unsettled in `approval_budget_context`.
- **Fail-closed**: unclassifiable instrument (`InstrumentParseError`), missing candidate notional, unverifiable open equity exposure/proceeds, and missing or non-positive attested equity each produce an explicit cannot-verify violation — mirroring the existing notional-check messages — never a silent pass. `None` lever = status quo, loosens nothing.
- **Crypto pinned unchanged**: policy tests assert representative crypto-spot candidates evaluate identically with the lever configured vs absent, even against hostile equity aggregates. The seeded default deliberately keeps the lever unconfigured — the full unit suite caught that seeding 100 would newly refuse an existing lowercase-instrument crypto approval, which the pinning constraint forbids.
- No product booleans (venue-neutrality posture); margin, PDT, and the options defined-risk half stay deferred; executor/cycle wiring is #1232. No broker calls; tightens paper approval only.

## Type of change
- [x] Feature

## Scope & Impact
- Affected areas / components: `core/instruments.py`, `features/trade_ideas/{budget,policy,service}.py`, `cli/commands/ideas.py`, `web/app.py` + envelope template, docs (STATUS, CLI spec).
- Behavior changes: none unless the operator configures the new lever (tests pin this); once configured, equity approvals are additionally constrained (tightening only).

## Test Plan
- [x] Unit tests added/updated (`test_policy_buying_power.py`, `test_service_buying_power.py`, budget/instrument lever tests) — 6820 unit tests pass
- [x] Ran locally: full `uv run local-ci` (pr profile) — all blocking gates PASS

## Quality Gates
- [x] `uv run local-ci` passes locally
- [x] `uv run mypy src/gpt_trader` clean
- [x] No `sys.path` hacks in tests
- [x] Import boundaries respected (features -> core only)

## Observability & Errors
- [x] Violations carry full diagnostic context (open_equity_notional, candidate_notional, unsettled_equity_proceeds, account_equity_snapshot)

## Agent Artifacts & Config (if touched)
- [x] `uv run agent-regenerate` run and refreshed artifacts committed (`--verify` clean)
- [x] Docs updated in the same PR (docs_link_audit/docs_currency both PASS)

## Breaking Changes
- [x] None