### PR TITLE
feat(trade-ideas): widen the replay-evidence tournament to the convergence proposers (#1245)

### DIFF
--- a/docs/paper_trading.md
+++ b/docs/paper_trading.md
@@ -347,13 +347,20 @@ The script mirrors the Stage-2 cycle turn's universe and granularity so the
 replay measures the proposer set that is actually running: it snapshot-builds
 the paper universe from read-only public Coinbase candles
 (`ideas snapshot build --from-coinbase`), runs one tournament per symbol with
-the active pair (`baseline-ma-10-50,regime-aware-ma-10-50` — the deterministic
-baseline is the benchmark side of the edge comparison), then renders the
-scorecard with all reports attached. Each run writes a self-contained
+the active pair plus the strategy-backed convergence proposers
+(`baseline-ma-10-50,regime-aware-ma-10-50,strategy-mean-reversion,strategy-regime-switcher`
+— the deterministic baseline is the benchmark side of the edge comparison,
+and the strategy-backed ids add genuine decision diversity, #1245), then
+renders the scorecard with all reports attached. The default lookback is 720
+hourly candles (~30 days) so the window samples more regime variety than a
+single 300-candle slice; expect a few minutes per symbol. Each run writes a self-contained
 directory under `var/data/trade_ideas/replay_evidence/<UTC timestamp>/`:
 the snapshot, per-symbol tournament reports, and the durable scorecard
 artifact. Override `REPLAY_SYMBOLS`, `REPLAY_GRANULARITY`, `REPLAY_LOOKBACK`,
-`REPLAY_PROPOSERS`, or `REPLAY_EVIDENCE_DIR` per invocation; everything is
+`REPLAY_PROPOSERS`, `REPLAY_PRICE_PRECISION`, or `REPLAY_EVIDENCE_DIR` per
+invocation (the replay price grid defaults to 0.0001, finer than the cycle's
+0.01, so low-priced symbols keep distinct stop/entry/target levels instead
+of failing the strategy adapter's fail-closed precision guard); everything is
 broker-free and never reads accounts or places orders. A symbol whose
 tournament fails keeps its error envelope in the run directory as evidence
 but is excluded from the scorecard render; the turn only fails when every

--- a/scripts/ops/replay_evidence.sh
+++ b/scripts/ops/replay_evidence.sh
@@ -24,13 +24,22 @@ export PATH="${HOME}/.local/bin:/opt/homebrew/bin:/usr/local/bin:${PATH}"
 
 # Defaults mirror the Stage-2 cycle turn (scripts/ops/stage2_cycle_turn.sh):
 # same universe and granularity, so replay evidence measures the proposer set
-# that is actually running. The proposer ids are the cycle's active pair —
-# the deterministic baseline plus the regime-aware overlay — at the cycle's
-# default MA windows (10/50).
+# that is actually running, plus the strategy-backed convergence proposers
+# (#1164) so benchmark edge is measured against genuine decision diversity,
+# not only the overlay pair (#1245). The 720-candle hourly lookback (~30
+# days) samples more regime variety than one 300-candle slice; the candle
+# fetcher chunks requests, so the lookback is bounded by runtime (roughly
+# 2.5 minutes per symbol at 720 candles x 4 proposers), not by the public
+# API's 300-candle page size.
 : "${REPLAY_SYMBOLS:=BTC-USD,ETH-USD,SOL-USD,XRP-USD,LTC-USD,LINK-USD,AVAX-USD,DOT-USD}"
 : "${REPLAY_GRANULARITY:=ONE_HOUR}"
-: "${REPLAY_LOOKBACK:=300}"
-: "${REPLAY_PROPOSERS:=baseline-ma-10-50,regime-aware-ma-10-50}"
+: "${REPLAY_LOOKBACK:=720}"
+: "${REPLAY_PROPOSERS:=baseline-ma-10-50,regime-aware-ma-10-50,strategy-mean-reversion,strategy-regime-switcher}"
+# Finer than the cycle's 0.01 default: the strategy adapter fails closed when
+# quantization collapses stop/entry/target on low-priced symbols (DOT at the
+# default grid), and replay evidence should measure those symbols, not drop
+# them. Replay-only; live proposal records keep their own precision.
+: "${REPLAY_PRICE_PRECISION:=0.0001}"
 : "${REPLAY_EVIDENCE_DIR:=var/data/trade_ideas/replay_evidence}"
 
 RUN_DIR="${REPLAY_EVIDENCE_DIR}/$(date -u +%Y%m%dT%H%M%SZ)"
@@ -54,6 +63,7 @@ for symbol in "${SYMBOLS[@]}"; do
     --file "${RUN_DIR}/snapshot.json" \
     --symbol "${symbol}" \
     --granularity "${REPLAY_GRANULARITY}" \
+    --price-precision "${REPLAY_PRICE_PRECISION}" \
     --proposers "${REPLAY_PROPOSERS}" \
     --format json \
     --output "${report}"; then


### PR DESCRIPTION
Closes #1245 (M5/W4, part of #1241).

## What

`scripts/ops/replay_evidence.sh` replayed only the (near-)identical overlay pair over a 300-candle slice. Three default changes, all env-overridable as before:

- **`REPLAY_PROPOSERS`** gains `strategy-mean-reversion` and `strategy-regime-switcher` (already tournament-runnable ids from the #1164 convergence) so benchmark edge is measured against genuine decision diversity.
- **`REPLAY_LOOKBACK`** 300 → 720 hourly candles (~30 days). The Coinbase fetcher chunks 300-candle pages, so the real bound is runtime — measured ~2.5 min/symbol at 4 proposers — not the API page size.
- **New `REPLAY_PRICE_PRECISION`** (default 0.0001, replay-only): the strategy adapter fails closed when the cycle's 0.01 grid collapses stop/entry/target on low-priced symbols, which dropped DOT-USD's entire tournament from the evidence run. Verified DOT passes at the finer grid.

`docs/paper_trading.md` replay-evidence section updated to match.

## Evidence run (exit criterion)

Full 8-symbol turn with the new defaults (`var/data/trade_ideas/replay_evidence/20260708T003718Z`, 664 snapshots/symbol; DOT re-verified at the finer grid). Pooled, resolved-weighted:

| proposer | ideas | resolved | pooled avg R | edge vs baseline |
|----------|------:|---------:|-------------:|-----------------:|
| snapshot-strategy-mean-reversion | 204 | 202 | **+0.2972** | **+0.1552** |
| baseline-ma-10-50 | 187 | 186 | +0.1420 | — |
| regime-aware-ma-10-50 | 128 | 128 | +0.0654 | -0.0766 |
| snapshot-strategy-regime-switcher | 171 | 170 | -0.1222 | -0.2642 |

Read: mean-reversion is the current leader and the first positive replay edge with real sample size. The regime-aware overlay is regime-dependent as expected — it led strongly where volatile regimes coincided with ideas (BTC +0.62 vs +0.22, XRP +1.19 vs -0.14) and lagged elsewhere; per-symbol detail is in the run artifacts. Rankings flipped between the 12-day and 30-day windows, which is exactly the single-window-overfit caution driving #1243/#1246.

## Verification

- `uv run local-ci` (pr profile): all checks pass.
- `bash -n` on the script; full evidence turn ran end-to-end (7/8 symbols + DOT re-run at the new default precision).
