### PR TITLE
feat(trade-ideas): use session-aware paper accounting

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -101,8 +101,12 @@ the approval loudly. Margin, pattern-day-trading, and the options defined-risk
 half stay deferred. The paper executor and exit monitor now refuse equity fills
 and closeout resolution outside XNYS regular hours, leaving the idea open and
 recording the skip in cycle manifest evidence; crypto retains 24x7 behavior and
-unclassifiable instruments fail closed. Session-date ratchet/expiry migration
-and the operator-gated equity-universe flip remain in #1232.
+unclassifiable instruments fail closed. The paper budget now groups realized
+losses by each closeout instrument's session date (XNYS for equities, UTC day
+for 24x7 crypto), and equity review-latency clocks pause while XNYS is closed.
+Hard idea expiries remain immutable, but the sweep cannot expire an equity idea
+until its session is open. Only the operator-gated equity-universe flip remains
+in #1232.
 
 **The promotion gates are now measurable in one command** (`ideas scorecard`,
 #1193): the Stage 1 -> 2 gates of the

--- a/docs/paper_trading.md
+++ b/docs/paper_trading.md
@@ -215,6 +215,16 @@ data. Both outcomes are explicit in the cycle manifest and retry on a later
 turn. Crypto remains 24x7; an instrument that cannot be classified to a known
 session is refused rather than silently assigned crypto semantics.
 
+The same calendar owns paper accounting time. Realized-loss windows compare
+each closeout against its own instrument's current session date, so a Friday
+equity loss remains in the XNYS daily-loss ratchet through the weekend and
+resets at Monday's open, while crypto still resets at UTC midnight. Human
+review latency consumes only open-session time for equities. The authored
+`time_horizon.expires_at` is never rewritten; an equity expiry sweep simply
+leaves the record untouched while XNYS is closed and may expire it once the
+next session opens. Calendar or instrument failures never undercount loss,
+admit a stale review, or mutate an expiry sweep.
+
 Strategy-backed proposers — the live strategy library running over the turn's
 snapshot through the `Proposer` contract — are opt-in until replay parity is
 demonstrated: pass `--proposer strategy-baseline-spot` (or

--- a/docs/specs/TRADE_IDEA_CLI_SPEC.md
+++ b/docs/specs/TRADE_IDEA_CLI_SPEC.md
@@ -607,6 +607,12 @@ Thin wrappers over `service.reject` / `service.request_changes` /
   - `time_horizon.expires_at` is set and `<= now`; or
   - the review deadline has elapsed under the current
     `RiskBudget.max_review_latency_hours` policy.
+  Review latency consumes wall-clock time for 24x7 crypto and open XNYS time
+  for equities. A due equity idea is not mutated while XNYS is closed; the
+  authored `time_horizon.expires_at` remains unchanged and the next open sweep
+  may expire it. An unclassifiable or unavailable session fails closed without
+  an expiry mutation. Queue status continues to show the immutable hard
+  horizon timestamp even when a closed equity session delays the sweep itself.
   The review-latency path can expire a far-future idea whose `expires_at` is
   still later than `now` when the review queue exceeds the configured budget.
   Report `data["expired"]` = list of decision_ids; success even when zero

--- a/src/gpt_trader/core/trading_calendar.py
+++ b/src/gpt_trader/core/trading_calendar.py
@@ -17,14 +17,15 @@ Two sessions are supported:
 Timezone rule follows the repo convention (``risk_units.py``): naive
 datetimes are treated as UTC, never host-local time.
 
-Consumers (ratchet day boundary, snapshot staleness, scheduler windows) are
-NOT wired here — that migration is venue phase P1-E.
+The paper lane uses this service for cycle/executor admission, per-instrument
+daily-loss windows, review latency, and expiry-sweep session guards. Snapshot
+staleness and non-paper runtime calendars remain separate concerns.
 """
 
 from __future__ import annotations
 
 from collections.abc import Callable
-from datetime import UTC, date, datetime
+from datetime import UTC, date, datetime, timedelta
 from functools import lru_cache
 from typing import TYPE_CHECKING, Protocol
 
@@ -102,6 +103,52 @@ exit monitor) so deterministic tests can pin session state; the default is
 unclassifiable instruments — callers must turn that into a loud skip or a
 typed refusal, never a silent pass.
 """
+
+
+def advance_by_open_time(
+    calendar: TradingCalendar,
+    start: datetime,
+    duration: timedelta,
+) -> datetime:
+    """Advance ``start`` by time during which ``calendar`` is open.
+
+    The 24x7 calendar therefore matches ordinary wall-clock arithmetic, while
+    a sessioned calendar pauses the duration across nights, weekends, and
+    holidays. Calendar-domain errors deliberately propagate to the caller so
+    decision paths can fail closed instead of silently shortening a review
+    window.
+    """
+    if duration < timedelta(0):
+        raise ValueError("Open-session duration must be non-negative")
+    cursor = _as_utc(start)
+    remaining = duration
+    while remaining > timedelta(0):
+        if not calendar.is_open(cursor):
+            next_open = calendar.next_open(cursor)
+            if next_open is None:
+                raise ValueError(f"Calendar {calendar.session_id!r} is closed and has no next open")
+            next_open = _as_utc(next_open)
+            if next_open <= cursor:
+                raise ValueError(
+                    f"Calendar {calendar.session_id!r} returned a non-advancing next open"
+                )
+            cursor = next_open
+            continue
+
+        next_close = calendar.next_close(cursor)
+        if next_close is None:
+            return cursor + remaining
+        next_close = _as_utc(next_close)
+        if next_close <= cursor:
+            raise ValueError(
+                f"Calendar {calendar.session_id!r} returned a non-advancing next close"
+            )
+        open_span = next_close - cursor
+        if remaining <= open_span:
+            return cursor + remaining
+        remaining -= open_span
+        cursor = next_close
+    return cursor
 
 
 class AlwaysOpenCalendar:
@@ -212,6 +259,7 @@ __all__ = [
     "ExchangeBackedCalendar",
     "SessionCalendarResolver",
     "TradingCalendar",
+    "advance_by_open_time",
     "get_calendar_for_instrument",
     "get_trading_calendar",
 ]

--- a/src/gpt_trader/features/trade_ideas/autonomy.py
+++ b/src/gpt_trader/features/trade_ideas/autonomy.py
@@ -251,6 +251,7 @@ def daily_loss_breach_evidence(
     max_daily_loss_pct: Decimal,
     budget_version: int,
     moment: datetime,
+    session_dates: tuple[str, ...] = (),
 ) -> tuple[str, ...] | None:
     """Return ratchet evidence when same-day realized loss breaches the budget cap.
 
@@ -263,10 +264,15 @@ def daily_loss_breach_evidence(
     """
     if same_day_realized_loss_pct <= max_daily_loss_pct:
         return None
+    window = (
+        " across session_dates=" + ",".join(session_dates)
+        if session_dates
+        else f" on trading_day={trading_day(moment).isoformat()}"
+    )
     return (
         f"same_day_realized_loss_pct={same_day_realized_loss_pct} exceeds "
         f"max_daily_loss_pct={max_daily_loss_pct} from risk budget version "
-        f"{budget_version} on trading_day={trading_day(moment).isoformat()}",
+        f"{budget_version}{window}",
     )
 
 

--- a/src/gpt_trader/features/trade_ideas/kernel.py
+++ b/src/gpt_trader/features/trade_ideas/kernel.py
@@ -80,6 +80,14 @@ class KernelRuntime(Protocol):
 
     def review_started_at(self, decision_id: str) -> datetime | None: ...
 
+    def review_deadline(
+        self,
+        idea: TradeIdea,
+        *,
+        review_started_at: datetime | None,
+        budget: RiskBudget,
+    ) -> datetime | None: ...
+
     def append_audit(
         self,
         idea: TradeIdea,
@@ -146,6 +154,7 @@ class KernelCheck:
             f"risk budget version {budget.version}: approval_violations=0",
             "budget envelope: "
             f"same_day_realized_loss_pct={budget_context.same_day_realized_loss_pct} "
+            f"daily_loss_session_dates={budget_context.daily_loss_session_dates} "
             f"open_approved_at_risk_pct={budget_context.open_approved_at_risk_pct} "
             f"candidate_max_loss_pct={self.candidate_max_loss_pct} "
             f"max_daily_loss_pct={budget.max_daily_loss_pct}",
@@ -211,6 +220,7 @@ class RiskKernel:
             budget_context=budget_context,
         )
         policy = ApprovalPolicy(resolution.mode)
+        review_started_at = self._runtime.review_started_at(idea.decision_id)
         violations = (
             *autonomy_resolution_violations(resolution),
             *policy.approval_violations(
@@ -219,7 +229,12 @@ class RiskKernel:
                 budget=budget,
                 open_approved_count=self._runtime.open_approved_count(),
                 now=evaluated_at,
-                review_started_at=self._runtime.review_started_at(idea.decision_id),
+                review_started_at=review_started_at,
+                review_deadline=self._runtime.review_deadline(
+                    idea,
+                    review_started_at=review_started_at,
+                    budget=budget,
+                ),
                 budget_context=budget_context,
             ),
         )

--- a/src/gpt_trader/features/trade_ideas/policy.py
+++ b/src/gpt_trader/features/trade_ideas/policy.py
@@ -61,6 +61,7 @@ class ApprovalBudgetContext:
 
     same_day_realized_loss_pct: Decimal = Decimal("0")
     same_day_realized_loss_unavailable_count: int = 0
+    daily_loss_session_dates: tuple[str, ...] = ()
     open_approved_at_risk_pct: Decimal = Decimal("0")
     open_at_risk_unavailable_count: int = 0
     open_notional: Decimal = Decimal("0")
@@ -189,6 +190,7 @@ class ApprovalPolicy:
         open_approved_count: int,
         now: datetime,
         review_started_at: datetime | None = None,
+        review_deadline: datetime | None = None,
         budget_context: ApprovalBudgetContext | None = None,
     ) -> list[str]:
         """Return every reason this approval must be refused; empty means allowed."""
@@ -324,6 +326,7 @@ class ApprovalPolicy:
             review_started_at=review_started_at,
             budget=budget,
             now=now,
+            review_deadline=review_deadline,
         )
         if review_latency_violation is not None:
             violations.append(review_latency_violation)
@@ -348,6 +351,7 @@ class ApprovalPolicy:
         review_started_at: datetime | None,
         budget: RiskBudget,
         now: datetime,
+        review_deadline: datetime | None = None,
     ) -> str | None:
         """Return a violation when the active review window has elapsed.
 
@@ -358,12 +362,14 @@ class ApprovalPolicy:
             return None
         if review_started_at is None:
             return None
-        review_deadline = review_started_at + timedelta(hours=budget.max_review_latency_hours)
-        if review_deadline > now:
+        effective_deadline = review_deadline or (
+            review_started_at + timedelta(hours=budget.max_review_latency_hours)
+        )
+        if effective_deadline > now:
             return None
         return (
             MODE_DEPENDENT_ELIGIBILITY_PREFIX
-            + f"Idea review deadline expired at {review_deadline.isoformat()} "
+            + f"Idea review deadline expired at {effective_deadline.isoformat()} "
             f"after max_review_latency_hours={budget.max_review_latency_hours}"
         )
 

--- a/src/gpt_trader/features/trade_ideas/service.py
+++ b/src/gpt_trader/features/trade_ideas/service.py
@@ -21,7 +21,12 @@ from gpt_trader.core.instruments import AssetClass, InstrumentParseError
 from gpt_trader.core.risk_units import (
     fraction_to_pct_points,
     pct_points_to_fraction,
-    same_trading_day,
+    trading_day,
+)
+from gpt_trader.core.trading_calendar import (
+    SessionCalendarResolver,
+    advance_by_open_time,
+    get_calendar_for_instrument,
 )
 from gpt_trader.errors import ValidationError
 from gpt_trader.features.trade_ideas.accounting import (
@@ -337,6 +342,7 @@ class TradeIdeaService:
         root: Path,
         *,
         now_factory: Callable[[], datetime] = _utc_now,
+        calendar_resolver: SessionCalendarResolver = get_calendar_for_instrument,
     ) -> None:
         self._root = root
         self._store = TradeIdeaStore(root / "records")
@@ -345,7 +351,64 @@ class TradeIdeaService:
         self._budget_log = RiskBudgetLog(root / "risk_budget.jsonl")
         self._autonomy_log = AutonomyStateLog(root / "autonomy_state.jsonl")
         self._now = now_factory
+        self._calendar_resolver = calendar_resolver
         self._kernel = RiskKernel(self, now_factory=self._now)
+
+    def review_deadline(
+        self,
+        idea: TradeIdea,
+        *,
+        review_started_at: datetime | None,
+        budget: RiskBudget,
+    ) -> datetime | None:
+        """Return the review deadline using only time the instrument is open.
+
+        Calendar-domain failures fail closed at the review start instant.
+        Unclassifiable legacy records retain their prior wall-clock deadline,
+        while expiry sweeps separately refuse to mutate any idea whose session
+        cannot be proven open.
+        """
+        if review_started_at is None:
+            return None
+        try:
+            calendar = self._calendar_resolver(idea.instrument)
+            return advance_by_open_time(
+                calendar,
+                review_started_at,
+                timedelta(hours=budget.max_review_latency_hours),
+            )
+        except InstrumentParseError:
+            # Preserve the legacy wall-clock review contract for stored ideas
+            # that predate the instrument taxonomy. They still cannot execute
+            # or be expiry-swept without a proven session.
+            return review_started_at + timedelta(hours=budget.max_review_latency_hours)
+        except ValueError:
+            return review_started_at
+
+    def _session_is_open(self, idea: TradeIdea, moment: datetime) -> bool:
+        """Fail closed when the instrument session cannot be proven open."""
+        try:
+            return self._calendar_resolver(idea.instrument).is_open(moment)
+        except (InstrumentParseError, ValueError):
+            return False
+
+    def _same_accounting_session(
+        self,
+        idea: TradeIdea,
+        first: datetime,
+        second: datetime,
+    ) -> tuple[bool, str]:
+        """Compare per-instrument session dates, conservatively on failure."""
+        try:
+            calendar = self._calendar_resolver(idea.instrument)
+            first_date = calendar.session_date(first)
+            second_date = calendar.session_date(second)
+            return first_date == second_date, f"{calendar.session_id}:{second_date.isoformat()}"
+        except (InstrumentParseError, ValueError):
+            # Never undercount a realized loss because its instrument or
+            # calendar could not be evaluated. Preserve the legacy UTC label
+            # in evidence and include the closeout conservatively.
+            return True, f"unresolved:{trading_day(second).isoformat()}"
 
     @property
     def kernel(self) -> RiskKernel:
@@ -511,6 +574,7 @@ class TradeIdeaService:
             max_daily_loss_pct=active_budget.max_daily_loss_pct,
             budget_version=active_budget.version,
             moment=now,
+            session_dates=context.daily_loss_session_dates,
         )
         reason = (
             "Automatic ratchet-down: same-trading-day realized loss breached max_daily_loss_pct"
@@ -595,6 +659,8 @@ class TradeIdeaService:
         budget: RiskBudget,
     ) -> list[str]:
         policy = ApprovalPolicy(resolution.mode)
+        now = self._now()
+        review_started_at = self.review_started_at(idea.decision_id)
         return [
             *autonomy_resolution_violations(resolution),
             *policy.approval_violations(
@@ -602,8 +668,13 @@ class TradeIdeaService:
                 actor_type=actor_type,
                 budget=budget,
                 open_approved_count=self.open_approved_count(),
-                now=self._now(),
-                review_started_at=self.review_started_at(idea.decision_id),
+                now=now,
+                review_started_at=review_started_at,
+                review_deadline=self.review_deadline(
+                    idea,
+                    review_started_at=review_started_at,
+                    budget=budget,
+                ),
                 budget_context=self.approval_budget_context(
                     exclude_decision_id=idea.decision_id,
                 ),
@@ -621,6 +692,7 @@ class TradeIdeaService:
         latest_events = self._latest_audit_events_by_decision_id()
         open_ideas: list[TradeIdea] = []
         same_day_closeouts: list[tuple[TradeIdea, CloseoutAttribution]] = []
+        daily_loss_session_dates: set[str] = set()
         for decision_id, event in latest_events.items():
             if event.after_state in OPEN_BUDGET_EXPOSURE_STATES:
                 if decision_id == exclude_decision_id:
@@ -639,12 +711,21 @@ class TradeIdeaService:
             ):
                 open_ideas.append(idea)
                 continue
-            if closeout is not None and same_trading_day(closeout.timestamp, evaluation_time):
+            same_session = False
+            session_date = ""
+            if closeout is not None:
+                same_session, session_date = self._same_accounting_session(
+                    idea,
+                    closeout.timestamp,
+                    evaluation_time,
+                )
+            if closeout is not None and same_session:
                 if (
                     event.after_state is TradeIdeaState.FILLED
                     or _closeout_has_realized_profit_loss(closeout)
                 ):
                     same_day_closeouts.append((idea, closeout))
+                    daily_loss_session_dates.add(session_date)
         closeouts = [closeout for _, closeout in same_day_closeouts]
         account_equity_snapshot = self._account_equity_snapshot(
             # Non-mutating read: building a budget context (e.g. during a
@@ -681,6 +762,7 @@ class TradeIdeaService:
         return ApprovalBudgetContext(
             same_day_realized_loss_pct=same_day_realized_loss_pct,
             same_day_realized_loss_unavailable_count=(same_day_realized_loss_unavailable_count),
+            daily_loss_session_dates=tuple(sorted(daily_loss_session_dates)),
             open_approved_at_risk_pct=open_approved_at_risk_pct,
             open_at_risk_unavailable_count=open_at_risk_unavailable_count,
             open_notional=open_notional,
@@ -729,6 +811,7 @@ class TradeIdeaService:
             "same_day_realized_loss_unavailable_count": (
                 context.same_day_realized_loss_unavailable_count
             ),
+            "daily_loss_session_dates": list(context.daily_loss_session_dates),
             "open_approved_at_risk_pct": str(context.open_approved_at_risk_pct),
             "open_at_risk_unavailable_count": context.open_at_risk_unavailable_count,
             "daily_loss_used_pct": str(daily_loss_used_pct),
@@ -1115,12 +1198,20 @@ class TradeIdeaService:
                 continue
             expires_at = view.idea.time_horizon.expires_at
             idea_expired = expires_at is not None and expires_at <= now
+            review_started_at = self._review_started_at_from_events(view.events)
             review_latency_violation = policy.review_latency_violation(
-                review_started_at=self._review_started_at_from_events(view.events),
+                review_started_at=review_started_at,
                 budget=budget,
                 now=now,
+                review_deadline=self.review_deadline(
+                    view.idea,
+                    review_started_at=review_started_at,
+                    budget=budget,
+                ),
             )
-            if idea_expired or review_latency_violation is not None:
+            if (idea_expired or review_latency_violation is not None) and self._session_is_open(
+                view.idea, now
+            ):
                 expired.append(
                     self.expire(
                         view.idea.decision_id,
@@ -1291,6 +1382,7 @@ class TradeIdeaService:
         # the autonomy log, mirroring the non-mutating budget read above.
         autonomy_resolution = self.peek_autonomy()
         policy = ApprovalPolicy(autonomy_resolution.mode)
+        review_started_at = self._review_started_at_from_events(view.events)
         policy_violations = [
             *autonomy_resolution_violations(autonomy_resolution),
             *policy.approval_violations(
@@ -1299,7 +1391,12 @@ class TradeIdeaService:
                 budget=effective_budget,
                 open_approved_count=self._open_approved_count_excluding(decision_id),
                 now=export_time,
-                review_started_at=self._review_started_at_from_events(view.events),
+                review_started_at=review_started_at,
+                review_deadline=self.review_deadline(
+                    view.idea,
+                    review_started_at=review_started_at,
+                    budget=effective_budget,
+                ),
                 budget_context=self.approval_budget_context(
                     exclude_decision_id=decision_id,
                     now=export_time,
@@ -1456,12 +1553,18 @@ class TradeIdeaService:
         review_latency_applies = ApprovalPolicy(self.peek_autonomy().mode).review_latency_applies
         upcoming_expirations: list[TradeIdeaQueueExpiration] = []
         for view in (*proposed, *needs_changes):
+            review_started_at = self._review_started_at_from_events(view.events)
             expiration = _queue_expiration(
                 view,
                 as_of,
                 window_end,
                 budget,
-                review_started_at=self._review_started_at_from_events(view.events),
+                review_started_at=review_started_at,
+                review_deadline=self.review_deadline(
+                    view.idea,
+                    review_started_at=review_started_at,
+                    budget=budget,
+                ),
                 review_latency_applies=review_latency_applies,
             )
             if expiration is not None:
@@ -1958,6 +2061,7 @@ def _queue_expiration(
     budget: RiskBudget,
     *,
     review_started_at: datetime | None,
+    review_deadline: datetime | None = None,
     review_latency_applies: bool = True,
 ) -> TradeIdeaQueueExpiration | None:
     deadlines: list[tuple[str, datetime]] = []
@@ -1965,8 +2069,10 @@ def _queue_expiration(
     if horizon_expires_at is not None:
         deadlines.append(("time_horizon", horizon_expires_at))
     if review_latency_applies and review_started_at is not None:
-        review_deadline = review_started_at + timedelta(hours=budget.max_review_latency_hours)
-        deadlines.append(("review_latency", review_deadline))
+        effective_review_deadline = review_deadline or (
+            review_started_at + timedelta(hours=budget.max_review_latency_hours)
+        )
+        deadlines.append(("review_latency", effective_review_deadline))
 
     upcoming = [
         (deadline_type, expires_at)
@@ -1991,6 +2097,7 @@ def create_trade_idea_service(
     root: Path | None = None,
     *,
     now_factory: Callable[[], datetime] = _utc_now,
+    calendar_resolver: SessionCalendarResolver = get_calendar_for_instrument,
 ) -> TradeIdeaService:
     """Resolve root (arg > GPT_TRADER_IDEAS_ROOT > default) and build the service.
 
@@ -1998,7 +2105,11 @@ def create_trade_idea_service(
     audited autonomy state log at each decision boundary
     (docs/decisions/persistent-autonomy-state.md).
     """
-    return TradeIdeaService(resolve_ideas_root(root), now_factory=now_factory)
+    return TradeIdeaService(
+        resolve_ideas_root(root),
+        now_factory=now_factory,
+        calendar_resolver=calendar_resolver,
+    )
 
 
 def _validate_audit_venue(venue: str) -> str:

--- a/tests/unit/gpt_trader/core/test_trading_calendar.py
+++ b/tests/unit/gpt_trader/core/test_trading_calendar.py
@@ -25,6 +25,7 @@ from gpt_trader.core.trading_calendar import (
     AlwaysOpenCalendar,
     ExchangeBackedCalendar,
     TradingCalendar,
+    advance_by_open_time,
     get_calendar_for_instrument,
     get_trading_calendar,
 )
@@ -62,6 +63,12 @@ class TestAlwaysOpenSession:
         moment = datetime(2026, 7, 6, 12, 0, tzinfo=UTC)
         assert calendar.next_open(moment) is None
         assert calendar.next_close(moment) is None
+
+    def test_open_time_matches_wall_clock(self) -> None:
+        start = datetime(2026, 7, 4, 12, 0, tzinfo=UTC)
+        assert advance_by_open_time(AlwaysOpenCalendar(), start, timedelta(hours=3)) == (
+            start + timedelta(hours=3)
+        )
 
 
 class TestXnysSession:
@@ -120,6 +127,24 @@ class TestXnysSession:
         assert type(next_open) is datetime  # not a pandas.Timestamp subclass
         assert next_open is not None and next_open.tzinfo == UTC
         assert type(xnys.session_date(_MONDAY_MIDDAY)) is date
+
+    def test_open_time_pauses_across_weekend(self, xnys: TradingCalendar) -> None:
+        # Friday 2026-07-10 has 30 open minutes left; the other 30 minutes
+        # resume after Monday's open.
+        friday = datetime(2026, 7, 10, 19, 30, tzinfo=UTC)
+        assert advance_by_open_time(xnys, friday, timedelta(hours=1)) == datetime(
+            2026, 7, 13, 14, 0, tzinfo=UTC
+        )
+
+    def test_open_time_respects_early_close(self, xnys: TradingCalendar) -> None:
+        christmas_eve = datetime(2025, 12, 24, 17, 30, tzinfo=UTC)
+        assert advance_by_open_time(xnys, christmas_eve, timedelta(hours=1)) == datetime(
+            2025, 12, 26, 15, 0, tzinfo=UTC
+        )
+
+    def test_zero_open_time_preserves_start(self, xnys: TradingCalendar) -> None:
+        closed = datetime(2026, 7, 11, 12, 0, tzinfo=UTC)
+        assert advance_by_open_time(xnys, closed, timedelta(0)) == closed
 
 
 class TestGetTradingCalendar:

--- a/tests/unit/gpt_trader/features/trade_ideas/test_service_autonomy.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_service_autonomy.py
@@ -269,7 +269,7 @@ def test_daily_loss_breach_ratchets_bounded_autonomy_down(
     assert latest.actor_id == RATCHET_ACTOR_ID
     assert latest.evidence
     assert "same_day_realized_loss_pct=12" in latest.evidence[0]
-    assert "trading_day=2026-06-12" in latest.evidence[0]
+    assert "session_dates=24x7:2026-06-12" in latest.evidence[0]
 
 
 def test_ratchet_fires_at_budget_decision_boundary(service: TradeIdeaService) -> None:

--- a/tests/unit/gpt_trader/features/trade_ideas/test_service_session_accounting.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_service_session_accounting.py
@@ -1,0 +1,301 @@
+"""Per-instrument session accounting for the paper trade-idea spine (#1232)."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+from tests.unit.gpt_trader.features.trade_ideas.conftest import (
+    attest_account_equity,
+    build_trade_idea,
+)
+
+from gpt_trader.core.trading_calendar import get_calendar_for_instrument
+from gpt_trader.features.trade_ideas import (
+    ActorType,
+    AutonomyMode,
+    CloseoutResolution,
+    PolicyViolationError,
+    TimeHorizon,
+    TradeIdeaService,
+    TradeIdeaState,
+)
+from gpt_trader.features.trade_ideas.autonomy import RATCHET_ACTOR_ID
+
+
+class MutableClock:
+    def __init__(self, now: datetime) -> None:
+        self.now = now
+
+    def __call__(self) -> datetime:
+        return self.now
+
+
+def _idea(decision_id: str, instrument: str, *, expires_at: datetime | None = None):
+    return build_trade_idea(
+        decision_id=decision_id,
+        instrument=instrument,
+        time_horizon=TimeHorizon(
+            expected_hold="several sessions",
+            expires_at=expires_at or datetime(2026, 7, 20, 20, 0, tzinfo=UTC),
+        ),
+    )
+
+
+def _record_loss(
+    service: TradeIdeaService,
+    *,
+    decision_id: str,
+    instrument: str,
+    loss_pct: str,
+) -> None:
+    idea = _idea(decision_id, instrument)
+    service.propose(idea, actor_id="test-proposer")
+    service.approve(decision_id, actor_id="test-operator", reason="test approval")
+    service.record_submission(decision_id, actor_id="test-operator", venue="manual")
+    service.record_fill(decision_id, actor_id="test-operator", venue="manual")
+    service.record_closeout_attribution(
+        decision_id,
+        actor_id="test-operator",
+        resolution=CloseoutResolution.INVALIDATION,
+        realized_profit_loss_percent=Decimal(loss_pct),
+    )
+
+
+def _service(tmp_path: Path, clock: MutableClock) -> TradeIdeaService:
+    service = TradeIdeaService(tmp_path / "ideas", now_factory=clock)
+    attest_account_equity(service)
+    return service
+
+
+def test_daily_loss_uses_each_closeouts_own_session_window(tmp_path: Path) -> None:
+    clock = MutableClock(datetime(2026, 7, 10, 19, 0, tzinfo=UTC))  # Friday, XNYS open
+    service = _service(tmp_path, clock)
+    _record_loss(
+        service,
+        decision_id="trade-20260710-equity-loss",
+        instrument="AAPL",
+        loss_pct="-3",
+    )
+    clock.now = datetime(2026, 7, 10, 23, 0, tzinfo=UTC)
+    _record_loss(
+        service,
+        decision_id="trade-20260710-crypto-loss",
+        instrument="BTC-USD",
+        loss_pct="-2",
+    )
+
+    clock.now = datetime(2026, 7, 11, 15, 0, tzinfo=UTC)  # Saturday
+    weekend = service.approval_budget_context()
+    assert weekend.same_day_realized_loss_pct == Decimal("3")
+    assert weekend.daily_loss_session_dates == ("XNYS:2026-07-10",)
+
+    clock.now = datetime(2026, 7, 13, 13, 29, tzinfo=UTC)  # Monday pre-open
+    assert service.approval_budget_context().same_day_realized_loss_pct == Decimal("3")
+
+    clock.now = datetime(2026, 7, 13, 13, 30, tzinfo=UTC)  # Monday open
+    monday = service.approval_budget_context()
+    assert monday.same_day_realized_loss_pct == Decimal("0")
+    assert monday.daily_loss_session_dates == ()
+
+
+def test_crypto_daily_loss_still_resets_at_utc_midnight(tmp_path: Path) -> None:
+    clock = MutableClock(datetime(2026, 7, 10, 23, 0, tzinfo=UTC))
+    service = _service(tmp_path, clock)
+    _record_loss(
+        service,
+        decision_id="trade-20260710-crypto-loss",
+        instrument="BTC-USD",
+        loss_pct="-2",
+    )
+
+    clock.now = datetime(2026, 7, 11, 0, 1, tzinfo=UTC)
+    assert service.approval_budget_context().same_day_realized_loss_pct == Decimal("0")
+
+
+def test_equity_weekend_loss_ratchets_with_truthful_session_evidence(tmp_path: Path) -> None:
+    clock = MutableClock(datetime(2026, 7, 10, 19, 0, tzinfo=UTC))
+    service = _service(tmp_path, clock)
+    _record_loss(
+        service,
+        decision_id="trade-20260710-equity-breach",
+        instrument="AAPL",
+        loss_pct="-12",
+    )
+    service.set_autonomy_mode(
+        AutonomyMode.BOUNDED_AUTONOMY,
+        actor_type=ActorType.HUMAN,
+        actor_id="test-operator",
+        reason="test bounded mode",
+    )
+    candidate = _idea("trade-20260711-candidate", "BTC-USD")
+    clock.now = datetime(2026, 7, 11, 15, 0, tzinfo=UTC)
+    service.propose(candidate, actor_id="test-proposer")
+
+    with pytest.raises(PolicyViolationError):
+        service.approve(candidate.decision_id, actor_id="test-operator", reason="risk check")
+
+    latest = service.autonomy_history()[-1]
+    assert latest.actor_id == RATCHET_ACTOR_ID
+    assert "session_dates=XNYS:2026-07-10" in latest.evidence[0]
+
+
+def test_equity_review_latency_pauses_while_xnys_is_closed(tmp_path: Path) -> None:
+    clock = MutableClock(datetime(2026, 7, 10, 19, 30, tzinfo=UTC))  # 30m before close
+    service = _service(tmp_path, clock)
+    current = service.current_budget()
+    service.update_budget(
+        replace(
+            current,
+            version=current.version + 1,
+            max_review_latency_hours=1,
+            reason="test one-open-hour review window",
+        ),
+        ActorType.HUMAN,
+        "test-operator",
+    )
+    idea = _idea("trade-20260710-review", "AAPL")
+    service.propose(idea, actor_id="test-proposer")
+
+    expected_deadline = datetime(2026, 7, 13, 14, 0, tzinfo=UTC)
+    assert (
+        service.review_deadline(
+            idea,
+            review_started_at=clock.now,
+            budget=service.current_budget(),
+        )
+        == expected_deadline
+    )
+
+    clock.now = datetime(2026, 7, 13, 13, 45, tzinfo=UTC)
+    queue = service.queue_status(warning_window_hours=1)
+    assert queue.upcoming_expirations[0].expires_at == expected_deadline
+
+    clock.now = expected_deadline + timedelta(minutes=1)
+    with pytest.raises(PolicyViolationError, match="review deadline expired"):
+        service.approve(idea.decision_id, actor_id="test-operator", reason="too late")
+
+
+def test_crypto_review_latency_remains_wall_clock(tmp_path: Path) -> None:
+    clock = MutableClock(datetime(2026, 7, 10, 23, 30, tzinfo=UTC))
+    service = _service(tmp_path, clock)
+    current = service.current_budget()
+    budget = replace(current, max_review_latency_hours=1)
+    idea = _idea("trade-20260710-crypto-review", "BTC-USD")
+    assert service.review_deadline(
+        idea,
+        review_started_at=clock.now,
+        budget=budget,
+    ) == datetime(2026, 7, 11, 0, 30, tzinfo=UTC)
+
+
+def test_hard_equity_expiry_sweep_waits_for_next_open(tmp_path: Path) -> None:
+    friday = datetime(2026, 7, 10, 19, 0, tzinfo=UTC)
+    clock = MutableClock(friday)
+    service = _service(tmp_path, clock)
+    idea = _idea(
+        "trade-20260710-hard-expiry",
+        "AAPL",
+        expires_at=datetime(2026, 7, 11, 12, 0, tzinfo=UTC),
+    )
+    service.propose(idea, actor_id="test-proposer")
+
+    clock.now = datetime(2026, 7, 11, 15, 0, tzinfo=UTC)
+    assert service.expire_due_ideas() == []
+    assert service.get(idea.decision_id).state is TradeIdeaState.PROPOSED
+    assert service.get(idea.decision_id).idea.time_horizon.expires_at == datetime(
+        2026, 7, 11, 12, 0, tzinfo=UTC
+    )
+
+    clock.now = datetime(2026, 7, 13, 13, 30, tzinfo=UTC)
+    assert [view.idea.decision_id for view in service.expire_due_ideas()] == [idea.decision_id]
+
+
+def test_bounded_autonomy_still_suppresses_review_latency_expiry(tmp_path: Path) -> None:
+    clock = MutableClock(datetime(2026, 7, 10, 19, 30, tzinfo=UTC))
+    service = _service(tmp_path, clock)
+    service.set_autonomy_mode(
+        AutonomyMode.BOUNDED_AUTONOMY,
+        actor_type=ActorType.HUMAN,
+        actor_id="test-operator",
+        reason="test bounded mode",
+    )
+    current = service.current_budget()
+    service.update_budget(
+        replace(current, version=current.version + 1, max_review_latency_hours=1),
+        ActorType.HUMAN,
+        "test-operator",
+    )
+    idea = _idea("trade-20260710-bounded", "AAPL")
+    service.propose(idea, actor_id="test-proposer")
+
+    clock.now = datetime(2026, 7, 13, 15, 0, tzinfo=UTC)
+    assert service.expire_due_ideas() == []
+    assert service.get(idea.decision_id).state is TradeIdeaState.PROPOSED
+
+
+def test_calendar_failure_refuses_review_and_never_mutates_sweep(tmp_path: Path) -> None:
+    clock = MutableClock(datetime(2026, 7, 10, 19, 0, tzinfo=UTC))
+
+    def broken_resolver(_instrument: str):
+        raise ValueError("calendar unavailable")
+
+    service = TradeIdeaService(
+        tmp_path / "ideas",
+        now_factory=clock,
+        calendar_resolver=broken_resolver,
+    )
+    attest_account_equity(service)
+    idea = _idea("trade-20260710-calendar-failure", "AAPL")
+    service.propose(idea, actor_id="test-proposer")
+
+    with pytest.raises(PolicyViolationError, match="review deadline expired"):
+        service.approve(idea.decision_id, actor_id="test-operator", reason="cannot verify")
+    assert service.expire_due_ideas() == []
+    assert service.get(idea.decision_id).state is TradeIdeaState.PROPOSED
+
+
+def test_calendar_failure_never_undercounts_a_realized_loss(tmp_path: Path) -> None:
+    clock = MutableClock(datetime(2026, 7, 10, 23, 0, tzinfo=UTC))
+    calendar_available = True
+
+    def toggle_resolver(instrument: str):
+        if not calendar_available:
+            raise ValueError("calendar unavailable")
+        return get_calendar_for_instrument(instrument)
+
+    service = TradeIdeaService(
+        tmp_path / "ideas",
+        now_factory=clock,
+        calendar_resolver=toggle_resolver,
+    )
+    attest_account_equity(service)
+    _record_loss(
+        service,
+        decision_id="trade-20260710-unresolved-loss",
+        instrument="BTC-USD",
+        loss_pct="-2",
+    )
+
+    calendar_available = False
+    clock.now = datetime(2026, 7, 11, 15, 0, tzinfo=UTC)
+    context = service.approval_budget_context()
+    assert context.same_day_realized_loss_pct == Decimal("2")
+    assert context.daily_loss_session_dates == ("unresolved:2026-07-11",)
+
+
+def test_unclassifiable_legacy_review_keeps_wall_clock_deadline(tmp_path: Path) -> None:
+    start = datetime(2026, 7, 10, 19, 0, tzinfo=UTC)
+    clock = MutableClock(start)
+    service = _service(tmp_path, clock)
+    idea = _idea("trade-20260710-legacy", "BTC-USD-PERP")
+    budget = replace(service.current_budget(), max_review_latency_hours=2)
+
+    assert service.review_deadline(
+        idea,
+        review_started_at=start,
+        budget=budget,
+    ) == start + timedelta(hours=2)

--- a/var/agents/configuration/environment_variables.json
+++ b/var/agents/configuration/environment_variables.json
@@ -855,7 +855,7 @@
       ],
       "code_references": [
         {
-          "line": 317,
+          "line": 322,
           "path": "src/gpt_trader/features/trade_ideas/service.py",
           "reader": "os.environ.get"
         }
@@ -1267,7 +1267,7 @@
       ],
       "code_references": [
         {
-          "line": 330,
+          "line": 335,
           "path": "src/gpt_trader/features/trade_ideas/service.py",
           "reader": "os.environ.get"
         }
@@ -1299,7 +1299,7 @@
       ],
       "code_references": [
         {
-          "line": 307,
+          "line": 312,
           "path": "src/gpt_trader/features/trade_ideas/service.py",
           "reader": "os.environ.get"
         }


### PR DESCRIPTION
## Summary

Tracking issue: https://github.com/Solders-Girdles-Org/GPT-Trader/issues/1232 — this is the third bounded paper-only slice; the issue must remain open for the separately gated equity-universe flip. Phase 3 gate packet: https://github.com/Solders-Girdles-Org/GPT-Trader/issues/1224#issuecomment-4959755629

- aggregate realized paper losses against each closeout instrument's current session date (XNYS equity, UTC-day 24x7 crypto)
- count equity review latency only while XNYS is open; keep policy, kernel, queue status, and expiry sweep on one computed deadline
- preserve the immutable authored hard expiry while refusing to mutate an equity expiry sweep when its session is closed
- fail conservatively on calendar/taxonomy errors: never undercount realized loss, never admit an unavailable calendar review, and never sweep an unprovable session
- retain legacy wall-clock review deadlines for unclassifiable stored ideas while their execution and expiry paths remain fail-closed

No live broker call, order placement/cancellation, funding, credential change, or execution authority is added.

## Type of change

- [ ] Refactor
- [x] Feature
- [ ] Bug fix
- [ ] Tests only
- [ ] CI/Docs/Tooling

## Scope & Impact

- Affected: core trading calendar, trade-idea policy/kernel/service, paper-accounting evidence, queue/expiry docs, generated environment reference, focused tests.
- Persisted `TradeIdea` and `TimeHorizon.expires_at` schemas/hashes are unchanged.
- Crypto remains 24x7 and UTC-day based.
- The live runtime risk manager is unchanged; this PR is confined to the paper trade-idea spine.

## Test Plan

- [x] Friday-to-Monday XNYS review duration, holiday/early close, exact boundary, 24x7, and zero-duration tests
- [x] Mixed equity/crypto daily-loss windows and truthful ratchet evidence
- [x] Equity review queue/policy deadline agreement and weekend-safe hard-expiry sweep
- [x] Bounded-autonomy latency suppression unchanged
- [x] Calendar failure conservatively retains realized loss and prevents expiry mutation
- [x] Legacy unclassifiable-instrument review compatibility pinned
- [x] Independent Claude Opus exact-diff review: approve; no correctness, safety, or authority-expansion defect found; its two suggested regression tests were added

## Quality Gates

- [x] `git diff --check`
- [x] focused trade-idea/calendar/CLI suite: 797 passed before final two negative regressions; final focused session/calendar suite: 34 passed
- [x] `uv run ruff check .`
- [x] `uv run black --check .`
- [x] `uv run mypy src/gpt_trader` (483 files)
- [x] docs link/reachability/currency gates
- [x] `uv run agent-regenerate --verify`
- [x] `uv run local-ci` after `uv sync --all-extras --dev`: 7,122 unit, 63 property, 13 contract, 84 integration; all PR-profile checks passed

The first `local-ci` attempt used a fresh worktree environment missing optional extras and therefore failed only on imports of FastAPI/JSON Schema in unrelated tests. After the required `uv sync --all-extras --dev`, the entire PR profile passed.

## Safety boundary

Paper-only timing and accounting. No brokerage adapter, provider credential, live smoke, canary, readiness, order submission, cancellation, funding, money movement, or autonomy expansion was run or added.
