### PR TITLE
fix(trade-ideas): anchor paper exits on recorded fill evidence

### DIFF
--- a/docs/paper_trading.md
+++ b/docs/paper_trading.md
@@ -240,6 +240,21 @@ data. Both outcomes are explicit in the cycle manifest and retry on a later
 turn. Crypto remains 24x7; an instrument that cannot be classified to a known
 session is refused rather than silently assigned crypto semantics.
 
+Exit evaluation is anchored on the venue-confirmed fill, not on a replay of the
+proposal. Reconciliation preserves the actual fill price, quantity, and
+timestamp as structured evidence on the FILLED audit event, and the exit
+monitor resolves the position from that fill using only post-fill candles — so
+a fill outside the planned entry zone still reaches its target, stop, or expiry
+mark. Fills recorded before evidence persistence existed are repaired from the
+cycle manifest's execution rows; when no fill price survives anywhere, the
+plan's zone midpoint (the documented sizing assumption) is used and the
+closeout evidence discloses `entry_price_source`. The report and scorecard
+classify every terminal idea through one lifecycle read model: an open fill
+inside its horizon is neither covered nor missing (`open_filled_count`), while
+a fill past `expires_at` without a closeout stays a visible failure
+(`overdue_unattributed_count`, with per-idea reasons); coverage is measured
+over closure-due ideas only.
+
 The same calendar owns paper accounting time. Realized-loss windows compare
 each closeout against its own instrument's current session date, so a Friday
 equity loss remains in the XNYS daily-loss ratchet through the weekend and

--- a/src/gpt_trader/features/idea_execution/cycle.py
+++ b/src/gpt_trader/features/idea_execution/cycle.py
@@ -225,6 +225,7 @@ class PaperCycleResult:
     report_summary: dict[str, Any] = field(default_factory=dict)
     session_gate: tuple[dict[str, Any], ...] = ()
     exit_monitor_skipped_closed_sessions: tuple[dict[str, str], ...] = ()
+    exit_monitor_unresolved: tuple[dict[str, str], ...] = ()
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -240,6 +241,7 @@ class PaperCycleResult:
             "exit_monitor_skipped_closed_sessions": [
                 dict(skip) for skip in self.exit_monitor_skipped_closed_sessions
             ],
+            "exit_monitor_unresolved": [dict(entry) for entry in self.exit_monitor_unresolved],
             "proposers": [turn.to_dict() for turn in self.proposer_turns],
             "execution": self.execution.to_dict(),
             "queue": self.queue,
@@ -396,19 +398,23 @@ class PaperCycleRunner:
         # P&L lands on the trail — the evidence the Stage 1->2 calibration /
         # expectancy / benchmark gates read (issue #1218). Runs before the report
         # so the fresh closeouts are reflected in this turn's artifact.
+        fallback_fills, manifest_unreadable_lines = self._legacy_fill_facts()
+        if manifest_unreadable_lines:
+            row["legacy_fill_manifest_unreadable_lines"] = manifest_unreadable_lines
         exit_monitor_pass = resolve_filled_ideas(
             self._service,
             snapshot,
             now=self._now_factory(),
             actor_id=self._actor_id,
             session_calendar_resolver=self._session_calendar_resolver,
-            fallback_fills=self._legacy_fill_facts(),
+            fallback_fills=fallback_fills,
         )
         resolved_decision_ids = tuple(record.decision_id for record in exit_monitor_pass.recorded)
         row["resolved_decision_ids"] = list(resolved_decision_ids)
         row["exit_monitor_skipped_closed_sessions"] = list(
             exit_monitor_pass.skipped_closed_sessions
         )
+        row["exit_monitor_unresolved"] = list(exit_monitor_pass.unresolved)
 
         report = build_trade_idea_track_record_report(self._service, now=self._now_factory())
         (run_dir / "report.json").write_text(
@@ -442,6 +448,7 @@ class PaperCycleRunner:
             report_summary=report_summary,
             session_gate=session_gate,
             exit_monitor_skipped_closed_sessions=exit_monitor_pass.skipped_closed_sessions,
+            exit_monitor_unresolved=exit_monitor_pass.unresolved,
         )
 
     def _session_decision(self, instrument: str, moment: datetime) -> dict[str, Any]:
@@ -668,7 +675,7 @@ class PaperCycleRunner:
             "granularities": sorted({series.granularity for series in snapshot.series}),
         }
 
-    def _legacy_fill_facts(self) -> dict[str, RecordedFill]:
+    def _legacy_fill_facts(self) -> tuple[dict[str, RecordedFill], int]:
         """Recover fill facts from manifest execution rows for pre-evidence fills.
 
         Fills recorded before fill-evidence persistence (#1212) carry no price
@@ -676,6 +683,11 @@ class PaperCycleRunner:
         this cycle's own manifest rows. Read them back only while such an open
         legacy fill exists; audit-trail evidence always takes precedence in the
         exit monitor, so this cost disappears once the legacy fills close.
+
+        Also returns the count of unreadable manifest lines (e.g. a partial
+        write from a killed turn) so the current turn's row can surface the
+        evidence loss instead of silently degrading to the zone-midpoint
+        estimate.
         """
         needs_fallback = False
         for view in self._service.list_views(TradeIdeaState.FILLED):
@@ -686,12 +698,13 @@ class PaperCycleRunner:
                 needs_fallback = True
                 break
         if not needs_fallback:
-            return {}
+            return {}, 0
 
         manifest_path = self._cycle_root / "manifest.jsonl"
         if not manifest_path.exists():
-            return {}
+            return {}, 0
         facts: dict[str, RecordedFill] = {}
+        unreadable_lines = 0
         with manifest_path.open("r", encoding="utf-8") as manifest_file:
             for line in manifest_file:
                 line = line.strip()
@@ -700,6 +713,7 @@ class PaperCycleRunner:
                 try:
                     row = json.loads(line)
                 except json.JSONDecodeError:
+                    unreadable_lines += 1
                     continue
                 execution = row.get("execution")
                 if not isinstance(execution, dict):
@@ -714,7 +728,7 @@ class PaperCycleRunner:
                     if fact is not None:
                         # First write wins: the original execution row is the fill.
                         facts.setdefault(entry["decision_id"], fact)
-        return facts
+        return facts, unreadable_lines
 
     def _append_manifest_row(self, row: dict[str, Any]) -> None:
         manifest_path = self._cycle_root / "manifest.jsonl"

--- a/src/gpt_trader/features/idea_execution/cycle.py
+++ b/src/gpt_trader/features/idea_execution/cycle.py
@@ -28,6 +28,7 @@ import secrets
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Any
 
@@ -53,10 +54,12 @@ from gpt_trader.features.trade_ideas import (
     AuditEvent,
     MarketSnapshot,
     Proposer,
+    RecordedFill,
     TradeIdeaService,
     TradeIdeaState,
     TradeIdeaView,
     market_snapshot_to_payload,
+    recorded_fill_from_view,
 )
 from gpt_trader.features.trade_ideas.report import build_trade_idea_track_record_report
 
@@ -127,6 +130,35 @@ def busy_instruments(service: TradeIdeaService) -> dict[str, BusyInstrument]:
                 ),
             )
     return busy
+
+
+def _manifest_fill_fact(entry: dict[str, Any]) -> RecordedFill | None:
+    """Build fallback fill facts from one manifest execution entry."""
+    decision_id = entry.get("decision_id")
+    if not isinstance(decision_id, str) or not decision_id:
+        return None
+    price = _optional_decimal(entry.get("fill_price"))
+    quantity = _optional_decimal(entry.get("quantity"))
+    if price is None and quantity is None:
+        return None
+    return RecordedFill(
+        filled_at=None,
+        price=price,
+        quantity=quantity,
+        venue=str(entry.get("venue") or "paper"),
+        external_order_id=str(entry.get("order_id") or ""),
+        source="cycle_manifest",
+    )
+
+
+def _optional_decimal(value: Any) -> Decimal | None:
+    if value is None or value == "":
+        return None
+    try:
+        parsed = Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return None
+    return parsed if parsed.is_finite() else None
 
 
 def _latest_approval_event(view: TradeIdeaView) -> AuditEvent | None:
@@ -370,6 +402,7 @@ class PaperCycleRunner:
             now=self._now_factory(),
             actor_id=self._actor_id,
             session_calendar_resolver=self._session_calendar_resolver,
+            fallback_fills=self._legacy_fill_facts(),
         )
         resolved_decision_ids = tuple(record.decision_id for record in exit_monitor_pass.recorded)
         row["resolved_decision_ids"] = list(resolved_decision_ids)
@@ -634,6 +667,54 @@ class PaperCycleRunner:
             "symbols": [series.symbol for series in snapshot.series],
             "granularities": sorted({series.granularity for series in snapshot.series}),
         }
+
+    def _legacy_fill_facts(self) -> dict[str, RecordedFill]:
+        """Recover fill facts from manifest execution rows for pre-evidence fills.
+
+        Fills recorded before fill-evidence persistence (#1212) carry no price
+        on their FILLED audit event, but the executed price/quantity live on
+        this cycle's own manifest rows. Read them back only while such an open
+        legacy fill exists; audit-trail evidence always takes precedence in the
+        exit monitor, so this cost disappears once the legacy fills close.
+        """
+        needs_fallback = False
+        for view in self._service.list_views(TradeIdeaState.FILLED):
+            if view.closeout_attribution is not None:
+                continue
+            recorded = recorded_fill_from_view(view)
+            if recorded is not None and recorded.price is None:
+                needs_fallback = True
+                break
+        if not needs_fallback:
+            return {}
+
+        manifest_path = self._cycle_root / "manifest.jsonl"
+        if not manifest_path.exists():
+            return {}
+        facts: dict[str, RecordedFill] = {}
+        with manifest_path.open("r", encoding="utf-8") as manifest_file:
+            for line in manifest_file:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                execution = row.get("execution")
+                if not isinstance(execution, dict):
+                    continue
+                executed = execution.get("executed")
+                if not isinstance(executed, list):
+                    continue
+                for entry in executed:
+                    if not isinstance(entry, dict):
+                        continue
+                    fact = _manifest_fill_fact(entry)
+                    if fact is not None:
+                        # First write wins: the original execution row is the fill.
+                        facts.setdefault(entry["decision_id"], fact)
+        return facts
 
     def _append_manifest_row(self, row: dict[str, Any]) -> None:
         manifest_path = self._cycle_root / "manifest.jsonl"

--- a/src/gpt_trader/features/idea_execution/executor.py
+++ b/src/gpt_trader/features/idea_execution/executor.py
@@ -376,6 +376,7 @@ class PaperIdeaExecutor:
             price=order.avg_fill_price,
             status="filled",
             decision_id=decision_id,
+            filled_at=order.updated_at or order.submitted_at or self._now_factory(),
         )
         report = PaperFillReconciler(
             self._service,

--- a/src/gpt_trader/features/idea_execution/exit_monitor.py
+++ b/src/gpt_trader/features/idea_execution/exit_monitor.py
@@ -67,10 +67,18 @@ _OUTCOME_TO_RESOLUTION: dict[ReplayOutcome, CloseoutResolution] = {
 
 @dataclass(frozen=True, slots=True)
 class ExitMonitorPass:
-    """One exit-monitor pass: closeouts recorded plus session skips left open."""
+    """One exit-monitor pass: closeouts recorded plus positions left open loudly.
+
+    ``unresolved`` carries the concrete blocking cause for every position the
+    pass could not close even though closure is owed: permanent defects
+    (unscoreable exit levels, no recorded quantity, no expiry) always, and
+    missing-data conditions (no candles, no post-fill window) once the idea has
+    expired. A position quietly waiting inside its horizon is not unresolved.
+    """
 
     recorded: tuple[CloseoutAttribution, ...]
     skipped_closed_sessions: tuple[dict[str, str], ...] = ()
+    unresolved: tuple[dict[str, str], ...] = ()
 
 
 def resolve_filled_ideas(
@@ -104,6 +112,7 @@ def resolve_filled_ideas(
     }
     recorded: list[CloseoutAttribution] = []
     skipped_closed: list[dict[str, str]] = []
+    unresolved: list[dict[str, str]] = []
     for view in service.list_views(TradeIdeaState.FILLED):
         if view.closeout_attribution is not None:
             continue
@@ -111,7 +120,7 @@ def resolve_filled_ideas(
         if closed_skip is not None:
             skipped_closed.append(closed_skip)
             continue
-        attribution = _resolve_one(
+        attribution, unresolved_reason = _resolve_one(
             view,
             candles_by_instrument,
             snapshot=snapshot,
@@ -122,9 +131,18 @@ def resolve_filled_ideas(
         )
         if attribution is not None:
             recorded.append(attribution)
+        elif unresolved_reason is not None:
+            unresolved.append(
+                {
+                    "decision_id": view.idea.decision_id,
+                    "instrument": view.idea.instrument,
+                    "reason": unresolved_reason,
+                }
+            )
     return ExitMonitorPass(
         recorded=tuple(recorded),
         skipped_closed_sessions=tuple(skipped_closed),
+        unresolved=tuple(unresolved),
     )
 
 
@@ -174,21 +192,33 @@ def _resolve_one(
     service: TradeIdeaService,
     actor_id: str,
     fallback_fill: RecordedFill | None = None,
-) -> CloseoutAttribution | None:
+) -> tuple[CloseoutAttribution | None, str | None]:
+    """Close one position, or explain why it stays open.
+
+    Returns ``(attribution, None)`` when a closeout was recorded,
+    ``(None, reason)`` when closure is owed but blocked (see
+    ``ExitMonitorPass.unresolved``), and ``(None, None)`` for a position
+    legitimately waiting inside its horizon.
+    """
     idea = view.idea
     candles = candles_by_instrument.get(idea.instrument.casefold())
     expires_at = idea.time_horizon.expires_at
     recorded_fill = recorded_fill_from_view(view)
-    if not candles or expires_at is None or recorded_fill is None:
-        return None
+    if recorded_fill is None or recorded_fill.filled_at is None:
+        # A FILLED view always carries a FILLED event with a timestamp; this
+        # branch guards data that bypassed the service.
+        return None, "no recorded fill event to anchor exit evaluation"
+    if expires_at is None:
+        return None, "idea has no expiry, so exit monitoring can never time it out"
+    expired = now >= expires_at
+    if not candles:
+        return None, ("no candles for instrument in this turn's snapshot" if expired else None)
     filled_at = recorded_fill.filled_at
-    if filled_at is None:
-        return None
 
     fill_price, entry_price_source = _fill_price_and_source(recorded_fill, fallback_fill)
     quantity = _fill_quantity(view, recorded_fill, fallback_fill)
     if quantity is None:
-        return None
+        return None, "no fill or sizing quantity recorded; realized P&L cannot be computed"
 
     try:
         result = score_filled_trade_idea(
@@ -198,38 +228,46 @@ def _resolve_one(
             future_candles=candles,
             level_extractor=exit_plan_scoring_levels,
         )
-    except ReplayScoringError:
-        return None
+    except ReplayScoringError as error:
+        return None, f"exit levels not scoreable: {error}"
 
     resolution = _OUTCOME_TO_RESOLUTION.get(result.outcome)
     if resolution is None:
-        return None  # NO_FUTURE_DATA -> no post-fill candles recorded yet
+        # NO_FUTURE_DATA: no candles at/after the fill (and before expiry).
+        return None, (
+            "no post-fill candles inside the idea's horizon are available" if expired else None
+        )
     # A timeout is only a real exit once the idea has expired; before that it is
     # merely the end of the candles recorded so far.
-    if result.outcome is ReplayOutcome.TIMED_OUT and now < expires_at:
-        return None
+    if result.outcome is ReplayOutcome.TIMED_OUT and not expired:
+        return None, None
     if result.entry_price is None or result.exit_price is None:
-        return None
+        return None, "scoring produced no entry/exit price"
 
     realized_amount = _realized_amount(
         idea.direction, quantity, result.entry_price, result.exit_price
     )
-    return service.record_closeout_attribution(
+    evidence = [
+        f"exit_monitor:{result.outcome.value}",
+        f"entry_price={result.entry_price}",
+        f"entry_price_source={entry_price_source}",
+        f"fill_time={filled_at.isoformat()}",
+        f"exit_price={result.exit_price}",
+        f"quantity={quantity}",
+        f"snapshot_as_of={snapshot.as_of.isoformat()}",
+    ]
+    if recorded_fill.corrupt_keys:
+        # Destroyed evidence must never masquerade as a by-design estimate.
+        evidence.append(f"evidence_corrupt_keys={','.join(recorded_fill.corrupt_keys)}")
+    attribution = service.record_closeout_attribution(
         idea.decision_id,
         actor_id=actor_id,
         actor_type=ActorType.SYSTEM,
         resolution=resolution,
         realized_profit_loss_amount=realized_amount,
-        evidence=(
-            f"exit_monitor:{result.outcome.value}",
-            f"entry_price={result.entry_price}",
-            f"entry_price_source={entry_price_source}",
-            f"fill_time={filled_at.isoformat()}",
-            f"exit_price={result.exit_price}",
-            f"quantity={quantity}",
-            f"snapshot_as_of={snapshot.as_of.isoformat()}",
-        ),
+        evidence=tuple(evidence),
     )
+    return attribution, None
 
 
 def _fill_price_and_source(

--- a/src/gpt_trader/features/idea_execution/exit_monitor.py
+++ b/src/gpt_trader/features/idea_execution/exit_monitor.py
@@ -1,14 +1,19 @@
 """Resolve filled paper ideas into audited closeouts (issue #1218).
 
-A ``FILLED`` idea is an open paper position. This monitor resolves it against the
-candles recorded after entry — first touch of the plan's target or stop, or a
-mark-to-market once past expiry — and records the outcome plus realized profit
-and loss on the audit trail through ``TradeIdeaService``.
+A ``FILLED`` idea is an open paper position. This monitor resolves it against
+the candles recorded after the venue-confirmed fill — first touch of the plan's
+target or stop, or a mark-to-market once past expiry — and records the outcome
+plus realized profit and loss on the audit trail through ``TradeIdeaService``.
 
-It reuses the replay scorer (``score_trade_idea``) so a live closeout and the
-scorecard's replay evidence share one resolution methodology; the structured
-exit plan (#1218a) supplies the levels via ``exit_plan_scoring_levels``. Realized
-P&L is recorded as a dollar amount (``quantity`` times the price move), which is
+Exit evaluation is anchored on the recorded fill (#1212), not on a replay of the
+proposal: ``score_filled_trade_idea`` inspects only candles at/after the fill
+timestamp, so a confirmed fill outside the planned entry zone still resolves.
+The entry price is, in order of evidentiary strength: the fill price on the
+FILLED audit event's evidence, a caller-supplied durable fallback (e.g. the
+paper cycle's manifest execution rows, for fills recorded before evidence
+persistence existed), or the plan's zone midpoint — the documented sizing
+assumption — with the source disclosed on the closeout evidence. Realized P&L
+is recorded as a dollar amount (``quantity`` times the price move), which is
 exactly what the Stage 1->2 calibration / expectancy / benchmark-edge gates read
 (``realized_profit_loss_amount`` vs the idea's recorded ``max_loss.amount``). The
 percent field is deliberately left unset to avoid conflating a position return
@@ -34,10 +39,10 @@ from gpt_trader.core.trading_calendar import (
 )
 from gpt_trader.features.trade_ideas import (
     ActorType,
-    AuditAction,
     CloseoutAttribution,
     CloseoutResolution,
     MarketSnapshot,
+    RecordedFill,
     ReplayOutcome,
     ReplayScoringError,
     TradeDirection,
@@ -45,7 +50,8 @@ from gpt_trader.features.trade_ideas import (
     TradeIdeaState,
     TradeIdeaView,
     exit_plan_scoring_levels,
-    score_trade_idea,
+    recorded_fill_from_view,
+    score_filled_trade_idea,
 )
 
 DEFAULT_EXIT_MONITOR_ACTOR_ID = "exit-monitor"
@@ -74,8 +80,13 @@ def resolve_filled_ideas(
     now: datetime,
     actor_id: str = DEFAULT_EXIT_MONITOR_ACTOR_ID,
     session_calendar_resolver: SessionCalendarResolver | None = None,
+    fallback_fills: Mapping[str, RecordedFill] | None = None,
 ) -> ExitMonitorPass:
     """Close every resolvable filled idea against ``snapshot``'s candles.
+
+    ``fallback_fills`` supplies durable fill facts (price/quantity) by decision
+    id for fills whose FILLED audit event predates fill-evidence persistence;
+    audit-trail evidence always takes precedence.
 
     Returns the closeout attributions recorded this pass plus the ideas it
     refused to resolve because their market session is closed at ``now``
@@ -84,8 +95,8 @@ def resolve_filled_ideas(
     ``FILLED`` — loudly, with the skip on the pass record — and resolves at
     the next open against that turn's own candles. Ideas that merely cannot
     be resolved yet (no candles for the instrument, no size, no exit levels,
-    entry not reached in the recorded window, or an unexpired end-of-candles)
-    are likewise left ``FILLED`` for a later turn.
+    no post-fill candles, or an unexpired end-of-candles) are likewise left
+    ``FILLED`` for a later turn.
     """
     resolver = session_calendar_resolver or get_calendar_for_instrument
     candles_by_instrument = {
@@ -107,6 +118,7 @@ def resolve_filled_ideas(
             now=now,
             service=service,
             actor_id=actor_id,
+            fallback_fill=(fallback_fills or {}).get(view.idea.decision_id),
         )
         if attribution is not None:
             recorded.append(attribution)
@@ -161,19 +173,28 @@ def _resolve_one(
     now: datetime,
     service: TradeIdeaService,
     actor_id: str,
+    fallback_fill: RecordedFill | None = None,
 ) -> CloseoutAttribution | None:
     idea = view.idea
     candles = candles_by_instrument.get(idea.instrument.casefold())
-    quantity = idea.sizing_recommendation.quantity
     expires_at = idea.time_horizon.expires_at
-    proposed_at = _proposed_at(view)
-    if not candles or quantity is None or expires_at is None or proposed_at is None:
+    recorded_fill = recorded_fill_from_view(view)
+    if not candles or expires_at is None or recorded_fill is None:
+        return None
+    filled_at = recorded_fill.filled_at
+    if filled_at is None:
+        return None
+
+    fill_price, entry_price_source = _fill_price_and_source(recorded_fill, fallback_fill)
+    quantity = _fill_quantity(view, recorded_fill, fallback_fill)
+    if quantity is None:
         return None
 
     try:
-        result = score_trade_idea(
+        result = score_filled_trade_idea(
             idea,
-            as_of=proposed_at,
+            filled_at=filled_at,
+            fill_price=fill_price,
             future_candles=candles,
             level_extractor=exit_plan_scoring_levels,
         )
@@ -182,7 +203,7 @@ def _resolve_one(
 
     resolution = _OUTCOME_TO_RESOLUTION.get(result.outcome)
     if resolution is None:
-        return None  # NOT_FILLED / NO_FUTURE_DATA -> position not resolvable yet
+        return None  # NO_FUTURE_DATA -> no post-fill candles recorded yet
     # A timeout is only a real exit once the idea has expired; before that it is
     # merely the end of the candles recorded so far.
     if result.outcome is ReplayOutcome.TIMED_OUT and now < expires_at:
@@ -202,11 +223,37 @@ def _resolve_one(
         evidence=(
             f"exit_monitor:{result.outcome.value}",
             f"entry_price={result.entry_price}",
+            f"entry_price_source={entry_price_source}",
+            f"fill_time={filled_at.isoformat()}",
             f"exit_price={result.exit_price}",
             f"quantity={quantity}",
             f"snapshot_as_of={snapshot.as_of.isoformat()}",
         ),
     )
+
+
+def _fill_price_and_source(
+    recorded_fill: RecordedFill,
+    fallback_fill: RecordedFill | None,
+) -> tuple[Decimal | None, str]:
+    """Pick the entry price by evidentiary strength and name its source."""
+    if recorded_fill.price is not None:
+        return recorded_fill.price, "recorded_fill"
+    if fallback_fill is not None and fallback_fill.price is not None:
+        return fallback_fill.price, fallback_fill.source
+    return None, "planned_zone_midpoint"
+
+
+def _fill_quantity(
+    view: TradeIdeaView,
+    recorded_fill: RecordedFill,
+    fallback_fill: RecordedFill | None,
+) -> Decimal | None:
+    if recorded_fill.quantity is not None:
+        return recorded_fill.quantity
+    if fallback_fill is not None and fallback_fill.quantity is not None:
+        return fallback_fill.quantity
+    return view.idea.sizing_recommendation.quantity
 
 
 def _realized_amount(
@@ -219,10 +266,3 @@ def _realized_amount(
         exit_price - entry_price if direction is TradeDirection.LONG else entry_price - exit_price
     )
     return quantity * move
-
-
-def _proposed_at(view: TradeIdeaView) -> datetime | None:
-    for event in view.events:
-        if event.action is AuditAction.PROPOSED:
-            return event.timestamp
-    return None

--- a/src/gpt_trader/features/trade_ideas/__init__.py
+++ b/src/gpt_trader/features/trade_ideas/__init__.py
@@ -65,11 +65,23 @@ from gpt_trader.features.trade_ideas.eligibility import (
     evaluate_eligibility,
     is_eligible,
 )
+from gpt_trader.features.trade_ideas.fill_evidence import (
+    FILL_SOURCE_AUDIT_EVENT,
+    FILL_SOURCE_AUDIT_EVIDENCE,
+    RecordedFill,
+    encode_fill_evidence,
+    recorded_fill_from_view,
+)
 from gpt_trader.features.trade_ideas.kernel import (
     KernelCheck,
     KernelRuntime,
     RiskKernel,
     autonomy_resolution_violations,
+)
+from gpt_trader.features.trade_ideas.lifecycle import (
+    LifecycleClassification,
+    classify_lifecycle,
+    unattributed_reason,
 )
 from gpt_trader.features.trade_ideas.models import (
     AutonomyMode,
@@ -136,6 +148,7 @@ from gpt_trader.features.trade_ideas.replay import (
     TradeIdeaReplayTournamentRunner,
     exit_plan_scoring_levels,
     extract_numeric_scoring_levels,
+    score_filled_trade_idea,
     score_trade_idea,
 )
 from gpt_trader.features.trade_ideas.report import (
@@ -238,9 +251,12 @@ __all__ = [
     "EntryZone",
     "ExitPlan",
     "EquityLedgerPoint",
+    "FILL_SOURCE_AUDIT_EVENT",
+    "FILL_SOURCE_AUDIT_EVIDENCE",
     "InvalidTransitionError",
     "KernelCheck",
     "KernelRuntime",
+    "LifecycleClassification",
     "MarketSnapshot",
     "MaxLoss",
     "MaxLossSnapshot",
@@ -261,6 +277,7 @@ __all__ = [
     "PositionSizerLike",
     "ProductType",
     "Proposer",
+    "RecordedFill",
     "ReplayOutcome",
     "REPLAY_OPTIMIZE_OBJECTIVES",
     "ReplayReport",
@@ -306,11 +323,13 @@ __all__ = [
     "autonomy_transition_violations",
     "build_trade_idea_track_record_report",
     "canonical_ticket_json",
+    "classify_lifecycle",
     "create_trade_idea_service",
     "compute_paper_accounting",
     "compute_portfolio_monitors",
     "daily_loss_breach_evidence",
     "drawdown_from_peak_breach_evidence",
+    "encode_fill_evidence",
     "equity_ledger",
     "evaluate_eligibility",
     "exit_plan_scoring_levels",
@@ -324,12 +343,15 @@ __all__ = [
     "new_event_id",
     "optimize_replay_min_history",
     "paper_fill_events_from_store_events",
+    "recorded_fill_from_view",
     "replay_optimize_baseline_candidates",
     "resolve_auto_approval_enabled",
     "resolve_autonomy",
     "resolve_ideas_root",
     "resolve_trade_idea_actor_id",
+    "score_filled_trade_idea",
     "score_trade_idea",
+    "unattributed_reason",
     "validate_paper_reconciliation_profile",
     "validate_transition",
 ]

--- a/src/gpt_trader/features/trade_ideas/fill_evidence.py
+++ b/src/gpt_trader/features/trade_ideas/fill_evidence.py
@@ -1,0 +1,127 @@
+"""Immutable actual-fill evidence carried on FILLED audit events (#1212).
+
+Paper reconciliation confirms a venue fill but historically recorded only the
+external order id, so exit monitoring had to reconstruct entry from the
+proposal's planned entry zone — and a confirmed fill outside that zone could
+never resolve. This module defines the provider-neutral codec for the fill
+facts: structured ``key=value`` evidence strings appended to the FILLED audit
+event (the same convention closeout evidence uses), decoded back into a
+``RecordedFill`` for exit evaluation.
+
+Existing audit records are untouched: a pre-evidence FILLED event decodes into
+a ``RecordedFill`` anchored at the audit event timestamp with unknown price and
+quantity (``source="audit_event"``), so legacy fills still resolve — via
+durable fallback evidence or the documented zone-midpoint estimate.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal, InvalidOperation
+
+from gpt_trader.features.trade_ideas.audit import AuditAction, AuditEvent
+from gpt_trader.features.trade_ideas.service_models import TradeIdeaView
+
+FILL_PRICE_EVIDENCE_KEY = "fill_price"
+FILL_QUANTITY_EVIDENCE_KEY = "fill_quantity"
+FILL_TIME_EVIDENCE_KEY = "fill_time"
+
+#: ``RecordedFill.source`` values, in decreasing evidentiary strength.
+FILL_SOURCE_AUDIT_EVIDENCE = "audit_evidence"
+FILL_SOURCE_AUDIT_EVENT = "audit_event"
+
+
+@dataclass(frozen=True, slots=True)
+class RecordedFill:
+    """Provider-neutral facts of one venue-confirmed fill.
+
+    ``filled_at`` is ``None`` only for fallback facts (e.g. cycle-manifest
+    execution rows) that know the price/quantity but not the exact fill time;
+    a fill decoded from the audit trail always carries an anchor timestamp.
+    """
+
+    filled_at: datetime | None
+    price: Decimal | None
+    quantity: Decimal | None
+    venue: str
+    external_order_id: str
+    source: str
+
+
+def encode_fill_evidence(
+    *,
+    price: Decimal | None,
+    quantity: Decimal | None,
+    filled_at: datetime | None,
+) -> tuple[str, ...]:
+    """Encode known fill facts as audit evidence strings; unknown facts are omitted."""
+    evidence: list[str] = []
+    if price is not None:
+        evidence.append(f"{FILL_PRICE_EVIDENCE_KEY}={price}")
+    if quantity is not None:
+        evidence.append(f"{FILL_QUANTITY_EVIDENCE_KEY}={quantity}")
+    if filled_at is not None:
+        evidence.append(f"{FILL_TIME_EVIDENCE_KEY}={filled_at.isoformat()}")
+    return tuple(evidence)
+
+
+def recorded_fill_from_view(view: TradeIdeaView) -> RecordedFill | None:
+    """Decode the actual-fill facts from a view's FILLED audit event.
+
+    Returns ``None`` when the idea never filled. A FILLED event without fill
+    evidence (recorded before evidence persistence existed) yields a fill
+    anchored at the audit event timestamp with unknown price and quantity.
+    """
+    filled_event = _filled_event(view)
+    if filled_event is None:
+        return None
+
+    price = _decimal_evidence(filled_event, FILL_PRICE_EVIDENCE_KEY)
+    quantity = _decimal_evidence(filled_event, FILL_QUANTITY_EVIDENCE_KEY)
+    filled_at = _datetime_evidence(filled_event, FILL_TIME_EVIDENCE_KEY)
+    has_evidence = price is not None or quantity is not None or filled_at is not None
+    return RecordedFill(
+        filled_at=filled_at if filled_at is not None else filled_event.timestamp,
+        price=price,
+        quantity=quantity,
+        venue=filled_event.venue,
+        external_order_id=filled_event.external_order_id,
+        source=FILL_SOURCE_AUDIT_EVIDENCE if has_evidence else FILL_SOURCE_AUDIT_EVENT,
+    )
+
+
+def _filled_event(view: TradeIdeaView) -> AuditEvent | None:
+    for event in reversed(view.events):
+        if event.action is AuditAction.FILLED:
+            return event
+    return None
+
+
+def _evidence_value(event: AuditEvent, key: str) -> str | None:
+    prefix = f"{key}="
+    for item in event.evidence:
+        if item.startswith(prefix):
+            return item[len(prefix) :]
+    return None
+
+
+def _decimal_evidence(event: AuditEvent, key: str) -> Decimal | None:
+    raw = _evidence_value(event, key)
+    if raw is None:
+        return None
+    try:
+        parsed = Decimal(raw)
+    except (InvalidOperation, ValueError):
+        return None
+    return parsed if parsed.is_finite() else None
+
+
+def _datetime_evidence(event: AuditEvent, key: str) -> datetime | None:
+    raw = _evidence_value(event, key)
+    if raw is None:
+        return None
+    try:
+        return datetime.fromisoformat(raw)
+    except ValueError:
+        return None

--- a/src/gpt_trader/features/trade_ideas/fill_evidence.py
+++ b/src/gpt_trader/features/trade_ideas/fill_evidence.py
@@ -17,7 +17,7 @@ durable fallback evidence or the documented zone-midpoint estimate.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import UTC, datetime
 from decimal import Decimal, InvalidOperation
 
 from gpt_trader.features.trade_ideas.audit import AuditAction, AuditEvent
@@ -39,6 +39,11 @@ class RecordedFill:
     ``filled_at`` is ``None`` only for fallback facts (e.g. cycle-manifest
     execution rows) that know the price/quantity but not the exact fill time;
     a fill decoded from the audit trail always carries an anchor timestamp.
+
+    ``corrupt_keys`` names evidence keys that were present on the FILLED event
+    but failed to decode: destroyed evidence must stay distinguishable from
+    evidence that never existed, so downstream consumers can disclose the
+    degradation instead of silently reporting an estimate as by-design.
     """
 
     filled_at: datetime | None
@@ -47,6 +52,7 @@ class RecordedFill:
     venue: str
     external_order_id: str
     source: str
+    corrupt_keys: tuple[str, ...] = ()
 
 
 def encode_fill_evidence(
@@ -55,13 +61,20 @@ def encode_fill_evidence(
     quantity: Decimal | None,
     filled_at: datetime | None,
 ) -> tuple[str, ...]:
-    """Encode known fill facts as audit evidence strings; unknown facts are omitted."""
+    """Encode known fill facts as audit evidence strings; unknown facts are omitted.
+
+    A naive ``filled_at`` is coerced to UTC: paper/mock timestamps are UTC by
+    construction, and a naive value written into evidence would later raise on
+    comparison against tz-aware candle timestamps.
+    """
     evidence: list[str] = []
     if price is not None:
         evidence.append(f"{FILL_PRICE_EVIDENCE_KEY}={price}")
     if quantity is not None:
         evidence.append(f"{FILL_QUANTITY_EVIDENCE_KEY}={quantity}")
     if filled_at is not None:
+        if filled_at.tzinfo is None:
+            filled_at = filled_at.replace(tzinfo=UTC)
         evidence.append(f"{FILL_TIME_EVIDENCE_KEY}={filled_at.isoformat()}")
     return tuple(evidence)
 
@@ -77,10 +90,13 @@ def recorded_fill_from_view(view: TradeIdeaView) -> RecordedFill | None:
     if filled_event is None:
         return None
 
-    price = _decimal_evidence(filled_event, FILL_PRICE_EVIDENCE_KEY)
-    quantity = _decimal_evidence(filled_event, FILL_QUANTITY_EVIDENCE_KEY)
-    filled_at = _datetime_evidence(filled_event, FILL_TIME_EVIDENCE_KEY)
-    has_evidence = price is not None or quantity is not None or filled_at is not None
+    corrupt: list[str] = []
+    price = _decimal_evidence(filled_event, FILL_PRICE_EVIDENCE_KEY, corrupt)
+    quantity = _decimal_evidence(filled_event, FILL_QUANTITY_EVIDENCE_KEY, corrupt)
+    filled_at = _datetime_evidence(filled_event, FILL_TIME_EVIDENCE_KEY, corrupt)
+    has_evidence = (
+        price is not None or quantity is not None or filled_at is not None or bool(corrupt)
+    )
     return RecordedFill(
         filled_at=filled_at if filled_at is not None else filled_event.timestamp,
         price=price,
@@ -88,6 +104,7 @@ def recorded_fill_from_view(view: TradeIdeaView) -> RecordedFill | None:
         venue=filled_event.venue,
         external_order_id=filled_event.external_order_id,
         source=FILL_SOURCE_AUDIT_EVIDENCE if has_evidence else FILL_SOURCE_AUDIT_EVENT,
+        corrupt_keys=tuple(corrupt),
     )
 
 
@@ -106,22 +123,33 @@ def _evidence_value(event: AuditEvent, key: str) -> str | None:
     return None
 
 
-def _decimal_evidence(event: AuditEvent, key: str) -> Decimal | None:
+def _decimal_evidence(event: AuditEvent, key: str, corrupt: list[str]) -> Decimal | None:
     raw = _evidence_value(event, key)
     if raw is None:
         return None
     try:
         parsed = Decimal(raw)
     except (InvalidOperation, ValueError):
+        corrupt.append(key)
         return None
-    return parsed if parsed.is_finite() else None
+    if not parsed.is_finite():
+        corrupt.append(key)
+        return None
+    return parsed
 
 
-def _datetime_evidence(event: AuditEvent, key: str) -> datetime | None:
+def _datetime_evidence(event: AuditEvent, key: str, corrupt: list[str]) -> datetime | None:
     raw = _evidence_value(event, key)
     if raw is None:
         return None
     try:
-        return datetime.fromisoformat(raw)
+        parsed = datetime.fromisoformat(raw)
     except ValueError:
+        corrupt.append(key)
         return None
+    if parsed.tzinfo is None:
+        # A naive anchor would raise on comparison against tz-aware candles;
+        # the encoder always writes UTC offsets, so naive == corrupt.
+        corrupt.append(key)
+        return None
+    return parsed

--- a/src/gpt_trader/features/trade_ideas/lifecycle.py
+++ b/src/gpt_trader/features/trade_ideas/lifecycle.py
@@ -59,5 +59,6 @@ def unattributed_reason(view: TradeIdeaView, *, now: datetime) -> str | None:
         return "filled idea has no expiry, so exit monitoring cannot resolve it"
     return (
         f"filled idea expired {expires_at.isoformat()} without a closeout; "
-        "awaiting exit-monitor resolution against post-fill candles"
+        "the exit monitor records its blocking cause per turn as "
+        "exit_monitor_unresolved on the cycle manifest"
     )

--- a/src/gpt_trader/features/trade_ideas/lifecycle.py
+++ b/src/gpt_trader/features/trade_ideas/lifecycle.py
@@ -1,0 +1,63 @@
+"""Canonical lifecycle read classification for trade-idea views (#1212).
+
+FILLED is a terminal workflow state (an open paper position never transitions
+again; closure is expressed by a ``CloseoutAttribution``), so state alone
+conflates a legitimately open position with a missing closeout. This read model
+is the one place that distinction is made; report, scorecard, and CLI
+consumers all classify through it.
+
+Overdue reuses the existing expiry/exit-monitor contract rather than inventing
+a second lifecycle clock: the exit monitor marks an unresolved fill to market
+once ``now`` reaches the idea's ``expires_at``, so an unclosed fill past that
+instant (or without any expiry to resolve against) is an overdue evidence
+failure. Any other terminal idea without attribution is overdue immediately —
+the cycle's auto-attribution leg owes it a closeout in the same turn.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+
+from gpt_trader.features.trade_ideas.service_models import TradeIdeaView
+from gpt_trader.features.trade_ideas.workflow import TERMINAL_STATES, TradeIdeaState
+
+
+class LifecycleClassification(str, Enum):
+    """Where one idea stands between proposal and attributed closeout."""
+
+    NOT_APPLICABLE = "not_applicable"
+    OPEN_FILLED = "open_filled"
+    CLOSED = "closed"
+    OVERDUE_UNATTRIBUTED = "overdue_unattributed"
+
+
+def classify_lifecycle(view: TradeIdeaView, *, now: datetime) -> LifecycleClassification:
+    """Classify one view; ``now`` decides whether an open fill is overdue."""
+    if view.state not in TERMINAL_STATES:
+        return LifecycleClassification.NOT_APPLICABLE
+    if view.closeout_attribution is not None:
+        return LifecycleClassification.CLOSED
+    if view.state is TradeIdeaState.FILLED:
+        expires_at = view.idea.time_horizon.expires_at
+        if expires_at is not None and now < expires_at:
+            return LifecycleClassification.OPEN_FILLED
+    return LifecycleClassification.OVERDUE_UNATTRIBUTED
+
+
+def unattributed_reason(view: TradeIdeaView, *, now: datetime) -> str | None:
+    """Explain an overdue classification; ``None`` for every other class."""
+    if classify_lifecycle(view, now=now) is not LifecycleClassification.OVERDUE_UNATTRIBUTED:
+        return None
+    if view.state is not TradeIdeaState.FILLED:
+        return (
+            f"terminal state '{view.state.value}' has no closeout attribution; "
+            "awaiting the cycle's auto-attribution leg"
+        )
+    expires_at = view.idea.time_horizon.expires_at
+    if expires_at is None:
+        return "filled idea has no expiry, so exit monitoring cannot resolve it"
+    return (
+        f"filled idea expired {expires_at.isoformat()} without a closeout; "
+        "awaiting exit-monitor resolution against post-fill candles"
+    )

--- a/src/gpt_trader/features/trade_ideas/paper_reconciliation.py
+++ b/src/gpt_trader/features/trade_ideas/paper_reconciliation.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import UTC, datetime
 from decimal import Decimal, InvalidOperation
 from typing import AbstractSet, Any
 
@@ -171,9 +171,7 @@ def paper_fill_events_from_store_events(
                 status=status,
                 decision_id=_safe_text_or_none(data.get("decision_id")),
                 source_index=index,
-                filled_at=_optional_datetime(
-                    data.get("filled_at") or data.get("timestamp") or data.get("created_at")
-                ),
+                filled_at=_first_datetime(data, ("filled_at", "timestamp", "created_at")),
             )
         )
     return tuple(fills)
@@ -588,14 +586,24 @@ def _optional_decimal(value: Any) -> Decimal | None:
     return parsed if parsed.is_finite() else None
 
 
-def _optional_datetime(value: Any) -> datetime | None:
-    text = _text(value)
-    if not text:
-        return None
-    try:
-        return datetime.fromisoformat(text)
-    except ValueError:
-        return None
+def _first_datetime(data: Mapping[str, Any], keys: tuple[str, ...]) -> datetime | None:
+    """Parse the first candidate key that yields a timestamp.
+
+    Each key is tried in turn — a present-but-malformed ``filled_at`` must not
+    mask a valid ``timestamp`` on the same event. Naive values are coerced to
+    UTC: paper/mock runtime timestamps are UTC by construction, and a naive
+    anchor would later raise against tz-aware candle timestamps.
+    """
+    for key in keys:
+        text = _text(data.get(key))
+        if not text:
+            continue
+        try:
+            parsed = datetime.fromisoformat(text)
+        except ValueError:
+            continue
+        return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
+    return None
 
 
 def _safe_text_or_none(value: Any) -> str | None:

--- a/src/gpt_trader/features/trade_ideas/paper_reconciliation.py
+++ b/src/gpt_trader/features/trade_ideas/paper_reconciliation.py
@@ -9,11 +9,13 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
+from datetime import datetime
 from decimal import Decimal, InvalidOperation
 from typing import AbstractSet, Any
 
 from gpt_trader.errors import ValidationError
 from gpt_trader.features.trade_ideas.audit import ActorType, AuditAction
+from gpt_trader.features.trade_ideas.fill_evidence import encode_fill_evidence
 from gpt_trader.features.trade_ideas.models import TradeDirection, is_safe_decision_id
 from gpt_trader.features.trade_ideas.service import TradeIdeaService, TradeIdeaView
 from gpt_trader.features.trade_ideas.workflow import TradeIdeaState
@@ -39,6 +41,7 @@ class PaperFillEvent:
     status: str
     decision_id: str | None = None
     source_index: int | None = None
+    filled_at: datetime | None = None
 
     @property
     def external_order_id(self) -> str:
@@ -55,6 +58,7 @@ class PaperFillEvent:
             "status": self.status,
             "decision_id": self.decision_id,
             "source_index": self.source_index,
+            "filled_at": self.filled_at.isoformat() if self.filled_at is not None else None,
         }
 
 
@@ -167,6 +171,9 @@ def paper_fill_events_from_store_events(
                 status=status,
                 decision_id=_safe_text_or_none(data.get("decision_id")),
                 source_index=index,
+                filled_at=_optional_datetime(
+                    data.get("filled_at") or data.get("timestamp") or data.get("created_at")
+                ),
             )
         )
     return tuple(fills)
@@ -327,6 +334,11 @@ class PaperFillReconciler:
                     external_order_id=event.external_order_id,
                     reason=_fill_reason(event),
                     actor_type=ActorType.VENUE,
+                    evidence=encode_fill_evidence(
+                        price=event.price,
+                        quantity=event.quantity,
+                        filled_at=event.filled_at,
+                    ),
                 )
                 recorded_fill = True
                 final_state = view.state.value
@@ -574,6 +586,16 @@ def _optional_decimal(value: Any) -> Decimal | None:
     except (InvalidOperation, ValueError):
         return None
     return parsed if parsed.is_finite() else None
+
+
+def _optional_datetime(value: Any) -> datetime | None:
+    text = _text(value)
+    if not text:
+        return None
+    try:
+        return datetime.fromisoformat(text)
+    except ValueError:
+        return None
 
 
 def _safe_text_or_none(value: Any) -> str | None:

--- a/src/gpt_trader/features/trade_ideas/replay.py
+++ b/src/gpt_trader/features/trade_ideas/replay.py
@@ -496,6 +496,91 @@ def score_trade_idea(
     )
 
 
+def score_filled_trade_idea(
+    idea: TradeIdea,
+    *,
+    filled_at: datetime,
+    fill_price: Decimal | None,
+    future_candles: Sequence[Candle],
+    level_extractor: LevelExtractor = extract_numeric_scoring_levels,
+    candle_duration: timedelta | None = None,
+) -> ReplayResult:
+    """Score an idea whose entry is a venue-confirmed fill, not a simulation.
+
+    ``score_trade_idea`` reconstructs entry from the planned entry zone, so a
+    confirmed fill outside that zone replays as NOT_FILLED forever (#1212).
+    Here the entry is a recorded fact: only candles at/after ``filled_at`` are
+    inspected, every candle may exit (there is no ambiguous entry bar), and the
+    entry price is the recorded fill — falling back to the plan's zone midpoint
+    (the documented sizing assumption) when no fill price was preserved.
+    """
+    if idea.time_horizon.expires_at is None:
+        raise ReplayScoringError(
+            f"Trade idea '{idea.decision_id}' has no expiry to score against",
+            field="time_horizon",
+        )
+    if idea.direction not in {TradeDirection.LONG, TradeDirection.SHORT}:
+        raise ReplayScoringError(
+            f"Trade idea '{idea.decision_id}' direction '{idea.direction.value}' is not scoreable",
+            field="direction",
+        )
+
+    levels = level_extractor(idea)
+    candles = tuple(
+        sorted(
+            (
+                candle
+                for candle in future_candles
+                if filled_at <= candle.ts
+                and _candle_ends_by_expiry(
+                    candle,
+                    expires_at=idea.time_horizon.expires_at,
+                    candle_duration=candle_duration,
+                )
+            ),
+            key=lambda candle: candle.ts,
+        )
+    )
+    if not candles:
+        return _result(
+            idea,
+            as_of=filled_at,
+            levels=levels,
+            outcome=ReplayOutcome.NO_FUTURE_DATA,
+        )
+
+    entry_price = fill_price if fill_price is not None else levels.entry_midpoint
+    for bars_evaluated, candle in enumerate(candles, start=1):
+        outcome_price = _bar_outcome_price(idea.direction, candle, levels)
+        if outcome_price is None:
+            continue
+        outcome, exit_price = outcome_price
+        return _result(
+            idea,
+            as_of=filled_at,
+            levels=levels,
+            outcome=outcome,
+            entry_time=filled_at,
+            entry_price=entry_price,
+            exit_time=candle.ts,
+            exit_price=exit_price,
+            bars_evaluated=bars_evaluated,
+        )
+
+    timeout_candle = candles[-1]
+    return _result(
+        idea,
+        as_of=filled_at,
+        levels=levels,
+        outcome=ReplayOutcome.TIMED_OUT,
+        entry_time=filled_at,
+        entry_price=entry_price,
+        exit_time=timeout_candle.ts,
+        exit_price=timeout_candle.close,
+        bars_evaluated=len(candles),
+    )
+
+
 @dataclass(frozen=True, slots=True)
 class ReplayRunnerConfig:
     """Configuration for replaying one historical candle series."""

--- a/src/gpt_trader/features/trade_ideas/report.py
+++ b/src/gpt_trader/features/trade_ideas/report.py
@@ -12,6 +12,11 @@ from gpt_trader.features.trade_ideas.artifacts import stable_artifact_id
 from gpt_trader.features.trade_ideas.audit import ActorType, AuditAction
 from gpt_trader.features.trade_ideas.closeout import CloseoutResolution
 from gpt_trader.features.trade_ideas.eligibility import evaluate_eligibility
+from gpt_trader.features.trade_ideas.lifecycle import (
+    LifecycleClassification,
+    classify_lifecycle,
+    unattributed_reason,
+)
 from gpt_trader.features.trade_ideas.models import ConfidenceLabel
 from gpt_trader.features.trade_ideas.policy import ApprovalPolicy
 from gpt_trader.features.trade_ideas.service import TradeIdeaService, TradeIdeaView
@@ -64,7 +69,7 @@ def build_trade_idea_track_record_report(
 
     quality = _quality_summary(service, views, now=report_cutoff)
     workflow = _workflow_summary(views, event_counts, state_counts)
-    closeouts = _closeout_summary(views)
+    closeouts = _closeout_summary(views, now=report_cutoff)
     monthly = _monthly_summary(views)
     filters = _filters_payload(since=since, until=until)
 
@@ -153,9 +158,10 @@ def format_trade_idea_track_record_report(report: Mapping[str, Any]) -> str:
         "Closeouts",
         (
             f"coverage: {closeouts['with_closeout_count']}/"
-            f"{closeouts['terminal_count']} terminal "
+            f"{closeouts['closure_due_count']} closure-due "
             f"({closeouts['coverage_rate_pct']}%)"
         ),
+        f"open_filled_count: {closeouts['open_filled_count']}",
         f"missing_closeout_count: {closeouts['missing_closeout_count']}",
         _counts_line("resolutions", closeouts["resolution_counts"]),
         _counts_line("outcomes", closeouts["outcome_distribution"]),
@@ -333,11 +339,13 @@ def _quality_summary(
     }
 
 
-def _closeout_summary(views: list[TradeIdeaView]) -> dict[str, Any]:
+def _closeout_summary(views: list[TradeIdeaView], *, now: datetime) -> dict[str, Any]:
     terminal_views = [view for view in views if view.state in TERMINAL_STATES]
     terminal_count = len(terminal_views)
     resolution_counts = {resolution.value: 0 for resolution in CloseoutResolution}
-    missing_closeout_ids: list[str] = []
+    open_filled_ids: list[str] = []
+    overdue_ids: list[str] = []
+    overdue_reasons: dict[str, str] = {}
     outcome_distribution = {
         "profit": 0,
         "loss": 0,
@@ -349,9 +357,21 @@ def _closeout_summary(views: list[TradeIdeaView]) -> dict[str, Any]:
     max_loss_comparisons: list[dict[str, Any]] = []
 
     for view in terminal_views:
+        classification = classify_lifecycle(view, now=now)
+        if classification is LifecycleClassification.OPEN_FILLED:
+            # A live paper position inside its horizon: closure is not due yet,
+            # so it is neither covered nor missing (#1212).
+            open_filled_ids.append(view.idea.decision_id)
+            continue
+        if classification is LifecycleClassification.OVERDUE_UNATTRIBUTED:
+            decision_id = view.idea.decision_id
+            overdue_ids.append(decision_id)
+            reason = unattributed_reason(view, now=now)
+            if reason is not None:
+                overdue_reasons[decision_id] = reason
+            continue
         closeout = view.closeout_attribution
-        if closeout is None:
-            missing_closeout_ids.append(view.idea.decision_id)
+        if closeout is None:  # pragma: no cover - CLOSED implies attribution
             continue
 
         resolution_counts[closeout.resolution.value] += 1
@@ -388,14 +408,24 @@ def _closeout_summary(views: list[TradeIdeaView]) -> dict[str, Any]:
         Decimal("0"),
     )
 
-    with_closeout_count = terminal_count - len(missing_closeout_ids)
+    # Coverage is measured over ideas whose closure is due: open fills are
+    # excluded from the denominator instead of reading as coverage failures,
+    # while overdue fills stay visible as missing closeouts (#1212).
+    closure_due_count = terminal_count - len(open_filled_ids)
+    with_closeout_count = closure_due_count - len(overdue_ids)
     return {
         "terminal_count": terminal_count,
+        "closure_due_count": closure_due_count,
         "with_closeout_count": with_closeout_count,
-        "missing_closeout_count": len(missing_closeout_ids),
-        "missing_closeout_decision_ids": sorted(missing_closeout_ids),
-        "coverage_rate": _rate(with_closeout_count, terminal_count),
-        "coverage_rate_pct": _percentage(with_closeout_count, terminal_count),
+        "missing_closeout_count": len(overdue_ids),
+        "missing_closeout_decision_ids": sorted(overdue_ids),
+        "open_filled_count": len(open_filled_ids),
+        "open_filled_decision_ids": sorted(open_filled_ids),
+        "overdue_unattributed_count": len(overdue_ids),
+        "overdue_unattributed_decision_ids": sorted(overdue_ids),
+        "overdue_unattributed_reasons": dict(sorted(overdue_reasons.items())),
+        "coverage_rate": _rate(with_closeout_count, closure_due_count),
+        "coverage_rate_pct": _percentage(with_closeout_count, closure_due_count),
         "resolution_counts": resolution_counts,
         "outcome_distribution": outcome_distribution,
         "realized_profit_loss": {

--- a/src/gpt_trader/features/trade_ideas/scorecard.py
+++ b/src/gpt_trader/features/trade_ideas/scorecard.py
@@ -22,6 +22,10 @@ from gpt_trader.features.trade_ideas.accounting import max_drawdown_from_peak_pe
 from gpt_trader.features.trade_ideas.artifacts import stable_artifact_id
 from gpt_trader.features.trade_ideas.audit import AuditAction
 from gpt_trader.features.trade_ideas.eligibility import evaluate_eligibility
+from gpt_trader.features.trade_ideas.lifecycle import (
+    LifecycleClassification,
+    classify_lifecycle,
+)
 from gpt_trader.features.trade_ideas.service import TradeIdeaService, TradeIdeaView
 from gpt_trader.features.trade_ideas.workflow import TERMINAL_STATES
 
@@ -85,7 +89,16 @@ def build_stage_promotion_scorecard(
     views = service.list_views()
 
     window_start = _observation_window_start(views, now=current_time, thresholds=tuned)
-    closed_views = [view for view in views if view.state in TERMINAL_STATES]
+    # A FILLED idea inside its horizon is an open position, not a closed trade:
+    # it must not inflate depth or dilute attribution/expectancy denominators.
+    # Overdue unattributed fills stay in — their missing closeout is exactly
+    # the evidence failure attribution_coverage exists to surface (#1212).
+    closed_views = [
+        view
+        for view in views
+        if view.state in TERMINAL_STATES
+        and classify_lifecycle(view, now=current_time) is not LifecycleClassification.OPEN_FILLED
+    ]
     closed_in_window = [
         view for view in closed_views if window_start <= _closed_at(view) <= current_time
     ]

--- a/src/gpt_trader/features/trade_ideas/service.py
+++ b/src/gpt_trader/features/trade_ideas/service.py
@@ -1255,6 +1255,7 @@ class TradeIdeaService:
         external_order_id: str = "",
         reason: str = "Venue confirmed fill",
         actor_type: ActorType = ActorType.VENUE,
+        evidence: tuple[str, ...] = (),
     ) -> TradeIdeaView:
         venue = _validate_audit_venue(venue)
         idea = self._require_idea(decision_id)
@@ -1265,6 +1266,7 @@ class TradeIdeaService:
             actor_type=actor_type,
             actor_id=actor_id,
             reason=reason,
+            evidence=evidence,
             venue=venue,
             external_order_id=external_order_id,
         )

--- a/tests/unit/gpt_trader/cli/commands/test_ideas_report.py
+++ b/tests/unit/gpt_trader/cli/commands/test_ideas_report.py
@@ -333,3 +333,53 @@ def test_report_is_read_only_and_does_not_seed_budget(
     assert not (root / "risk_budget.jsonl").exists()
     assert response["data"]["proposal_volume"]["idea_count"] == 1
     assert response["data"]["workflow"]["current_state_counts"]["proposed"] == 1
+
+
+def test_report_separates_open_fills_from_overdue_missing_closeouts(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An unexpired open fill is not a missing closeout; an expired one is (#1212).
+
+    FILLED is a terminal workflow state, so the old aggregation counted every
+    open paper position as a missing attribution — a scorecard-visible evidence
+    failure it could never repair while the position legitimately stayed open.
+    """
+    root = tmp_path / "ideas"
+    service = _service(root)
+    attest_account_equity(service)
+
+    def _fill(decision_id: str, expires_at: datetime) -> None:
+        idea = build_trade_idea(
+            decision_id=decision_id,
+            time_horizon=TimeHorizon(expected_hold="3-10 days", expires_at=expires_at),
+        )
+        service.propose(idea, actor_id="idea-generator-v1")
+        service.approve(decision_id, actor_id="rj", reason="Risk verified")
+        service.record_submission(decision_id, actor_id="operator", venue="manual")
+        service.record_fill(decision_id, actor_id="operator", venue="manual")
+
+    # Still inside its horizon at report time: a legitimately open position.
+    _fill("trade-report-open-fill", datetime(2035, 6, 19, 16, 0, tzinfo=UTC))
+    # Expired without a closeout: an overdue attribution the report must flag.
+    _fill("trade-report-overdue-fill", datetime(2026, 6, 13, 16, 0, tzinfo=UTC))
+
+    exit_code, response = _run_json(capsys, ["ideas", "report", *_root_args(root)])
+
+    assert exit_code == 0
+    closeouts = response["data"]["closeouts"]
+    assert closeouts["terminal_count"] == 2
+    assert closeouts["open_filled_count"] == 1
+    assert closeouts["open_filled_decision_ids"] == ["trade-report-open-fill"]
+    assert closeouts["overdue_unattributed_count"] == 1
+    assert closeouts["overdue_unattributed_decision_ids"] == ["trade-report-overdue-fill"]
+    assert closeouts["missing_closeout_count"] == 1
+    assert closeouts["missing_closeout_decision_ids"] == ["trade-report-overdue-fill"]
+    reasons = closeouts["overdue_unattributed_reasons"]
+    assert set(reasons) == {"trade-report-overdue-fill"}
+    assert "expired" in reasons["trade-report-overdue-fill"]
+    # Coverage is measured over ideas whose closure is due: the open fill is
+    # excluded from the denominator instead of reading as a coverage failure.
+    assert closeouts["with_closeout_count"] == 0
+    assert closeouts["coverage_rate_pct"] == "0.00"
+    assert closeouts["closure_due_count"] == 1

--- a/tests/unit/gpt_trader/features/idea_execution/conftest.py
+++ b/tests/unit/gpt_trader/features/idea_execution/conftest.py
@@ -15,6 +15,10 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from tests.unit.gpt_trader.features.trade_ideas.conftest import (
+    attest_account_equity,
+    build_trade_idea,
+)
 
 from gpt_trader.core import Candle
 from gpt_trader.features.brokerages.mock import DeterministicBroker
@@ -27,6 +31,7 @@ from gpt_trader.features.trade_ideas import (
     Confidence,
     ConfidenceLabel,
     EntryZone,
+    ExitPlan,
     MarketSnapshot,
     MaxLoss,
     ProductType,
@@ -156,3 +161,70 @@ def manifest_rows(tmp_path: Path) -> list[dict[str, Any]]:
     if not manifest_path.exists():
         return []
     return [json.loads(line) for line in manifest_path.read_text().splitlines() if line]
+
+
+# --- shared exit-monitor builders (test_exit_monitor*.py) ---
+
+EXIT_CLOCK = datetime(2026, 6, 12, 12, 0, tzinfo=UTC)
+EXIT_QUANTITY = Decimal("0.1")
+
+
+@pytest.fixture
+def service(tmp_path: Path) -> TradeIdeaService:
+    """Frozen-clock service for the exit-monitor test modules."""
+    built = TradeIdeaService(tmp_path / "trade_ideas", now_factory=lambda: EXIT_CLOCK)
+    attest_account_equity(built)
+    return built
+
+
+def fill_exit_idea(
+    service: TradeIdeaService,
+    *,
+    decision_id: str = "trade-20260612-001",
+    instrument: str = "BTC-USD",
+    fill_evidence: tuple[str, ...] = (),
+) -> None:
+    """Propose/approve/submit/fill one long idea (zone 100-102, stop 95, target 113)."""
+    idea = build_trade_idea(
+        decision_id=decision_id,
+        instrument=instrument,
+        entry_zone=EntryZone(lower=Decimal("100"), upper=Decimal("102")),
+        invalidation="Close below 95",
+        target_exit="Take profit at 113 or exit at expiry",
+        exit_plan=ExitPlan(stop=Decimal("95"), target=Decimal("113")),
+        sizing_recommendation=SizingRecommendation(
+            quantity=EXIT_QUANTITY, notional=Decimal("10.1"), rationale="test"
+        ),
+        time_horizon=TimeHorizon(expected_hold="1-4h", expires_at=EXIT_CLOCK + timedelta(hours=4)),
+    )
+    service.propose(idea, actor_id="proposer")
+    service.approve(decision_id, actor_id="rj", reason="verified")
+    service.record_submission(decision_id, actor_id="executor", venue="coinbase")
+    service.record_fill(
+        decision_id,
+        actor_id="coinbase",
+        venue="coinbase",
+        evidence=fill_evidence,
+    )
+
+
+def exit_candle(offset_hours: int, *, high: str, low: str, close: str) -> Candle:
+    price = Decimal(close)
+    return Candle(
+        ts=EXIT_CLOCK + timedelta(hours=offset_hours),
+        open=price,
+        high=Decimal(high),
+        low=Decimal(low),
+        close=price,
+        volume=Decimal("1000"),
+    )
+
+
+def exit_snapshot(*candles: Candle, symbol: str = "BTC-USD") -> MarketSnapshot:
+    # as_of sits after the recorded candles: the monitor runs on a later turn's
+    # snapshot whose bars span the position's post-entry history.
+    return MarketSnapshot(
+        as_of=EXIT_CLOCK + timedelta(hours=3),
+        source="test:fixture",
+        series=(SymbolSeries(symbol=symbol, granularity="ONE_HOUR", candles=candles),),
+    )

--- a/tests/unit/gpt_trader/features/idea_execution/test_cycle_closeout.py
+++ b/tests/unit/gpt_trader/features/idea_execution/test_cycle_closeout.py
@@ -9,8 +9,10 @@ manual `ideas closeout record` per expiry. Shared builders live in conftest.py.
 
 from __future__ import annotations
 
+import json
 from dataclasses import replace
 from datetime import timedelta
+from decimal import Decimal
 from pathlib import Path
 
 from tests.unit.gpt_trader.features.idea_execution.conftest import (
@@ -22,9 +24,11 @@ from tests.unit.gpt_trader.features.idea_execution.conftest import (
     snapshot_provider,
 )
 
+from gpt_trader.core import Candle
 from gpt_trader.features.trade_ideas import (
     ActorType,
     CloseoutResolution,
+    SymbolSeries,
     TimeHorizon,
     TradeIdeaService,
 )
@@ -72,3 +76,82 @@ def test_preexisting_expired_idea_is_backfilled(
     assert result.expired_decision_ids == ()
     assert result.attributed_decision_ids == (decision_id,)
     assert cycle_service.get_closeout_attribution(decision_id) is not None
+
+
+def test_legacy_fill_is_repaired_from_manifest_execution_evidence(
+    cycle_service: TradeIdeaService, tmp_path: Path
+) -> None:
+    """The cycle supplies its own manifest fill facts as fallback evidence (#1212).
+
+    Fills recorded before fill-evidence persistence existed carry no price on
+    the FILLED audit event; the executed price still lives on the manifest's
+    execution row. The exit monitor must resolve such a position from that
+    durable evidence — even when the fill landed outside the planned entry
+    zone, which the old proposal-replay path could never resolve.
+    """
+    decision_id = "trade-20260703-cycle-legacy"
+    cycle_service.propose(build_cycle_idea(decision_id), actor_id="test-proposer")
+    cycle_service.approve(decision_id, actor_id="rj", reason="verified")
+    cycle_service.record_submission(
+        decision_id, actor_id="executor", venue="paper", external_order_id="MOCK_000001"
+    )
+    # Legacy fill: no evidence on the audit event, price 62000 outside zone
+    # 60000-61500 so the zone midpoint is never revisited by the candles below.
+    cycle_service.record_fill(
+        decision_id, actor_id="paper-cycle", venue="paper", external_order_id="MOCK_000001"
+    )
+    manifest_path = tmp_path / "cycle" / "manifest.jsonl"
+    manifest_path.parent.mkdir(parents=True)
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "run_id": "cycle-20260703T120000Z-legacy",
+                "execution": {
+                    "enabled": True,
+                    "executed": [
+                        {
+                            "decision_id": decision_id,
+                            "client_order_id": decision_id,
+                            "order_id": "MOCK_000001",
+                            "symbol": "BTC-USD",
+                            "side": "buy",
+                            "quantity": "0.1",
+                            "fill_price": "62000",
+                            "final_state": "filled",
+                        }
+                    ],
+                    "skipped": [],
+                },
+            },
+            sort_keys=True,
+        )
+        + "\n"
+    )
+
+    # A later turn: post-fill candles ride from 62000 to the 67000 target
+    # without ever touching the planned zone midpoint 60750.
+    later = CYCLE_NOW + timedelta(hours=6)
+    candles = tuple(
+        Candle(
+            ts=CYCLE_NOW + timedelta(hours=index + 1),
+            open=Decimal("62000"),
+            high=Decimal("62500") if index < 3 else Decimal("67100"),
+            low=Decimal("61900"),
+            close=Decimal("62200"),
+            volume=Decimal("10"),
+        )
+        for index in range(4)
+    )
+    series = SymbolSeries(symbol="BTC-USD", granularity="ONE_HOUR", candles=candles)
+
+    result = make_cycle_runner(cycle_service, tmp_path, proposers=[], now=later).run(
+        snapshot_provider(snapshot(series, as_of=later))
+    )
+
+    assert result.resolved_decision_ids == (decision_id,)
+    closeout = cycle_service.get_closeout_attribution(decision_id)
+    assert closeout is not None
+    assert closeout.resolution is CloseoutResolution.THESIS_TARGET
+    # manifest fill 62000 -> target 67000 on qty 0.1: +500
+    assert closeout.realized_profit_loss_amount == Decimal("500.0")
+    assert "entry_price_source=cycle_manifest" in closeout.evidence

--- a/tests/unit/gpt_trader/features/idea_execution/test_cycle_closeout.py
+++ b/tests/unit/gpt_trader/features/idea_execution/test_cycle_closeout.py
@@ -20,6 +20,7 @@ from tests.unit.gpt_trader.features.idea_execution.conftest import (
     build_cycle_idea,
     flat_series,
     make_cycle_runner,
+    manifest_rows,
     snapshot,
     snapshot_provider,
 )
@@ -155,3 +156,114 @@ def test_legacy_fill_is_repaired_from_manifest_execution_evidence(
     # manifest fill 62000 -> target 67000 on qty 0.1: +500
     assert closeout.realized_profit_loss_amount == Decimal("500.0")
     assert "entry_price_source=cycle_manifest" in closeout.evidence
+
+
+def test_manifest_fallback_survives_corruption_and_keeps_first_fill(
+    cycle_service: TradeIdeaService, tmp_path: Path
+) -> None:
+    """Corrupt manifest lines are counted on the turn's row; first fill wins."""
+    decision_id = "trade-20260703-cycle-legacy"
+    cycle_service.propose(build_cycle_idea(decision_id), actor_id="test-proposer")
+    cycle_service.approve(decision_id, actor_id="rj", reason="verified")
+    cycle_service.record_submission(
+        decision_id, actor_id="executor", venue="paper", external_order_id="MOCK_000001"
+    )
+    cycle_service.record_fill(
+        decision_id, actor_id="paper-cycle", venue="paper", external_order_id="MOCK_000001"
+    )
+    manifest_path = tmp_path / "cycle" / "manifest.jsonl"
+    manifest_path.parent.mkdir(parents=True)
+
+    def _row(fill_price: str) -> str:
+        return json.dumps(
+            {
+                "run_id": f"cycle-legacy-{fill_price}",
+                "execution": {
+                    "enabled": True,
+                    "executed": [
+                        {
+                            "decision_id": decision_id,
+                            "order_id": "MOCK_000001",
+                            "symbol": "BTC-USD",
+                            "side": "buy",
+                            "quantity": "0.1",
+                            "fill_price": fill_price,
+                            "final_state": "filled",
+                        }
+                    ],
+                    "skipped": [],
+                },
+            },
+            sort_keys=True,
+        )
+
+    manifest_path.write_text(
+        '{"run_id": "cycle-corrupt", "execution":'  # truncated write from a killed turn
+        + "\n"
+        + _row("62000")
+        + "\n"
+        + _row("64000")  # later duplicate must not override the original fill
+        + "\n"
+    )
+
+    later = CYCLE_NOW + timedelta(hours=6)
+    candles = tuple(
+        Candle(
+            ts=CYCLE_NOW + timedelta(hours=index + 1),
+            open=Decimal("62000"),
+            high=Decimal("62500") if index < 3 else Decimal("67100"),
+            low=Decimal("61900"),
+            close=Decimal("62200"),
+            volume=Decimal("10"),
+        )
+        for index in range(4)
+    )
+    series = SymbolSeries(symbol="BTC-USD", granularity="ONE_HOUR", candles=candles)
+
+    make_cycle_runner(cycle_service, tmp_path, proposers=[], now=later).run(
+        snapshot_provider(snapshot(series, as_of=later))
+    )
+
+    closeout = cycle_service.get_closeout_attribution(decision_id)
+    assert closeout is not None
+    # first recorded fill (62000) wins: 67000 target on qty 0.1 -> +500
+    assert closeout.realized_profit_loss_amount == Decimal("500.0")
+    # manifest_rows() would choke on the deliberately corrupt line; the turn's
+    # own row is the last (valid) line.
+    turn_row = json.loads(manifest_path.read_text().splitlines()[-1])
+    assert turn_row["legacy_fill_manifest_unreadable_lines"] == 1
+
+
+def test_unresolved_exit_monitor_entries_land_on_the_manifest_row(
+    cycle_service: TradeIdeaService, tmp_path: Path
+) -> None:
+    """An expired fill the monitor cannot close explains itself in the evidence."""
+    decision_id = "trade-20260703-cycle-stuck"
+    stuck = replace(
+        build_cycle_idea(decision_id),
+        time_horizon=TimeHorizon(
+            expected_hold="3-10 days",
+            expires_at=CYCLE_NOW + timedelta(hours=1),
+        ),
+    )
+    cycle_service.propose(stuck, actor_id="test-proposer")
+    cycle_service.approve(decision_id, actor_id="rj", reason="verified")
+    cycle_service.record_submission(
+        decision_id, actor_id="executor", venue="paper", external_order_id="MOCK_000001"
+    )
+    cycle_service.record_fill(
+        decision_id, actor_id="paper-cycle", venue="paper", external_order_id="MOCK_000001"
+    )
+
+    # A turn after expiry whose snapshot has no candles for the instrument.
+    later = CYCLE_NOW + timedelta(hours=6)
+    result = make_cycle_runner(cycle_service, tmp_path, proposers=[], now=later).run(
+        snapshot_provider(snapshot(flat_series("ETH-USD"), as_of=later))
+    )
+
+    assert result.resolved_decision_ids == ()
+    (entry,) = result.exit_monitor_unresolved
+    assert entry["decision_id"] == decision_id
+    assert "no candles" in entry["reason"]
+    rows = manifest_rows(tmp_path)
+    assert rows[-1]["exit_monitor_unresolved"][0]["decision_id"] == decision_id

--- a/tests/unit/gpt_trader/features/idea_execution/test_exit_monitor.py
+++ b/tests/unit/gpt_trader/features/idea_execution/test_exit_monitor.py
@@ -3,98 +3,39 @@
 Each test fills an idea with a known ExitPlan, then drives the snapshot's candles
 so the position hits its target, hits its stop, sits open, or expires — and pins
 the recorded closeout resolution and the dollar realized P&L the Stage 1->2 gates
-read (``realized_profit_loss_amount`` = quantity x price move).
+read (``realized_profit_loss_amount`` = quantity x price move). Exit evaluation
+is anchored on the recorded fill (#1212); shared builders live in conftest.py.
 """
 
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
-from pathlib import Path
 
-import pytest
-from tests.unit.gpt_trader.features.trade_ideas.conftest import (
-    attest_account_equity,
-    build_trade_idea,
+from tests.unit.gpt_trader.features.idea_execution.conftest import (
+    EXIT_CLOCK as CLOCK,
+)
+from tests.unit.gpt_trader.features.idea_execution.conftest import (
+    EXIT_QUANTITY as QUANTITY,
+)
+from tests.unit.gpt_trader.features.idea_execution.conftest import (
+    exit_candle as _candle,
+)
+from tests.unit.gpt_trader.features.idea_execution.conftest import (
+    exit_snapshot as _snapshot,
+)
+from tests.unit.gpt_trader.features.idea_execution.conftest import (
+    fill_exit_idea as _fill_idea,
 )
 
-from gpt_trader.core import Candle
 from gpt_trader.features.idea_execution import resolve_filled_ideas
 from gpt_trader.features.trade_ideas import (
     CloseoutResolution,
-    EntryZone,
-    ExitPlan,
-    MarketSnapshot,
     RecordedFill,
-    SizingRecommendation,
-    SymbolSeries,
-    TimeHorizon,
     TradeIdeaService,
     TradeIdeaState,
     encode_fill_evidence,
 )
-
-CLOCK = datetime(2026, 6, 12, 12, 0, tzinfo=UTC)
-QUANTITY = Decimal("0.1")
-
-
-@pytest.fixture
-def service(tmp_path: Path) -> TradeIdeaService:
-    built = TradeIdeaService(tmp_path / "trade_ideas", now_factory=lambda: CLOCK)
-    attest_account_equity(built)
-    return built
-
-
-def _fill_idea(
-    service: TradeIdeaService,
-    *,
-    decision_id: str = "trade-20260612-001",
-    instrument: str = "BTC-USD",
-    fill_evidence: tuple[str, ...] = (),
-) -> None:
-    idea = build_trade_idea(
-        decision_id=decision_id,
-        instrument=instrument,
-        entry_zone=EntryZone(lower=Decimal("100"), upper=Decimal("102")),
-        invalidation="Close below 95",
-        target_exit="Take profit at 113 or exit at expiry",
-        exit_plan=ExitPlan(stop=Decimal("95"), target=Decimal("113")),
-        sizing_recommendation=SizingRecommendation(
-            quantity=QUANTITY, notional=Decimal("10.1"), rationale="test"
-        ),
-        time_horizon=TimeHorizon(expected_hold="1-4h", expires_at=CLOCK + timedelta(hours=4)),
-    )
-    service.propose(idea, actor_id="proposer")
-    service.approve(decision_id, actor_id="rj", reason="verified")
-    service.record_submission(decision_id, actor_id="executor", venue="coinbase")
-    service.record_fill(
-        decision_id,
-        actor_id="coinbase",
-        venue="coinbase",
-        evidence=fill_evidence,
-    )
-
-
-def _candle(offset_hours: int, *, high: str, low: str, close: str) -> Candle:
-    price = Decimal(close)
-    return Candle(
-        ts=CLOCK + timedelta(hours=offset_hours),
-        open=price,
-        high=Decimal(high),
-        low=Decimal(low),
-        close=price,
-        volume=Decimal("1000"),
-    )
-
-
-def _snapshot(*candles: Candle, symbol: str = "BTC-USD") -> MarketSnapshot:
-    # as_of sits after the recorded candles: the monitor runs on a later turn's
-    # snapshot whose bars span the position's post-entry history.
-    return MarketSnapshot(
-        as_of=CLOCK + timedelta(hours=3),
-        source="test:fixture",
-        series=(SymbolSeries(symbol=symbol, granularity="ONE_HOUR", candles=candles),),
-    )
 
 
 def test_target_hit_records_thesis_target_with_positive_pnl(service: TradeIdeaService) -> None:

--- a/tests/unit/gpt_trader/features/idea_execution/test_exit_monitor.py
+++ b/tests/unit/gpt_trader/features/idea_execution/test_exit_monitor.py
@@ -25,11 +25,13 @@ from gpt_trader.features.trade_ideas import (
     EntryZone,
     ExitPlan,
     MarketSnapshot,
+    RecordedFill,
     SizingRecommendation,
     SymbolSeries,
     TimeHorizon,
     TradeIdeaService,
     TradeIdeaState,
+    encode_fill_evidence,
 )
 
 CLOCK = datetime(2026, 6, 12, 12, 0, tzinfo=UTC)
@@ -48,6 +50,7 @@ def _fill_idea(
     *,
     decision_id: str = "trade-20260612-001",
     instrument: str = "BTC-USD",
+    fill_evidence: tuple[str, ...] = (),
 ) -> None:
     idea = build_trade_idea(
         decision_id=decision_id,
@@ -64,7 +67,12 @@ def _fill_idea(
     service.propose(idea, actor_id="proposer")
     service.approve(decision_id, actor_id="rj", reason="verified")
     service.record_submission(decision_id, actor_id="executor", venue="coinbase")
-    service.record_fill(decision_id, actor_id="coinbase", venue="coinbase")
+    service.record_fill(
+        decision_id,
+        actor_id="coinbase",
+        venue="coinbase",
+        evidence=fill_evidence,
+    )
 
 
 def _candle(offset_hours: int, *, high: str, low: str, close: str) -> Candle:
@@ -236,3 +244,103 @@ def test_already_closed_and_sizeless_ideas_are_skipped(service: TradeIdeaService
 
     # A second pass is idempotent: the idea already carries a closeout.
     assert resolve_filled_ideas(service, snapshot, now=CLOCK + timedelta(hours=2)).recorded == ()
+
+
+def test_out_of_zone_fill_resolves_from_recorded_fill_price(service: TradeIdeaService) -> None:
+    """A venue-confirmed fill outside the planned entry zone must still resolve.
+
+    Historically the monitor re-simulated entry from the proposal's entry zone
+    (issue #1212): a confirmed fill whose price never revisited the zone
+    replayed as NOT_FILLED and the position stayed open indefinitely.
+    """
+    _fill_idea(
+        service,
+        fill_evidence=encode_fill_evidence(
+            price=Decimal("105"),
+            quantity=QUANTITY,
+            filled_at=CLOCK,
+        ),
+    )
+    snapshot = _snapshot(
+        _candle(0, high="106", low="103.5", close="104"),  # never touches zone 100-102
+        _candle(1, high="114", low="103", close="113"),  # hits target 113
+    )
+
+    (closeout,) = resolve_filled_ideas(service, snapshot, now=CLOCK + timedelta(hours=2)).recorded
+
+    assert closeout.resolution is CloseoutResolution.THESIS_TARGET
+    # actual fill 105, exit 113, qty 0.1 -> +0.8 (not the zone-midpoint 101 estimate)
+    assert closeout.realized_profit_loss_amount == Decimal("0.8")
+    assert "entry_price=105" in closeout.evidence
+    assert "entry_price_source=recorded_fill" in closeout.evidence
+
+
+def test_pre_fill_candles_are_not_used_for_exit_evaluation(service: TradeIdeaService) -> None:
+    """Only candles at/after the recorded fill time may resolve the position."""
+    _fill_idea(
+        service,
+        fill_evidence=encode_fill_evidence(
+            price=Decimal("105"),
+            quantity=QUANTITY,
+            filled_at=CLOCK + timedelta(hours=2),
+        ),
+    )
+    snapshot = _snapshot(
+        _candle(0, high="114", low="100", close="104"),  # pre-fill target touch: must not exit
+        _candle(2, high="108", low="103", close="106.5"),  # last post-fill mark
+    )
+
+    # Unexpired: no post-fill touch, so the position stays open.
+    assert resolve_filled_ideas(service, snapshot, now=CLOCK + timedelta(hours=3)).recorded == ()
+
+    # Expired: mark-to-market from the actual fill, using post-fill candles only.
+    (closeout,) = resolve_filled_ideas(service, snapshot, now=CLOCK + timedelta(hours=5)).recorded
+    assert closeout.resolution is CloseoutResolution.EXPIRY
+    # entry 105, mark 106.5, qty 0.1 -> +0.15
+    assert closeout.realized_profit_loss_amount == Decimal("0.15")
+
+
+def test_legacy_fill_without_price_marks_expiry_from_zone_midpoint(
+    service: TradeIdeaService,
+) -> None:
+    """A pre-evidence fill still resolves, disclosing the estimated entry price."""
+    _fill_idea(service)  # no fill evidence recorded (legacy)
+    snapshot = _snapshot(
+        _candle(0, high="106", low="103.5", close="104"),  # out of zone: old replay hangs here
+        _candle(1, high="108", low="103", close="107"),
+    )
+
+    (closeout,) = resolve_filled_ideas(service, snapshot, now=CLOCK + timedelta(hours=5)).recorded
+
+    assert closeout.resolution is CloseoutResolution.EXPIRY
+    # documented estimate: zone midpoint 101, mark 107, qty 0.1 -> +0.6
+    assert closeout.realized_profit_loss_amount == Decimal("0.6")
+    assert "entry_price_source=planned_zone_midpoint" in closeout.evidence
+
+
+def test_fallback_fill_facts_repair_legacy_fills(service: TradeIdeaService) -> None:
+    """Durable execution evidence (cycle manifest) supplies legacy fill facts."""
+    _fill_idea(service)  # legacy: no evidence on the FILLED audit event
+    snapshot = _snapshot(
+        _candle(0, high="106", low="103.5", close="104"),
+        _candle(1, high="114", low="103", close="113"),  # hits target 113
+    )
+    fallback = RecordedFill(
+        filled_at=None,
+        price=Decimal("105"),
+        quantity=QUANTITY,
+        venue="paper",
+        external_order_id="MOCK_000001",
+        source="cycle_manifest",
+    )
+
+    (closeout,) = resolve_filled_ideas(
+        service,
+        snapshot,
+        now=CLOCK + timedelta(hours=2),
+        fallback_fills={"trade-20260612-001": fallback},
+    ).recorded
+
+    assert closeout.resolution is CloseoutResolution.THESIS_TARGET
+    assert closeout.realized_profit_loss_amount == Decimal("0.8")
+    assert "entry_price_source=cycle_manifest" in closeout.evidence

--- a/tests/unit/gpt_trader/features/idea_execution/test_exit_monitor_evidence.py
+++ b/tests/unit/gpt_trader/features/idea_execution/test_exit_monitor_evidence.py
@@ -1,0 +1,189 @@
+"""Fill-evidence and unresolved-cause behavior of the exit monitor (#1212).
+
+SHORT-direction exits, permanently unscoreable ideas, expired fills without
+candles, and corrupt fill evidence: each must either resolve from the recorded
+fill facts or explain itself on the pass's ``unresolved`` record instead of
+being silently retried forever. Shared builders live in conftest.py.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import timedelta
+from decimal import Decimal
+
+from tests.unit.gpt_trader.features.idea_execution.conftest import (
+    EXIT_CLOCK as CLOCK,
+)
+from tests.unit.gpt_trader.features.idea_execution.conftest import (
+    EXIT_QUANTITY as QUANTITY,
+)
+from tests.unit.gpt_trader.features.idea_execution.conftest import (
+    exit_candle as _candle,
+)
+from tests.unit.gpt_trader.features.idea_execution.conftest import (
+    exit_snapshot as _snapshot,
+)
+from tests.unit.gpt_trader.features.idea_execution.conftest import (
+    fill_exit_idea as _fill_idea,
+)
+from tests.unit.gpt_trader.features.trade_ideas.conftest import build_trade_idea
+
+from gpt_trader.features.idea_execution import resolve_filled_ideas
+from gpt_trader.features.trade_ideas import (
+    ActorType,
+    CloseoutResolution,
+    EntryZone,
+    ExitPlan,
+    SizingRecommendation,
+    TimeHorizon,
+    TradeDirection,
+    TradeIdeaService,
+    encode_fill_evidence,
+)
+
+
+def _fill_short_idea(service: TradeIdeaService, *, fill_evidence: tuple[str, ...] = ()) -> None:
+    budget = service.current_budget()
+    service.update_budget(
+        replace(
+            budget,
+            version=budget.version + 1,
+            allow_naked_shorts=True,
+            reason="test: allow shorts",
+        ),
+        actor_type=ActorType.HUMAN,
+        actor_id="test-operator",
+    )
+    idea = build_trade_idea(
+        decision_id="trade-20260612-001",
+        direction=TradeDirection.SHORT,
+        entry_zone=EntryZone(lower=Decimal("100"), upper=Decimal("102")),
+        invalidation="Close above 107",
+        target_exit="Take profit at 90 or exit at expiry",
+        exit_plan=ExitPlan(stop=Decimal("107"), target=Decimal("90")),
+        sizing_recommendation=SizingRecommendation(
+            quantity=QUANTITY, notional=Decimal("10.1"), rationale="test"
+        ),
+        time_horizon=TimeHorizon(expected_hold="1-4h", expires_at=CLOCK + timedelta(hours=4)),
+    )
+    service.propose(idea, actor_id="proposer")
+    service.approve("trade-20260612-001", actor_id="rj", reason="verified")
+    service.record_submission("trade-20260612-001", actor_id="executor", venue="coinbase")
+    service.record_fill(
+        "trade-20260612-001",
+        actor_id="coinbase",
+        venue="coinbase",
+        evidence=fill_evidence,
+    )
+
+
+def test_short_fill_resolves_target_with_positive_pnl(service: TradeIdeaService) -> None:
+    """SHORT exits invert both the touch sense and the P&L sign."""
+    _fill_short_idea(
+        service,
+        fill_evidence=encode_fill_evidence(
+            price=Decimal("105"), quantity=QUANTITY, filled_at=CLOCK
+        ),
+    )
+    snapshot = _snapshot(
+        _candle(0, high="106", low="103", close="104"),
+        _candle(1, high="105", low="89", close="91"),  # touches target 90 from above
+    )
+
+    (closeout,) = resolve_filled_ideas(service, snapshot, now=CLOCK + timedelta(hours=2)).recorded
+
+    assert closeout.resolution is CloseoutResolution.THESIS_TARGET
+    # short entry 105, exit 90, qty 0.1 -> +1.5
+    assert closeout.realized_profit_loss_amount == Decimal("1.5")
+
+
+def test_short_fill_resolves_stop_with_negative_pnl(service: TradeIdeaService) -> None:
+    _fill_short_idea(
+        service,
+        fill_evidence=encode_fill_evidence(
+            price=Decimal("105"), quantity=QUANTITY, filled_at=CLOCK
+        ),
+    )
+    snapshot = _snapshot(
+        _candle(0, high="106", low="103", close="104"),
+        _candle(1, high="108", low="103", close="107"),  # breaches stop 107 above entry
+    )
+
+    (closeout,) = resolve_filled_ideas(service, snapshot, now=CLOCK + timedelta(hours=2)).recorded
+
+    assert closeout.resolution is CloseoutResolution.INVALIDATION
+    # short entry 105, exit 107, qty 0.1 -> -0.2
+    assert closeout.realized_profit_loss_amount == Decimal("-0.2")
+
+
+def test_unscoreable_exit_levels_surface_as_unresolved(service: TradeIdeaService) -> None:
+    """A permanently unscoreable idea must not be silently retried forever.
+
+    Level extraction failures are properties of the idea (no numeric stop or
+    target anywhere), so no later turn can succeed; the pass must say so
+    instead of swallowing the error (#1212 curation finding).
+    """
+    idea = build_trade_idea(
+        decision_id="trade-20260612-001",
+        entry_zone=EntryZone(lower=Decimal("100"), upper=Decimal("102")),
+        invalidation="close on vibes",
+        target_exit="exit when it feels right",
+        exit_plan=None,
+        sizing_recommendation=SizingRecommendation(
+            quantity=QUANTITY, notional=Decimal("10.1"), rationale="test"
+        ),
+        time_horizon=TimeHorizon(expected_hold="1-4h", expires_at=CLOCK + timedelta(hours=4)),
+    )
+    service.propose(idea, actor_id="proposer")
+    service.approve("trade-20260612-001", actor_id="rj", reason="verified")
+    service.record_submission("trade-20260612-001", actor_id="executor", venue="coinbase")
+    service.record_fill("trade-20260612-001", actor_id="coinbase", venue="coinbase")
+    snapshot = _snapshot(
+        _candle(0, high="103", low="100", close="102"),
+        _candle(1, high="114", low="101", close="113"),
+    )
+
+    monitor_pass = resolve_filled_ideas(service, snapshot, now=CLOCK + timedelta(hours=2))
+
+    assert monitor_pass.recorded == ()
+    (entry,) = monitor_pass.unresolved
+    assert entry["decision_id"] == "trade-20260612-001"
+    assert "not scoreable" in entry["reason"]
+
+
+def test_expired_fill_without_candles_surfaces_as_unresolved(service: TradeIdeaService) -> None:
+    """Past expiry, every non-closing pass must explain itself on the record."""
+    _fill_idea(service)
+    other_symbol_only = _snapshot(
+        _candle(0, high="103", low="100", close="102"),
+        symbol="ETH-USD",
+    )
+
+    # While the position is inside its horizon, waiting quietly is normal.
+    open_pass = resolve_filled_ideas(service, other_symbol_only, now=CLOCK + timedelta(hours=2))
+    assert open_pass.unresolved == ()
+
+    # Once expired, the missing candles are an evidence failure, not a wait.
+    expired_pass = resolve_filled_ideas(service, other_symbol_only, now=CLOCK + timedelta(hours=5))
+    assert expired_pass.recorded == ()
+    (entry,) = expired_pass.unresolved
+    assert entry["decision_id"] == "trade-20260612-001"
+    assert "no candles" in entry["reason"]
+
+
+def test_corrupt_fill_price_evidence_is_disclosed_on_the_closeout(
+    service: TradeIdeaService,
+) -> None:
+    """Destroyed evidence must never masquerade as a by-design estimate."""
+    _fill_idea(service, fill_evidence=("fill_price=12.3.4", f"fill_quantity={QUANTITY}"))
+    snapshot = _snapshot(
+        _candle(0, high="103", low="100", close="102"),
+        _candle(1, high="114", low="101", close="113"),  # hits target 113
+    )
+
+    (closeout,) = resolve_filled_ideas(service, snapshot, now=CLOCK + timedelta(hours=2)).recorded
+
+    assert closeout.resolution is CloseoutResolution.THESIS_TARGET
+    assert "entry_price_source=planned_zone_midpoint" in closeout.evidence
+    assert "evidence_corrupt_keys=fill_price" in closeout.evidence

--- a/tests/unit/gpt_trader/features/trade_ideas/test_fill_evidence.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_fill_evidence.py
@@ -1,0 +1,110 @@
+"""Immutable actual-fill evidence on the FILLED audit event (#1212).
+
+Paper reconciliation historically dropped the venue-confirmed fill price,
+quantity, and timestamp: the FILLED audit event carried only the order id, so
+exit monitoring had to reconstruct entry from the proposal's planned entry
+zone. These tests pin the provider-neutral evidence codec: structured
+``key=value`` evidence strings on the FILLED event, decoded back into a
+``RecordedFill`` for exit evaluation, with the audit event timestamp as the
+anchor when no explicit fill time was recorded (legacy fills).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from pathlib import Path
+
+from tests.unit.gpt_trader.features.trade_ideas.conftest import (
+    reconciliation_service as _service,
+)
+from tests.unit.gpt_trader.features.trade_ideas.conftest import (
+    submitted_idea as _submitted_idea,
+)
+
+from gpt_trader.features.trade_ideas import (
+    RecordedFill,
+    encode_fill_evidence,
+    recorded_fill_from_view,
+)
+
+FILL_TIME = datetime(2026, 6, 12, 10, 30, tzinfo=UTC)
+
+
+def test_encode_fill_evidence_emits_structured_strings() -> None:
+    evidence = encode_fill_evidence(
+        price=Decimal("60750"),
+        quantity=Decimal("0.1"),
+        filled_at=FILL_TIME,
+    )
+
+    assert evidence == (
+        "fill_price=60750",
+        "fill_quantity=0.1",
+        "fill_time=2026-06-12T10:30:00+00:00",
+    )
+
+
+def test_encode_fill_evidence_omits_unknown_facts() -> None:
+    assert encode_fill_evidence(price=None, quantity=None, filled_at=None) == ()
+    assert encode_fill_evidence(price=Decimal("101.5"), quantity=None, filled_at=None) == (
+        "fill_price=101.5",
+    )
+
+
+def test_recorded_fill_round_trips_through_audit_evidence(tmp_path: Path) -> None:
+    service = _service(tmp_path / "ideas")
+    decision_id = _submitted_idea(service, external_order_id="MOCK_000009")
+    service.record_fill(
+        decision_id,
+        actor_id="paper-fill-reconciler",
+        venue="paper",
+        external_order_id="MOCK_000009",
+        evidence=encode_fill_evidence(
+            price=Decimal("60750"),
+            quantity=Decimal("0.1"),
+            filled_at=FILL_TIME,
+        ),
+    )
+
+    recorded = recorded_fill_from_view(service.get(decision_id))
+
+    assert recorded == RecordedFill(
+        filled_at=FILL_TIME,
+        price=Decimal("60750"),
+        quantity=Decimal("0.1"),
+        venue="paper",
+        external_order_id="MOCK_000009",
+        source="audit_evidence",
+    )
+
+
+def test_recorded_fill_falls_back_to_audit_event_timestamp(tmp_path: Path) -> None:
+    """A pre-evidence FILLED event still anchors exit evaluation at its timestamp."""
+    service = _service(tmp_path / "ideas")
+    decision_id = _submitted_idea(service, external_order_id="MOCK_000001")
+    service.record_fill(
+        decision_id,
+        actor_id="paper-fill-reconciler",
+        venue="paper",
+        external_order_id="MOCK_000001",
+    )
+    view = service.get(decision_id)
+
+    recorded = recorded_fill_from_view(view)
+
+    assert recorded == RecordedFill(
+        filled_at=view.events[-1].timestamp,
+        price=None,
+        quantity=None,
+        venue="paper",
+        external_order_id="MOCK_000001",
+        source="audit_event",
+    )
+
+
+def test_recorded_fill_is_none_for_unfilled_ideas(tmp_path: Path) -> None:
+    service = _service(tmp_path / "ideas")
+    decision_id = _submitted_idea(service)
+
+    assert recorded_fill_from_view(service.get(decision_id)) is None

--- a/tests/unit/gpt_trader/features/trade_ideas/test_fill_evidence.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_fill_evidence.py
@@ -108,3 +108,41 @@ def test_recorded_fill_is_none_for_unfilled_ideas(tmp_path: Path) -> None:
     decision_id = _submitted_idea(service)
 
     assert recorded_fill_from_view(service.get(decision_id)) is None
+
+
+def test_encode_coerces_naive_fill_time_to_utc() -> None:
+    """A naive timestamp must never reach tz-aware candle comparisons."""
+    evidence = encode_fill_evidence(
+        price=None,
+        quantity=None,
+        filled_at=datetime(2026, 6, 12, 10, 30),  # naive
+    )
+
+    assert evidence == ("fill_time=2026-06-12T10:30:00+00:00",)
+
+
+def test_corrupt_evidence_values_are_reported_not_silently_absent(tmp_path: Path) -> None:
+    """Destroyed evidence is distinguishable from evidence that never existed."""
+    service = _service(tmp_path / "ideas")
+    decision_id = _submitted_idea(service, external_order_id="MOCK_000009")
+    service.record_fill(
+        decision_id,
+        actor_id="paper-fill-reconciler",
+        venue="paper",
+        external_order_id="MOCK_000009",
+        evidence=(
+            "fill_price=12.3.4",  # unparseable
+            "fill_quantity=NaN",  # non-finite
+            "fill_time=2026-06-12T10:30:00",  # naive: rejected as corrupt
+        ),
+    )
+    view = service.get(decision_id)
+
+    recorded = recorded_fill_from_view(view)
+
+    assert recorded is not None
+    assert recorded.price is None
+    assert recorded.quantity is None
+    assert recorded.filled_at == view.events[-1].timestamp  # anchor falls back
+    assert recorded.source == "audit_evidence"
+    assert recorded.corrupt_keys == ("fill_price", "fill_quantity", "fill_time")

--- a/tests/unit/gpt_trader/features/trade_ideas/test_lifecycle.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_lifecycle.py
@@ -1,0 +1,121 @@
+"""Canonical lifecycle read classification (#1212).
+
+One read model answers "is this idea an open position, a closed trade, or an
+overdue evidence failure?" for report, scorecard, and CLI consumers. FILLED is
+a terminal workflow state, so state alone conflates a legitimately open
+position with a missing closeout; the classification separates them using the
+existing expiry contract: an unclosed fill becomes overdue once its idea's
+``expires_at`` has passed (the exit monitor would have marked it to market by
+then), and any other terminal idea without attribution is overdue immediately
+(auto-attribution owes it in the same turn).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+from tests.unit.gpt_trader.features.trade_ideas.conftest import (
+    attest_account_equity,
+    build_trade_idea,
+)
+
+from gpt_trader.features.trade_ideas import (
+    CloseoutResolution,
+    LifecycleClassification,
+    TimeHorizon,
+    TradeIdeaService,
+    TradeIdeaState,
+    TradeIdeaView,
+    classify_lifecycle,
+)
+
+CLOCK = datetime(2026, 6, 12, 12, 0, tzinfo=UTC)
+
+
+@pytest.fixture
+def service(tmp_path: Path) -> TradeIdeaService:
+    built = TradeIdeaService(tmp_path / "ideas", now_factory=lambda: CLOCK)
+    attest_account_equity(built)
+    return built
+
+
+def _filled_idea(service: TradeIdeaService, *, expires_at: datetime | None) -> str:
+    decision_id = "trade-20260612-001"
+    idea = build_trade_idea(
+        decision_id=decision_id,
+        time_horizon=TimeHorizon(expected_hold="1-4h", expires_at=expires_at),
+    )
+    service.propose(idea, actor_id="proposer")
+    service.approve(decision_id, actor_id="rj", reason="verified")
+    service.record_submission(decision_id, actor_id="executor", venue="paper")
+    service.record_fill(decision_id, actor_id="paper", venue="paper")
+    return decision_id
+
+
+def test_non_terminal_idea_is_not_applicable(service: TradeIdeaService) -> None:
+    idea = build_trade_idea(
+        time_horizon=TimeHorizon(expected_hold="1-4h", expires_at=CLOCK + timedelta(hours=4))
+    )
+    service.propose(idea, actor_id="proposer")
+
+    view = service.get(idea.decision_id)
+
+    assert classify_lifecycle(view, now=CLOCK) is LifecycleClassification.NOT_APPLICABLE
+
+
+def test_attributed_terminal_idea_is_closed(service: TradeIdeaService) -> None:
+    decision_id = _filled_idea(service, expires_at=CLOCK + timedelta(hours=4))
+    service.record_closeout_attribution(
+        decision_id,
+        actor_id="exit-monitor",
+        resolution=CloseoutResolution.THESIS_TARGET,
+        realized_profit_loss_amount=Decimal("1.2"),
+    )
+
+    view = service.get(decision_id)
+
+    assert classify_lifecycle(view, now=CLOCK) is LifecycleClassification.CLOSED
+
+
+def test_unexpired_fill_without_closeout_is_open(service: TradeIdeaService) -> None:
+    decision_id = _filled_idea(service, expires_at=CLOCK + timedelta(hours=4))
+
+    view = service.get(decision_id)
+
+    assert classify_lifecycle(view, now=CLOCK) is LifecycleClassification.OPEN_FILLED
+
+
+def test_expired_fill_without_closeout_is_overdue(service: TradeIdeaService) -> None:
+    decision_id = _filled_idea(service, expires_at=CLOCK + timedelta(hours=4))
+
+    view = service.get(decision_id)
+
+    late = CLOCK + timedelta(hours=5)
+    assert classify_lifecycle(view, now=late) is LifecycleClassification.OVERDUE_UNATTRIBUTED
+
+
+def test_fill_without_expiry_is_overdue() -> None:
+    # Approval policy refuses expiry-less ideas, so this state can only come
+    # from legacy/imported records; classification must still surface it.
+    view = TradeIdeaView(
+        idea=build_trade_idea(time_horizon=TimeHorizon(expected_hold="1-4h", expires_at=None)),
+        state=TradeIdeaState.FILLED,
+        events=(),
+    )
+
+    assert classify_lifecycle(view, now=CLOCK) is LifecycleClassification.OVERDUE_UNATTRIBUTED
+
+
+def test_unattributed_non_filled_terminal_idea_is_overdue(service: TradeIdeaService) -> None:
+    idea = build_trade_idea(
+        time_horizon=TimeHorizon(expected_hold="1-4h", expires_at=CLOCK + timedelta(hours=4))
+    )
+    service.propose(idea, actor_id="proposer")
+    service.expire(idea.decision_id)
+
+    view = service.get(idea.decision_id)
+
+    assert classify_lifecycle(view, now=CLOCK) is LifecycleClassification.OVERDUE_UNATTRIBUTED

--- a/tests/unit/gpt_trader/features/trade_ideas/test_paper_reconciliation.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_paper_reconciliation.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from dataclasses import replace
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
@@ -259,3 +261,45 @@ def test_live_profiles_are_rejected_for_paper_reconciliation() -> None:
 
     with pytest.raises(PaperFillProfileError):
         validate_paper_reconciliation_profile("prod")
+
+
+def test_apply_records_actual_fill_evidence_on_filled_event(tmp_path: Path) -> None:
+    """Reconciliation must preserve the venue-confirmed fill facts (#1212).
+
+    The fill price/quantity/time were historically dropped, forcing exit
+    monitoring to reconstruct entry from the proposal's planned entry zone.
+    """
+    service = _service(tmp_path / "ideas")
+    decision_id = _approved_idea(service)
+    event = replace(
+        _fill_event(client_order_id=decision_id),
+        filled_at=datetime(2026, 6, 12, 10, 30, tzinfo=UTC),
+    )
+
+    report = PaperFillReconciler(service, actor_id="paper-reconciler").reconcile_fills(
+        [event],
+        apply=True,
+    )
+
+    assert report.recorded_count == 1
+    filled_event = service.get(decision_id).events[-1]
+    assert filled_event.action is AuditAction.FILLED
+    assert filled_event.evidence == (
+        "fill_price=60750",
+        "fill_quantity=0.1",
+        "fill_time=2026-06-12T10:30:00+00:00",
+    )
+
+
+def test_apply_records_fill_evidence_without_fill_time(tmp_path: Path) -> None:
+    """Store-event fills carry no timestamp; price/quantity must still land."""
+    service = _service(tmp_path / "ideas")
+    decision_id = _approved_idea(service)
+
+    PaperFillReconciler(service, actor_id="paper-reconciler").reconcile_fills(
+        [_fill_event(client_order_id=decision_id)],
+        apply=True,
+    )
+
+    filled_event = service.get(decision_id).events[-1]
+    assert filled_event.evidence == ("fill_price=60750", "fill_quantity=0.1")

--- a/tests/unit/gpt_trader/features/trade_ideas/test_paper_reconciliation.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_paper_reconciliation.py
@@ -303,3 +303,51 @@ def test_apply_records_fill_evidence_without_fill_time(tmp_path: Path) -> None:
 
     filled_event = service.get(decision_id).events[-1]
     assert filled_event.evidence == ("fill_price=60750", "fill_quantity=0.1")
+
+
+def test_store_event_timestamp_fallback_skips_malformed_candidates(tmp_path: Path) -> None:
+    """A garbage filled_at must not mask a valid timestamp on the same event."""
+    from gpt_trader.features.trade_ideas import paper_fill_events_from_store_events
+
+    (event,) = paper_fill_events_from_store_events(
+        [
+            {
+                "type": "trade",
+                "data": {
+                    "order_id": "MOCK_000004",
+                    "symbol": "BTC-USD",
+                    "side": "buy",
+                    "quantity": "0.1",
+                    "price": "60750",
+                    "status": "filled",
+                    "filled_at": "not-a-timestamp",
+                    "timestamp": "2026-06-12T10:30:00+00:00",
+                },
+            }
+        ]
+    )
+
+    assert event.filled_at == datetime(2026, 6, 12, 10, 30, tzinfo=UTC)
+
+
+def test_store_event_naive_timestamp_is_coerced_to_utc(tmp_path: Path) -> None:
+    from gpt_trader.features.trade_ideas import paper_fill_events_from_store_events
+
+    (event,) = paper_fill_events_from_store_events(
+        [
+            {
+                "type": "trade",
+                "data": {
+                    "order_id": "MOCK_000005",
+                    "symbol": "BTC-USD",
+                    "side": "buy",
+                    "quantity": "0.1",
+                    "price": "60750",
+                    "status": "filled",
+                    "timestamp": "2026-06-12T10:30:00",
+                },
+            }
+        ]
+    )
+
+    assert event.filled_at == datetime(2026, 6, 12, 10, 30, tzinfo=UTC)

--- a/tests/unit/gpt_trader/features/trade_ideas/test_replay.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_replay.py
@@ -14,6 +14,7 @@ from gpt_trader.features.trade_ideas import (
     TradeDirection,
     TradeIdea,
     TradeIdeaService,
+    score_filled_trade_idea,
     score_trade_idea,
 )
 
@@ -343,3 +344,28 @@ def test_replay_granularity_table_agrees_with_recorder_builder() -> None:
     }
 
     assert _GRANULARITY_DURATION_BY_ALIAS == recorder_table
+
+
+def test_score_filled_trade_idea_scores_stop_before_target_in_one_bar() -> None:
+    """Fill-anchored scoring keeps the conservative same-bar ordering."""
+    result = score_filled_trade_idea(
+        scoreable_idea(),
+        filled_at=AS_OF,
+        fill_price=Decimal("104"),
+        future_candles=(candle(1, high="114", low="94", close="100"),),  # touches both
+    )
+
+    assert result.outcome is ReplayOutcome.STOP_HIT
+    assert result.exit_price == Decimal("95")
+
+
+def test_score_filled_trade_idea_with_no_in_horizon_candles_is_no_future_data() -> None:
+    """A fill at/after expiry has no scorable window; it must not fabricate."""
+    result = score_filled_trade_idea(
+        scoreable_idea(),
+        filled_at=AS_OF + timedelta(hours=4),  # == expires_at
+        fill_price=Decimal("104"),
+        future_candles=(candle(5, high="114", low="94", close="100"),),  # post-expiry
+    )
+
+    assert result.outcome is ReplayOutcome.NO_FUTURE_DATA

--- a/tests/unit/gpt_trader/features/trade_ideas/test_scorecard.py
+++ b/tests/unit/gpt_trader/features/trade_ideas/test_scorecard.py
@@ -304,3 +304,37 @@ def test_metric_path_never_references_the_cycle_manifest() -> None:
             "metrics must compute from the idea-level closeout/audit trail"
         )
     assert "idea_execution" not in Path(scorecard.__file__).read_text(encoding="utf-8")
+
+
+def test_open_fill_is_not_a_closed_idea_but_overdue_fill_is(tmp_path: Path) -> None:
+    """The gates read closed trades; an open position is not one (#1212).
+
+    FILLED is a terminal workflow state, so the window used to count a live
+    unexpired position as a closed idea (inflating depth, diluting attribution
+    coverage). An expired fill without a closeout must still count — as an
+    attribution failure — so overdue evidence stays a visible red.
+    """
+    clock = _Clock(_START)
+    service = _service(tmp_path / "ideas", clock)
+    attest_account_equity(service)
+    now = _START + timedelta(days=3)
+
+    def _fill(decision_id: str, *, expires_at: datetime) -> None:
+        clock.now = _START
+        idea = _idea(decision_id, expires_at=expires_at)
+        service.propose(idea, actor_id="proposer-a")
+        service.approve(decision_id, actor_id="rj", reason="Risk verified")
+        service.record_submission(decision_id, actor_id="operator", venue="manual")
+        service.record_fill(decision_id, actor_id="operator", venue="manual")
+
+    _fill("trade-scorecard-open", expires_at=now + timedelta(days=30))
+    _fill("trade-scorecard-overdue", expires_at=now - timedelta(days=1))
+
+    scorecard = build_stage_promotion_scorecard(service, now=now)
+
+    # Only the overdue fill is a closed idea; the open position is excluded.
+    assert scorecard["observation_window"]["closed_idea_count"] == 1
+    coverage = scorecard["gates"]["attribution_coverage"]
+    assert coverage["status"] == "fail"
+    assert coverage["measured"]["attributed_count"] == 0
+    assert coverage["measured"]["closed_idea_count"] == 1


### PR DESCRIPTION
Part of #1212 (operate-to-evidence: closeout/attribution truth).

## Problem

Paper reconciliation confirmed venue fills but dropped the actual fill price, quantity, and timestamp — `record_fill` persisted only the order id. Exit monitoring then re-simulated entry from the proposal's planned entry zone via the replay scorer, so:

- a confirmed fill whose price never revisited the planned zone replayed as `NOT_FILLED` forever and could never close (the stuck `trade-20260710-ethusd-6d6cc203` fill, expired 2026-07-12, diagnosed candle-by-candle: the only zone-midpoint touch was the pre-proposal 02:00 bar, excluded by the `as_of` filter);
- every open FILLED position counted as a *missing closeout* in the report and as a *closed idea* in the scorecard, conflating live positions with evidence failures.

## Change

**Fill evidence (new `fill_evidence.py`).** Reconciliation now records `fill_price=` / `fill_quantity=` / `fill_time=` as structured evidence on the FILLED audit event — the same `key=value` convention closeout evidence uses. Existing audit records and hashes are untouched; pre-evidence FILLED events decode to an audit-event-timestamp anchor with unknown price. The paper executor's machine leg passes the broker order's fill facts through the same reconciler path.

**Fill-anchored exit resolution (`score_filled_trade_idea`).** The exit monitor no longer replays entry from the proposal: it inspects only candles at/after the recorded fill, every bar may exit (no ambiguous entry bar), and entry price is chosen by evidentiary strength — recorded fill evidence → durable cycle-manifest execution row (repairs legacy fills; the cycle reads its own manifest only while an open pre-evidence fill exists) → documented zone-midpoint sizing assumption. The source is disclosed as `entry_price_source=` on the closeout evidence.

**Canonical lifecycle classification (new `lifecycle.py`).** One read model — `open_filled` / `closed` / `overdue_unattributed` / `not_applicable` — reusing the existing expiry contract (a fill is overdue once `now >= expires_at`; other unattributed terminals are overdue immediately). Report and scorecard both classify through it:

- `missing_closeout_count` now means *overdue*, not *open*; open fills are excluded from the coverage denominator (`closure_due_count`) instead of reading as failures.
- New stable JSON fields: `closure_due_count`, `open_filled_count`/`_decision_ids`, `overdue_unattributed_count`/`_decision_ids`/`_reasons`. All existing keys preserved.
- Scorecard depth/attribution/expectancy/benchmark gates no longer count open positions as closed ideas; overdue fills remain in as visible attribution failures.

## Evidence

- Read-only against the operational store: `terminal=41, closure_due=35, with_closeout=34, open_filled=6, overdue=1 (the ETH idea, with a structured reason), coverage 97.14%`. The next scheduled cycle turn closes ETH deterministically from its manifest fill price (1771.48 → target 1811.54, verified against recorded snapshot candles).
- TDD: each defect pinned by a red regression first (out-of-zone fill, pre-fill candle exclusion, legacy midpoint fallback, manifest repair, report/scorecard population splits).
- `uv run local-ci` (default pr profile) fully green; 7,156 unit tests pass; repeated monitor/reconciliation passes stay idempotent (existing dedupe + closeout-exists guards, covered by tests).

Paper-only: no broker calls, no credentials, no operational-store mutation (verification reads only), no scheduler changes.