### PR TITLE
feat(trade-ideas): regime-conditioned exit plans — first replay-visible decision channel (#1242)

### DIFF
--- a/src/gpt_trader/features/trade_ideas/baseline.py
+++ b/src/gpt_trader/features/trade_ideas/baseline.py
@@ -41,6 +41,28 @@ ConfidenceOverlay = Callable[[str, Confidence], Confidence]
 
 
 @dataclass(frozen=True, slots=True)
+class ExitLevels:
+    """Stop/target inputs a wrapping proposer may adjust before an idea is built.
+
+    ``stop_basis`` is the prose clause the invalidation text uses to describe
+    what the stop level is ("the 50-bar average" by default), so adjusted
+    levels and their written rationale cannot drift apart.
+    """
+
+    stop_level: Decimal
+    reward_multiple: Decimal
+    stop_basis: str
+
+
+# Per-run hook letting wrapping proposers adjust exit levels (symbol, close,
+# proposed levels) before validation, sizing, and prose are built. The
+# baseline re-quantizes and re-validates the result, so an adjustment that
+# breaks stop < entry < target ordering skips the idea instead of emitting an
+# inconsistent record.
+ExitLevelsOverlay = Callable[[str, Decimal, ExitLevels], ExitLevels]
+
+
+@dataclass(frozen=True, slots=True)
 class BaselineProposerConfig:
     short_window: int = 10
     long_window: int = 50
@@ -88,10 +110,16 @@ class BaselineProposer:
         snapshot: MarketSnapshot,
         *,
         confidence_overlay: ConfidenceOverlay | None = None,
+        exit_overlay: ExitLevelsOverlay | None = None,
     ) -> list[TradeIdea]:
         ideas: list[TradeIdea] = []
         for series in snapshot.series:
-            idea = self._propose_for_series(snapshot, series, confidence_overlay=confidence_overlay)
+            idea = self._propose_for_series(
+                snapshot,
+                series,
+                confidence_overlay=confidence_overlay,
+                exit_overlay=exit_overlay,
+            )
             if idea is not None:
                 ideas.append(idea)
         return ideas
@@ -102,6 +130,7 @@ class BaselineProposer:
         series: SymbolSeries,
         *,
         confidence_overlay: ConfidenceOverlay | None = None,
+        exit_overlay: ExitLevelsOverlay | None = None,
     ) -> TradeIdea | None:
         config = self._config
         as_of = _utc_aware(snapshot.as_of)
@@ -125,13 +154,21 @@ class BaselineProposer:
             return None
 
         close = closes[-1]
-        stop_level = long_now.quantize(config.price_precision)
-        if close <= stop_level:
+        long_level = long_now.quantize(config.price_precision)
+        levels = ExitLevels(
+            stop_level=long_level,
+            reward_multiple=config.reward_multiple,
+            stop_basis=f"the {config.long_window}-bar average",
+        )
+        if exit_overlay is not None:
+            levels = exit_overlay(series.symbol, close, levels)
+        stop_level = levels.stop_level.quantize(config.price_precision)
+        if stop_level <= 0 or close <= stop_level:
             return None
 
         entry_lower = (close * (1 - config.entry_band_pct / 100)).quantize(config.price_precision)
         entry_upper = (close * (1 + config.entry_band_pct / 100)).quantize(config.price_precision)
-        target = (close + config.reward_multiple * (close - stop_level)).quantize(
+        target = (close + levels.reward_multiple * (close - stop_level)).quantize(
             config.price_precision
         )
         # On low-priced symbols the price precision can round the stop, entry
@@ -183,15 +220,15 @@ class BaselineProposer:
                 f"{series.symbol} {config.short_window}-bar average crossed above the "
                 f"{config.long_window}-bar average within the last "
                 f"{config.crossover_lookback} bars and closed at {close} above the "
-                f"long-term average {stop_level}, signalling upward momentum"
+                f"long-term average {long_level}, signalling upward momentum"
             ),
             instrument=series.symbol,
             product_type=ProductType.SPOT,
             direction=TradeDirection.LONG,
             entry_zone=EntryZone(lower=entry_lower, upper=entry_upper),
-            invalidation=f"Close below the {config.long_window}-bar average ({stop_level})",
+            invalidation=f"Close below {levels.stop_basis} ({stop_level})",
             target_exit=(
-                f"Take profit near {target} ({config.reward_multiple}R) or exit at expiry"
+                f"Take profit near {target} ({levels.reward_multiple}R) or exit at expiry"
             ),
             max_loss=MaxLoss(
                 amount=sizing.estimated_loss_amount,

--- a/src/gpt_trader/features/trade_ideas/regime.py
+++ b/src/gpt_trader/features/trade_ideas/regime.py
@@ -25,6 +25,7 @@ from gpt_trader.features.intelligence.regime import (
 from gpt_trader.features.trade_ideas.baseline import (
     BaselineProposer,
     BaselineProposerConfig,
+    ExitLevels,
 )
 from gpt_trader.features.trade_ideas.eligibility import evaluate_eligibility
 from gpt_trader.features.trade_ideas.models import (
@@ -55,11 +56,33 @@ RegimeDetectorFactory = Callable[[RegimeConfig], RegimeDetector]
 
 @dataclass(frozen=True, slots=True)
 class RegimeAwareProposerConfig:
-    """Configuration for the regime-aware MA proposer."""
+    """Configuration for the regime-aware MA proposer.
+
+    ``volatile_stop_distance_multiplier`` widens the baseline stop distance
+    (anchored at the last close) when the detected regime is volatile, and
+    ``volatile_reward_multiple`` optionally replaces the baseline reward
+    multiple there — the regime overlay's replay-visible decision channel
+    (#1242). A multiplier of 1 with no reward override reproduces baseline
+    levels exactly.
+    """
 
     baseline_config: BaselineProposerConfig = field(default_factory=BaselineProposerConfig)
     regime_config: RegimeConfig = field(default_factory=RegimeConfig)
     suppressed_regimes: tuple[RegimeType, ...] = DEFAULT_SUPPRESSED_REGIMES
+    volatile_stop_distance_multiplier: Decimal = Decimal("1.5")
+    volatile_reward_multiple: Decimal | None = None
+
+    def __post_init__(self) -> None:
+        if self.volatile_stop_distance_multiplier <= 0:
+            raise ValidationError(
+                "volatile_stop_distance_multiplier must be positive",
+                field="volatile_stop_distance_multiplier",
+            )
+        if self.volatile_reward_multiple is not None and self.volatile_reward_multiple <= 0:
+            raise ValidationError(
+                "volatile_reward_multiple must be positive",
+                field="volatile_reward_multiple",
+            )
 
 
 class RegimeAwareProposer:
@@ -98,8 +121,16 @@ class RegimeAwareProposer:
                 rationale=confidence.rationale,
             )
 
+        def overlay_exit(symbol: str, close: Decimal, levels: ExitLevels) -> ExitLevels:
+            state = states.get(symbol, RegimeState.unknown())
+            return _regime_exit_levels(levels, close=close, state=state, config=self._config)
+
         ideas: list[TradeIdea] = []
-        for idea in self._baseline.propose(snapshot, confidence_overlay=overlay_label):
+        for idea in self._baseline.propose(
+            snapshot,
+            confidence_overlay=overlay_label,
+            exit_overlay=overlay_exit,
+        ):
             state = states.get(idea.instrument, RegimeState.unknown())
             # UNKNOWN means the detector has not warmed up (long EMA plus
             # persistence ticks); a "regime-aware" idea with a 0.0-confidence
@@ -173,6 +204,38 @@ def _detect_series_regime(detector: RegimeDetector, series: SymbolSeries) -> Reg
     return state
 
 
+def _regime_exit_levels(
+    levels: ExitLevels,
+    *,
+    close: Decimal,
+    state: RegimeState,
+    config: RegimeAwareProposerConfig,
+) -> ExitLevels:
+    """Widen the stop distance (anchored at the close) in volatile regimes.
+
+    UNKNOWN and quiet regimes pass baseline levels through untouched, so any
+    level difference from baseline is attributable to a volatile
+    classification at proposal time.
+    """
+    if state.regime is RegimeType.UNKNOWN or not state.is_volatile():
+        return levels
+    multiplier = config.volatile_stop_distance_multiplier
+    reward_multiple = (
+        config.volatile_reward_multiple
+        if config.volatile_reward_multiple is not None
+        else levels.reward_multiple
+    )
+    if multiplier == 1 and reward_multiple == levels.reward_multiple:
+        return levels
+    return ExitLevels(
+        stop_level=close - multiplier * (close - levels.stop_level),
+        reward_multiple=reward_multiple,
+        stop_basis=(
+            f"the volatility-adjusted stop ({multiplier}x the distance to " f"{levels.stop_basis})"
+        ),
+    )
+
+
 def _regime_config_fingerprint(config: RegimeConfig) -> str:
     payload = json.dumps(config.to_dict(), sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:12]
@@ -185,6 +248,12 @@ def _proposer_config_fingerprint(config: RegimeAwareProposerConfig) -> str:
             "baseline": {spec.name: str(getattr(baseline, spec.name)) for spec in fields(baseline)},
             "regime": config.regime_config.to_dict(),
             "suppressed_regimes": [regime.name for regime in config.suppressed_regimes],
+            "volatile_stop_distance_multiplier": str(config.volatile_stop_distance_multiplier),
+            "volatile_reward_multiple": (
+                str(config.volatile_reward_multiple)
+                if config.volatile_reward_multiple is not None
+                else None
+            ),
         },
         sort_keys=True,
         separators=(",", ":"),

--- a/tests/unit/gpt_trader/features/trade_ideas/test_baseline_proposer.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_baseline_proposer.py
@@ -245,3 +245,83 @@ def test_decision_ids_are_distinct_per_symbol(symbol: str) -> None:
     ]
 
     assert symbol.lower().replace("-", "") in idea.decision_id
+
+
+def test_exit_overlay_adjusts_levels_prose_and_sizing() -> None:
+    from gpt_trader.features.trade_ideas.baseline import ExitLevels
+
+    def widen(symbol: str, close: Decimal, levels: ExitLevels) -> ExitLevels:
+        return ExitLevels(
+            stop_level=close - 2 * (close - levels.stop_level),
+            reward_multiple=Decimal("3"),
+            stop_basis="the widened stop",
+        )
+
+    snapshot = snapshot_of(make_series(GOLDEN_CROSS))
+    baseline_idea = BaselineProposer(CONFIG).propose(snapshot)[0]
+    idea = BaselineProposer(CONFIG).propose(snapshot, exit_overlay=widen)[0]
+
+    # close 104, baseline stop 100.30 -> widened stop 96.60, 3R target 126.20.
+    assert idea.exit_plan is not None
+    assert idea.exit_plan.stop == Decimal("96.60")
+    assert idea.exit_plan.target == Decimal("126.20")
+    assert idea.invalidation == "Close below the widened stop (96.60)"
+    assert "(3R)" in idea.target_exit
+    assert str(idea.exit_plan.target) in idea.target_exit
+    assert idea.entry_zone == baseline_idea.entry_zone
+    # Sizing and its written risk snapshot must follow the adjusted stop
+    # distance: (105.04 - 96.60) / 105.04 = 8.04%, not the baseline's 4.51%.
+    assert any("stop distance is 8.04% from there" in item for item in idea.max_loss.assumptions)
+    assert any(
+        "stop distance is 4.51% from there" in item for item in baseline_idea.max_loss.assumptions
+    )
+    assert evaluate_eligibility(idea) == []
+
+
+def test_exit_overlay_without_adjustment_reproduces_baseline_record() -> None:
+    from gpt_trader.features.trade_ideas.baseline import ExitLevels
+
+    def passthrough(symbol: str, close: Decimal, levels: ExitLevels) -> ExitLevels:
+        return levels
+
+    snapshot = snapshot_of(make_series(GOLDEN_CROSS))
+    baseline_idea = BaselineProposer(CONFIG).propose(snapshot)[0]
+    idea = BaselineProposer(CONFIG).propose(snapshot, exit_overlay=passthrough)[0]
+
+    assert idea == baseline_idea
+
+
+def test_exit_overlay_that_breaks_level_ordering_skips_idea() -> None:
+    from gpt_trader.features.trade_ideas.baseline import ExitLevels
+
+    def stop_above_close(symbol: str, close: Decimal, levels: ExitLevels) -> ExitLevels:
+        return ExitLevels(
+            stop_level=close + 1,
+            reward_multiple=levels.reward_multiple,
+            stop_basis=levels.stop_basis,
+        )
+
+    assert (
+        BaselineProposer(CONFIG).propose(
+            snapshot_of(make_series(GOLDEN_CROSS)), exit_overlay=stop_above_close
+        )
+        == []
+    )
+
+
+def test_exit_overlay_that_produces_non_positive_stop_skips_idea() -> None:
+    from gpt_trader.features.trade_ideas.baseline import ExitLevels
+
+    def negative_stop(symbol: str, close: Decimal, levels: ExitLevels) -> ExitLevels:
+        return ExitLevels(
+            stop_level=Decimal("-1"),
+            reward_multiple=levels.reward_multiple,
+            stop_basis=levels.stop_basis,
+        )
+
+    assert (
+        BaselineProposer(CONFIG).propose(
+            snapshot_of(make_series(GOLDEN_CROSS)), exit_overlay=negative_stop
+        )
+        == []
+    )

--- a/tests/unit/gpt_trader/features/trade_ideas/test_regime_proposer.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_regime_proposer.py
@@ -268,3 +268,76 @@ def test_replay_runner_scores_regime_aware_proposer_on_historical_candles() -> N
     assert report.ideas_proposed == 1
     assert report.target_hits == 1
     assert report.ideas[0].outcome is ReplayOutcome.TARGET_HIT
+
+
+def test_volatile_regime_widens_stop_and_target() -> None:
+    # The replay-visible decision channel (#1242): a volatile classification
+    # widens the stop distance about the close and moves the target with it.
+    snapshot = snapshot_of(make_series(GOLDEN_CROSS))
+    baseline_idea = BaselineProposer(CONFIG.baseline_config).propose(snapshot)[0]
+    factory, _detectors = scripted_factory(regime_state(RegimeType.BULL_VOLATILE))
+    idea = RegimeAwareProposer(CONFIG, detector_factory=factory).propose(snapshot)[0]
+
+    assert baseline_idea.exit_plan is not None
+    assert idea.exit_plan is not None
+    # close 104, 20-bar average 100.30 -> stop 104 - 1.5 * 3.70 = 98.45,
+    # 2R target 104 + 2 * 5.55 = 115.10.
+    assert baseline_idea.exit_plan.stop == Decimal("100.30")
+    assert idea.exit_plan.stop == Decimal("98.45")
+    assert idea.exit_plan.target == Decimal("115.10")
+    assert idea.entry_zone == baseline_idea.entry_zone
+    assert "volatility-adjusted stop" in idea.invalidation
+    assert "98.45" in idea.invalidation
+    assert "115.10" in idea.target_exit
+    assert any("stop distance is 6.27% from there" in item for item in idea.max_loss.assumptions)
+    assert evaluate_eligibility(idea) == []
+
+
+def test_quiet_regime_reproduces_baseline_levels() -> None:
+    # With the default multiplier the diff must be attributable to volatility:
+    # quiet regimes keep baseline levels exactly.
+    snapshot = snapshot_of(make_series(GOLDEN_CROSS))
+    baseline_idea = BaselineProposer(CONFIG.baseline_config).propose(snapshot)[0]
+    factory, _detectors = scripted_factory(regime_state(RegimeType.BULL_QUIET))
+    idea = RegimeAwareProposer(CONFIG, detector_factory=factory).propose(snapshot)[0]
+
+    assert idea.exit_plan == baseline_idea.exit_plan
+    assert idea.entry_zone == baseline_idea.entry_zone
+    assert idea.invalidation.startswith("Close below the 20-bar average (100.30)")
+
+
+def test_volatile_reward_multiple_override_moves_target() -> None:
+    config = RegimeAwareProposerConfig(
+        baseline_config=CONFIG.baseline_config,
+        volatile_reward_multiple=Decimal("3"),
+    )
+    factory, _detectors = scripted_factory(regime_state(RegimeType.BULL_VOLATILE))
+    idea = RegimeAwareProposer(config, detector_factory=factory).propose(
+        snapshot_of(make_series(GOLDEN_CROSS))
+    )[0]
+
+    assert idea.exit_plan is not None
+    # stop 98.45; 3R target = 104 + 3 * 5.55 = 120.65.
+    assert idea.exit_plan.target == Decimal("120.65")
+    assert "(3R)" in idea.target_exit
+
+
+def test_exit_channel_config_enters_decision_id() -> None:
+    snapshot = snapshot_of(make_series(GOLDEN_CROSS))
+    factory, _detectors = scripted_factory(regime_state(RegimeType.BULL_VOLATILE))
+
+    default_ids = [
+        idea.decision_id
+        for idea in RegimeAwareProposer(CONFIG, detector_factory=factory).propose(snapshot)
+    ]
+    wider = RegimeAwareProposerConfig(
+        baseline_config=CONFIG.baseline_config,
+        volatile_stop_distance_multiplier=Decimal("2"),
+    )
+    wider_ids = [
+        idea.decision_id
+        for idea in RegimeAwareProposer(wider, detector_factory=factory).propose(snapshot)
+    ]
+
+    assert default_ids and wider_ids
+    assert set(default_ids).isdisjoint(wider_ids)


### PR DESCRIPTION
Closes #1242 (M5/W1, part of #1241).

## What

The regime-aware proposer had no channel through which regime state could affect replay-measurable outcomes: it only relabeled confidence (invisible to replay `return_r`) and suppressed regimes that never coincide with a long golden cross (0/84 on the evidence window). Edge read exactly 0.0000 on every symbol.

This gives the overlay decision authority over the exit plan:

- **`baseline.py`**: new `ExitLevels` overlay hook, the exit-plan mirror of the existing `ConfidenceOverlay`. Adjusted stop/target flow through the *single* idea-construction path, so prose (`invalidation` via `stop_basis`, `target_exit`), sizing, `max_loss` assumptions, and the structured `exit_plan` (#1218) can never drift apart. An adjustment that breaks `stop < entry < target` ordering (or produces a non-positive stop) skips the idea instead of emitting an inconsistent record. No overlay ⇒ byte-identical baseline records (test-enforced by `idea == baseline_idea`).
- **`regime.py`**: in volatile regimes (`RegimeState.is_volatile()`), widen the stop distance anchored at the close by `volatile_stop_distance_multiplier` (default 1.5) and optionally override the reward multiple (`volatile_reward_multiple`, default None = keep baseline). UNKNOWN and quiet regimes pass baseline levels through untouched, so any level diff is attributable to a volatile classification at proposal time. Both knobs enter `_proposer_config_fingerprint`, so differently configured runs cannot collide on `decision_id` (test-enforced).

## Measured edge (exit criterion)

Replayed against the recorded 2026-07-07 evidence window (8-symbol paper universe × 244 hourly snapshots, `ideas replay tournament --proposers baseline-ma-10-50,regime-aware-ma-10-50`):

| symbol | baseline avg R | regime-aware avg R | edge_r |
|--------|---------------|-------------------|--------|
| BTC-USD | -0.4000 | -0.3002 | **+0.0998** |
| ETH-USD | -0.2500 | -0.2209 | **+0.0291** |
| SOL-USD | 0.5000 | 0.5218 | **+0.0218** |
| LINK-USD | 0.1960 | 0.1991 | **+0.0031** |
| LTC-USD | 0.0603 | 0.0099 | -0.0504 |
| AVAX/DOT/XRP | — | — | 0.0000 (no idea coincided with a volatile regime) |

Pooled: **-0.1926 vs -0.2119 = +0.0193R** over 82 resolved ideas. Same idea count (84) on both sides — the diff is exit levels only, exactly attributable.

**Default disclosure:** the multiplier sweep on this window is monotone (1.25: -0.004, 1.5: +0.019, 2: +0.034, 3: +0.045). Picking the max would fit one mostly-bull ~12-day window, so the default stays mid-range at 1.5; measured multi-window tuning is #1243 (counterfactual evidence) and #1246 (expectancy hunt).

## Verification

- `uv run local-ci` (pr profile): all checks pass (498 trade_ideas unit tests, incl. 9 new).
- New tests: volatile-regime widened levels with consistent prose/sizing/exit_plan; quiet-regime byte-identical baseline levels; reward-multiple override; exit-channel knobs enter decision_id; overlay passthrough reproduces the exact baseline record; ordering-breaking and non-positive-stop adjustments skip the idea.
- Small n (82 resolved) and a single window: this PR claims a *live, attributable channel*, not proven alpha — that accrual is the rest of #1241.
