### PR TITLE
feat(trade-ideas): measured per-regime entry policy + suppression counterfactuals in replay evidence (#1243)

### DIFF
--- a/docs/paper_trading.md
+++ b/docs/paper_trading.md
@@ -382,6 +382,12 @@ baseline-ma-…` lines are the replay read on benchmark edge. When the replay
 artifact carries sizing (`capital_weighted_avg_r=… (n=…)`), that row is the
 only aggregate that can see the sizing channel — proposers with identical
 levels but different notional commitment separate there and nowhere else.
+Overlay proposers additionally print a `counterfactuals:` line (candidates
+vs emitted, UNKNOWN skips, suppressions by regime, exit plans adjusted, and
+the emitted-ideas regime distribution) so a decision channel that never
+fires is visible in every run instead of requiring a manual audit — the M5
+diagnosis found regime suppression had fired 0/84 times with nothing
+reporting it.
 
 ## Readiness Evidence Inputs
 

--- a/src/gpt_trader/features/trade_ideas/regime.py
+++ b/src/gpt_trader/features/trade_ideas/regime.py
@@ -13,7 +13,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field, fields, replace
 from datetime import UTC, datetime
 from decimal import Decimal
-from typing import Protocol
+from typing import Any, Protocol
 
 from gpt_trader.errors import ValidationError
 from gpt_trader.features.intelligence.regime import (
@@ -38,7 +38,17 @@ from gpt_trader.features.trade_ideas.sizing import TradeIdeaPositionSizingBridge
 from gpt_trader.features.trade_ideas.snapshot import MarketSnapshot, SymbolSeries
 
 REGIME_DETECTOR_VERSION = "market-regime-detector-v1"
-DEFAULT_SUPPRESSED_REGIMES = (RegimeType.CRISIS, RegimeType.BEAR_VOLATILE)
+# CRISIS/BEAR_VOLATILE are risk posture (replay cannot price crisis slippage
+# or gap risk). BULL_VOLATILE is measured (#1243): the long crossover's
+# expectancy there was negative in all four readings across two
+# non-overlapping 2026 windows and both exit variants (12d: -0.17/-0.22,
+# 30d: -0.47/-0.20, n~80 combined), the only regime consistently negative;
+# denying it improved total pooled R on both windows.
+DEFAULT_SUPPRESSED_REGIMES = (
+    RegimeType.CRISIS,
+    RegimeType.BEAR_VOLATILE,
+    RegimeType.BULL_VOLATILE,
+)
 
 
 class RegimeDetector(Protocol):
@@ -85,6 +95,34 @@ class RegimeAwareProposerConfig:
             )
 
 
+@dataclass
+class RegimeProposalDiagnostics:
+    """Counterfactual counts for regime-overlay decisions (#1243).
+
+    Cumulative since proposer construction, so a replay run over many
+    snapshots aggregates naturally. These counts exist to make a dead
+    decision channel visible in evidence output — the M5 diagnosis found
+    suppression had fired 0/84 times and nothing reported it.
+    """
+
+    candidate_ideas: int = 0
+    emitted_ideas: int = 0
+    unknown_skipped: int = 0
+    suppressed_by_regime: dict[str, int] = field(default_factory=dict)
+    exit_plans_adjusted: int = 0
+    emitted_by_regime: dict[str, int] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "candidate_ideas": self.candidate_ideas,
+            "emitted_ideas": self.emitted_ideas,
+            "unknown_skipped": self.unknown_skipped,
+            "suppressed_by_regime": dict(sorted(self.suppressed_by_regime.items())),
+            "exit_plans_adjusted": self.exit_plans_adjusted,
+            "emitted_by_regime": dict(sorted(self.emitted_by_regime.items())),
+        }
+
+
 class RegimeAwareProposer:
     """MA-crossover proposer enriched with MarketRegimeDetector state."""
 
@@ -103,6 +141,11 @@ class RegimeAwareProposer:
         self._detector_factory = detector_factory
         self._config_fingerprint = _regime_config_fingerprint(self._config.regime_config)
         self._identity_fingerprint = _proposer_config_fingerprint(self._config)
+        self._diagnostics = RegimeProposalDiagnostics()
+
+    def replay_diagnostics(self) -> dict[str, Any]:
+        """Counterfactual counts accumulated across every ``propose`` call."""
+        return self._diagnostics.to_dict()
 
     @property
     def proposer_id(self) -> str:
@@ -123,23 +166,36 @@ class RegimeAwareProposer:
 
         def overlay_exit(symbol: str, close: Decimal, levels: ExitLevels) -> ExitLevels:
             state = states.get(symbol, RegimeState.unknown())
-            return _regime_exit_levels(levels, close=close, state=state, config=self._config)
+            adjusted = _regime_exit_levels(levels, close=close, state=state, config=self._config)
+            if adjusted != levels:
+                diagnostics.exit_plans_adjusted += 1
+            return adjusted
 
+        diagnostics = self._diagnostics
         ideas: list[TradeIdea] = []
         for idea in self._baseline.propose(
             snapshot,
             confidence_overlay=overlay_label,
             exit_overlay=overlay_exit,
         ):
+            diagnostics.candidate_ideas += 1
             state = states.get(idea.instrument, RegimeState.unknown())
             # UNKNOWN means the detector has not warmed up (long EMA plus
             # persistence ticks); a "regime-aware" idea with a 0.0-confidence
             # overlay would be self-contradictory, so treat it as unready
             # rather than persisting a proposal.
             if state.regime is RegimeType.UNKNOWN:
+                diagnostics.unknown_skipped += 1
                 continue
             if state.regime in self._config.suppressed_regimes:
+                name = state.regime.name
+                diagnostics.suppressed_by_regime[name] = (
+                    diagnostics.suppressed_by_regime.get(name, 0) + 1
+                )
                 continue
+            diagnostics.emitted_ideas += 1
+            name = state.regime.name
+            diagnostics.emitted_by_regime[name] = diagnostics.emitted_by_regime.get(name, 0) + 1
             ideas.append(self._enrich_idea(snapshot, idea, state))
         return ideas
 
@@ -341,4 +397,5 @@ __all__ = [
     "RegimeAwareProposerConfig",
     "RegimeDetector",
     "RegimeDetectorFactory",
+    "RegimeProposalDiagnostics",
 ]

--- a/src/gpt_trader/features/trade_ideas/replay.py
+++ b/src/gpt_trader/features/trade_ideas/replay.py
@@ -8,12 +8,12 @@ subsequent candles using only the plan already written on the trade idea.
 from __future__ import annotations
 
 import re
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from decimal import Decimal
 from enum import Enum
-from typing import Any
+from typing import Any, Protocol, runtime_checkable
 
 from gpt_trader.core import Candle
 from gpt_trader.errors import ValidationError
@@ -103,6 +103,20 @@ class ReplayResult:
         }
 
 
+@runtime_checkable
+class DiagnosticsProposer(Protocol):
+    """Optional proposer surface exposing counterfactual decision counts.
+
+    A proposer that filters or rewrites another proposer's output (the
+    regime overlay) can report how often each channel fired; the replay
+    runner attaches those counts to the report so a dead channel is visible
+    in evidence output instead of requiring a manual audit (#1243). Counts
+    are cumulative since proposer construction.
+    """
+
+    def replay_diagnostics(self) -> Mapping[str, Any]: ...
+
+
 @dataclass(frozen=True, slots=True)
 class ReplayReport:
     """Aggregate calibration report for a proposer replay run."""
@@ -115,6 +129,7 @@ class ReplayReport:
     ideas: tuple[ReplayResult, ...]
     eligibility_checked: int = 0
     eligibility_passed: int = 0
+    proposer_diagnostics: Mapping[str, Any] | None = None
 
     @property
     def ideas_proposed(self) -> int:
@@ -226,6 +241,9 @@ class ReplayReport:
             "eligibility_checked": self.eligibility_checked,
             "eligibility_passed": self.eligibility_passed,
             "eligibility_pass_rate": str(self.eligibility_pass_rate),
+            "proposer_diagnostics": (
+                dict(self.proposer_diagnostics) if self.proposer_diagnostics is not None else None
+            ),
             "ideas": [idea.to_dict() for idea in self.ideas],
         }
 
@@ -559,6 +577,11 @@ class TradeIdeaReplayRunner:
             ideas=tuple(results),
             eligibility_checked=eligibility_checked,
             eligibility_passed=eligibility_passed,
+            proposer_diagnostics=(
+                dict(self._proposer.replay_diagnostics())
+                if isinstance(self._proposer, DiagnosticsProposer)
+                else None
+            ),
         )
 
 

--- a/src/gpt_trader/features/trade_ideas/scorecard.py
+++ b/src/gpt_trader/features/trade_ideas/scorecard.py
@@ -186,6 +186,9 @@ def build_replay_evidence(
             "capital_weighted_average_return_r": report.get("capital_weighted_average_return_r"),
             "capital_weighted_sample": report.get("capital_weighted_sample"),
             "eligibility_pass_rate": report.get("eligibility_pass_rate"),
+            # Overlay counterfactual counts (#1243); absent for proposers
+            # that expose no diagnostics and on pre-#1243 artifacts.
+            "proposer_diagnostics": report.get("proposer_diagnostics"),
         }
         for report in reports
     ]
@@ -260,6 +263,9 @@ def _replay_evidence_lines(evidence: Mapping[str, Any]) -> list[str]:
                 f" (n={row.get('capital_weighted_sample')})"
             )
         lines.append(line)
+        diagnostics = row.get("proposer_diagnostics")
+        if diagnostics:
+            lines.append(_proposer_diagnostics_line(row["proposer_id"], diagnostics))
     edge = evidence["benchmark_edge"]
     if edge["comparisons"]:
         for comparison in edge["comparisons"]:
@@ -272,6 +278,28 @@ def _replay_evidence_lines(evidence: Mapping[str, Any]) -> list[str]:
     else:
         lines.append(f"edge: {edge['detail']}")
     return lines
+
+
+def _proposer_diagnostics_line(proposer_id: str, diagnostics: Mapping[str, Any]) -> str:
+    """Render overlay counterfactuals so a dead channel is visible per run."""
+    suppressed = diagnostics.get("suppressed_by_regime") or {}
+    emitted_by_regime = diagnostics.get("emitted_by_regime") or {}
+    return (
+        f"{proposer_id} counterfactuals: "
+        f"candidates={diagnostics.get('candidate_ideas')}, "
+        f"emitted={diagnostics.get('emitted_ideas')}, "
+        f"unknown_skipped={diagnostics.get('unknown_skipped')}, "
+        f"suppressed={_regime_counts(suppressed)}, "
+        f"exit_plans_adjusted={diagnostics.get('exit_plans_adjusted')}, "
+        f"emitted_by_regime={_regime_counts(emitted_by_regime)}"
+    )
+
+
+def _regime_counts(counts: Mapping[str, Any]) -> str:
+    if not counts:
+        return "none"
+    body = ", ".join(f"{name}:{count}" for name, count in sorted(counts.items()))
+    return "{" + body + "}"
 
 
 def _gate_line(name: str, verdict: Mapping[str, Any]) -> str:

--- a/tests/unit/gpt_trader/features/trade_ideas/test_regime_overlay_diagnostics.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_regime_overlay_diagnostics.py
@@ -1,0 +1,152 @@
+"""Regime-overlay counterfactual diagnostics (#1243).
+
+Split from test_regime_proposer.py (400-line hygiene cap): the diagnostics
+counts that make each overlay decision channel's activity visible in replay
+evidence, and their attachment to ``ReplayReport``.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from decimal import Decimal
+
+from tests.unit.gpt_trader.features.trade_ideas.test_regime_proposer import (
+    AS_OF,
+    CONFIG,
+    GOLDEN_CROSS,
+    make_series,
+    regime_state,
+    scripted_factory,
+    snapshot_of,
+)
+
+from gpt_trader.core import Candle
+from gpt_trader.features.intelligence.regime import RegimeState, RegimeType
+from gpt_trader.features.trade_ideas import (
+    BaselineProposer,
+    BaselineProposerConfig,
+    RegimeAwareProposer,
+    RegimeAwareProposerConfig,
+    ReplayRunnerConfig,
+    TradeIdeaReplayRunner,
+)
+
+
+def test_replay_diagnostics_count_suppression_and_exit_adjustments() -> None:
+    # The M5 diagnosis found suppression fired 0/84 with nothing reporting
+    # it; the diagnostics make each overlay channel's activity countable.
+    snapshot = snapshot_of(make_series(GOLDEN_CROSS))
+    factory, _detectors = scripted_factory(regime_state(RegimeType.CRISIS))
+    proposer = RegimeAwareProposer(CONFIG, detector_factory=factory)
+
+    assert proposer.propose(snapshot) == []
+    diagnostics = proposer.replay_diagnostics()
+    assert diagnostics["candidate_ideas"] == 1
+    assert diagnostics["emitted_ideas"] == 0
+    assert diagnostics["suppressed_by_regime"] == {"CRISIS": 1}
+    # CRISIS is volatile, so the exit channel also fired before suppression.
+    assert diagnostics["exit_plans_adjusted"] == 1
+
+    # Counts are cumulative across propose calls.
+    proposer.propose(snapshot)
+    assert proposer.replay_diagnostics()["suppressed_by_regime"] == {"CRISIS": 2}
+
+
+def test_replay_diagnostics_count_unknown_and_emitted_regimes() -> None:
+    snapshot = snapshot_of(make_series(GOLDEN_CROSS))
+
+    unknown_factory, _ = scripted_factory(RegimeState.unknown())
+    unready = RegimeAwareProposer(CONFIG, detector_factory=unknown_factory)
+    assert unready.propose(snapshot) == []
+    assert unready.replay_diagnostics()["unknown_skipped"] == 1
+
+    quiet_factory, _ = scripted_factory(regime_state(RegimeType.BULL_QUIET))
+    emitting = RegimeAwareProposer(CONFIG, detector_factory=quiet_factory)
+    assert len(emitting.propose(snapshot)) == 1
+    diagnostics = emitting.replay_diagnostics()
+    assert diagnostics["emitted_ideas"] == 1
+    assert diagnostics["emitted_by_regime"] == {"BULL_QUIET": 1}
+    assert diagnostics["exit_plans_adjusted"] == 0
+    assert diagnostics["suppressed_by_regime"] == {}
+
+
+def test_changing_the_per_regime_entry_policy_changes_counts_and_idea_set() -> None:
+    # The entry policy is the suppressed_regimes tuple: widening it to a
+    # regime that actually occurs must move ideas from emitted to suppressed.
+    snapshot = snapshot_of(make_series(GOLDEN_CROSS))
+    factory, _detectors = scripted_factory(regime_state(RegimeType.BULL_QUIET))
+
+    default_policy = RegimeAwareProposer(CONFIG, detector_factory=factory)
+    assert len(default_policy.propose(snapshot)) == 1
+    assert default_policy.replay_diagnostics()["suppressed_by_regime"] == {}
+
+    deny_bull_quiet = RegimeAwareProposer(
+        RegimeAwareProposerConfig(
+            baseline_config=CONFIG.baseline_config,
+            suppressed_regimes=(RegimeType.BULL_QUIET,),
+        ),
+        detector_factory=factory,
+    )
+    assert deny_bull_quiet.propose(snapshot) == []
+    assert deny_bull_quiet.replay_diagnostics()["suppressed_by_regime"] == {"BULL_QUIET": 1}
+
+
+def test_replay_report_attaches_regime_counterfactual_diagnostics() -> None:
+    def candle(offset_hours: int, close: str = "100") -> Candle:
+        price = Decimal(close)
+        return Candle(
+            ts=AS_OF + timedelta(hours=offset_hours),
+            open=price,
+            high=price,
+            low=price,
+            close=price,
+            volume=Decimal("1000"),
+        )
+
+    factory, _detectors = scripted_factory(regime_state(RegimeType.CRISIS))
+    proposer = RegimeAwareProposer(
+        RegimeAwareProposerConfig(
+            baseline_config=BaselineProposerConfig(
+                short_window=2,
+                long_window=4,
+                crossover_lookback=1,
+                expiry_hours=3,
+            )
+        ),
+        detector_factory=factory,
+    )
+
+    report = TradeIdeaReplayRunner(
+        proposer,
+        config=ReplayRunnerConfig(source="fixture:candles", min_history=5),
+    ).run_series(
+        symbol="BTC-USD",
+        granularity="ONE_HOUR",
+        candles=(
+            candle(-5),
+            candle(-4),
+            candle(-3),
+            candle(-2),
+            candle(-1, close="110"),
+            candle(0, close="111"),
+        ),
+    )
+
+    assert report.ideas_proposed == 0
+    diagnostics = report.proposer_diagnostics
+    assert diagnostics is not None
+    assert diagnostics["suppressed_by_regime"] == {"CRISIS": 1}
+    assert report.to_dict()["proposer_diagnostics"]["suppressed_by_regime"] == {"CRISIS": 1}
+    # The plain baseline exposes no diagnostics surface: its report says so.
+    baseline_report = TradeIdeaReplayRunner(
+        BaselineProposer(
+            BaselineProposerConfig(short_window=2, long_window=4, crossover_lookback=1)
+        ),
+        config=ReplayRunnerConfig(source="fixture:candles", min_history=5),
+    ).run_series(
+        symbol="BTC-USD",
+        granularity="ONE_HOUR",
+        candles=(candle(-5), candle(-4), candle(-3), candle(-2), candle(-1), candle(0)),
+    )
+    assert baseline_report.proposer_diagnostics is None
+    assert baseline_report.to_dict()["proposer_diagnostics"] is None

--- a/tests/unit/gpt_trader/features/trade_ideas/test_regime_proposer.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_regime_proposer.py
@@ -114,14 +114,17 @@ def test_regime_aware_proposer_enriches_baseline_signal() -> None:
     assert idea.decision_id.startswith("trade-20260612-btcusd-")
     assert idea.confidence.label is ConfidenceLabel.MEDIUM
     assert "Regime overlay classified BTC-USD as BULL_QUIET" in idea.thesis
-    assert "CRISIS or BEAR_VOLATILE" in idea.invalidation
+    assert "CRISIS or BEAR_VOLATILE or BULL_VOLATILE" in idea.invalidation
     assert any(
         f"detector={REGIME_DETECTOR_VERSION}" in item
         and "config_sha256=" in item
         and "state=BULL_QUIET" in item
         for item in idea.data_used
     )
-    assert "Regime overlay is CRISIS or BEAR_VOLATILE before review" in idea.do_not_trade_if
+    assert (
+        "Regime overlay is CRISIS or BEAR_VOLATILE or BULL_VOLATILE before review"
+        in idea.do_not_trade_if
+    )
     assert evaluate_eligibility(idea) == []
     assert len(detectors) == 1
     assert len(detectors[0].updates) == len(GOLDEN_CROSS)
@@ -141,7 +144,7 @@ def test_regime_aware_proposer_uses_configured_suppressed_regime_text() -> None:
 
     assert len(ideas) == 1
     assert "regime overlay shifts to SIDEWAYS_VOLATILE" in ideas[0].invalidation
-    assert "CRISIS or BEAR_VOLATILE" not in ideas[0].invalidation
+    assert "CRISIS or BEAR_VOLATILE" not in ideas[0].invalidation  # default policy text gone
     assert "Regime overlay is SIDEWAYS_VOLATILE before review" in ideas[0].do_not_trade_if
 
 
@@ -275,7 +278,7 @@ def test_volatile_regime_widens_stop_and_target() -> None:
     # widens the stop distance about the close and moves the target with it.
     snapshot = snapshot_of(make_series(GOLDEN_CROSS))
     baseline_idea = BaselineProposer(CONFIG.baseline_config).propose(snapshot)[0]
-    factory, _detectors = scripted_factory(regime_state(RegimeType.BULL_VOLATILE))
+    factory, _detectors = scripted_factory(regime_state(RegimeType.SIDEWAYS_VOLATILE))
     idea = RegimeAwareProposer(CONFIG, detector_factory=factory).propose(snapshot)[0]
 
     assert baseline_idea.exit_plan is not None
@@ -311,7 +314,7 @@ def test_volatile_reward_multiple_override_moves_target() -> None:
         baseline_config=CONFIG.baseline_config,
         volatile_reward_multiple=Decimal("3"),
     )
-    factory, _detectors = scripted_factory(regime_state(RegimeType.BULL_VOLATILE))
+    factory, _detectors = scripted_factory(regime_state(RegimeType.SIDEWAYS_VOLATILE))
     idea = RegimeAwareProposer(config, detector_factory=factory).propose(
         snapshot_of(make_series(GOLDEN_CROSS))
     )[0]
@@ -324,7 +327,7 @@ def test_volatile_reward_multiple_override_moves_target() -> None:
 
 def test_exit_channel_config_enters_decision_id() -> None:
     snapshot = snapshot_of(make_series(GOLDEN_CROSS))
-    factory, _detectors = scripted_factory(regime_state(RegimeType.BULL_VOLATILE))
+    factory, _detectors = scripted_factory(regime_state(RegimeType.SIDEWAYS_VOLATILE))
 
     default_ids = [
         idea.decision_id

--- a/tests/unit/gpt_trader/features/trade_ideas/test_scorecard_replay_evidence.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_scorecard_replay_evidence.py
@@ -154,3 +154,55 @@ def test_replay_evidence_renders_pre_weighted_artifacts_without_the_weighted_cla
     rendered = "\n".join(_replay_evidence_lines(evidence))
     assert "capital_weighted" not in rendered
     assert "avg_r=0.2" in rendered
+
+
+def test_replay_evidence_renders_proposer_counterfactuals_when_present() -> None:
+    payload = {
+        "symbol": "BTC-USD",
+        "granularity": "ONE_HOUR",
+        "source": "fixture:candles",
+        "snapshots_evaluated": 240,
+        "rankings": [],
+        "reports": [
+            {
+                "proposer_id": "baseline-ma-10-50",
+                "ideas_proposed": 12,
+                "resolved_ideas": 10,
+                "target_hit_rate": "0.4",
+                "stop_hit_rate": "0.6",
+                "average_return_r": "0.05",
+                "eligibility_pass_rate": "1",
+            },
+            {
+                "proposer_id": "regime-aware-ma-10-50",
+                "ideas_proposed": 8,
+                "resolved_ideas": 8,
+                "target_hit_rate": "0.5",
+                "stop_hit_rate": "0.5",
+                "average_return_r": "0.15",
+                "eligibility_pass_rate": "1",
+                "proposer_diagnostics": {
+                    "candidate_ideas": 12,
+                    "emitted_ideas": 8,
+                    "unknown_skipped": 1,
+                    "suppressed_by_regime": {"BEAR_VOLATILE": 2, "CRISIS": 1},
+                    "exit_plans_adjusted": 4,
+                    "emitted_by_regime": {"BULL_QUIET": 5, "BULL_VOLATILE": 3},
+                },
+            },
+        ],
+    }
+
+    evidence = build_replay_evidence(payload)
+
+    rows = {row["proposer_id"]: row for row in evidence["calibration"]}
+    assert rows["baseline-ma-10-50"]["proposer_diagnostics"] is None
+    assert rows["regime-aware-ma-10-50"]["proposer_diagnostics"]["emitted_ideas"] == 8
+    rendered = "\n".join(_replay_evidence_lines(evidence))
+    assert (
+        "regime-aware-ma-10-50 counterfactuals: candidates=12, emitted=8, "
+        "unknown_skipped=1, suppressed={BEAR_VOLATILE:2, CRISIS:1}, "
+        "exit_plans_adjusted=4, emitted_by_regime={BULL_QUIET:5, BULL_VOLATILE:3}"
+    ) in rendered
+    # No counterfactual line for proposers without diagnostics.
+    assert "baseline-ma-10-50 counterfactuals" not in rendered


### PR DESCRIPTION
Closes #1243 (M5/W2, part of #1241).

## What

Two halves: make every overlay decision channel's activity **countable in evidence output**, and replace the prior-driven deny list with a **measured** one.

### Counterfactual instrumentation

- `RegimeAwareProposer` accumulates `RegimeProposalDiagnostics`: candidate ideas from the wrapped baseline, emitted ideas, UNKNOWN skips, suppressions by regime, exit-plan adjustments, and the emitted-ideas regime distribution. Cumulative across `propose` calls, so a replay run aggregates naturally.
- `TradeIdeaReplayRunner` attaches them to `ReplayReport` through a structural `DiagnosticsProposer` protocol (proposers without the surface report `null` — no coupling, old artifacts unaffected).
- The scorecard's replay-evidence render prints a per-proposer line: `regime-aware-ma-10-50 counterfactuals: candidates=12, emitted=8, unknown_skipped=1, suppressed={BEAR_VOLATILE:2, CRISIS:1}, exit_plans_adjusted=4, emitted_by_regime={…}`. The M5 diagnosis found suppression had fired 0/84 with nothing reporting it; that state is now impossible to miss.

### Measured entry policy

The per-regime entry policy is the existing `suppressed_regimes` config (fingerprinted, prose-integrated). What changed is the default, from measurement over two non-overlapping 2026 windows (May 09–Jun 07, Jun 08–Jul 08; 8-symbol paper universe, hourly) under both exit variants (stop-widen on/off):

| regime | 12d avg R | 30d avg R | verdict |
|---|---:|---:|---|
| BULL_VOLATILE | -0.17 / -0.22 | -0.47 / -0.20 | **negative in all 4 readings (n≈80) → denied** |
| BULL_QUIET | -0.27 | +0.39 | sign flips → stays allowed |
| BEAR_QUIET | +0.00 | +0.17 | stays allowed |
| CRISIS | (none) | +0.07 / -0.06 | stays denied as risk posture, not expectancy |
| BEAR_VOLATILE | (none) | +0.55 (n=7) | n too small; stays denied as risk posture |

Denying BULL_VOLATILE improves **total pooled R on both windows** (12d: -15.8R → -9.9R; 30d: +6.2R → +27.3R). Judged on total R, not residual average, since forgone negative-expectancy trades free capital regardless of what the remaining pool averages. `DEFAULT_SUPPRESSED_REGIMES` = (CRISIS, BEAR_VOLATILE, BULL_VOLATILE), with the measurement recorded in the code comment.

Honest caveats: two contiguous windows is a thin base; the counterfactual lines now make suppression activity visible in every evidence run, so drift will be seen, and the policy stays one config knob away. With the measured default, W1's volatile-stop-widening fires mainly on SIDEWAYS_VOLATILE and non-default configs — the exit-channel tests repin on SIDEWAYS_VOLATILE accordingly.

## Exit criteria mapping

- *Counts per proposer alongside calibration rows*: render test pins the exact line; runner test pins report attachment (and `null` for the plain baseline).
- *Policy config changes counts and idea set*: test-enforced (`deny BULL_QUIET` flips an emitted idea to suppressed).
- *Default justified from measured per-regime expectancy, recorded*: table above + code comment.

## Verification

- `uv run local-ci` (pr profile): all checks pass (527 trade_ideas unit tests, incl. 5 new; diagnostics tests split to `test_regime_overlay_diagnostics.py` under the 400-line cap).
