### PR TITLE
feat(ops): adopt mean reversion Stage-2 benchmark

### DIFF
--- a/docs/paper_trading.md
+++ b/docs/paper_trading.md
@@ -251,8 +251,8 @@ next session opens. Calendar or instrument failures never undercount loss,
 admit a stale review, or mutate an expiry sweep.
 
 Strategy-backed proposers — the live strategy library running over the turn's
-snapshot through the `Proposer` contract — are opt-in until replay parity is
-demonstrated: pass `--proposer strategy-baseline-spot` (or
+snapshot through the `Proposer` contract — remain opt-in at the CLI and in the
+Stage-1 wrapper: pass `--proposer strategy-baseline-spot` (or
 `strategy-baseline-perps`, `strategy-mean-reversion`,
 `strategy-regime-switcher`; all emit long-only spot ideas), or set
 `CYCLE_PROPOSERS="baseline regime-aware strategy-baseline-spot"`. Each
@@ -270,7 +270,10 @@ sets the two audited Stage-2 gates (`GPT_TRADER_IDEAS_AUTO_APPROVAL=1`,
 `GPT_TRADER_IDEAS_AUTO_EXECUTION=1`), system-approves every violation-free
 proposal inside the budget envelope (`ideas approve --auto-sweep`), then runs one
 cycle turn so those approvals paper-execute against the turn's snapshot. It is
-paper-only and never contacts a live broker. To run unattended Stage-2 turns,
+paper-only and never contacts a live broker. Its accepted benchmark set is
+`baseline`, `regime-aware`, and `strategy-mean-reversion`; this does not change
+the general CLI or Stage-1 defaults. `CYCLE_PROPOSERS` replaces that full set as
+an explicit operator rollback/config control. To run unattended Stage-2 turns,
 point the launchd/cron entry below at `stage2_cycle_turn.sh` instead of
 `stage1_cycle_turn.sh`; the same env overrides (`CYCLE_SYMBOLS`, etc.), overlap
 lock, and manifest-row evidence contract apply.

--- a/scripts/ops/stage2_cycle_turn.sh
+++ b/scripts/ops/stage2_cycle_turn.sh
@@ -32,8 +32,9 @@ export PATH="${HOME}/.local/bin:/opt/homebrew/bin:/usr/local/bin:${PATH}"
 : "${CYCLE_GRANULARITY:=ONE_HOUR}"
 : "${CYCLE_LOOKBACK:=200}"
 : "${CYCLE_PRICE_PRECISION:=0.01}"
-# Space-separated proposer names; empty means the CLI default (all proposers).
-: "${CYCLE_PROPOSERS:=}"
+# The accepted Stage-2 benchmark set. Operators can replace the full set with
+# a space-separated CYCLE_PROPOSERS value to roll back or run a narrower turn.
+: "${CYCLE_PROPOSERS:=baseline regime-aware strategy-mean-reversion}"
 
 # The two Stage-2 gates. Both must be enabled for the loop to auto-approve and
 # auto-execute, and each still no-ops unless the audited autonomy mode resolves

--- a/tests/unit/scripts/test_cycle_turn_wrappers.py
+++ b/tests/unit/scripts/test_cycle_turn_wrappers.py
@@ -1,0 +1,88 @@
+"""Contract tests for the Stage-1 and Stage-2 scheduler wrappers."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _run_wrapper(
+    tmp_path: Path,
+    script_name: str,
+    *,
+    proposers: str | None = None,
+) -> list[str]:
+    home = tmp_path / "home"
+    bin_dir = home / ".local" / "bin"
+    bin_dir.mkdir(parents=True)
+    call_log = tmp_path / "uv-calls.log"
+    fake_uv = bin_dir / "uv"
+    fake_uv.write_text(
+        "#!/usr/bin/env bash\n"
+        "printf '%s|%s|%s\\n' "
+        '"${GPT_TRADER_IDEAS_AUTO_APPROVAL:-}" '
+        '"${GPT_TRADER_IDEAS_AUTO_EXECUTION:-}" "$*" >> "${UV_CALL_LOG}"\n',
+        encoding="utf-8",
+    )
+    fake_uv.chmod(0o755)
+
+    env = os.environ.copy()
+    env.update({"HOME": str(home), "UV_CALL_LOG": str(call_log)})
+    env.pop("GPT_TRADER_IDEAS_AUTO_APPROVAL", None)
+    env.pop("GPT_TRADER_IDEAS_AUTO_EXECUTION", None)
+    if proposers is None:
+        env.pop("CYCLE_PROPOSERS", None)
+    else:
+        env["CYCLE_PROPOSERS"] = proposers
+
+    subprocess.run(
+        ["bash", str(REPO_ROOT / "scripts" / "ops" / script_name)],
+        check=True,
+        cwd=REPO_ROOT,
+        env=env,
+    )
+    return call_log.read_text(encoding="utf-8").splitlines()
+
+
+def test_stage2_wrapper_uses_accepted_benchmark_set_and_paper_gates(tmp_path: Path) -> None:
+    calls = _run_wrapper(tmp_path, "stage2_cycle_turn.sh")
+
+    assert calls[0] == "1|1|run gpt-trader ideas approve --auto-sweep --format json"
+    assert calls[1].startswith("1|1|run gpt-trader ideas cycle --from-coinbase ")
+    assert calls[1].count("--proposer") == 3
+    assert "--proposer baseline" in calls[1]
+    assert "--proposer regime-aware" in calls[1]
+    assert "--proposer strategy-mean-reversion" in calls[1]
+    assert "gpt-trader run" not in calls[1]
+
+
+def test_stage2_wrapper_operator_override_replaces_benchmark_set(tmp_path: Path) -> None:
+    calls = _run_wrapper(tmp_path, "stage2_cycle_turn.sh", proposers="baseline")
+
+    assert calls[1].count("--proposer") == 1
+    assert "--proposer baseline" in calls[1]
+    assert "regime-aware" not in calls[1]
+    assert "strategy-mean-reversion" not in calls[1]
+
+
+def test_stage1_wrapper_keeps_cli_defaults_and_does_not_enable_stage2_gates(
+    tmp_path: Path,
+) -> None:
+    (call,) = _run_wrapper(tmp_path, "stage1_cycle_turn.sh")
+
+    assert call.startswith("||run gpt-trader ideas cycle --from-coinbase ")
+    assert "--proposer" not in call
+
+
+@pytest.mark.parametrize("script_name", ["stage1_cycle_turn.sh", "stage2_cycle_turn.sh"])
+def test_wrapper_operator_override_remains_explicit(script_name: str, tmp_path: Path) -> None:
+    calls = _run_wrapper(tmp_path, script_name, proposers="regime-aware baseline")
+    cycle_call = calls[-1]
+
+    assert cycle_call.count("--proposer") == 2
+    assert "--proposer regime-aware --proposer baseline" in cycle_call

--- a/tests/unit/scripts/test_cycle_turn_wrappers.py
+++ b/tests/unit/scripts/test_cycle_turn_wrappers.py
@@ -3,12 +3,45 @@
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _bash_executable() -> str:
+    if sys.platform != "win32":
+        bash = shutil.which("bash")
+        assert bash is not None
+        return bash
+
+    git = shutil.which("git")
+    candidates = [
+        Path(os.environ.get("ProgramFiles", "")) / "Git" / "bin" / "bash.exe",
+        Path(os.environ.get("ProgramW6432", "")) / "Git" / "bin" / "bash.exe",
+    ]
+    if git is not None:
+        candidates.extend(
+            [
+                Path(git).resolve().parents[1] / "bin" / "bash.exe",
+                Path(git).resolve().parents[1] / "usr" / "bin" / "bash.exe",
+            ]
+        )
+    for candidate in candidates:
+        if candidate.is_file():
+            return str(candidate)
+    pytest.fail("Git for Windows Bash is required to exercise scheduler wrappers portably")
+
+
+def _shell_path(path: Path) -> str:
+    if sys.platform != "win32":
+        return str(path)
+    drive, tail = os.path.splitdrive(str(path.resolve()))
+    return f"/{drive[0].lower()}{tail.replace(os.sep, '/')}"
 
 
 def _run_wrapper(
@@ -32,7 +65,7 @@ def _run_wrapper(
     fake_uv.chmod(0o755)
 
     env = os.environ.copy()
-    env.update({"HOME": str(home), "UV_CALL_LOG": str(call_log)})
+    env.update({"HOME": _shell_path(home), "UV_CALL_LOG": _shell_path(call_log)})
     env.pop("GPT_TRADER_IDEAS_AUTO_APPROVAL", None)
     env.pop("GPT_TRADER_IDEAS_AUTO_EXECUTION", None)
     if proposers is None:
@@ -41,7 +74,7 @@ def _run_wrapper(
         env["CYCLE_PROPOSERS"] = proposers
 
     subprocess.run(
-        ["bash", str(REPO_ROOT / "scripts" / "ops" / script_name)],
+        [_bash_executable(), str(REPO_ROOT / "scripts" / "ops" / script_name)],
         check=True,
         cwd=REPO_ROOT,
         env=env,


### PR DESCRIPTION
## Summary

Adopt `strategy-mean-reversion` in the Stage-2 cycle wrapper's default benchmark set, preserving the explicit `CYCLE_PROPOSERS` replacement override for rollback/configuration.

References #1252 (W0 only; W1-W5 remain open).

Pipeline: `goal-pipeline-20260713-gpt-trader-1252-agentic-alpha`

## Type of change

- [x] Feature
- [x] Tests only
- [x] CI/Docs/Tooling

## Scope & Impact

- Affected areas / components: Stage-2 operator wrapper, paper-operation documentation, wrapper contract tests.
- Behavior change: Stage-2 wrapper defaults to `baseline`, `regime-aware`, and `strategy-mean-reversion`.
- Unchanged: Stage-1 wrapper, general CLI defaults, budget/approval/audit rails, broker-neutral records, execution authority, and live behavior.
- Rollback/config control: setting space-separated `CYCLE_PROPOSERS` replaces the full Stage-2 default set.

## Test Plan

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Contract tests (if applicable)
- [x] Focused wrapper and autonomy-gate suites passed (25 tests)
- [x] Full local PR gate passed

## Quality Gates

- [x] `uv sync --all-extras --dev`
- [x] `uv run pytest tests/unit/scripts/test_cycle_turn_wrappers.py tests/unit/gpt_trader/features/idea_execution/test_cycle_auto_approval.py tests/unit/gpt_trader/features/trade_ideas/test_service_auto_approval.py -q` (25 passed)
- [x] `uv run ruff check .`
- [x] `uv run black --check .`
- [x] `uv run mypy src/gpt_trader`
- [x] `uv run agent-regenerate` (no generated diff)
- [x] `uv run agent-regenerate --verify`
- [x] `uv run local-ci` (all 21 enabled PR-profile lanes passed: 7,136 unit, Stage-1 smoke, 63 property, 13 contract, 84 integration)
- [x] No `sys.path` hacks; import boundaries passed in local CI

## Observability & Errors

- [x] No runtime logging or error-path change.
- [x] Tests execute the wrappers against a local fake `uv`, so no Coinbase, broker, credential, model, or API path is exercised.

## Agent Artifacts & Config

- [x] `uv run agent-regenerate` produced no `var/agents/**` change.
- [x] `uv run agent-regenerate --verify` is clean.
- [x] Docs link and reachability checks pass.

## Breaking Changes

- [x] None

## Checklist

- [x] W0 acceptance criteria met; W1-W5 excluded.
- [x] Affected paths listed above.
- [x] No credentials, live orders, money movement, production/canary trading, autonomy promotion, execution-authority changes, or unrelated cleanup.
