### PR TITLE
feat(trade-ideas): compose mixed paper cycle data

### DIFF
--- a/docs/paper_trading.md
+++ b/docs/paper_trading.md
@@ -202,11 +202,36 @@ proposer set are env-overridable there (`CYCLE_SYMBOLS`, `CYCLE_GRANULARITY`,
 `CYCLE_PROPOSERS`, for example `CYCLE_PROPOSERS=baseline`); cadence belongs
 only in the scheduler entry.
 
+An opt-in mixed-universe source is available for a manually invoked paper
+turn, but is deliberately absent from both Stage 1/2 scripts and their default
+universes:
+
+```bash
+export ALPACA_API_KEY_ID=<market-data-key-id>
+export ALPACA_API_SECRET_KEY=<market-data-secret>
+uv run gpt-trader ideas cycle \
+  --from-coinbase --symbols BTC-USD,ETH-USD \
+  --from-alpaca --equity-symbols AAPL,MSFT,SPY \
+  --granularity ONE_HOUR --lookback 200
+```
+
+This composes public Coinbase crypto candles with authenticated, read-only
+Alpaca equity candles at one shared `as_of` instant. Equities are structurally
+fixed to completed `ONE_DAY` bars and the official
+`https://data.alpaca.markets` host; there is no cycle URL override. The two
+Alpaca environment variables must be market-data-only keys. This path imports
+no Alpaca account, broker, or order surface, and a configured provider failure
+fails the whole turn instead of running on a partial universe. It remains a
+dormant preparation route until the credential-gated smoke test is explicitly
+opted in and recorded; do not update scheduled scripts merely because the CLI
+surface exists.
+
 Shrinking `CYCLE_SYMBOLS` never strands an unresolved trade: each turn tops the
 snapshot fetch up with any instrument that still has an open idea or a filled
 idea awaiting closeout, so the exit monitor keeps receiving candles until the
-position resolves. Top-up fetches are per-symbol and non-fatal — a delisted
-instrument defers its own resolution without failing the turn.
+position resolves. In mixed mode, crypto top-ups route only to Coinbase and
+equity top-ups only to Alpaca. Top-up fetches are per-symbol and non-fatal — a
+delisted instrument defers its own resolution without failing the turn.
 
 Sessioned instruments also fail safely: the paper executor leaves an approved
 equity idea unsubmitted while XNYS is closed, and the exit monitor leaves a

--- a/docs/specs/TRADE_IDEA_CLI_SPEC.md
+++ b/docs/specs/TRADE_IDEA_CLI_SPEC.md
@@ -81,6 +81,10 @@ gpt-trader ideas
 │   └── build        --from-coinbase --symbols BTC-USD,ETH-USD
 │                    --granularity GRANULARITY --lookback N --out snapshot.json
 │                    [--as-of TIMESTAMP] [--source-label LABEL]
+├── cycle            (--snapshot PATH | --from-coinbase --symbols BTC-USD,ETH-USD
+│                    --granularity GRANULARITY --lookback N)
+│                    [--from-alpaca --equity-symbols AAPL,MSFT,SPY]
+│                    [--proposer PROPOSER] [--no-execute-approved]
 ├── resubmit         --file PATH | --stdin   [--actor-type {ai,human}] [--reason TEXT]
 ├── list             [--state STATE] [--instrument SYMBOL] [--decision-id ID]
 │                    [--direction DIRECTION]
@@ -582,6 +586,36 @@ Stage 2 auto-approval inside the budget envelope
   and the audited autonomy log must resolve to `bounded_autonomy` at execution
   time. Without both gates, `execute-paper` and `ideas cycle` preserve the
   previous typed refusal / audited skip behavior.
+
+### `ideas cycle`
+
+- Runs one local paper-cycle turn. Its execution leg can reach only
+  `DeterministicBroker`; neither source mode constructs a live broker or order
+  client.
+- The required source is either a local `--snapshot PATH` or an explicit
+  Coinbase read with `--from-coinbase`, `--symbols`, `--granularity`, and
+  `--lookback`.
+- `--from-alpaca --equity-symbols AAPL,MSFT,SPY` is a cycle-only modifier to
+  the Coinbase source. It adds authenticated read-only Alpaca Market Data
+  candles; it cannot be combined with `--snapshot`, and neither option is
+  accepted alone.
+- Coinbase symbols must classify as crypto pairs. Alpaca symbols must classify
+  as bare equity tickers. Duplicates, malformed symbols, wrong asset classes,
+  and cross-list overlap are rejected before either provider is dispatched.
+- Both configured requests share one `as_of` and `--lookback`. Coinbase keeps
+  the selected granularity; Alpaca is fixed to completed `ONE_DAY` bars and
+  `https://data.alpaca.markets`. The cycle parser exposes no Alpaca base-URL
+  override, generic HTTP client, account client, or order client.
+- Configured Coinbase and Alpaca reads are all-or-nothing. Busy-instrument
+  top-ups remain per-symbol and non-fatal: crypto routes to Coinbase, while
+  equity routes to Alpaca only when mixed mode is enabled.
+- The combined evidence source is
+  `composite[<coinbase-source>;<alpaca-source>]`, with deterministic crypto-then-equity
+  series order. `MarketSnapshot` revalidates duplicate-series and look-ahead
+  invariants after composition.
+- The mixed route is dormant: repository Stage 1/2 scripts and default
+  universes remain Coinbase-only until a separate credential-gated smoke
+  receipt and operational change are approved.
 
 ### `ideas execute-paper`
 

--- a/src/gpt_trader/cli/commands/ideas.py
+++ b/src/gpt_trader/cli/commands/ideas.py
@@ -36,6 +36,7 @@ from gpt_trader.cli.commands.ideas_input import (
     _load_trade_idea,
 )
 from gpt_trader.cli.response import CliError, CliErrorCode, CliResponse, RawCliOutput
+from gpt_trader.core.instruments import AssetClass, Instrument, InstrumentParseError
 from gpt_trader.errors import ValidationError
 from gpt_trader.features.brokerages.mock import DeterministicBroker
 from gpt_trader.features.idea_execution import (
@@ -1178,17 +1179,32 @@ def register(subparsers: Any) -> None:
         help="Fetch read-only public Coinbase market candles for this turn",
     )
     cycle.add_argument(
+        "--from-alpaca",
+        action="store_true",
+        help=(
+            "Also fetch keyed read-only Alpaca ONE_DAY equity candles; valid only "
+            "with --from-coinbase"
+        ),
+    )
+    cycle.add_argument(
         "--symbols",
         help="Comma-separated Coinbase product ids (required with --from-coinbase)",
     )
     cycle.add_argument(
         "--granularity",
-        help="Candle granularity, for example ONE_HOUR or ONE_DAY (required with --from-coinbase)",
+        help=(
+            "Coinbase candle granularity, for example ONE_HOUR or ONE_DAY "
+            "(required with --from-coinbase)"
+        ),
     )
     cycle.add_argument(
         "--lookback",
         type=_positive_int_value,
         help="Completed candles per symbol (required with --from-coinbase)",
+    )
+    cycle.add_argument(
+        "--equity-symbols",
+        help="Comma-separated equity tickers (required with --from-alpaca)",
     )
     cycle.add_argument(
         "--coinbase-base-url",
@@ -1197,8 +1213,8 @@ def register(subparsers: Any) -> None:
     )
     cycle.add_argument(
         "--source-label",
-        default=DEFAULT_SNAPSHOT_SOURCE_LABEL,
-        help="Source label stamped into snapshot metadata",
+        default=None,
+        help="Optional source label stamped into snapshot metadata",
     )
     cycle.add_argument(
         "--proposer",
@@ -1227,6 +1243,9 @@ def register(subparsers: Any) -> None:
         help="Skip the paper-execution leg for APPROVED ideas this turn",
     )
     cycle.set_defaults(handler=_handle_cycle, subcommand="cycle", execute_approved=True)
+    # Mixed-cycle Alpaca reads are intentionally pinned to the recorder's
+    # official data host. There is no CLI URL override that could receive keys.
+    cycle.set_defaults(alpaca_data_base_url=DEFAULT_ALPACA_DATA_BASE_URL)
 
     budget = ideas_subparsers.add_parser("budget", help="Inspect or update risk budget")
     budget_subparsers = budget.add_subparsers(dest="budget_command", required=True)
@@ -3039,11 +3058,93 @@ def _cycle_busy_symbol_extras(
     )
 
 
+def _cycle_symbols(
+    value: str,
+    *,
+    expected_asset_class: AssetClass,
+    field: str,
+) -> tuple[str, ...]:
+    """Parse and attest a provider-specific cycle symbol allowlist."""
+    symbols = _snapshot_symbols(value)
+    for symbol in symbols:
+        try:
+            instrument = Instrument.parse(symbol)
+        except InstrumentParseError as error:
+            raise SnapshotBuildInputError(str(error), field=field) from error
+        if instrument.asset_class is not expected_asset_class:
+            raise SnapshotBuildInputError(
+                f"--{field.replace('_', '-')} accepts only "
+                f"{expected_asset_class.value} instruments; got {symbol}",
+                field=field,
+            )
+    return symbols
+
+
+def _merge_cycle_snapshots(
+    crypto_snapshot: MarketSnapshot,
+    equity_snapshot: MarketSnapshot,
+) -> MarketSnapshot:
+    """Compose two provider reads that attest the same point in time."""
+    if crypto_snapshot.as_of != equity_snapshot.as_of:
+        raise SnapshotBuildInputError(
+            "Mixed cycle snapshots must share the exact same as_of instant",
+            field="as_of",
+        )
+    return MarketSnapshot(
+        as_of=crypto_snapshot.as_of,
+        source=f"composite[{crypto_snapshot.source};{equity_snapshot.source}]",
+        series=(*crypto_snapshot.series, *equity_snapshot.series),
+    )
+
+
+async def _build_configured_cycle_snapshot(
+    args: Namespace,
+    crypto_request: MarketSnapshotBuildRequest,
+    equity_request: MarketSnapshotBuildRequest | None,
+) -> MarketSnapshot:
+    if equity_request is None:
+        return await _build_coinbase_market_snapshot(args, crypto_request)
+    crypto_snapshot, equity_snapshot = await asyncio.gather(
+        _build_coinbase_market_snapshot(args, crypto_request),
+        _build_alpaca_equities_market_snapshot(args, equity_request),
+    )
+    return _merge_cycle_snapshots(crypto_snapshot, equity_snapshot)
+
+
+async def _build_cycle_top_up(
+    args: Namespace,
+    request: MarketSnapshotBuildRequest,
+    symbol: str,
+) -> MarketSnapshot:
+    """Route one busy-instrument read without exposing a generic data escape."""
+    instrument = Instrument.parse(symbol)
+    if instrument.asset_class is AssetClass.CRYPTO:
+        return await _build_coinbase_market_snapshot(args, replace(request, symbols=(symbol,)))
+    if not args.from_alpaca:
+        raise SnapshotBuildInputError(
+            "Equity busy-instrument top-ups require --from-alpaca",
+            field="from_alpaca",
+        )
+    return await _build_alpaca_equities_market_snapshot(
+        args,
+        replace(request, symbols=(symbol,), granularity="ONE_DAY"),
+    )
+
+
 def _handle_cycle(args: Namespace) -> CliResponse:
     command = "ideas cycle"
     try:
-        service = _service(args)
         if args.snapshot is not None:
+            if args.from_alpaca:
+                raise SnapshotBuildInputError(
+                    "--from-alpaca requires --from-coinbase",
+                    field="from_alpaca",
+                )
+            if args.equity_symbols is not None:
+                raise SnapshotBuildInputError(
+                    "--equity-symbols requires --from-alpaca",
+                    field="equity_symbols",
+                )
             snapshot_path = args.snapshot
 
             def snapshot_provider() -> tuple[MarketSnapshot, str]:
@@ -3066,15 +3167,59 @@ def _handle_cycle(args: Namespace) -> CliResponse:
                     CliErrorCode.MISSING_ARGUMENT,
                     f"--from-coinbase requires {', '.join(missing)}",
                 )
+            if args.from_alpaca and args.equity_symbols is None:
+                return _failure(
+                    command,
+                    args,
+                    CliErrorCode.MISSING_ARGUMENT,
+                    "--from-alpaca requires --equity-symbols",
+                )
+            if not args.from_alpaca and args.equity_symbols is not None:
+                raise SnapshotBuildInputError(
+                    "--equity-symbols requires --from-alpaca",
+                    field="equity_symbols",
+                )
+            crypto_symbols = _cycle_symbols(
+                args.symbols,
+                expected_asset_class=AssetClass.CRYPTO,
+                field="symbols",
+            )
+            equity_symbols = (
+                _cycle_symbols(
+                    args.equity_symbols,
+                    expected_asset_class=AssetClass.EQUITY,
+                    field="equity_symbols",
+                )
+                if args.from_alpaca
+                else ()
+            )
+            if set(crypto_symbols) & set(equity_symbols):
+                raise SnapshotBuildInputError(
+                    "--symbols and --equity-symbols must not overlap",
+                    field="equity_symbols",
+                )
+            as_of = datetime.now(UTC)
             request = MarketSnapshotBuildRequest(
-                symbols=_snapshot_symbols(args.symbols),
+                symbols=crypto_symbols,
                 granularity=_snapshot_granularity(args.granularity),
                 lookback=args.lookback,
-                as_of=datetime.now(UTC),
+                as_of=as_of,
+            )
+            equity_request = (
+                MarketSnapshotBuildRequest(
+                    symbols=equity_symbols,
+                    granularity="ONE_DAY",
+                    lookback=args.lookback,
+                    as_of=as_of,
+                )
+                if args.from_alpaca
+                else None
             )
 
             def snapshot_provider() -> tuple[MarketSnapshot, str]:
-                snapshot = asyncio.run(_build_coinbase_market_snapshot(args, request))
+                snapshot = asyncio.run(
+                    _build_configured_cycle_snapshot(args, request, equity_request)
+                )
                 # Busy instruments must keep receiving candles after the
                 # configured universe drops them: without fresh candles the
                 # exit monitor can never resolve their filled ideas, so the
@@ -3084,16 +3229,13 @@ def _handle_cycle(args: Namespace) -> CliResponse:
                 # simply stays open until candles are available again.
                 for symbol in _cycle_busy_symbol_extras(service, snapshot.symbols()):
                     try:
-                        extra = asyncio.run(
-                            _build_coinbase_market_snapshot(
-                                args, replace(request, symbols=(symbol,))
-                            )
-                        )
+                        extra = asyncio.run(_build_cycle_top_up(args, request, symbol))
                     except Exception:  # noqa: BLE001
                         continue
                     snapshot = replace(snapshot, series=(*snapshot.series, *extra.series))
                 return snapshot, snapshot.source
 
+        service = _service(args)
         selected_proposers = tuple(dict.fromkeys(args.proposers or DEFAULT_CYCLE_PROPOSERS))
         runner = PaperCycleRunner(
             service,

--- a/tests/unit/gpt_trader/cli/commands/test_ideas_cycle_mixed_source.py
+++ b/tests/unit/gpt_trader/cli/commands/test_ideas_cycle_mixed_source.py
@@ -1,0 +1,299 @@
+"""Mixed Coinbase/Alpaca read-only source tests for ``ideas cycle``."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from gpt_trader import cli
+from gpt_trader.core import Candle
+from gpt_trader.features.trade_ideas import (
+    MarketSnapshot,
+    SymbolSeries,
+    TimeHorizon,
+    TradeIdeaService,
+)
+from tests.unit.gpt_trader.cli.commands.conftest import attest_ideas_root
+from tests.unit.gpt_trader.features.trade_ideas.conftest import build_trade_idea
+
+
+def _run_json(capsys: pytest.CaptureFixture[str], argv: list[str]) -> tuple[int, dict[str, Any]]:
+    exit_code = cli.main(argv)
+    return exit_code, json.loads(capsys.readouterr().out)
+
+
+def _root_args(root: Path) -> list[str]:
+    return ["--ideas-root", str(root), "--format", "json"]
+
+
+def _flat_series(symbol: str, *, as_of: datetime, granularity: str) -> SymbolSeries:
+    step = timedelta(days=1) if granularity == "ONE_DAY" else timedelta(hours=1)
+    start = as_of - (step * 60)
+    return SymbolSeries(
+        symbol=symbol,
+        granularity=granularity,
+        candles=tuple(
+            Candle(
+                ts=start + (step * index),
+                open=Decimal("100"),
+                high=Decimal("100"),
+                low=Decimal("100"),
+                close=Decimal("100"),
+                volume=Decimal("10"),
+            )
+            for index in range(59)
+        ),
+    )
+
+
+def _install_fake_builder(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    provider: str,
+    fail: bool = False,
+) -> list[tuple[tuple[str, ...], str, int, datetime]]:
+    requests: list[tuple[tuple[str, ...], str, int, datetime]] = []
+
+    async def fake_build(args: Any, request: Any) -> MarketSnapshot:
+        requests.append((request.symbols, request.granularity, request.lookback, request.as_of))
+        if fail:
+            raise RuntimeError(f"{provider.title()} data unavailable")
+        return MarketSnapshot(
+            as_of=request.as_of,
+            source=f"test:fake-{provider}",
+            series=tuple(
+                _flat_series(
+                    symbol,
+                    as_of=request.as_of,
+                    granularity=request.granularity,
+                )
+                for symbol in request.symbols
+            ),
+        )
+
+    helper = (
+        "_build_coinbase_market_snapshot"
+        if provider == "coinbase"
+        else "_build_alpaca_equities_market_snapshot"
+    )
+    monkeypatch.setattr(f"gpt_trader.cli.commands.ideas.{helper}", fake_build)
+    return requests
+
+
+def _seed_busy_instrument(root: Path, instrument: str) -> None:
+    TradeIdeaService(root).propose(
+        build_trade_idea(
+            decision_id=(
+                f"trade-{datetime.now(UTC):%Y%m%d}-" f"{instrument.replace('-', '').lower()}-busy"
+            ),
+            instrument=instrument,
+            time_horizon=TimeHorizon(
+                expected_hold="3-10 days",
+                expires_at=datetime.now(UTC) + timedelta(days=7),
+            ),
+        ),
+        actor_id="test-proposer",
+    )
+
+
+def _mixed_args(root: Path) -> list[str]:
+    return [
+        "ideas",
+        "cycle",
+        "--from-coinbase",
+        "--from-alpaca",
+        "--symbols",
+        "BTC-USD",
+        "--equity-symbols",
+        "AAPL",
+        "--granularity",
+        "ONE_HOUR",
+        "--lookback",
+        "60",
+        *_root_args(root),
+    ]
+
+
+def test_cycle_mixed_source_composes_one_attested_snapshot(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "ideas"
+    attest_ideas_root(root)
+    coinbase_requests = _install_fake_builder(monkeypatch, provider="coinbase")
+    alpaca_requests = _install_fake_builder(monkeypatch, provider="alpaca")
+    argv = _mixed_args(root)
+    argv[argv.index("BTC-USD")] = "BTC-USD,ETH-USD"
+    argv[argv.index("AAPL")] = "AAPL,MSFT"
+
+    exit_code, response = _run_json(capsys, argv)
+
+    assert exit_code == 0
+    snapshot = response["data"]["snapshot"]
+    assert snapshot["symbols"] == ["BTC-USD", "ETH-USD", "AAPL", "MSFT"]
+    assert snapshot["source"] == "composite[test:fake-coinbase;test:fake-alpaca]"
+    assert [request[:3] for request in coinbase_requests] == [
+        (("BTC-USD", "ETH-USD"), "ONE_HOUR", 60)
+    ]
+    assert [request[:3] for request in alpaca_requests] == [(("AAPL", "MSFT"), "ONE_DAY", 60)]
+    assert coinbase_requests[0][3] == alpaca_requests[0][3]
+    manifest = json.loads((root / "cycle" / "manifest.jsonl").read_text().splitlines()[0])
+    assert manifest["snapshot"]["as_of"] == alpaca_requests[0][3].isoformat()
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected_message"),
+    [
+        (
+            ["ideas", "cycle", "--snapshot", "snapshot.json", "--from-alpaca"],
+            "requires --from-coinbase",
+        ),
+        (
+            [
+                "ideas",
+                "cycle",
+                "--from-coinbase",
+                "--from-alpaca",
+                "--symbols",
+                "BTC-USD",
+                "--granularity",
+                "ONE_HOUR",
+                "--lookback",
+                "60",
+            ],
+            "requires --equity-symbols",
+        ),
+        (
+            [
+                "ideas",
+                "cycle",
+                "--from-coinbase",
+                "--symbols",
+                "BTC-USD",
+                "--equity-symbols",
+                "AAPL",
+                "--granularity",
+                "ONE_HOUR",
+                "--lookback",
+                "60",
+            ],
+            "requires --from-alpaca",
+        ),
+        (
+            [
+                "ideas",
+                "cycle",
+                "--from-coinbase",
+                "--symbols",
+                "AAPL",
+                "--granularity",
+                "ONE_HOUR",
+                "--lookback",
+                "60",
+            ],
+            "accepts only crypto instruments",
+        ),
+        (
+            [
+                "ideas",
+                "cycle",
+                "--from-coinbase",
+                "--from-alpaca",
+                "--symbols",
+                "BTC-USD",
+                "--equity-symbols",
+                "ETH-USD",
+                "--granularity",
+                "ONE_HOUR",
+                "--lookback",
+                "60",
+            ],
+            "accepts only equity instruments",
+        ),
+    ],
+)
+def test_cycle_mixed_source_rejects_invalid_routes_before_dispatch(
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    argv: list[str],
+    expected_message: str,
+) -> None:
+    coinbase_requests = _install_fake_builder(monkeypatch, provider="coinbase")
+    alpaca_requests = _install_fake_builder(monkeypatch, provider="alpaca")
+    if "snapshot.json" in argv:
+        (tmp_path / "snapshot.json").write_text("{}", encoding="utf-8")
+        argv = [
+            str(tmp_path / "snapshot.json") if item == "snapshot.json" else item for item in argv
+        ]
+
+    exit_code, response = _run_json(capsys, [*argv, *_root_args(tmp_path / "ideas")])
+
+    assert exit_code != 0
+    assert expected_message in response["errors"][0]["message"]
+    assert coinbase_requests == []
+    assert alpaca_requests == []
+
+
+def test_cycle_mixed_source_primary_failure_fails_the_turn(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "ideas"
+    attest_ideas_root(root)
+    _install_fake_builder(monkeypatch, provider="coinbase")
+    _install_fake_builder(monkeypatch, provider="alpaca", fail=True)
+
+    exit_code, response = _run_json(capsys, _mixed_args(root))
+
+    assert exit_code != 0
+    assert response["success"] is False
+    manifest = json.loads((root / "cycle" / "manifest.jsonl").read_text().splitlines()[0])
+    assert manifest["outcome"] == "failed"
+    assert "Alpaca data unavailable" in manifest["error"]
+    assert "snapshot" not in manifest
+
+
+def test_cycle_mixed_source_exposes_no_alpaca_url_override(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    with pytest.raises(SystemExit) as error:
+        cli.main(
+            [
+                *_mixed_args(tmp_path / "ideas"),
+                "--alpaca-data-base-url",
+                "https://example.invalid",
+            ]
+        )
+
+    assert error.value.code == 2
+    assert "unrecognized arguments: --alpaca-data-base-url" in capsys.readouterr().err
+
+
+def test_cycle_mixed_source_routes_busy_top_ups_by_asset_class(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "ideas"
+    attest_ideas_root(root)
+    _seed_busy_instrument(root, "ETH-USD")
+    _seed_busy_instrument(root, "AAPL")
+    coinbase_requests = _install_fake_builder(monkeypatch, provider="coinbase")
+    alpaca_requests = _install_fake_builder(monkeypatch, provider="alpaca")
+    argv = _mixed_args(root)
+    argv[argv.index("AAPL")] = "MSFT"
+
+    exit_code, response = _run_json(capsys, argv)
+
+    assert exit_code == 0
+    assert response["data"]["snapshot"]["symbols"] == ["BTC-USD", "MSFT", "AAPL", "ETH-USD"]
+    assert [request[:3] for request in coinbase_requests] == [
+        (("BTC-USD",), "ONE_HOUR", 60),
+        (("ETH-USD",), "ONE_HOUR", 60),
+    ]
+    assert [request[:3] for request in alpaca_requests] == [
+        (("MSFT",), "ONE_DAY", 60),
+        (("AAPL",), "ONE_DAY", 60),
+    ]


### PR DESCRIPTION
## Summary

Adds a dormant, opt-in mixed market-data source for the existing paper-only `ideas cycle`: Coinbase crypto plus authenticated read-only Alpaca equity candles at one shared point in time.

Related issue / finding / routed package: Refs #1232; prerequisite toward #1224 P1-E.

This PR deliberately does **not** change Stage 1/2 scripts or default universes, run a credentialed smoke test, construct any live broker/account/order client, or add execution authority.

## Type of change
- [ ] Refactor
- [x] Feature
- [ ] Bug fix
- [ ] Tests only
- [x] CI/Docs/Tooling

## Scope & Impact
- Affected areas / components: `ideas cycle` composition root, mixed-source CLI tests, paper workflow/spec docs.
- Behavior changes: `--from-alpaca --equity-symbols ...` can modify an explicit `--from-coinbase` paper turn. Equity reads are fixed to `ONE_DAY` and `https://data.alpaca.markets`; the parser exposes no Alpaca URL override.
- Configured provider reads are all-or-nothing. Busy-instrument top-ups remain non-fatal and route crypto only to Coinbase and equities only to Alpaca in mixed mode.
- Provider-specific symbol lists are classified and rejected before dispatch; the merged `MarketSnapshot` rechecks duplicate/look-ahead invariants.

## Test Plan
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Contract tests (existing suite)
- [x] Ran locally: full `uv run local-ci` PR profile
- [x] Markers used appropriately (`unit`/`integration`/`slow`/`perf`)

Focused verification:
- 52 cycle/snapshot/equity-recorder tests passed before test-file split.
- 9 focused mixed-source tests passed after split, including no URL override, validation-before-dispatch, shared `as_of`, atomic provider failure, and provider-routed top-ups.
- Independent Claude Opus exact-diff review: **Approve**, no material correctness or authority-boundary finding.

Full PR gate after `uv sync --all-extras --dev`:
- 7,131 unit tests passed
- Stage 1 rails end-to-end smoke passed
- 63 property tests passed
- 13 contract tests passed
- 84 integration tests passed (3 deselected)

## Quality Gates
- [x] `uv run local-ci` passes locally
- [x] `uv run mypy src/gpt_trader` clean
- [x] No `sys.path` hacks in tests; async builders use async fakes
- [x] Import boundaries respected

## Observability & Errors
- [x] Existing cycle manifest records composed source, shared `as_of`, symbols, granularities, and atomic failure evidence
- [x] Validation errors identify the offending provider-specific flag/symbol

## Agent Artifacts & Config (if touched)
- [x] `uv run agent-regenerate --verify` clean; no generated artifact diff
- [x] Docs link, reachability, and currency gates pass

## Breaking Changes
- [x] None
- [ ] Documented in PR body and the linked issue if any

## Deferred credentialed smoke

Not run: `ALPACA_API_KEY_ID` and `ALPACA_API_SECRET_KEY` are absent. The exact safe command remains an explicit operator opt-in after market-data-only keys are available:

```bash
uv run gpt-trader ideas snapshot build --from-alpaca --symbols AAPL,MSFT,SPY --granularity ONE_DAY --lookback 10 --out /tmp/gpt-trader-alpaca-smoke.json --format json
```

The later operational script/default-universe flip remains a separate PR after that receipt.

## Checklist
- [x] Acceptance criteria for this bounded prerequisite met
- [x] Affected paths listed in PR description
