### PR TITLE
feat: add provider-aware account review commands

### DIFF
--- a/docs/ROBINHOOD.md
+++ b/docs/ROBINHOOD.md
@@ -71,6 +71,38 @@ provider order-check, quote, and market-data disclosure evidence. Single-leg
 option reviews retain a provider-specific immutable record rather than forcing
 the option shape into the equity request contract.
 
+## Provider-aware account commands
+
+The application composition root exposes each adapter only to the three
+provider-aware account commands. The legacy `account snapshot` command is not
+provider-aware and retains its runtime-telemetry contract.
+
+```bash
+uv run gpt-trader account observe --provider robinhood-crypto --format json
+uv run gpt-trader account diagnose --provider robinhood-agentic --format json
+uv run gpt-trader account preview --provider robinhood-crypto \
+  --instrument BTC-USD --side buy --quantity <quantity> --order-type market \
+  --format json
+uv run gpt-trader account preview --provider robinhood-agentic \
+  --instrument <symbol> --side buy --quantity <quantity> --order-type limit \
+  --limit-price <price> --format json
+uv run gpt-trader account preview --provider robinhood-agentic \
+  --product-type option --instrument <option-instrument-uuid> \
+  --side buy --position-effect open --quantity 1 --order-type limit \
+  --limit-price <price> --format json
+```
+
+All preview results are marked non-binding. Provider rejections return an error
+without falling through to a place/cancel path, and command-scoped sessions are
+closed after success or failure. Rejected responses retain their masked
+identity/request/evidence binding; provider evidence JSON redacts account and
+portfolio identifiers and includes a digest of the sanitized record.
+
+`ideas export-ticket --venue robinhood` is a separate local render-only action.
+It accepts approved ideas only, emits the existing canonical broker-neutral
+ticket artifact, never imports or calls a Robinhood adapter, and remains absent
+from `mark-submitted`, `mark-filled`, and reconciliation venue choices.
+
 ## Explicit Agentic non-mutation smoke
 
 The live smoke is never automatic. It performs account/portfolio reads and the

--- a/docs/specs/TRADE_IDEA_CLI_SPEC.md
+++ b/docs/specs/TRADE_IDEA_CLI_SPEC.md
@@ -91,7 +91,7 @@ gpt-trader ideas
 ├── show             DECISION_ID [--events]
 ├── report           [--since ISO|YYYY-MM-DD] [--until ISO|YYYY-MM-DD]
 │                    [--output PATH] [--output-dir DIR] [--format text|json|csv]
-├── export-ticket    --decision-id ID --venue {coinbase,manual}
+├── export-ticket    --decision-id ID --venue {coinbase,manual,robinhood}
 │                    [--venue-order-type TEXT] [--time-in-force TEXT]
 │                    [--client-order-id ID] [--out PATH] [--format {json,text}]
 ├── replay
@@ -372,7 +372,8 @@ already exist (`IDEA_NOT_FOUND` otherwise). Service/audit layer enforces the
   surfaces, and it does not mutate the persisted `TradeIdea.broker_ticket`.
 - Required options:
   - `--decision-id ID`
-  - `--venue {coinbase,manual}`
+  - `--venue {coinbase,manual,robinhood}`. Robinhood is render-only and is
+    deliberately absent from lifecycle-recording commands.
 - Optional venue placeholders:
   - `--venue-order-type TEXT` (default `operator_selected`)
   - `--time-in-force TEXT` (default `operator_selected`)
@@ -397,6 +398,8 @@ already exist (`IDEA_NOT_FOUND` otherwise). Service/audit layer enforces the
   `needs_changes`, `rejected`, or pre-approval `expired`. Approved ideas also
   recheck `time_horizon.expires_at` at export time and fail instead of
   producing an actionable ticket when the idea has gone stale.
+  Robinhood export is narrower: it succeeds only while the idea is `approved`,
+  so the artifact cannot claim a Robinhood submitted or filled state.
 - Payload includes:
   - `schema_version`, `decision_id`, `record_hash`, deterministic
     `generated_at`, and `ticket_hash`.
@@ -424,9 +427,9 @@ Example:
 ```bash
 uv run gpt-trader ideas export-ticket \
   --decision-id trade-20350612-btcusd-4c5a9e2d \
-  --venue coinbase \
-  --venue-order-type limit \
-  --time-in-force GTC \
+  --venue robinhood \
+  --venue-order-type operator_selected \
+  --time-in-force operator_selected \
   --out review_artifacts/tmp/trade-ticket.json
 ```
 

--- a/src/gpt_trader/cli/commands/account.py
+++ b/src/gpt_trader/cli/commands/account.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 from argparse import ArgumentTypeError, Namespace
 from decimal import Decimal, InvalidOperation
@@ -11,7 +12,7 @@ from typing import Any
 from gpt_trader.app.container import ApplicationContainer, create_application_container
 from gpt_trader.cli import options, services
 from gpt_trader.cli.response import CliErrorCode, CliResponse
-from gpt_trader.features.brokerages.accounts import PreviewRequest
+from gpt_trader.features.brokerages.accounts import AccountObservation, PreviewRequest
 from gpt_trader.features.brokerages.coinbase.account_access import (
     CoinbaseAccountViolation,
 )
@@ -27,12 +28,28 @@ from gpt_trader.features.brokerages.coinbase.preview_access import (
 from gpt_trader.features.brokerages.coinbase.read_preview_access import (
     CoinbaseReadPreviewAccess,
 )
+from gpt_trader.features.brokerages.robinhood.agentic.errors import (
+    RobinhoodAgenticViolation,
+)
+from gpt_trader.features.brokerages.robinhood.agentic.models import (
+    RobinhoodAgenticOptionReviewEvidence,
+    RobinhoodAgenticOptionReviewRequest,
+)
+from gpt_trader.features.brokerages.robinhood.crypto.account_access import (
+    RobinhoodCryptoViolation,
+)
 from gpt_trader.utilities.logging_patterns import get_logger
 
 SNAPSHOT_COMMAND_NAME = "account snapshot"
 OBSERVE_COMMAND_NAME = "account observe"
 PREVIEW_COMMAND_NAME = "account preview"
 DIAGNOSE_COMMAND_NAME = "account diagnose"
+PROVIDER_CHOICES = ("coinbase", "robinhood-crypto", "robinhood-agentic")
+_PROVIDER_LABELS = {
+    "coinbase": "Coinbase",
+    "robinhood-crypto": "Robinhood Crypto",
+    "robinhood-agentic": "Robinhood Agentic",
+}
 
 logger = get_logger(__name__, component="account_cli")
 
@@ -47,8 +64,9 @@ def _positive_decimal_value(raw: str) -> Decimal:
     return value
 
 
-def _coinbase_error_response(
+def _provider_error_response(
     *,
+    provider: str,
     command: str,
     failure_label: str,
     exc: Exception,
@@ -62,7 +80,13 @@ def _coinbase_error_response(
         code = CliErrorCode.NETWORK_ERROR
     elif isinstance(
         exc,
-        (CoinbaseAccountViolation, CoinbasePreviewViolation, PermissionDeniedError),
+        (
+            CoinbaseAccountViolation,
+            CoinbasePreviewViolation,
+            PermissionDeniedError,
+            RobinhoodCryptoViolation,
+            RobinhoodAgenticViolation,
+        ),
     ):
         code = CliErrorCode.POLICY_VIOLATION
     else:
@@ -70,7 +94,7 @@ def _coinbase_error_response(
     return CliResponse.error_response(
         command=command,
         code=code,
-        message=f"Coinbase {failure_label} failed: {exc}",
+        message=f"{_PROVIDER_LABELS[provider]} {failure_label} failed: {exc}",
         warnings=list(warnings),
     )
 
@@ -90,7 +114,7 @@ def register(subparsers: Any) -> None:
         help="Read a provider-attested real-account observation",
     )
     options.add_profile_option(observe, inherit_from_parent=True)
-    observe.add_argument("--provider", required=True, choices=("coinbase",))
+    observe.add_argument("--provider", required=True, choices=PROVIDER_CHOICES)
     options.add_output_options(observe, include_quiet=False)
     observe.set_defaults(handler=_handle_observe, subcommand="observe")
 
@@ -99,19 +123,54 @@ def register(subparsers: Any) -> None:
         help="Request a non-binding provider order preview",
     )
     options.add_profile_option(preview, inherit_from_parent=True)
-    preview.add_argument("--provider", required=True, choices=("coinbase",))
-    preview.add_argument("--instrument", required=True)
+    preview.add_argument("--provider", required=True, choices=PROVIDER_CHOICES)
+    preview.add_argument(
+        "--product-type",
+        choices=("equity", "option"),
+        default="equity",
+        help="Preview shape; option is accepted only by Robinhood Agentic",
+    )
+    preview.add_argument(
+        "--instrument",
+        required=True,
+        help="Symbol for equity/crypto previews or provider option id for option reviews",
+    )
     preview.add_argument("--side", required=True, choices=("buy", "sell"))
     preview.add_argument("--quantity", required=True, type=_positive_decimal_value)
-    preview.add_argument("--order-type", required=True, choices=("market", "limit"))
+    preview.add_argument(
+        "--order-type",
+        required=True,
+        choices=("market", "limit", "stop_limit", "stop_market"),
+    )
     preview.add_argument("--limit-price", type=_positive_decimal_value)
+    preview.add_argument("--stop-price", type=_positive_decimal_value)
+    preview.add_argument("--position-effect", choices=("open", "close"))
+    preview.add_argument(
+        "--time-in-force",
+        dest="preview_time_in_force",
+        choices=("gfd", "gtc"),
+        default="gfd",
+    )
+    preview.add_argument(
+        "--market-hours",
+        choices=(
+            "regular_hours",
+            "regular_curb_hours",
+            "regular_curb_overnight_hours",
+        ),
+        default="regular_hours",
+    )
+    preview.add_argument("--chain-symbol")
+    preview.add_argument("--underlying-type", choices=("equity", "index"))
     options.add_output_options(preview, include_quiet=False)
     preview.set_defaults(handler=_handle_preview, subcommand="preview")
 
     diagnose = account_subparsers.add_parser(
         "diagnose",
-        help="Diagnose Coinbase credentials, permissions, and market-data access",
+        help="Diagnose provider-attested account observation access",
     )
+    options.add_profile_option(diagnose, inherit_from_parent=True)
+    diagnose.add_argument("--provider", choices=PROVIDER_CHOICES, default="coinbase")
     options.add_output_options(diagnose, include_quiet=False)
     diagnose.set_defaults(handler=_handle_diagnose, subcommand="diagnose")
 
@@ -162,48 +221,12 @@ def _handle_snapshot(args: Namespace) -> CliResponse | int:
 
 
 def _handle_observe(args: Namespace) -> CliResponse:
-    try:
-        container = getattr(args, "application_container", None)
-        config = (
-            container.config
-            if container is not None
-            else services.build_config_from_args(args, skip={"account_command", "provider"})
-        )
-        access = _build_coinbase_access(config, container=container)
-    except Exception as exc:  # noqa: BLE001
-        return CliResponse.error_response(
-            command=OBSERVE_COMMAND_NAME,
-            code=CliErrorCode.CONFIG_INVALID,
-            message=f"Failed to initialize Coinbase account access: {exc}",
-        )
-
-    try:
-        observation = access.reader.read_account()
-        return CliResponse.success_response(
-            command=OBSERVE_COMMAND_NAME,
-            data=observation.to_dict(),
-            warnings=[*access.warnings, *observation.warnings],
-        )
-    except Exception as exc:  # noqa: BLE001
-        return _coinbase_error_response(
-            command=OBSERVE_COMMAND_NAME,
-            failure_label="account observation",
-            exc=exc,
-            warnings=access.warnings,
-        )
-    finally:
-        _close_coinbase_access(access)
+    return _handle_account_read(args, command=OBSERVE_COMMAND_NAME, diagnose=False)
 
 
 def _handle_preview(args: Namespace) -> CliResponse:
     try:
-        request = PreviewRequest(
-            instrument=args.instrument,
-            side=args.side,
-            quantity=args.quantity,
-            order_type=args.order_type,
-            limit_price=args.limit_price,
-        )
+        request = _preview_request_from_args(args)
     except ValueError as exc:
         return CliResponse.error_response(
             command=PREVIEW_COMMAND_NAME,
@@ -211,46 +234,269 @@ def _handle_preview(args: Namespace) -> CliResponse:
             message=str(exc),
         )
 
+    if args.provider == "robinhood-agentic":
+        return asyncio.run(_handle_agentic_preview(args, request))
+    if isinstance(request, RobinhoodAgenticOptionReviewRequest):
+        raise AssertionError("option requests must route through Robinhood Agentic")
+    return _handle_sync_preview(args, request)
+
+
+def _preview_request_from_args(
+    args: Namespace,
+) -> PreviewRequest | RobinhoodAgenticOptionReviewRequest:
+    product_type = getattr(args, "product_type", "equity")
+    if product_type == "option":
+        if args.provider != "robinhood-agentic":
+            raise ValueError("option reviews are accepted only by Robinhood Agentic")
+        if getattr(args, "position_effect", None) is None:
+            raise ValueError("--position-effect is required for option reviews")
+        integral_quantity = args.quantity.to_integral_value()
+        if args.quantity != integral_quantity:
+            raise ValueError("option review quantity must be a whole number")
+        return RobinhoodAgenticOptionReviewRequest(
+            option_id=args.instrument,
+            side=args.side,
+            position_effect=args.position_effect,
+            quantity=int(integral_quantity),
+            order_type=args.order_type,
+            price=args.limit_price,
+            stop_price=getattr(args, "stop_price", None),
+            time_in_force=getattr(args, "preview_time_in_force", "gfd"),
+            market_hours=getattr(args, "market_hours", "regular_hours"),
+            chain_symbol=getattr(args, "chain_symbol", None),
+            underlying_type=getattr(args, "underlying_type", None),
+        )
+
+    option_only_values = (
+        getattr(args, "position_effect", None),
+        getattr(args, "stop_price", None),
+        getattr(args, "chain_symbol", None),
+        getattr(args, "underlying_type", None),
+    )
+    option_only_override = (
+        getattr(args, "preview_time_in_force", "gfd") != "gfd"
+        or getattr(args, "market_hours", "regular_hours") != "regular_hours"
+    )
+    if any(value is not None for value in option_only_values) or option_only_override:
+        raise ValueError("option-specific arguments require --product-type option")
+    return PreviewRequest(
+        instrument=args.instrument,
+        side=args.side,
+        quantity=args.quantity,
+        order_type=args.order_type,
+        limit_price=args.limit_price,
+    )
+
+
+def _resolve_access_inputs(args: Namespace) -> tuple[Any, ApplicationContainer | None]:
+    container = getattr(args, "application_container", None)
+    config = (
+        container.config
+        if container is not None
+        else services.build_config_from_args(args, skip={"account_command", "provider"})
+    )
+    return config, container
+
+
+def _build_sync_access(
+    provider: str,
+    config: Any,
+    *,
+    container: ApplicationContainer | None = None,
+) -> Any:
+    if provider == "coinbase":
+        return _build_coinbase_access(config, container=container)
+    if provider == "robinhood-crypto":
+        composition_root = container or create_application_container(config)
+        return composition_root.create_robinhood_crypto_read_preview_access()
+    raise ValueError(f"unsupported synchronous account provider: {provider}")
+
+
+async def _build_agentic_access(
+    config: Any,
+    *,
+    container: ApplicationContainer | None = None,
+) -> Any:
+    composition_root = container or create_application_container(config)
+    return await composition_root.create_robinhood_agentic_read_review_access()
+
+
+def _handle_sync_preview(args: Namespace, request: PreviewRequest) -> CliResponse:
     try:
-        container = getattr(args, "application_container", None)
-        config = (
-            container.config
-            if container is not None
-            else services.build_config_from_args(args, skip={"account_command", "provider"})
-        )
-        access = _build_coinbase_access(config, container=container)
+        config, container = _resolve_access_inputs(args)
+        access = _build_sync_access(args.provider, config, container=container)
     except Exception as exc:  # noqa: BLE001
-        return CliResponse.error_response(
-            command=PREVIEW_COMMAND_NAME,
-            code=CliErrorCode.CONFIG_INVALID,
-            message=f"Failed to initialize Coinbase account access: {exc}",
-        )
+        return _initialization_error(args.provider, PREVIEW_COMMAND_NAME, exc)
 
     try:
         result = access.preview_provider.preview(request)
-        if result.errors:
-            return CliResponse.error_response(
-                command=PREVIEW_COMMAND_NAME,
-                code=CliErrorCode.OPERATION_FAILED,
-                message="Coinbase rejected the preview request",
-                details={"provider_errors": list(result.errors)},
-                warnings=[*access.warnings, *result.warnings],
-            )
-        return CliResponse.success_response(
-            command=PREVIEW_COMMAND_NAME,
+        return _preview_response(
+            provider=args.provider,
             data=result.to_dict(),
-            warnings=[*access.warnings, *result.warnings],
-            was_noop=True,
+            errors=result.errors,
+            warnings=(*getattr(access, "warnings", ()), *result.warnings),
         )
     except Exception as exc:  # noqa: BLE001
-        return _coinbase_error_response(
+        return _provider_error_response(
+            provider=args.provider,
             command=PREVIEW_COMMAND_NAME,
             failure_label="preview",
             exc=exc,
-            warnings=access.warnings,
+            warnings=tuple(getattr(access, "warnings", ())),
         )
     finally:
-        _close_coinbase_access(access)
+        _close_sync_access(args.provider, access)
+
+
+async def _handle_agentic_preview(
+    args: Namespace,
+    request: PreviewRequest | RobinhoodAgenticOptionReviewRequest,
+) -> CliResponse:
+    try:
+        config, container = _resolve_access_inputs(args)
+        access = await _build_agentic_access(config, container=container)
+    except Exception as exc:  # noqa: BLE001
+        return _initialization_error(args.provider, PREVIEW_COMMAND_NAME, exc)
+
+    try:
+        if isinstance(request, RobinhoodAgenticOptionReviewRequest):
+            evidence = await access.review_option_order(request)
+            data = _option_review_to_dict(evidence)
+            errors = (
+                ()
+                if not evidence.errors
+                else (
+                    "provider order checks: " f"{data['provider_evidence']['order_checks_json']}",
+                )
+            )
+            warnings: tuple[str, ...] = ()
+        else:
+            evidence = await access.review_equity_order(request)
+            order_checks_json, order_checks_sha256 = _sanitize_provider_json(
+                evidence.order_checks_json
+            )
+            quote_json, quote_sha256 = _sanitize_provider_json(evidence.quote_json)
+            data = {
+                **evidence.preview.to_dict(),
+                "provider_evidence": {
+                    "order_checks_json": order_checks_json,
+                    "order_checks_sha256": order_checks_sha256,
+                    "quote_json": quote_json,
+                    "quote_sha256": quote_sha256,
+                    "market_data_disclosure": evidence.market_data_disclosure,
+                },
+            }
+            errors = (
+                ()
+                if not evidence.preview.errors
+                else (f"provider order checks: {order_checks_json}",)
+            )
+            warnings = evidence.preview.warnings
+        return _preview_response(
+            provider=args.provider,
+            data=data,
+            errors=errors,
+            warnings=warnings,
+        )
+    except Exception as exc:  # noqa: BLE001
+        return _provider_error_response(
+            provider=args.provider,
+            command=PREVIEW_COMMAND_NAME,
+            failure_label="review",
+            exc=exc,
+        )
+    finally:
+        await _close_agentic_access(access)
+
+
+def _option_review_to_dict(evidence: RobinhoodAgenticOptionReviewEvidence) -> dict[str, Any]:
+    request = evidence.request
+    order_checks_json, order_checks_sha256 = _sanitize_provider_json(evidence.order_checks_json)
+    quotes_json, quotes_sha256 = _sanitize_provider_json(evidence.quotes_json)
+    collateral_json, collateral_sha256 = _sanitize_provider_json(evidence.collateral_json)
+    return {
+        "provider": "robinhood-agentic",
+        "kind": "provider_simulation",
+        "generated_at": evidence.generated_at.isoformat(),
+        "identity_fingerprint": evidence.identity_fingerprint,
+        "request": {
+            "product_type": "option",
+            "option_id": request.option_id,
+            "side": request.side.value.lower(),
+            "position_effect": request.position_effect,
+            "quantity": request.quantity,
+            "order_type": request.order_type,
+            "price": None if request.price is None else str(request.price),
+            "stop_price": None if request.stop_price is None else str(request.stop_price),
+            "time_in_force": request.time_in_force,
+            "market_hours": request.market_hours,
+            "chain_symbol": request.chain_symbol,
+            "underlying_type": request.underlying_type,
+        },
+        "estimated_fee": None if evidence.total_fee is None else str(evidence.total_fee),
+        "errors": list(evidence.errors),
+        "non_binding": True,
+        "provider_evidence": {
+            "order_checks_json": order_checks_json,
+            "order_checks_sha256": order_checks_sha256,
+            "quotes_json": quotes_json,
+            "quotes_sha256": quotes_sha256,
+            "collateral_json": collateral_json,
+            "collateral_sha256": collateral_sha256,
+        },
+    }
+
+
+_SENSITIVE_EVIDENCE_KEYS = frozenset(
+    {"account_id", "account_number", "account_uuid", "portfolio_id", "portfolio_uuid"}
+)
+
+
+def _sanitize_provider_json(encoded: str) -> tuple[str, str]:
+    """Redact provider identifiers while retaining immutable evidence integrity."""
+    payload = json.loads(encoded)
+
+    def redact(value: Any) -> Any:
+        if isinstance(value, dict):
+            return {
+                key: ("<redacted>" if key.lower() in _SENSITIVE_EVIDENCE_KEYS else redact(item))
+                for key, item in value.items()
+            }
+        if isinstance(value, list):
+            return [redact(item) for item in value]
+        return value
+
+    sanitized = json.dumps(redact(payload), sort_keys=True, separators=(",", ":"))
+    digest = hashlib.sha256(sanitized.encode("utf-8")).hexdigest()
+    return sanitized, digest
+
+
+def _preview_response(
+    *,
+    provider: str,
+    data: dict[str, Any],
+    errors: tuple[str, ...],
+    warnings: tuple[str, ...],
+) -> CliResponse:
+    if errors:
+        details: dict[str, Any] = {
+            "provider_errors": list(errors),
+            "non_binding": True,
+            "evidence": data,
+        }
+        return CliResponse.error_response(
+            command=PREVIEW_COMMAND_NAME,
+            code=CliErrorCode.OPERATION_FAILED,
+            message=f"{_PROVIDER_LABELS[provider]} rejected the preview request",
+            details=details,
+            warnings=list(warnings),
+        )
+    return CliResponse.success_response(
+        command=PREVIEW_COMMAND_NAME,
+        data=data,
+        warnings=list(warnings),
+        was_noop=True,
+    )
 
 
 def _build_coinbase_access(
@@ -262,123 +508,122 @@ def _build_coinbase_access(
     return composition_root.create_coinbase_read_preview_access()
 
 
-def _close_coinbase_access(access: Any) -> None:
+def _close_sync_access(provider: str, access: Any) -> None:
     try:
         close = getattr(access, "close", None)
         if callable(close):
             close()
     except Exception as exc:  # noqa: BLE001
         logger.warning(
-            "Failed to close Coinbase account access",
+            "Failed to close account access",
+            provider=provider,
             error_type=type(exc).__name__,
-            error_message=str(exc),
         )
 
 
-def _handle_diagnose(args: Namespace) -> CliResponse | int:
-    output_format = getattr(args, "output_format", "text")
-
-    from gpt_trader.features.brokerages.coinbase.auth import SimpleAuth
-    from gpt_trader.features.brokerages.coinbase.client import CoinbaseClient
-    from gpt_trader.features.brokerages.coinbase.credentials import resolve_coinbase_credentials
-
-    creds = resolve_coinbase_credentials()
-    if not creds:
-        message = (
-            "Coinbase credentials not found. Set COINBASE_CREDENTIALS_FILE to a JSON key file, "
-            "or set COINBASE_CDP_API_KEY + COINBASE_CDP_PRIVATE_KEY."
+async def _close_agentic_access(access: Any) -> None:
+    try:
+        await access.close()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "Failed to close account access",
+            provider="robinhood-agentic",
+            error_type=type(exc).__name__,
         )
-        if output_format == "json":
-            return CliResponse.error_response(
-                command=DIAGNOSE_COMMAND_NAME,
-                code=CliErrorCode.CONFIG_INVALID,
-                message=message,
-            )
-        print(message)
-        return 1
 
-    diag: dict[str, Any] = {
-        "credential_source": creds.source,
-        "masked_key_name": creds.masked_key_name,
-        "warnings": list(creds.warnings),
-    }
 
-    auth = SimpleAuth(key_name=creds.key_name, private_key=creds.private_key)
-    client = CoinbaseClient(base_url="https://api.coinbase.com", auth=auth, api_mode="advanced")
+def _handle_diagnose(args: Namespace) -> CliResponse:
+    return _handle_account_read(args, command=DIAGNOSE_COMMAND_NAME, diagnose=True)
+
+
+def _handle_account_read(
+    args: Namespace,
+    *,
+    command: str,
+    diagnose: bool,
+) -> CliResponse:
+    if args.provider == "robinhood-agentic":
+        return asyncio.run(_handle_agentic_account_read(args, command=command, diagnose=diagnose))
 
     try:
-        # 1) Key permissions (auth-required)
-        try:
-            permissions = client.get_key_permissions() or {}
-            diag["key_permissions"] = {
-                "can_view": bool(permissions.get("can_view")),
-                "can_trade": bool(permissions.get("can_trade")),
-                "portfolio_type": str(permissions.get("portfolio_type") or ""),
-                "portfolio_uuid": str(permissions.get("portfolio_uuid") or ""),
-            }
-        except Exception as exc:  # noqa: BLE001
-            diag["key_permissions_error"] = f"{type(exc).__name__}: {exc}"
+        config, container = _resolve_access_inputs(args)
+        access = _build_sync_access(args.provider, config, container=container)
+    except Exception as exc:  # noqa: BLE001
+        return _initialization_error(args.provider, command, exc)
 
-        # 2) Accounts (auth-required)
-        try:
-            accounts_payload = client.get_accounts() or {}
-            accounts = accounts_payload.get("accounts", [])
-            non_zero = []
-            for a in accounts or []:
-                try:
-                    currency = str(a.get("currency") or "")
-                    avail = str(a.get("available_balance", {}).get("value", "0"))
-                    hold = str(a.get("hold", {}).get("value", "0"))
-                    total = Decimal(avail) + Decimal(hold)
-                    if total > 0:
-                        non_zero.append({"asset": currency, "total": str(total)})
-                except Exception:  # noqa: BLE001
-                    continue
-
-            diag["accounts"] = {
-                "count": len(accounts) if isinstance(accounts, list) else 0,
-                "non_zero_count": len(non_zero),
-                "non_zero_sample": non_zero[:10],
-            }
-        except Exception as exc:  # noqa: BLE001
-            diag["accounts_error"] = f"{type(exc).__name__}: {exc}"
-
-        # 3) Market ticker + candles (public)
-        try:
-            # Prefer normalized market ticker so we always surface a usable price
-            # even when the raw public payload omits a top-level "price" field.
-            normalized = client.get_ticker("BTC-USD") or {}
-            diag["market_ticker"] = {
-                "product_id": "BTC-USD",
-                "price": str(normalized.get("price") or ""),
-                "bid": str(normalized.get("bid") or ""),
-                "ask": str(normalized.get("ask") or ""),
-            }
-
-            # If the price still isn't available, include raw keys for debugging
-            # (safe: market data is public and contains no secrets).
-            if not diag["market_ticker"]["price"] or diag["market_ticker"]["price"] == "0":
-                raw_public = client.get_market_product_ticker("BTC-USD") or {}
-                if isinstance(raw_public, dict):
-                    diag["market_ticker"]["raw_keys"] = sorted(list(raw_public.keys()))[:50]
-        except Exception as exc:  # noqa: BLE001
-            diag["market_ticker_error"] = f"{type(exc).__name__}: {exc}"
-
-        try:
-            candles = client.get_market_product_candles("BTC-USD", "ONE_MINUTE", limit=2) or {}
-            candle_count = len(candles.get("candles", []) or []) if isinstance(candles, dict) else 0
-            diag["market_candles"] = {"product_id": "BTC-USD", "count": candle_count}
-        except Exception as exc:  # noqa: BLE001
-            diag["market_candles_error"] = f"{type(exc).__name__}: {exc}"
-
-        if output_format == "json":
-            return CliResponse.success_response(command=DIAGNOSE_COMMAND_NAME, data=diag)
-
-        print(json.dumps(diag, indent=2, default=str))
-        return 0
-
+    try:
+        observation = access.reader.read_account()
+        warnings = (*getattr(access, "warnings", ()), *observation.warnings)
+        return _observation_response(command, observation, warnings=warnings, diagnose=diagnose)
+    except Exception as exc:  # noqa: BLE001
+        return _provider_error_response(
+            provider=args.provider,
+            command=command,
+            failure_label="account observation",
+            exc=exc,
+            warnings=tuple(getattr(access, "warnings", ())),
+        )
     finally:
-        try:
-            client.close()
-        except Exception:  # noqa: BLE001
-            pass
+        _close_sync_access(args.provider, access)
+
+
+async def _handle_agentic_account_read(
+    args: Namespace,
+    *,
+    command: str,
+    diagnose: bool,
+) -> CliResponse:
+    try:
+        config, container = _resolve_access_inputs(args)
+        access = await _build_agentic_access(config, container=container)
+    except Exception as exc:  # noqa: BLE001
+        return _initialization_error(args.provider, command, exc)
+
+    try:
+        observation = await access.read_account()
+        return _observation_response(
+            command,
+            observation,
+            warnings=observation.warnings,
+            diagnose=diagnose,
+        )
+    except Exception as exc:  # noqa: BLE001
+        return _provider_error_response(
+            provider=args.provider,
+            command=command,
+            failure_label="account observation",
+            exc=exc,
+        )
+    finally:
+        await _close_agentic_access(access)
+
+
+def _observation_response(
+    command: str,
+    observation: AccountObservation,
+    *,
+    warnings: tuple[str, ...],
+    diagnose: bool,
+) -> CliResponse:
+    if diagnose:
+        data: dict[str, Any] = {
+            "provider": observation.identity.provider.value,
+            "status": "available",
+            "identity": observation.identity.to_dict(),
+            "observation_schema_version": observation.to_dict()["schema_version"],
+            "balance_count": len(observation.balances),
+            "position_count": len(observation.positions),
+            "option_position_count": len(observation.option_positions),
+            "buying_power_dimensions": sorted(observation.buying_power),
+        }
+    else:
+        data = observation.to_dict()
+    return CliResponse.success_response(command=command, data=data, warnings=list(warnings))
+
+
+def _initialization_error(provider: str, command: str, exc: Exception) -> CliResponse:
+    return CliResponse.error_response(
+        command=command,
+        code=CliErrorCode.CONFIG_INVALID,
+        message=f"Failed to initialize {_PROVIDER_LABELS[provider]} account access: {exc}",
+    )

--- a/src/gpt_trader/cli/commands/ideas.py
+++ b/src/gpt_trader/cli/commands/ideas.py
@@ -146,6 +146,7 @@ from gpt_trader.features.trade_ideas.scorecard import (
 from gpt_trader.persistence.event_store import EventStore
 
 VENUE_CHOICES = ("coinbase", "manual")
+EXPORT_TICKET_VENUE_CHOICES = (*VENUE_CHOICES, "robinhood")
 # --strategy flag values: live-trade strategies runnable as snapshot proposers.
 # The CLI is the composition root — it constructs the strategy so the
 # strategy_tools slice never imports live_trade (SnapshotDecider is structural).
@@ -558,8 +559,9 @@ def register(subparsers: Any) -> None:
         help="Export a deterministic broker-neutral ticket artifact",
         description=(
             "Render a deterministic broker-neutral ticket JSON artifact from an approved "
-            "or terminal-approved trade idea. This command reads only local trade-idea "
-            "records and never contacts a broker, account, preflight, or canary surface."
+            "or terminal-approved trade idea. Robinhood exports require the approved state. "
+            "This command reads only local trade-idea records and never contacts a broker, "
+            "account, preflight, or canary surface."
         ),
     )
     export_ticket.add_argument(
@@ -588,7 +590,7 @@ def register(subparsers: Any) -> None:
         required=True,
         help="Approved or terminal-approved trade idea decision identifier",
     )
-    export_ticket.add_argument("--venue", required=True, choices=VENUE_CHOICES)
+    export_ticket.add_argument("--venue", required=True, choices=EXPORT_TICKET_VENUE_CHOICES)
     export_ticket.add_argument(
         "--venue-order-type",
         default=DEFAULT_VENUE_ORDER_TYPE,

--- a/src/gpt_trader/features/trade_ideas/broker_payloads.py
+++ b/src/gpt_trader/features/trade_ideas/broker_payloads.py
@@ -34,7 +34,7 @@ from gpt_trader.features.trade_ideas.workflow import (
 TICKET_PAYLOAD_SCHEMA_VERSION = "gpt-trader.trade_idea_ticket.v1"
 DEFAULT_VENUE_ORDER_TYPE = "operator_selected"
 DEFAULT_TIME_IN_FORCE = "operator_selected"
-EXPORT_TICKET_VENUES = frozenset({TicketVenue.COINBASE, TicketVenue.MANUAL})
+EXPORT_TICKET_VENUES = frozenset({TicketVenue.COINBASE, TicketVenue.MANUAL, TicketVenue.ROBINHOOD})
 MAX_CLIENT_ORDER_ID_LENGTH = 128
 
 _CLIENT_ORDER_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
@@ -100,7 +100,7 @@ def build_broker_neutral_ticket_payload(
     approval_policy_violations: list[str],
 ) -> dict[str, Any]:
     """Build a stable broker-neutral ticket payload from audited local state."""
-    _require_exportable_state(idea.decision_id, state, events)
+    _require_exportable_state(idea.decision_id, state, events, venue=request.venue)
     latest_event = events[-1]
     approval_event = _latest_event(events, AuditAction.APPROVED)
     terminal_event = latest_event if state in TERMINAL_STATES else None
@@ -201,7 +201,16 @@ def _require_exportable_state(
     decision_id: str,
     state: TradeIdeaState,
     events: tuple[AuditEvent, ...],
+    *,
+    venue: TicketVenue,
 ) -> None:
+    if venue is TicketVenue.ROBINHOOD and state is not TradeIdeaState.APPROVED:
+        raise InvalidTransitionError(
+            f"Trade idea '{decision_id}' must be approved for render-only Robinhood "
+            f"ticket export; got '{state.value}'",
+            field="after_state",
+            value=state.value,
+        )
     if state in {
         TradeIdeaState.APPROVED,
         TradeIdeaState.SUBMITTED,

--- a/src/gpt_trader/features/trade_ideas/models.py
+++ b/src/gpt_trader/features/trade_ideas/models.py
@@ -54,6 +54,7 @@ class TicketVenue(str, Enum):
     COINBASE = "coinbase"
     MANUAL = "manual"
     PAPER = "paper"
+    ROBINHOOD = "robinhood"
     NONE = "none"
 
 

--- a/tests/unit/gpt_trader/cli/commands/test_ideas_export_ticket.py
+++ b/tests/unit/gpt_trader/cli/commands/test_ideas_export_ticket.py
@@ -102,7 +102,7 @@ def _propose_and_approve(
     assert approved["data"]["state"] == "approved"
 
 
-def _export_args(root: Path, decision_id: str) -> list[str]:
+def _export_args(root: Path, decision_id: str, *, venue: str = "coinbase") -> list[str]:
     return [
         "ideas",
         "export-ticket",
@@ -111,7 +111,7 @@ def _export_args(root: Path, decision_id: str) -> list[str]:
         "--decision-id",
         decision_id,
         "--venue",
-        "coinbase",
+        venue,
         "--venue-order-type",
         "limit",
         "--time-in-force",
@@ -146,6 +146,49 @@ def test_export_ticket_defaults_to_raw_json_for_approved_idea(
     }
     assert ticket["record_hash"]
     assert ticket["ticket_hash"]
+
+
+def test_export_ticket_accepts_robinhood_as_render_only_venue(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    root = tmp_path / "ideas"
+    payload = _idea_payload(decision_id="trade-export-robinhood")
+    _propose_and_approve(capsys, root, payload)
+
+    exit_code, output = _run(
+        capsys,
+        _export_args(root, payload["decision_id"], venue="robinhood"),
+    )
+
+    assert exit_code == 0
+    ticket = json.loads(output)
+    assert ticket["venue_request"]["venue"] == "robinhood"
+    assert ticket["broker_ticket"]["exported"] == {
+        "venue": "robinhood",
+        "status": "approved",
+    }
+    assert ticket["venue_request"]["client_order_id"].startswith(
+        "gpt-trader-robinhood-trade-export-robinhood-"
+    )
+
+
+@pytest.mark.parametrize("subcommand", ["mark-submitted", "mark-filled"])
+def test_robinhood_remains_unavailable_to_lifecycle_commands(subcommand: str) -> None:
+    parser = cli._build_parser()
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(
+            [
+                "ideas",
+                subcommand,
+                "trade-render-only",
+                "--actor",
+                "operator",
+                "--venue",
+                "robinhood",
+            ]
+        )
 
 
 def test_export_ticket_rejects_unapproved_idea_with_json_error(

--- a/tests/unit/gpt_trader/cli/test_commands_account.py
+++ b/tests/unit/gpt_trader/cli/test_commands_account.py
@@ -39,6 +39,7 @@ def test_account_provider_commands_parse() -> None:
     account_cmd.register(subparsers)
 
     observe = parser.parse_args(["account", "observe", "--provider", "coinbase"])
+    crypto_observe = parser.parse_args(["account", "observe", "--provider", "robinhood-crypto"])
     preview = parser.parse_args(
         [
             "account",
@@ -57,8 +58,34 @@ def test_account_provider_commands_parse() -> None:
     )
 
     assert observe.provider == "coinbase"
+    assert crypto_observe.provider == "robinhood-crypto"
     assert preview.provider == "coinbase"
     assert preview.quantity == Decimal("0.01")
+
+    option_preview = parser.parse_args(
+        [
+            "account",
+            "preview",
+            "--provider",
+            "robinhood-agentic",
+            "--product-type",
+            "option",
+            "--instrument",
+            "option-id",
+            "--side",
+            "buy",
+            "--position-effect",
+            "open",
+            "--quantity",
+            "1",
+            "--order-type",
+            "limit",
+            "--limit-price",
+            "1.25",
+        ]
+    )
+    assert option_preview.product_type == "option"
+    assert option_preview.position_effect == "open"
 
 
 def test_legacy_snapshot_rejects_provider_override() -> None:
@@ -237,3 +264,108 @@ def test_coinbase_access_uses_injected_composition_root() -> None:
             return access
 
     assert account_cmd._build_coinbase_access("ignored", container=Container()) is access
+
+
+def _observation(provider: AccountProvider) -> AccountObservation:
+    return AccountObservation(
+        identity=AccountIdentity(
+            provider=provider,
+            account_id="account-1234",
+            portfolio_id="account-1234",
+            interface="typed-read-review",
+        ),
+        generated_at=datetime(2026, 7, 13, tzinfo=UTC),
+        buying_power={"cash": Decimal("100")},
+    )
+
+
+def test_robinhood_crypto_observe_and_diagnose_use_composition_root() -> None:
+    closed = {"count": 0}
+
+    class Reader:
+        def read_account(self) -> AccountObservation:
+            return _observation(AccountProvider.ROBINHOOD_CRYPTO)
+
+    access = SimpleNamespace(
+        reader=Reader(),
+        warnings=("read only",),
+        close=lambda: closed.__setitem__("count", closed["count"] + 1),
+    )
+
+    class Container:
+        config = object()
+
+        def create_robinhood_crypto_read_preview_access(self) -> object:
+            return access
+
+    observe = account_cmd._handle_observe(
+        Namespace(provider="robinhood-crypto", application_container=Container())
+    )
+    diagnose = account_cmd._handle_diagnose(
+        Namespace(provider="robinhood-crypto", application_container=Container())
+    )
+
+    assert observe.success is True
+    assert observe.data["identity"]["provider"] == "robinhood_crypto"
+    assert diagnose.success is True
+    assert diagnose.data == {
+        "provider": "robinhood_crypto",
+        "status": "available",
+        "identity": diagnose.data["identity"],
+        "observation_schema_version": "gpt-trader.account-observation.v1",
+        "balance_count": 0,
+        "position_count": 0,
+        "option_position_count": 0,
+        "buying_power_dimensions": ["cash"],
+    }
+    assert diagnose.data["identity"]["account_id"] == "********1234"
+    assert closed["count"] == 2
+
+
+def test_robinhood_crypto_rejected_preview_is_non_binding_and_closes() -> None:
+    closed = {"value": False}
+
+    class PreviewProvider:
+        def preview(self, request: PreviewRequest) -> PreviewResult:
+            return PreviewResult(
+                provider=AccountProvider.ROBINHOOD_CRYPTO,
+                kind=PreviewKind.PROVIDER_ESTIMATE,
+                generated_at=datetime(2026, 7, 13, tzinfo=UTC),
+                identity_fingerprint="fingerprint",
+                request=request,
+                errors=("market requests only; no provider estimate was dispatched",),
+            )
+
+    access = SimpleNamespace(
+        preview_provider=PreviewProvider(),
+        close=lambda: closed.__setitem__("value", True),
+    )
+
+    class Container:
+        config = object()
+
+        def create_robinhood_crypto_read_preview_access(self) -> object:
+            return access
+
+    response = account_cmd._handle_preview(
+        Namespace(
+            provider="robinhood-crypto",
+            product_type="equity",
+            instrument="BTC-USD",
+            side="buy",
+            quantity=Decimal("0.01"),
+            order_type="limit",
+            limit_price=Decimal("100"),
+            application_container=Container(),
+        )
+    )
+
+    assert response.success is False
+    details = response.errors[0].details
+    assert details["provider_errors"] == [
+        "market requests only; no provider estimate was dispatched"
+    ]
+    assert details["non_binding"] is True
+    assert details["evidence"]["identity_fingerprint"] == "fingerprint"
+    assert details["evidence"]["request"]["instrument"] == "BTC-USD"
+    assert closed["value"] is True

--- a/tests/unit/gpt_trader/cli/test_commands_account_agentic.py
+++ b/tests/unit/gpt_trader/cli/test_commands_account_agentic.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+import json
+from argparse import Namespace
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+
+import gpt_trader.cli.commands.account as account_cmd
+from gpt_trader.features.brokerages.accounts import (
+    AccountIdentity,
+    AccountObservation,
+    AccountProvider,
+    PreviewKind,
+    PreviewRequest,
+    PreviewResult,
+)
+from gpt_trader.features.brokerages.robinhood.agentic.models import (
+    RobinhoodAgenticEquityReviewEvidence,
+    RobinhoodAgenticOptionReviewEvidence,
+    RobinhoodAgenticOptionReviewRequest,
+)
+
+
+def _observation(provider: AccountProvider) -> AccountObservation:
+    return AccountObservation(
+        identity=AccountIdentity(
+            provider=provider,
+            account_id="account-1234",
+            portfolio_id="account-1234",
+            interface="typed-read-review",
+        ),
+        generated_at=datetime(2026, 7, 13, tzinfo=UTC),
+        buying_power={"cash": Decimal("100")},
+    )
+
+
+def test_agentic_observe_and_equity_review_are_typed_and_close() -> None:
+    closed = {"count": 0}
+    observation = _observation(AccountProvider.ROBINHOOD_AGENTIC)
+
+    class Access:
+        async def read_account(self) -> AccountObservation:
+            return observation
+
+        async def review_equity_order(
+            self, request: PreviewRequest
+        ) -> RobinhoodAgenticEquityReviewEvidence:
+            return RobinhoodAgenticEquityReviewEvidence(
+                preview=PreviewResult(
+                    provider=AccountProvider.ROBINHOOD_AGENTIC,
+                    kind=PreviewKind.PROVIDER_SIMULATION,
+                    generated_at=datetime(2026, 7, 13, tzinfo=UTC),
+                    identity_fingerprint=observation.identity.fingerprint,
+                    request=request,
+                    estimated_total=Decimal("50"),
+                ),
+                order_checks_json="{}",
+                quote_json='{"ask_price":"50"}',
+                market_data_disclosure="non-binding",
+            )
+
+        async def close(self) -> None:
+            closed["count"] += 1
+
+    class Container:
+        config = object()
+
+        async def create_robinhood_agentic_read_review_access(self) -> Access:
+            return Access()
+
+    observed = account_cmd._handle_observe(
+        Namespace(provider="robinhood-agentic", application_container=Container())
+    )
+    reviewed = account_cmd._handle_preview(
+        Namespace(
+            provider="robinhood-agentic",
+            product_type="equity",
+            instrument="AAPL",
+            side="buy",
+            quantity=Decimal("1"),
+            order_type="market",
+            limit_price=None,
+            application_container=Container(),
+        )
+    )
+
+    assert observed.data["identity"]["provider"] == "robinhood_agentic"
+    assert reviewed.success is True
+    assert reviewed.data["non_binding"] is True
+    assert reviewed.data["provider_evidence"]["order_checks_json"] == "{}"
+    assert closed["count"] == 2
+
+
+def test_agentic_option_review_uses_provider_specific_shape() -> None:
+    captured: list[RobinhoodAgenticOptionReviewRequest] = []
+
+    class Access:
+        async def review_option_order(
+            self, request: RobinhoodAgenticOptionReviewRequest
+        ) -> RobinhoodAgenticOptionReviewEvidence:
+            captured.append(request)
+            return RobinhoodAgenticOptionReviewEvidence(
+                request=request,
+                generated_at=datetime(2026, 7, 13, tzinfo=UTC),
+                identity_fingerprint="fingerprint",
+                order_checks_json="{}",
+                quotes_json="[]",
+                total_fee=Decimal("0.03"),
+                collateral_json='{"account_number":"RH-PRIVATE-1234"}',
+            )
+
+        async def close(self) -> None:
+            return None
+
+    class Container:
+        config = object()
+
+        async def create_robinhood_agentic_read_review_access(self) -> Access:
+            return Access()
+
+    response = account_cmd._handle_preview(
+        Namespace(
+            provider="robinhood-agentic",
+            product_type="option",
+            instrument="option-id",
+            side="buy",
+            position_effect="open",
+            quantity=Decimal("2"),
+            order_type="limit",
+            limit_price=Decimal("1.25"),
+            stop_price=None,
+            preview_time_in_force="gfd",
+            market_hours="regular_hours",
+            chain_symbol="AAPL",
+            underlying_type="equity",
+            application_container=Container(),
+        )
+    )
+
+    assert response.success is True
+    assert response.data["request"]["product_type"] == "option"
+    assert response.data["estimated_fee"] == "0.03"
+    assert response.data["non_binding"] is True
+    assert response.data["provider_evidence"]["collateral_json"] == (
+        '{"account_number":"<redacted>"}'
+    )
+    assert "RH-PRIVATE-1234" not in json.dumps(response.data)
+    assert len(response.data["provider_evidence"]["collateral_sha256"]) == 64
+    assert captured[0].quantity == 2
+
+
+def test_agentic_rejected_review_retains_immutable_provider_evidence() -> None:
+    class Access:
+        async def review_equity_order(
+            self, request: PreviewRequest
+        ) -> RobinhoodAgenticEquityReviewEvidence:
+            return RobinhoodAgenticEquityReviewEvidence(
+                preview=PreviewResult(
+                    provider=AccountProvider.ROBINHOOD_AGENTIC,
+                    kind=PreviewKind.PROVIDER_SIMULATION,
+                    generated_at=datetime(2026, 7, 13, tzinfo=UTC),
+                    identity_fingerprint="fingerprint",
+                    request=request,
+                    errors=('provider order checks: {"buying_power":"insufficient"}',),
+                ),
+                order_checks_json='{"buying_power":"insufficient"}',
+                quote_json="null",
+                market_data_disclosure="non-binding",
+            )
+
+        async def close(self) -> None:
+            return None
+
+    class Container:
+        config = object()
+
+        async def create_robinhood_agentic_read_review_access(self) -> Access:
+            return Access()
+
+    response = account_cmd._handle_preview(
+        Namespace(
+            provider="robinhood-agentic",
+            product_type="equity",
+            instrument="AAPL",
+            side="buy",
+            quantity=Decimal("1"),
+            order_type="market",
+            limit_price=None,
+            application_container=Container(),
+        )
+    )
+
+    assert response.success is False
+    assert response.errors[0].details["non_binding"] is True
+    evidence = response.errors[0].details["evidence"]
+    assert evidence["identity_fingerprint"] == "fingerprint"
+    assert evidence["request"]["instrument"] == "AAPL"
+    assert evidence["provider_evidence"]["order_checks_json"] == ('{"buying_power":"insufficient"}')
+    assert evidence["provider_evidence"]["market_data_disclosure"] == "non-binding"
+
+
+def test_agentic_observe_closes_session_after_failure() -> None:
+    closed = {"value": False}
+
+    class Access:
+        async def read_account(self) -> AccountObservation:
+            raise RuntimeError("provider unavailable")
+
+        async def close(self) -> None:
+            closed["value"] = True
+
+    class Container:
+        config = object()
+
+        async def create_robinhood_agentic_read_review_access(self) -> Access:
+            return Access()
+
+    response = account_cmd._handle_observe(
+        Namespace(provider="robinhood-agentic", application_container=Container())
+    )
+
+    assert response.success is False
+    assert closed["value"] is True
+
+
+@pytest.mark.parametrize(
+    ("provider", "quantity", "message"),
+    [
+        ("coinbase", Decimal("1"), "accepted only by Robinhood Agentic"),
+        ("robinhood-agentic", Decimal("1.5"), "whole number"),
+    ],
+)
+def test_option_preview_rejects_wrong_provider_or_fractional_quantity_before_access(
+    provider: str,
+    quantity: Decimal,
+    message: str,
+) -> None:
+    response = account_cmd._handle_preview(
+        Namespace(
+            provider=provider,
+            product_type="option",
+            instrument="option-id",
+            side="buy",
+            position_effect="open",
+            quantity=quantity,
+            order_type="limit",
+            limit_price=Decimal("1"),
+            stop_price=None,
+            time_in_force="gfd",
+            market_hours="regular_hours",
+            chain_symbol=None,
+            underlying_type=None,
+        )
+    )
+
+    assert response.success is False
+    assert message in response.errors[0].message
+
+
+def test_equity_preview_rejects_option_only_time_or_market_overrides_before_access() -> None:
+    response = account_cmd._handle_preview(
+        Namespace(
+            provider="robinhood-agentic",
+            product_type="equity",
+            instrument="AAPL",
+            side="buy",
+            quantity=Decimal("1"),
+            order_type="market",
+            limit_price=None,
+            preview_time_in_force="gtc",
+            market_hours="regular_curb_overnight_hours",
+        )
+    )
+
+    assert response.success is False
+    assert "option-specific arguments" in response.errors[0].message

--- a/tests/unit/gpt_trader/features/trade_ideas/test_broker_payloads_robinhood.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_broker_payloads_robinhood.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from tests.unit.gpt_trader.features.trade_ideas.conftest import (
+    attest_account_equity,
+    build_trade_idea,
+)
+
+from gpt_trader.features.trade_ideas import (
+    InvalidTransitionError,
+    TradeIdeaService,
+    TradeIdeaState,
+)
+
+
+@pytest.fixture
+def service(tmp_path: Path) -> TradeIdeaService:
+    built = TradeIdeaService(
+        tmp_path / "trade_ideas",
+        now_factory=lambda: datetime(2026, 6, 12, 10, 0, tzinfo=UTC),
+    )
+    attest_account_equity(built)
+    return built
+
+
+def _mapping(value: object) -> Mapping[str, object]:
+    assert isinstance(value, Mapping)
+    return value
+
+
+def _text(value: object) -> str:
+    assert isinstance(value, str)
+    return value
+
+
+def test_robinhood_ticket_export_is_render_only_and_does_not_mutate_state(
+    service: TradeIdeaService,
+) -> None:
+    idea = build_trade_idea(decision_id="trade-robinhood-render-only")
+    service.propose(idea, actor_id="idea-generator-v1")
+    service.approve(idea.decision_id, actor_id="rj", reason="Risk verified")
+    before = service.get(idea.decision_id)
+
+    payload = service.export_broker_ticket_payload(
+        idea.decision_id,
+        venue="robinhood",
+        venue_order_type="operator_selected",
+        time_in_force="operator_selected",
+    )
+
+    after = service.get(idea.decision_id)
+    assert _mapping(payload["broker_ticket"])["exported"] == {
+        "venue": "robinhood",
+        "status": "approved",
+    }
+    venue_request = _mapping(payload["venue_request"])
+    assert _text(venue_request["client_order_id"]).startswith(
+        "gpt-trader-robinhood-trade-robinhood-render-only-"
+    )
+    assert _mapping(payload["venue_payload"])["venue"] == "robinhood"
+    assert before.idea.to_dict() == after.idea.to_dict()
+    assert before.events == after.events
+    assert after.state is TradeIdeaState.APPROVED
+
+
+def test_robinhood_ticket_export_refuses_submitted_state(
+    service: TradeIdeaService,
+) -> None:
+    idea = build_trade_idea(decision_id="trade-robinhood-no-submitted-state")
+    service.propose(idea, actor_id="idea-generator-v1")
+    service.approve(idea.decision_id, actor_id="rj", reason="Risk verified")
+    service.record_submission(idea.decision_id, actor_id="operator", venue="manual")
+
+    with pytest.raises(InvalidTransitionError, match="render-only Robinhood") as exc_info:
+        service.export_broker_ticket_payload(
+            idea.decision_id,
+            venue="robinhood",
+            venue_order_type="operator_selected",
+            time_in_force="operator_selected",
+        )
+
+    assert exc_info.value.context["field"] == "after_state"
+    assert exc_info.value.context["value"] == "submitted"

--- a/tests/unit/gpt_trader/features/trade_ideas/test_service_preapproval_broker_ticket.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_service_preapproval_broker_ticket.py
@@ -50,6 +50,7 @@ def test_propose_accepts_explicit_default_broker_ticket(service: TradeIdeaServic
     [
         BrokerTicket(venue=TicketVenue.COINBASE, status=TicketStatus.NOT_CREATED),
         BrokerTicket(venue=TicketVenue.MANUAL, status=TicketStatus.NOT_CREATED),
+        BrokerTicket(venue=TicketVenue.ROBINHOOD, status=TicketStatus.NOT_CREATED),
         BrokerTicket(venue=TicketVenue.NONE, status=TicketStatus.DRAFTED),
         BrokerTicket(venue=TicketVenue.NONE, status=TicketStatus.APPROVED),
         BrokerTicket(venue=TicketVenue.NONE, status=TicketStatus.SUBMITTED),
@@ -100,6 +101,7 @@ def test_resubmit_accepts_explicit_default_broker_ticket(service: TradeIdeaServi
     [
         BrokerTicket(venue=TicketVenue.COINBASE, status=TicketStatus.NOT_CREATED),
         BrokerTicket(venue=TicketVenue.MANUAL, status=TicketStatus.NOT_CREATED),
+        BrokerTicket(venue=TicketVenue.ROBINHOOD, status=TicketStatus.NOT_CREATED),
         BrokerTicket(venue=TicketVenue.NONE, status=TicketStatus.DRAFTED),
         BrokerTicket(venue=TicketVenue.NONE, status=TicketStatus.APPROVED),
         BrokerTicket(venue=TicketVenue.NONE, status=TicketStatus.SUBMITTED),


### PR DESCRIPTION
## Summary

Related issue / finding / routed package: Refs #1224

- route `account observe`, `account diagnose`, and non-binding `account preview` explicitly through the accepted Coinbase, Robinhood Crypto, and Robinhood Agentic composition-root capabilities
- support typed Agentic equity and single-leg option review shapes, preserve rejected-review evidence, redact provider identifiers, and close every command-scoped session on success or failure
- keep the legacy runtime-telemetry `account snapshot` contract unchanged
- add `TicketVenue.ROBINHOOD` only to deterministic local ticket export; keep it absent from submitted/filled/reconciliation choices and require the approved state

This completes issue #1224 Phase 2. It adds no order submission, cancellation, transfer, funding, money movement, broker registration, generic HTTP/MCP surface, or execution authority.

## Type of change

- [ ] Refactor
- [x] Feature
- [ ] Bug fix
- [ ] Tests only
- [ ] CI/Docs/Tooling

## Scope & Impact

- Affected areas / components: account CLI composition, Robinhood provider docs, trade-idea ticket enum/export renderer, focused CLI/render tests
- Behavior changes: Coinbase `account diagnose` now uses the same fail-closed provider-neutral attested observation contract as the other providers instead of raw independent market-data probes. `account snapshot` is unchanged.

## Test Plan

- [x] Unit tests added/updated
- [x] Integration tests pass unchanged
- [x] Contract tests pass unchanged
- [x] Focused CLI/render/security tests (65 passed)
- [x] Negative coverage: wrong provider/option shape, fractional option quantity, ignored time/market overrides, rejected evidence binding/redaction, failure-path lifecycle cleanup, Robinhood lifecycle-command rejection, and non-approved render rejection
- [ ] Live brokerage smoke (intentionally unrun; existing opt-in provider smokes remain separately gated)

## Quality Gates

- [x] `uv run --all-extras local-ci` passes locally (7096 unit, 63 property, 13 contract, 84 integration)
- [x] `uv run --all-extras mypy src/gpt_trader` clean (483 source files)
- [x] No `sys.path` hacks in tests; async paths use typed fakes
- [x] Import boundaries respected (`scripts/ci/check_import_boundaries.py`)

## Observability & Errors

- [x] Account/portfolio identifiers are masked; provider evidence JSON recursively redacts identity keys
- [x] Rejected previews remain explicitly non-binding and retain sanitized identity/request/evidence context

## Agent Artifacts & Config (if touched)

- [x] `uv run --all-extras agent-regenerate` and `uv run --all-extras agent-regenerate --verify`
- [x] Docs link, reachability, and currency gates pass

## Breaking Changes

- [x] None to persisted schemas or legacy snapshot behavior
- [x] Intentional CLI behavior change documented above for Coinbase diagnose

## Screenshots / Logs (optional)

Independent exact-diff review reproduced three issues (identifier exposure, silently ignored equity overrides, and unbound rejected evidence); all were fixed and re-reviewed clean. Claude Opus independently confirmed no authority expansion. No live provider call was run for this PR.

## Checklist

- [x] Remaining Phase 2 acceptance criteria in #1224 met
- [x] Affected paths listed in PR description
