### PR TITLE
feat(trade-ideas): capital-weighted replay returns — make the sizing channel measurable (#1244)

### DIFF
--- a/docs/paper_trading.md
+++ b/docs/paper_trading.md
@@ -371,7 +371,10 @@ Both raw replay artifacts and the CliResponse envelope written by
 `--format json --output <path>` are accepted. Interpretation: per-proposer
 `target_hit_rate` / `stop_hit_rate` are the replay read on risk calibration,
 `average_return_r` is the replay read on expectancy, and the `edge vs
-baseline-ma-…` lines are the replay read on benchmark edge.
+baseline-ma-…` lines are the replay read on benchmark edge. When the replay
+artifact carries sizing (`capital_weighted_avg_r=… (n=…)`), that row is the
+only aggregate that can see the sizing channel — proposers with identical
+levels but different notional commitment separate there and nowhere else.
 
 ## Readiness Evidence Inputs
 

--- a/src/gpt_trader/features/trade_ideas/replay.py
+++ b/src/gpt_trader/features/trade_ideas/replay.py
@@ -70,6 +70,10 @@ class ReplayResult:
     return_r: Decimal | None = None
     return_pct: Decimal | None = None
     bars_evaluated: int = 0
+    # Notional the idea's sizing recommendation would have deployed; carries
+    # the sizing channel into replay so capital-weighted aggregates can rank
+    # proposers that differ only in how much they commit (#1244).
+    sized_notional: Decimal | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -93,6 +97,9 @@ class ReplayResult:
             "return_r": str(self.return_r) if self.return_r is not None else None,
             "return_pct": str(self.return_pct) if self.return_pct is not None else None,
             "bars_evaluated": self.bars_evaluated,
+            "sized_notional": (
+                str(self.sized_notional) if self.sized_notional is not None else None
+            ),
         }
 
 
@@ -157,6 +164,35 @@ class ReplayReport:
         return sum(returns, Decimal("0")) / Decimal(len(returns))
 
     @property
+    def capital_weighted_average_return_r(self) -> Decimal | None:
+        """Average R weighted by each idea's sized notional.
+
+        Reported alongside — never replacing — the per-idea average: it is
+        the only replay aggregate that can see the sizing channel, where two
+        proposers with identical levels differ in how much they commit.
+        """
+        weighted = self._capital_weighted_returns()
+        if not weighted:
+            return None
+        total_notional = sum((notional for _, notional in weighted), Decimal("0"))
+        weighted_sum = sum((value * notional for value, notional in weighted), Decimal("0"))
+        return weighted_sum / total_notional
+
+    @property
+    def capital_weighted_sample(self) -> int:
+        """Resolved ideas that carry a positive sized notional."""
+        return len(self._capital_weighted_returns())
+
+    def _capital_weighted_returns(self) -> list[tuple[Decimal, Decimal]]:
+        return [
+            (idea.return_r, idea.sized_notional)
+            for idea in self.ideas
+            if idea.return_r is not None
+            and idea.sized_notional is not None
+            and idea.sized_notional > 0
+        ]
+
+    @property
     def eligibility_pass_rate(self) -> Decimal:
         if self.eligibility_checked == 0:
             return Decimal("0")
@@ -181,6 +217,12 @@ class ReplayReport:
             "average_return_r": (
                 str(self.average_return_r) if self.average_return_r is not None else None
             ),
+            "capital_weighted_average_return_r": (
+                str(self.capital_weighted_average_return_r)
+                if self.capital_weighted_average_return_r is not None
+                else None
+            ),
+            "capital_weighted_sample": self.capital_weighted_sample,
             "eligibility_checked": self.eligibility_checked,
             "eligibility_passed": self.eligibility_passed,
             "eligibility_pass_rate": str(self.eligibility_pass_rate),
@@ -193,7 +235,12 @@ class ReplayReport:
 
 @dataclass(frozen=True, slots=True)
 class ReplayTournamentRanking:
-    """One ranked proposer row in a replay tournament."""
+    """One ranked proposer row in a replay tournament.
+
+    Ranking order stays on the per-idea metrics; the capital-weighted average
+    is reported beside them so the sizing channel is visible without changing
+    what the tournament optimizes.
+    """
 
     rank: int
     proposer_id: str
@@ -203,6 +250,8 @@ class ReplayTournamentRanking:
     stop_hit_rate: Decimal
     average_return_r: Decimal | None
     eligibility_pass_rate: Decimal
+    capital_weighted_average_return_r: Decimal | None = None
+    capital_weighted_sample: int = 0
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -216,6 +265,12 @@ class ReplayTournamentRanking:
                 str(self.average_return_r) if self.average_return_r is not None else None
             ),
             "eligibility_pass_rate": str(self.eligibility_pass_rate),
+            "capital_weighted_average_return_r": (
+                str(self.capital_weighted_average_return_r)
+                if self.capital_weighted_average_return_r is not None
+                else None
+            ),
+            "capital_weighted_sample": self.capital_weighted_sample,
         }
 
 
@@ -585,6 +640,8 @@ def _rank_tournament_reports(
             stop_hit_rate=report.stop_hit_rate,
             average_return_r=report.average_return_r,
             eligibility_pass_rate=report.eligibility_pass_rate,
+            capital_weighted_average_return_r=report.capital_weighted_average_return_r,
+            capital_weighted_sample=report.capital_weighted_sample,
         )
         for index, report in enumerate(ordered, start=1)
     )
@@ -863,4 +920,5 @@ def _result(
         return_r=return_r,
         return_pct=return_pct,
         bars_evaluated=bars_evaluated,
+        sized_notional=idea.sizing_recommendation.notional,
     )

--- a/src/gpt_trader/features/trade_ideas/scorecard.py
+++ b/src/gpt_trader/features/trade_ideas/scorecard.py
@@ -181,6 +181,10 @@ def build_replay_evidence(
             "target_hit_rate": report.get("target_hit_rate"),
             "stop_hit_rate": report.get("stop_hit_rate"),
             "average_return_r": report.get("average_return_r"),
+            # Sizing-visible aggregate (#1244); absent on pre-#1244 replay
+            # artifacts, which still render with the per-idea metrics alone.
+            "capital_weighted_average_return_r": report.get("capital_weighted_average_return_r"),
+            "capital_weighted_sample": report.get("capital_weighted_sample"),
             "eligibility_pass_rate": report.get("eligibility_pass_rate"),
         }
         for report in reports
@@ -243,13 +247,19 @@ def _replay_evidence_lines(evidence: Mapping[str, Any]) -> list[str]:
         ),
     ]
     for row in evidence["calibration"]:
-        lines.append(
+        line = (
             f"{row['proposer_id']}: resolved={row['resolved_ideas']}, "
             f"target_hit_rate={row['target_hit_rate']}, "
             f"stop_hit_rate={row['stop_hit_rate']}, "
             f"avg_r={row['average_return_r']}, "
             f"eligibility_pass_rate={row['eligibility_pass_rate']}"
         )
+        if row.get("capital_weighted_average_return_r") is not None:
+            line += (
+                f", capital_weighted_avg_r={row['capital_weighted_average_return_r']}"
+                f" (n={row.get('capital_weighted_sample')})"
+            )
+        lines.append(line)
     edge = evidence["benchmark_edge"]
     if edge["comparisons"]:
         for comparison in edge["comparisons"]:

--- a/tests/unit/gpt_trader/features/trade_ideas/test_replay_runner.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_replay_runner.py
@@ -288,3 +288,89 @@ def test_replay_runner_config_rejects_non_positive_min_history() -> None:
         assert exc.context["field"] == "min_history"
     else:  # pragma: no cover - defensive assertion
         raise AssertionError("ReplayRunnerConfig should reject min_history=0")
+
+
+def test_tournament_capital_weighted_average_sees_sizing_differences() -> None:
+    # Two proposers with identical entries/exits but different notional
+    # commitment must rank identically on per-idea avg R while their
+    # capital-weighted rows diverge (#1244) — the sizing channel is invisible
+    # to every other replay aggregate.
+    from gpt_trader.features.trade_ideas import SizingRecommendation
+
+    class SizedProposer:
+        def __init__(self, proposer_id: str, notionals: list[str]) -> None:
+            self.proposer_id = proposer_id
+            self._notionals = list(notionals)
+            self._calls = 0
+
+        def propose(self, snapshot: MarketSnapshot) -> list[TradeIdea]:
+            notional = Decimal(self._notionals[self._calls])
+            self._calls += 1
+            return [
+                scoreable_idea(
+                    sizing_recommendation=SizingRecommendation(
+                        quantity=notional / Decimal("101"),
+                        notional=notional,
+                        rationale="scripted sizing for the weighted-replay test",
+                    ),
+                )
+            ]
+
+    candles = (
+        candle(0),
+        # Snapshot 1 idea: fills here, targets on the next candle (+2R).
+        candle(1),
+        # Snapshot 2 idea: fills here (favorable exit deferred on the entry
+        # candle), stops on the next candle (-1R).
+        candle(2, high="113"),
+        # Snapshot 3 idea: fills and stops in-candle (-1R).
+        candle(3, low="94"),
+    )
+    flat_sizer = SizedProposer("flat-sizing", ["1000", "1000", "1000"])
+    conviction_sizer = SizedProposer("conviction-sizing", ["3000", "1000", "1000"])
+
+    report = TradeIdeaReplayTournamentRunner(
+        (flat_sizer, conviction_sizer),
+        config=ReplayRunnerConfig(source="fixture:candles", min_history=1),
+    ).run_series(symbol="BTC-USD", granularity="ONE_HOUR", candles=candles)
+
+    rows = {ranking.proposer_id: ranking for ranking in report.rankings}
+    flat = rows["flat-sizing"]
+    conviction = rows["conviction-sizing"]
+    # Identical levels: same resolved count and per-idea average R (0.0000).
+    assert flat.resolved_ideas == conviction.resolved_ideas == 3
+    assert flat.average_return_r == conviction.average_return_r == Decimal("0")
+    # The weighted view separates them: the conviction sizer commits 3x on
+    # the winner, so (2*3000 - 1000 - 1000) / 5000 = 0.8 vs flat 0.
+    assert flat.capital_weighted_average_return_r == Decimal("0")
+    assert conviction.capital_weighted_average_return_r == Decimal("0.8")
+    assert flat.capital_weighted_sample == conviction.capital_weighted_sample == 3
+    ranking_payload = report.to_dict()["rankings"]
+    assert {row["capital_weighted_average_return_r"] for row in ranking_payload} == {"0", "0.8"}
+
+
+def test_replay_result_carries_sized_notional() -> None:
+    class OneShotProposer:
+        proposer_id = "one-shot"
+
+        def __init__(self) -> None:
+            self._fired = False
+
+        def propose(self, snapshot: MarketSnapshot) -> list[TradeIdea]:
+            if self._fired:
+                return []
+            self._fired = True
+            return [scoreable_idea()]
+
+    report = TradeIdeaReplayRunner(
+        OneShotProposer(),
+        config=ReplayRunnerConfig(source="fixture:candles", min_history=1),
+    ).run_series(
+        symbol="BTC-USD",
+        granularity="ONE_HOUR",
+        candles=(candle(0), candle(1), candle(2, high="113")),
+    )
+
+    assert report.ideas[0].sized_notional == Decimal("6075")
+    assert report.to_dict()["ideas"][0]["sized_notional"] == "6075"
+    assert report.capital_weighted_sample == 1

--- a/tests/unit/gpt_trader/features/trade_ideas/test_scorecard.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_scorecard.py
@@ -24,7 +24,6 @@ from gpt_trader.features.trade_ideas import (
     TradeIdeaService,
 )
 from gpt_trader.features.trade_ideas.scorecard import (
-    REPLAY_EVIDENCE_LABEL,
     WALL_CLOCK_EVIDENCE_LABEL,
     ScorecardThresholds,
     build_replay_evidence,
@@ -253,76 +252,6 @@ def test_benchmark_edge_needs_both_baseline_and_candidate_closeouts(
     gate = payload["gates"]["benchmark_edge"]
     assert gate["status"] == "not_yet_measurable"
     assert gate["measured"]["baseline_closeout_count"] == 0
-
-
-def test_replay_evidence_is_labeled_and_reports_edge_vs_baseline() -> None:
-    tournament_payload = {
-        "symbol": "BTC-USD",
-        "granularity": "ONE_HOUR",
-        "source": "fixture:candles",
-        "snapshots_evaluated": 240,
-        "rankings": [],
-        "reports": [
-            {
-                "proposer_id": "baseline-ma-10-50",
-                "ideas_proposed": 12,
-                "resolved_ideas": 10,
-                "target_hit_rate": "0.4",
-                "stop_hit_rate": "0.6",
-                "average_return_r": "0.05",
-                "eligibility_pass_rate": "1",
-            },
-            {
-                "proposer_id": "regime-switcher",
-                "ideas_proposed": 9,
-                "resolved_ideas": 8,
-                "target_hit_rate": "0.5",
-                "stop_hit_rate": "0.5",
-                "average_return_r": "0.35",
-                "eligibility_pass_rate": "1",
-            },
-        ],
-    }
-
-    evidence = build_replay_evidence(tournament_payload)
-
-    assert evidence["evidence"] == REPLAY_EVIDENCE_LABEL
-    assert evidence["snapshots_evaluated"] == 240
-    assert [row["proposer_id"] for row in evidence["calibration"]] == [
-        "baseline-ma-10-50",
-        "regime-switcher",
-    ]
-    edge = evidence["benchmark_edge"]
-    assert edge["baseline_proposer_id"] == "baseline-ma-10-50"
-    assert edge["comparisons"] == [
-        {
-            "proposer_id": "regime-switcher",
-            "average_return_r": "0.35",
-            "edge_r": "0.3000",
-        }
-    ]
-
-
-def test_replay_evidence_from_single_baseline_report_has_no_edge() -> None:
-    single_payload = {
-        "proposer_id": "baseline-ma-10-50",
-        "symbol": "BTC-USD",
-        "granularity": "ONE_HOUR",
-        "source": "fixture:candles",
-        "snapshots_evaluated": 100,
-        "ideas_proposed": 5,
-        "resolved_ideas": 4,
-        "target_hit_rate": "0.5",
-        "stop_hit_rate": "0.5",
-        "average_return_r": "0.2",
-        "eligibility_pass_rate": "1",
-    }
-
-    evidence = build_replay_evidence(single_payload)
-
-    assert evidence["evidence"] == REPLAY_EVIDENCE_LABEL
-    assert evidence["benchmark_edge"]["comparisons"] == []
-    assert "non-baseline" in evidence["benchmark_edge"]["detail"]
 
 
 def test_text_rendering_separates_wall_clock_gates_from_replay_evidence(

--- a/tests/unit/gpt_trader/features/trade_ideas/test_scorecard_replay_evidence.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_scorecard_replay_evidence.py
@@ -1,0 +1,156 @@
+"""Replay-derived evidence labeling for the promotion scorecard.
+
+Split from test_scorecard.py (400-line hygiene cap): the pure
+``build_replay_evidence`` contract — labeling, benchmark edge vs the
+deterministic baseline, and the capital-weighted sizing channel (#1244) —
+independent of any stored idea trail.
+"""
+
+from __future__ import annotations
+
+from gpt_trader.features.trade_ideas.scorecard import (
+    REPLAY_EVIDENCE_LABEL,
+    _replay_evidence_lines,
+    build_replay_evidence,
+)
+
+
+def test_replay_evidence_is_labeled_and_reports_edge_vs_baseline() -> None:
+    tournament_payload = {
+        "symbol": "BTC-USD",
+        "granularity": "ONE_HOUR",
+        "source": "fixture:candles",
+        "snapshots_evaluated": 240,
+        "rankings": [],
+        "reports": [
+            {
+                "proposer_id": "baseline-ma-10-50",
+                "ideas_proposed": 12,
+                "resolved_ideas": 10,
+                "target_hit_rate": "0.4",
+                "stop_hit_rate": "0.6",
+                "average_return_r": "0.05",
+                "eligibility_pass_rate": "1",
+            },
+            {
+                "proposer_id": "regime-switcher",
+                "ideas_proposed": 9,
+                "resolved_ideas": 8,
+                "target_hit_rate": "0.5",
+                "stop_hit_rate": "0.5",
+                "average_return_r": "0.35",
+                "eligibility_pass_rate": "1",
+            },
+        ],
+    }
+
+    evidence = build_replay_evidence(tournament_payload)
+
+    assert evidence["evidence"] == REPLAY_EVIDENCE_LABEL
+    assert evidence["snapshots_evaluated"] == 240
+    assert [row["proposer_id"] for row in evidence["calibration"]] == [
+        "baseline-ma-10-50",
+        "regime-switcher",
+    ]
+    edge = evidence["benchmark_edge"]
+    assert edge["baseline_proposer_id"] == "baseline-ma-10-50"
+    assert edge["comparisons"] == [
+        {
+            "proposer_id": "regime-switcher",
+            "average_return_r": "0.35",
+            "edge_r": "0.3000",
+        }
+    ]
+
+
+def test_replay_evidence_from_single_baseline_report_has_no_edge() -> None:
+    single_payload = {
+        "proposer_id": "baseline-ma-10-50",
+        "symbol": "BTC-USD",
+        "granularity": "ONE_HOUR",
+        "source": "fixture:candles",
+        "snapshots_evaluated": 100,
+        "ideas_proposed": 5,
+        "resolved_ideas": 4,
+        "target_hit_rate": "0.5",
+        "stop_hit_rate": "0.5",
+        "average_return_r": "0.2",
+        "eligibility_pass_rate": "1",
+    }
+
+    evidence = build_replay_evidence(single_payload)
+
+    assert evidence["evidence"] == REPLAY_EVIDENCE_LABEL
+    assert evidence["benchmark_edge"]["comparisons"] == []
+    assert "non-baseline" in evidence["benchmark_edge"]["detail"]
+
+
+def test_replay_evidence_carries_capital_weighted_metrics_when_present() -> None:
+    payload = {
+        "symbol": "BTC-USD",
+        "granularity": "ONE_HOUR",
+        "source": "fixture:candles",
+        "snapshots_evaluated": 240,
+        "rankings": [],
+        "reports": [
+            {
+                "proposer_id": "baseline-ma-10-50",
+                "ideas_proposed": 12,
+                "resolved_ideas": 10,
+                "target_hit_rate": "0.4",
+                "stop_hit_rate": "0.6",
+                "average_return_r": "0.05",
+                "capital_weighted_average_return_r": "0.02",
+                "capital_weighted_sample": 10,
+                "eligibility_pass_rate": "1",
+            },
+            {
+                "proposer_id": "conviction-sizer",
+                "ideas_proposed": 12,
+                "resolved_ideas": 10,
+                "target_hit_rate": "0.4",
+                "stop_hit_rate": "0.6",
+                "average_return_r": "0.05",
+                "capital_weighted_average_return_r": "0.80",
+                "capital_weighted_sample": 10,
+                "eligibility_pass_rate": "1",
+            },
+        ],
+    }
+
+    evidence = build_replay_evidence(payload)
+
+    weighted = {
+        row["proposer_id"]: row["capital_weighted_average_return_r"]
+        for row in evidence["calibration"]
+    }
+    # Identical per-idea averages, sizing-visible difference preserved.
+    assert weighted == {"baseline-ma-10-50": "0.02", "conviction-sizer": "0.80"}
+    rendered = "\n".join(_replay_evidence_lines(evidence))
+    assert "capital_weighted_avg_r=0.80 (n=10)" in rendered
+
+
+def test_replay_evidence_renders_pre_weighted_artifacts_without_the_weighted_clause() -> None:
+    # Replay artifacts written before #1244 carry no capital-weighted keys;
+    # they must render with the per-idea metrics alone, not crash or print
+    # a None clause.
+    payload = {
+        "proposer_id": "baseline-ma-10-50",
+        "symbol": "BTC-USD",
+        "granularity": "ONE_HOUR",
+        "source": "fixture:candles",
+        "snapshots_evaluated": 100,
+        "ideas_proposed": 5,
+        "resolved_ideas": 4,
+        "target_hit_rate": "0.5",
+        "stop_hit_rate": "0.5",
+        "average_return_r": "0.2",
+        "eligibility_pass_rate": "1",
+    }
+
+    evidence = build_replay_evidence(payload)
+
+    assert evidence["calibration"][0]["capital_weighted_average_return_r"] is None
+    rendered = "\n".join(_replay_evidence_lines(evidence))
+    assert "capital_weighted" not in rendered
+    assert "avg_r=0.2" in rendered


### PR DESCRIPTION
Closes #1244 (M5/W3, part of #1241).

## What

Replay `return_r` is a pure function of entry/stop/target, so the sizing channel — where the regime overlay's confidence relabel actually lands (via `TradeIdeaPositionSizingBridge`) — was invisible to every replay aggregate: two proposers with identical levels but different notional commitment ranked identically. That silenced one of the three channels behind the M5 edge-0 diagnosis.

- **`replay.py`**: `ReplayResult` carries `sized_notional` (from the idea's sizing recommendation at scoring time). `ReplayReport` gains `capital_weighted_average_return_r` — Σ(R·notional)/Σ(notional) over resolved ideas with positive notional — plus `capital_weighted_sample` so the effective sample is always visible next to the weighted number. Tournament ranking rows carry both; **ranking order stays on per-idea metrics** (the weighted view is reported beside them, never optimized for).
- **`scorecard.py`**: `build_replay_evidence` forwards the weighted fields; the render appends `capital_weighted_avg_r=… (n=…)` to each calibration row. Pre-#1244 replay artifacts have no weighted keys and render exactly as before (test-enforced).
- **Hygiene**: `test_scorecard.py` crossed the 400-line cap; the pure `build_replay_evidence` tests moved to `test_scorecard_replay_evidence.py`, same precedent as `test_scorecard_drawdown_gate.py`.

## Exit criteria mapping

- *Identical levels, different sizing ⇒ different weighted rows*: test-enforced end-to-end through `TradeIdeaReplayTournamentRunner` — a flat sizer and a conviction sizer (3× notional on the winner) both read per-idea avg R 0.0000 while the weighted rows read 0 vs 0.8.
- *Rendered alongside per-idea avg R without touching gate verdicts*: weighted fields live only in the replay-evidence block (labeled, never blended); gate verdict code paths untouched.
- *Statistical floor*: the weighted row prints its own `n`.

## Verification

- `uv run local-ci` (pr profile): all checks pass (522 trade_ideas unit tests, incl. 4 new).
